### PR TITLE
Adjust Frontier roles

### DIFF
--- a/Resources/Prototypes/Maps/frontier.yml
+++ b/Resources/Prototypes/Maps/frontier.yml
@@ -19,5 +19,7 @@
           availableJobs:
             Passenger: [ -1, -1 ]
             HeadOfPersonnel: [ 1, 3 ]
-            HeadOfSecurity: [1, 3]
+            HeadOfSecurity: [ 1, 2 ]
+            SecurityOfficer: [ 1, 4 ]
+            # StationEngineer: [ 1, 1 ] # TODO uncomment when grid unprotected???
             Valet: [ 7, 7 ]


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
This PR adds direct station security officer roles, so that they don't all have to be hired from HoP (with their passenger PDAs). 1 less HoS slot is available as a result.

**Media**
No.

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl: router
- tweak: Nanotrasen has supplied the station with Security Officer job positions, so that you don't get confused by "a random passenger" detaining you.
