### PR TITLE
add knives to ammo vendor

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/ammo.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/ammo.yml
@@ -1,6 +1,7 @@
 ﻿- type: vendingMachineInventory
   id: AmmoVendInventory
   startingInventory:
+    SurvivalKnife: 15
     WeaponLaserGun: 15
 
     WeaponSniperMosin: 15


### PR DESCRIPTION
## About the PR
freedom? you mean knives?

if you dont get prospector its hard to get a knife which is extremely important for surviving, since you can stab a fish thats floating ontop of your canisters, but you can't shoot it.

dunno how this will play with restock pr since arbitrage might not be a thing but idk

**Media**
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- add: The Liberation Station now sells knives to reduce the number of freak carp accidents.