### PR TITLE
lobby_ui_bandaid

### DIFF
--- a/Content.Client/Lobby/LobbyState.cs
+++ b/Content.Client/Lobby/LobbyState.cs
@@ -198,7 +198,7 @@ namespace Content.Client.Lobby
 
             if (_gameTicker.ServerInfoBlob != null)
             {
-                _lobby!.ServerInfo.SetInfoBlob(_gameTicker.ServerInfoBlob);
+                //_lobby!.ServerInfo.SetInfoBlob(_gameTicker.ServerInfoBlob);
             }
         }
 

--- a/Content.Client/Lobby/UI/LobbyGui.xaml
+++ b/Content.Client/Lobby/UI/LobbyGui.xaml
@@ -69,7 +69,7 @@
                 <controls:HSpacer Spacing="10"/>
                 <!-- Server info -->
                 <controls:NanoHeading Text="{Loc 'ui-lobby-server-info-block'}" />
-                <info:ServerInfo Name="ServerInfo" Access="Public" MinSize="0 30" VerticalExpand="false" Margin="3 3 3 3" MaxWidth="400" HorizontalAlignment="Left"/>
+                <!-- <info:ServerInfo Name="ServerInfo" Access="Public" MinSize="0 30" VerticalExpand="false" Margin="3 3 3 3" MaxWidth="400" HorizontalAlignment="Left"/> -->
                 <Label Name="StationTime" Access="Public" FontColorOverride="{x:Static maths:Color.LightGray}" Margin="3 3 3 3" HorizontalAlignment="Left"/>
                 <controls:HSpacer Spacing="5"/>
                 <lobbyUi:LobbyCharacterPreviewPanel Name="CharacterPreview" Access="Public" />


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
quick band aid fix we are just going to not display server player count and stuff for the time being, i need to look further to see where the blob is built to really fix this
