### PR TITLE
Various Chemistry Jug Fixes

### DIFF
--- a/Resources/Locale/en-US/prototypes/catalog/cargo/cargo-vending.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/cargo/cargo-vending.ftl
@@ -63,3 +63,6 @@ ent-CrateVendingMachineRestockDiscountDans = { ent-CrateVendingMachineRestockDis
 
 ent-CrateVendingMachineRestockDonut = { ent-CrateVendingMachineRestockDonutFilled }
     .desc = { ent-CrateVendingMachineRestockDonutFilled.desc }
+
+ent-CrateVendingMachineRestockChemVend = { ent-CrateVendingMachineRestockChemVendFilled }
+    .desc = { CrateVendingMachineRestockChemVendFilled.desc }

--- a/Resources/Locale/en-US/prototypes/catalog/fills/crates/vending-crates.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/fills/crates/vending-crates.ftl
@@ -63,3 +63,6 @@ ent-CrateVendingMachineRestockDiscountDansFilled = Discount Dans restock crate
 
 ent-CrateVendingMachineRestockDonutFilled = Donut restock crate
     .desc = Contains a restock box for a Monkin' Donuts dispenser.
+
+ent-CrateVendingMachineRestockChemVendFilled = ChemVend restock crate
+    .desc = Contains a restock box for the ChemVend.

--- a/Resources/Prototypes/Catalog/Fills/Crates/chemistry.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/chemistry.yml
@@ -20,6 +20,10 @@
           amount: 1
         - id: JugSilicon
           amount: 1
+        - id: JugNitrogen
+          amount: 1
+        - id: JugOxygen
+          amount: 1
 
 - type: entity
   id: CrateChemistryS
@@ -36,6 +40,10 @@
         - id: JugPotassium
           amount: 1
         - id: JugRadium
+          amount: 1
+        - id: JugSugar
+          amount: 1
+        - id: JugEthanol
           amount: 1
 
 - type: entity


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Chem Crates now have all the chems that the dispenser does. Took some liberties with Ethanol and Sugar since they aren't on the periodic table but oh well who cares
Also fixed the ChemVend not having a description or name so it's clearer that people can restock it if/when it's used

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: Lank
- add: Chemical Crates now contain every necessary precursor. 
