### PR TITLE
Frontier

### DIFF
--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -445,7 +445,9 @@ public abstract class SharedDoorSystem : EntitySystem
             if (otherPhysics == physics)
                 continue;
 
-            if (!otherPhysics.CanCollide)
+            //TODO: Make only shutters ignore these objects upon colliding instead of all airlocks
+            // Excludes Glasslayer for windows, GlassAirlockLayer for windoors, TableLayer for tables
+            if (!otherPhysics.CanCollide || otherPhysics.CollisionLayer == (int) CollisionGroup.GlassLayer || otherPhysics.CollisionLayer == (int) CollisionGroup.GlassAirlockLayer || otherPhysics.CollisionLayer == (int) CollisionGroup.TableLayer)
                 continue;
 
             //If the colliding entity is a slippable item ignore it by the airlock

--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -447,7 +447,15 @@ public abstract class SharedDoorSystem : EntitySystem
 
             //TODO: Make only shutters ignore these objects upon colliding instead of all airlocks
             // Excludes Glasslayer for windows, GlassAirlockLayer for windoors, TableLayer for tables
-            if (!otherPhysics.CanCollide || otherPhysics.CollisionLayer == (int) CollisionGroup.GlassLayer || otherPhysics.CollisionLayer == (int) CollisionGroup.GlassAirlockLayer || otherPhysics.CollisionLayer == (int) CollisionGroup.TableLayer)
+            if (!otherPhysics.CanCollide ||
+                    otherPhysics.CollisionLayer == (int) CollisionGroup.GlassLayer ||
+                    otherPhysics.CollisionLayer == (int) CollisionGroup.GlassAirlockLayer ||
+                    otherPhysics.CollisionLayer == (int) CollisionGroup.TableLayer ||
+                    // Objects without any of these 3 collisiongroups won't obstruct shutters
+                    (otherPhysics.CollisionLayer & ((int) CollisionGroup.Impassable |
+                                                   (int) CollisionGroup.MidImpassable |
+                                                   (int) CollisionGroup.HighImpassable))
+                        == 0)
                 continue;
 
             //If the colliding entity is a slippable item ignore it by the airlock

--- a/Resources/Prototypes/Entities/Structures/conveyor.yml
+++ b/Resources/Prototypes/Entities/Structures/conveyor.yml
@@ -29,7 +29,6 @@
           - 0.55,0.55
           - -0.55,0.55
         layer:
-        - Impassable
         - MidImpassable
         - LowImpassable
         hard: False

--- a/Resources/Prototypes/Entities/Structures/conveyor.yml
+++ b/Resources/Prototypes/Entities/Structures/conveyor.yml
@@ -29,7 +29,6 @@
           - 0.55,0.55
           - -0.55,0.55
         layer:
-        - MidImpassable
         - LowImpassable
         hard: False
   - type: Conveyor


### PR DESCRIPTION
I thought a fix existed and noticed shutter not closing over conveyor belt. But then it turned out it didn't fix it. So I did.
This includes one cherry-picked commit from upstream.

I did not extensively test shutters after that, but the logic is sound: Objects which don't have any of Impassable, HighImpassable or MidImpassable should not block the shutters.

cheers

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR.

## About the PR
<!-- What does it change? What other things could this impact?


**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):


- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB


:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->