### PR TITLE
Borg crew monitor + slight refactor

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Power/powercells.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/powercells.yml
@@ -206,27 +206,6 @@
       autoRechargeRate: 0.16667 #takes about 5 minutes to charge itself back to full
 
 - type: entity
-  name: silicon integrated power cell
-  description: A rechargeable modified microreactor cell. Intended for cyborg devices, it slowly recharges by itself.
-  id: PowerCellSiliconTool
-  suffix: Full
-  parent: BasePowerCell
-  components:
-    - type: Sprite
-      layers:
-      - map: [ "enum.PowerCellVisualLayers.Base" ]
-        state: microreactor
-      - map: [ "enum.PowerCellVisualLayers.Unshaded" ]
-        state: o2
-        shader: unshaded
-    - type: Battery
-      maxCharge: 200
-      startingCharge: 200
-    - type: BatterySelfRecharger
-      autoRecharge: true
-      autoRechargeRate: 0.66667 #takes about 5 minutes to charge itself back to full
-
-- type: entity
   name: antique power cell prototype
   description: A small cell that self recharges. Used in old laser arms research.
   id: PowerCellAntiqueProto

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healthanalyzer.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healthanalyzer.yml
@@ -52,14 +52,3 @@
     slots:
       cell_slot:
         name: power-cell-slot-component-slot-name-default
-
-- type: entity
-  id: HandheldHealthAnalyzerSilicon
-  parent: HandheldHealthAnalyzer
-  suffix: Silicon
-  components:
-  - type: ItemSlots
-    slots:
-      cell_slot:
-        name: power-cell-slot-component-slot-name-default
-        startingItem: PowerCellSiliconTool

--- a/Resources/Prototypes/_NF/Entities/Objects/Specific/Borgs/borgs_tools.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Specific/Borgs/borgs_tools.yml
@@ -1,0 +1,21 @@
+- type: entity
+  id: HandheldHealthAnalyzerBorg
+  parent: HandheldHealthAnalyzer
+  suffix: Borg
+  components:
+  - type: ItemSlots
+    slots:
+      cell_slot:
+        name: power-cell-slot-component-slot-name-default
+        startingItem: PowerCellBorgTool
+
+- type: entity
+  id: HandheldCrewMonitorBorg
+  parent: HandheldCrewMonitor
+  suffix: Borg
+  components:
+  - type: ItemSlots
+    slots:
+      cell_slot:
+        name: power-cell-slot-component-slot-name-default
+        startingItem: PowerCellBorgTool

--- a/Resources/Prototypes/_NF/Entities/Objects/Specific/Power/powercells.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Specific/Power/powercells.yml
@@ -1,0 +1,13 @@
+- type: entity
+  name: borg integrated power cell
+  description: A rechargeable modified microreactor cell. Intended for cyborg tools, it slowly recharges by itself.
+  id: PowerCellBorgTool
+  suffix: Full
+  parent: PowerCellMicroreactor
+  components:
+    - type: Battery
+      maxCharge: 200
+      startingCharge: 200
+    - type: BatterySelfRecharger
+      autoRecharge: true
+      autoRechargeRate: 0.66667 #takes about 5 minutes to charge itself back to full

--- a/Resources/Prototypes/_Nyano/Entities/Mobs/Player/borgs.yml
+++ b/Resources/Prototypes/_Nyano/Entities/Mobs/Player/borgs.yml
@@ -191,7 +191,7 @@
     slots:
       analyzer_slot:
         name: HealthAnalyzer
-        startingItem: HandheldHealthAnalyzerSilicon
+        startingItem: HandheldHealthAnalyzerBorg
         locked: true
       hypospray_slot:
         name: Hypospray
@@ -226,8 +226,8 @@
     tools:
       - id: HyposprayBorgMedical
       - id: Syringe
-      - id: HandheldHealthAnalyzerSilicon
-      - id: HandheldCrewMonitor
+      - id: HandheldHealthAnalyzerBorg
+      - id: HandheldCrewMonitorBorg
       - id: FireExtinguisher
       - id: StackHolderHealingItem
   - type: ItemSlots


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Turns out borgs also have crew monitors that need power, also I got the dev build to work so it's even tested.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: crazybrain
- fix: Medical cyborgs now have self-recharching crew monitors.
