### PR TITLE
Nerf crates to carry the default entity limit of 30 entities

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/base_structurecrates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/base_structurecrates.yml
@@ -35,7 +35,6 @@
         layer:
         - MachineLayer
   - type: EntityStorage
-    capacity: 500
   - type: PlaceableSurface
     isPlaceable: false # defaults to closed.
   - type: Damageable


### PR DESCRIPTION
Per #bulletin-board "lower capacity of crates", cherry-picked from mining-station-14