### PR TITLE
Show NF guidebook pages by default, float to top

### DIFF
--- a/Content.Client/Guidebook/Controls/GuidebookWindow.xaml.cs
+++ b/Content.Client/Guidebook/Controls/GuidebookWindow.xaml.cs
@@ -86,6 +86,11 @@ public sealed partial class GuidebookWindow : FancyWindow, ILinkClickHandler
             var item = Tree.Items.FirstOrDefault(x => x.Metadata is GuideEntry entry && entry.Id == selected);
             Tree.SetSelectedIndex(item?.Index);
         }
+        else
+        {
+            var item = Tree.Items.First();
+            Tree.SetSelectedIndex(item?.Index);
+        }
     }
 
     private IEnumerable<GuideEntry> GetSortedRootEntries(List<string>? rootEntries)

--- a/Resources/Prototypes/Guidebook/ss14.yml
+++ b/Resources/Prototypes/Guidebook/ss14.yml
@@ -3,7 +3,6 @@
   name: guide-entry-ss14
   text: "/ServerInfo/Guidebook/SpaceStation14.xml"
   children:
-  - Adventure
   - Controls
   - Jobs
   - Survival

--- a/Resources/Prototypes/_NF/Guidebook/guidebook.yml
+++ b/Resources/Prototypes/_NF/Guidebook/guidebook.yml
@@ -2,6 +2,7 @@
   id: Adventure
   name: guide-entry-adventure
   text: "/ServerInfo/Guidebook/Adventure/Adventure.xml"
+  priority: -1
   children:
   - Bank
   - Shipyard


### PR DESCRIPTION
## About the PR
- Shows the top guidebook page by default when guidebook is opened.
- Reorganize hierarchy so that NF guidebook pages show at the top.

**Media**
![image](https://github.com/new-frontiers-14/frontier-station-14/assets/3229565/7008c57e-4d6c-4d91-af3e-2baaf511fb1a)


- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
