### PR TITLE
Add rotational anchors

### DIFF
--- a/Content.Server/Shuttles/Components/ShuttleComponent.cs
+++ b/Content.Server/Shuttles/Components/ShuttleComponent.cs
@@ -48,5 +48,8 @@ namespace Content.Server.Shuttles.Components
         /// </summary>
         [DataField("linearDamping"), ViewVariables(VVAccess.ReadWrite)]
         public float LinearDamping = 0.05f;
+
+        [DataField("angularDamping"), ViewVariables(VVAccess.ReadWrite)]
+        public float AngularDamping = 0.05f;
     }
 }

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
@@ -305,7 +305,7 @@ public sealed partial class ShuttleSystem
                         {
                             _physics.SetLinearDamping(body, shuttle.LinearDamping);
                         }
-                        _physics.SetAngularDamping(body, ShuttleAngularDamping);
+                        _physics.SetAngularDamping(body, shuttle.AngularDamping);
                     }
 
                     MapId mapId;

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.cs
@@ -44,8 +44,6 @@ public sealed partial class ShuttleSystem : SharedShuttleSystem
 
     public const float TileMassMultiplier = 0.5f;
 
-    public const float ShuttleAngularDamping = 0.05f;
-
     public override void Initialize()
     {
         base.Initialize();
@@ -153,7 +151,7 @@ public sealed partial class ShuttleSystem : SharedShuttleSystem
         _physics.SetBodyStatus(component, BodyStatus.InAir);
         _physics.SetFixedRotation(uid, false, manager: manager, body: component);
         _physics.SetLinearDamping(component, shuttle.LinearDamping);
-        _physics.SetAngularDamping(component, ShuttleAngularDamping);
+        _physics.SetAngularDamping(component, shuttle.AngularDamping);
     }
 
     private void Disable(EntityUid uid, PhysicsComponent component)

--- a/Resources/Maps/cargodepot.yml
+++ b/Resources/Maps/cargodepot.yml
@@ -52,6 +52,7 @@ entities:
     - type: OccluderTree
     - type: Shuttle
       linearDamping: 10000
+      angularDamping: 10000
     - nextUpdate: 9845.535748
       type: GridPathfinding
     - gravityShakeSound: !type:SoundPathSpecifier

--- a/Resources/Maps/frontier.yml
+++ b/Resources/Maps/frontier.yml
@@ -152,6 +152,7 @@ entities:
       type: Fixtures
     - type: OccluderTree
     - linearDamping: 10000
+      angularDamping: 10000
       type: Shuttle
     - type: GridPathfinding
     - gravityShakeSound: !type:SoundPathSpecifier


### PR DESCRIPTION
## About the PR
Make anchors better by making it harder for people to *rotate* Frontier Station and its cargo depots.