### PR TITLE
Initial Role Timers

### DIFF
--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -210,7 +210,7 @@ namespace Content.Shared.CCVar
         /// If roles should be restricted based on time.
         /// </summary>
         public static readonly CVarDef<bool>
-            GameRoleTimers = CVarDef.Create("game.role_timers", false, CVar.SERVER | CVar.REPLICATED);
+            GameRoleTimers = CVarDef.Create("game.role_timers", true, CVar.SERVER | CVar.REPLICATED);
 
         /// <summary>
         ///     Whether a random position offset will be applied to the station on roundstart.

--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -3,16 +3,16 @@
   name: job-name-qm
   description: job-description-qm
   playTimeTracker: JobQuartermaster
-  requirements:
-    - !type:RoleTimeRequirement
-      role: JobCargoTechnician
-      time: 21600 #6 hrs
-    - !type:RoleTimeRequirement
-      role: JobSalvageSpecialist
-      time: 21600 #6 hrs
-    - !type:DepartmentTimeRequirement
-      department: Cargo
-      time: 108000 # 30 hrs
+  # requirements:
+    # - !type:RoleTimeRequirement
+      # role: JobCargoTechnician
+      # time: 21600 #6 hrs
+    # - !type:RoleTimeRequirement
+      # role: JobSalvageSpecialist
+      # time: 21600 #6 hrs
+    # - !type:DepartmentTimeRequirement
+      # department: Cargo
+      # time: 108000 # 30 hrs
   weight: 10
   startingGear: QuartermasterGear
   icon: "QuarterMaster"

--- a/Resources/Prototypes/Roles/Jobs/Cargo/salvage_specialist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/salvage_specialist.yml
@@ -3,10 +3,10 @@
   name: job-name-salvagespec
   description: job-description-salvagespec
   playTimeTracker: JobSalvageSpecialist
-  requirements:
-    - !type:DepartmentTimeRequirement
-      department: Cargo
-      time: 3600
+  # requirements:
+    # - !type:DepartmentTimeRequirement
+      # department: Cargo
+      # time: 3600
   icon: "ShaftMiner"
   startingGear: SalvageSpecialistGear
   supervisors: job-supervisors-qm

--- a/Resources/Prototypes/Roles/Jobs/Civilian/bartender.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/bartender.yml
@@ -4,9 +4,9 @@
   description: job-description-bartender
   playTimeTracker: JobBartender
   requirements:
-    - !type:DepartmentTimeRequirement
-      department: Civilian
-      time: 1800
+    # - !type:DepartmentTimeRequirement
+      # department: Civilian
+      # time: 1800
   startingGear: BartenderGear
   icon: "Bartender"
   supervisors: job-supervisors-hop

--- a/Resources/Prototypes/Roles/Jobs/Civilian/chef.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/chef.yml
@@ -3,10 +3,10 @@
   name: job-name-chef
   description: job-description-chef
   playTimeTracker: JobChef
-  requirements:
-    - !type:DepartmentTimeRequirement
-      department: Civilian
-      time: 1800
+  # requirements:
+    # - !type:DepartmentTimeRequirement
+      # department: Civilian
+      # time: 1800
   startingGear: ChefGear
   icon: "Chef"
   supervisors: job-supervisors-hop

--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -3,25 +3,25 @@
   name: job-name-captain
   description: job-description-captain
   playTimeTracker: JobCaptain
-  requirements:
-    - !type:RoleTimeRequirement
-      role: JobHeadOfPersonnel
-      time: 21600 #6 hrs
-    - !type:RoleTimeRequirement
-      role: JobHeadOfSecurity
-      time: 21600 #6 hrs
-    - !type:RoleTimeRequirement
-      role: JobChiefMedicalOfficer
-      time: 21600 #6 hrs
-    - !type:RoleTimeRequirement
-      role: JobChiefEngineer
-      time: 21600 #6 hrs
-    - !type:RoleTimeRequirement
-      role: JobResearchDirector
-      time: 21600 #6 hrs
-    - !type:RoleTimeRequirement
-      role: JobQuartermaster
-      time: 21600 #6 hrs
+  # requirements:
+    # - !type:RoleTimeRequirement
+      # role: JobHeadOfPersonnel
+      # time: 21600 #6 hrs
+    # - !type:RoleTimeRequirement
+      # role: JobHeadOfSecurity
+      # time: 21600 #6 hrs
+    # - !type:RoleTimeRequirement
+      # role: JobChiefMedicalOfficer
+      # time: 21600 #6 hrs
+    # - !type:RoleTimeRequirement
+      # role: JobChiefEngineer
+      # time: 21600 #6 hrs
+    # - !type:RoleTimeRequirement
+      # role: JobResearchDirector
+      # time: 21600 #6 hrs
+    # - !type:RoleTimeRequirement
+      # role: JobQuartermaster
+      # time: 21600 #6 hrs
   weight: 20
   startingGear: CaptainGear
   icon: "Captain"

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -4,18 +4,8 @@
   description: job-description-hop
   playTimeTracker: JobHeadOfPersonnel
   requirements:
-    - !type:DepartmentTimeRequirement
-      department: Engineering
-      time: 54000 # 15 hrs
-    - !type:DepartmentTimeRequirement
-      department: Medical
-      time: 54000 # 15 hrs
-    - !type:DepartmentTimeRequirement
-      department: Security
-      time: 54000 # 15 hrs
-    - !type:DepartmentTimeRequirement
-      department: Command
-      time: 72000 # 20 hrs
+    - !type:OverallPlaytimeRequirement
+      time: 36000
   weight: 20
   startingGear: HoPGear
   icon: "HeadOfPersonnel"

--- a/Resources/Prototypes/Roles/Jobs/Engineering/atmospheric_technician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/atmospheric_technician.yml
@@ -4,9 +4,9 @@
   description: job-description-atmostech
   playTimeTracker: JobAtmosphericTechnician
   requirements:
-    - !type:DepartmentTimeRequirement
-      department: Engineering
-      time: 3600
+    # - !type:DepartmentTimeRequirement
+      # department: Engineering
+      # time: 3600
   startingGear: AtmosphericTechnicianGear
   icon: "AtmosphericTechnician"
   supervisors: job-supervisors-ce

--- a/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
@@ -3,16 +3,16 @@
   name: job-name-ce
   description: job-description-ce
   playTimeTracker: JobChiefEngineer
-  requirements:
-    - !type:RoleTimeRequirement
-      role: JobAtmosphericTechnician
-      time: 21600 #6 hrs
-    - !type:RoleTimeRequirement
-      role: JobStationEngineer
-      time: 21600 #6 hrs
-    - !type:DepartmentTimeRequirement
-      department: Engineering
-      time: 108000 # 30 hrs
+  # requirements:
+    # - !type:RoleTimeRequirement
+      # role: JobAtmosphericTechnician
+      # time: 21600 #6 hrs
+    # - !type:RoleTimeRequirement
+      # role: JobStationEngineer
+      # time: 21600 #6 hrs
+    # - !type:DepartmentTimeRequirement
+      # department: Engineering
+      # time: 108000 # 30 hrs
   weight: 10
   startingGear: ChiefEngineerGear
   icon: "ChiefEngineer"

--- a/Resources/Prototypes/Roles/Jobs/Engineering/station_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/station_engineer.yml
@@ -3,10 +3,10 @@
   name: job-name-engineer
   description: job-description-engineer
   playTimeTracker: JobStationEngineer
-  requirements:
-    - !type:DepartmentTimeRequirement
-      department: Engineering
-      time: 1800
+  # requirements:
+    # - !type:DepartmentTimeRequirement
+      # department: Engineering
+      # time: 1800
   startingGear: StationEngineerGear
   icon: "StationEngineer"
   supervisors: job-supervisors-ce

--- a/Resources/Prototypes/Roles/Jobs/Medical/chemist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chemist.yml
@@ -3,10 +3,10 @@
   name: job-name-chemist
   description: job-description-chemist
   playTimeTracker: JobChemist
-  requirements:
-    - !type:DepartmentTimeRequirement
-      department: Medical
-      time: 1800
+  # requirements:
+    # - !type:DepartmentTimeRequirement
+      # department: Medical
+      # time: 1800
   startingGear: ChemistGear
   icon: "Chemist"
   supervisors: job-supervisors-cmo

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -5,16 +5,16 @@
   name: job-name-cmo
   description: job-description-cmo
   playTimeTracker: JobChiefMedicalOfficer
-  requirements:
-    - !type:RoleTimeRequirement
-      role: JobChemist
-      time: 21600 #6 hrs
-    - !type:RoleTimeRequirement
-      role: JobMedicalDoctor
-      time: 21600 #6 hrs
-    - !type:DepartmentTimeRequirement
-      department: Medical
-      time: 108000 # 30 hrs
+  # requirements:
+    # - !type:RoleTimeRequirement
+      # role: JobChemist
+      # time: 21600 #6 hrs
+    # - !type:RoleTimeRequirement
+      # role: JobMedicalDoctor
+      # time: 21600 #6 hrs
+    # - !type:DepartmentTimeRequirement
+      # department: Medical
+      # time: 108000 # 30 hrs
   weight: 10
   startingGear: CMOGear
   icon: "ChiefMedicalOfficer"

--- a/Resources/Prototypes/Roles/Jobs/Medical/medical_doctor.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/medical_doctor.yml
@@ -3,10 +3,10 @@
   name: job-name-doctor
   description: job-description-doctor
   playTimeTracker: JobMedicalDoctor
-  requirements:
-    - !type:DepartmentTimeRequirement
-      department: Medical
-      time: 1800
+  # requirements:
+    # - !type:DepartmentTimeRequirement
+      # department: Medical
+      # time: 1800
   startingGear: DoctorGear
   icon: "MedicalDoctor"
   supervisors: job-supervisors-cmo

--- a/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
@@ -3,12 +3,12 @@
   name: job-name-paramedic
   description: job-description-paramedic
   playTimeTracker: JobParamedic
-  requirements:
-    - !type:DepartmentTimeRequirement
-      department: Medical
-      time: 9000
-    - !type:OverallPlaytimeRequirement
-      time: 54000
+  # requirements:
+    # - !type:DepartmentTimeRequirement
+      # department: Medical
+      # time: 9000
+    # - !type:OverallPlaytimeRequirement
+      # time: 54000
   startingGear: ParamedicGear
   icon: "Paramedic"
   supervisors: job-supervisors-cmo

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -3,10 +3,10 @@
   name: job-name-rd
   description: job-description-rd
   playTimeTracker: JobResearchDirector
-  requirements:
-    - !type:DepartmentTimeRequirement
-      department: Science
-      time: 108000 # 30 hrs
+  # requirements:
+    # - !type:DepartmentTimeRequirement
+      # department: Science
+      # time: 108000 # 30 hrs
   weight: 10
   startingGear: ResearchDirectorGear
   icon: "ResearchDirector"

--- a/Resources/Prototypes/Roles/Jobs/Science/scientist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/scientist.yml
@@ -3,10 +3,10 @@
   name: job-name-scientist
   description: job-description-scientist
   playTimeTracker: JobScientist
-  requirements:
-    - !type:DepartmentTimeRequirement
-      department: Science
-      time: 1800
+  # requirements:
+    # - !type:DepartmentTimeRequirement
+      # department: Science
+      # time: 1800
   startingGear: ScientistGear
   icon: "Scientist"
   supervisors: job-supervisors-rd

--- a/Resources/Prototypes/Roles/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/detective.yml
@@ -4,9 +4,8 @@
   description: job-description-detective
   playTimeTracker: JobDetective
   requirements:
-  - !type:DepartmentTimeRequirement
-    department: Security
-    time: 7200 #2 hrs
+    - !type:OverallPlaytimeRequirement
+      time: 10800 #3 hr
   startingGear: DetectiveGear
   icon: "Detective"
   supervisors: job-supervisors-hos

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -4,18 +4,20 @@
   description: job-description-hos
   playTimeTracker: JobHeadOfSecurity
   requirements:
-    - !type:RoleTimeRequirement
-      role: JobWarden
-      time: 21600 #6 hrs
-    - !type:RoleTimeRequirement
-      role: JobDetective
-      time: 7200 #2 hrs
-    - !type:RoleTimeRequirement
-      role: JobSecurityOfficer
-      time: 36000 #10 hrs
-    - !type:DepartmentTimeRequirement
-      department: Security
-      time: 108000 # 30 hrs
+    - !type:OverallPlaytimeRequirement
+      time: 50400
+    # - !type:RoleTimeRequirement
+      # role: JobWarden
+      # time: 21600 #6 hrs
+    # - !type:RoleTimeRequirement
+      # role: JobDetective
+      # time: 7200 #2 hrs
+    # - !type:RoleTimeRequirement
+      # role: JobSecurityOfficer
+      # time: 36000 #10 hrs
+    # - !type:DepartmentTimeRequirement
+      # department: Security
+      # time: 108000 # 30 hrs
   weight: 10
   startingGear: HoSGear
   icon: "HeadOfSecurity"

--- a/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
@@ -4,9 +4,8 @@
   description: job-description-security
   playTimeTracker: JobSecurityOfficer
   requirements:
-    - !type:DepartmentTimeRequirement
-      department: Security
-      time: 3600 #1 hr
+    - !type:OverallPlaytimeRequirement
+      time: 7200 #2 hr
   startingGear: SecurityOfficerGear
   icon: "SecurityOfficer"
   supervisors: job-supervisors-hos

--- a/Resources/Prototypes/Roles/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/warden.yml
@@ -4,9 +4,8 @@
   description: job-description-warden
   playTimeTracker: JobWarden
   requirements:
-    - !type:DepartmentTimeRequirement
-      department: Security
-      time: 10800
+    - !type:OverallPlaytimeRequirement
+      time: 14400
   startingGear: WardenGear
   icon: "Warden"
   supervisors: job-supervisors-hos


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Role timers turned on after 2 weeks to give everyone some time in game and to learn the format better.  These will likely be raised again in a few weeks, I just didnt want these roles to go empty and unused/untested and not get feedback.  Hopefully this can cut a lot of the issues theres been with chaotic stations and mismanaged power.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: checkraze
- add: added the role timers
