### PR TITLE
Flavorol

### DIFF
--- a/Resources/Locale/en-US/_NF/reagents/foods.ftl
+++ b/Resources/Locale/en-US/_NF/reagents/foods.ftl
@@ -1,0 +1,1 @@
+reagent-name-flaverol = Flaverol

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/bread.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/bread.yml
@@ -17,11 +17,13 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 26
+        maxVol: 31
         reagents:
         - ReagentId: Nutriment
           Quantity: 20
-
+        - ReagentId: Flavorol
+          Quantity: 5
+          
 - type: entity
   parent: FoodBreadBase
   id: FoodBreadSliceBase
@@ -37,11 +39,12 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 8
+        maxVol: 9
         reagents:
         - ReagentId: Nutriment
           Quantity: 4
-
+        - ReagentId: Flavorol
+          Quantity: 1
 # Custom Bread Example
 
 - type: entity
@@ -128,10 +131,12 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 20
+        maxVol: 25
         reagents:
         - ReagentId: Nutriment
           Quantity: 15
+        - ReagentId: Flavorol
+          Quantity: 5
 # Tastes like bread, banana, nut.
 
 - type: entity
@@ -151,10 +156,12 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 5
+        maxVol: 6
         reagents:
         - ReagentId: Nutriment
           Quantity: 3
+        - ReagentId: Flavorol
+          Quantity: 1
 
 - type: entity
   name: cream cheese bread
@@ -176,11 +183,13 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 35
+        maxVol: 40
         reagents:
         - ReagentId: Nutriment
           Quantity: 20
         - ReagentId: Vitamin
+          Quantity: 5
+        - ReagentId: Flavorol
           Quantity: 5
 # Tastes like bread, cheese.
 
@@ -208,7 +217,9 @@
           Quantity: 4
         - ReagentId: Vitamin
           Quantity: 1.2
-
+        - ReagentId: Flavorol
+          Quantity: 1.5
+          
 - type: entity
   name: meat bread
   parent: FoodBreadBase
@@ -228,12 +239,14 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 45
+        maxVol: 50
         reagents:
         - ReagentId: Nutriment
           Quantity: 30
         - ReagentId: Vitamin
           Quantity: 5
+        - ReagentId: Flavorol
+          Quantity: 10
 # Tastes like bread, meat.
 
 - type: entity
@@ -259,7 +272,9 @@
           Quantity: 6
         - ReagentId: Vitamin
           Quantity: 1.2
-
+        - ReagentId: Flavorol
+          Quantity: 2
+          
 - type: entity
   name: mimana bread
   parent: FoodBreadBase
@@ -279,7 +294,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 40
+        maxVol: 45
         reagents:
         - ReagentId: Nutriment
           Quantity: 15
@@ -288,6 +303,8 @@
         - ReagentId: Nothing
           Quantity: 5
         - ReagentId: MuteToxin
+          Quantity: 5
+        - ReagentId: Flavorol
           Quantity: 5
 # Tastes like bread, cheese.
 
@@ -318,7 +335,9 @@
           Quantity: 1
         - ReagentId: MuteToxin
           Quantity: 1
-
+        - ReagentId: Flavorol
+          Quantity: 1
+          
 - type: entity
   name: bread
   parent: FoodBreadBase
@@ -370,6 +389,8 @@
           Quantity: 5
         - ReagentId: Protein
           Quantity: 5
+        - ReagentId: Flavorol
+          Quantity: 5
 
 - type: entity
   name: sausage bread slice
@@ -396,6 +417,8 @@
           Quantity: 1
         - ReagentId: Protein
           Quantity: 1
+        - ReagentId: Flavorol
+          Quantity: 2
 
 - type: entity
   name: spider meat bread
@@ -416,7 +439,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 60
+        maxVol: 70
         reagents:
         - ReagentId: Nutriment
           Quantity: 30
@@ -424,6 +447,8 @@
           Quantity: 5
         - ReagentId: Toxin
           Quantity: 15
+        - ReagentId: Flavorol
+          Quantity: 10
 # Tastes like bread, cobwebs.
 
 - type: entity
@@ -451,7 +476,9 @@
           Quantity: 1.2
         - ReagentId: Toxin
           Quantity: 3
-
+        - ReagentId: Flavorol
+          Quantity: 2
+          
 - type: entity
   name: tofu bread
   parent: FoodBreadBase
@@ -471,12 +498,14 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 48
+        maxVol: 62
         reagents:
         - ReagentId: Nutriment
           Quantity: 30
         - ReagentId: Protein
           Quantity: 12
+        - ReagentId: Flavorol
+          Quantity: 15
 # Tastes like bread, tofu.
 
 - type: entity
@@ -502,7 +531,9 @@
           Quantity: 6
         - ReagentId: Vitamin
           Quantity: 2.4
-
+        - ReagentId: Flavorol
+          Quantity: 3
+          
 - type: entity
   name: xeno meat bread
   parent: FoodBreadBase
@@ -528,6 +559,8 @@
           Quantity: 30
         - ReagentId: Vitamin
           Quantity: 5
+        - ReagentId: Flavorol
+          Quantity: 10
 # Tastes like bread, acid.
 
 - type: entity
@@ -553,7 +586,8 @@
           Quantity: 6
         - ReagentId: Vitamin
           Quantity: 1.2
-
+        - ReagentId: Flavorol
+          Quantity: 2.4
 # Other than bread/slices
 
 - type: entity
@@ -570,7 +604,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 15
+        maxVol: 20
         reagents:
         - ReagentId: Nutriment
           Quantity: 6
@@ -580,6 +614,8 @@
           Quantity: 1
         - ReagentId: Blackpepper
           Quantity: 1
+        - ReagentId: Flavorol
+          Quantity: 5
 # Tastes like France.
 
 - type: entity
@@ -603,6 +639,8 @@
           Quantity: 5
         - ReagentId: Vitamin
           Quantity: 1
+        - ReagentId: Flavorol
+          Quantity: 1
 # Tastes like bread, butter.
 
 - type: entity
@@ -620,12 +658,14 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 10
+        maxVol: 12
         reagents:
         - ReagentId: Nutriment
           Quantity: 4
         - ReagentId: Vitamin
           Quantity: 2
+        - ReagentId: Flavorol
+          Quantity: 1
 # Tastes like bread, butter.
 
 - type: entity
@@ -644,11 +684,13 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 15
+        maxVol: 20
         reagents:
         - ReagentId: Nutriment
           Quantity: 6
         - ReagentId: Vitamin
+          Quantity: 5
+        - ReagentId: Flavorol
           Quantity: 5
 # Tastes like garlic, Italy.
 
@@ -668,12 +710,14 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 10
+        maxVol: 12
         reagents:
         - ReagentId: Nutriment
           Quantity: 4
         - ReagentId: Vitamin
           Quantity: 4
+        - ReagentId: Flavorol
+          Quantity: 2
 # Tastes like garlic, Italy.
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/cake.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/cake.yml
@@ -15,12 +15,14 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 30
+        maxVol: 50
         reagents:
         - ReagentId: Nutriment
           Quantity: 20
         - ReagentId: Vitamin
           Quantity: 5
+        - ReagentId: Flavorol
+          Quantity: 20
   - type: Item
     size: 25
 
@@ -44,6 +46,8 @@
           Quantity: 4
         - ReagentId: Vitamin
           Quantity: 1
+        - ReagentId: Flavorol
+          Quantity: 4
   - type: Item
     size: 5
 
@@ -122,7 +126,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 30
+        maxVol: 35
         reagents:
         - ReagentId: JuiceCarrot
           Quantity: 15
@@ -130,7 +134,9 @@
           Quantity: 5
         - ReagentId: Vitamin
           Quantity: 5
-
+        - ReagentId: Flavorol
+          Quantity: 5
+          
 - type: entity
   name: slice of carrot cake
   parent: FoodCakeSliceBase
@@ -153,7 +159,8 @@
           Quantity: 1
         - ReagentId: Vitamin
           Quantity: 1
-
+        - ReagentId: Flavorol
+          Quantity: 1
 # Tastes like sweetness, cake, carrot.
 
 - type: entity
@@ -299,7 +306,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 35
+        maxVol: 55
         reagents:
         - ReagentId: Nutriment
           Quantity: 20
@@ -307,6 +314,8 @@
           Quantity: 5
         - ReagentId: Vitamin
           Quantity: 5
+        - ReagentId: Flavorol
+          Quantity: 20
 
 - type: entity
   name: slice of chocolate cake
@@ -328,6 +337,8 @@
           Quantity: 1
         - ReagentId: Vitamin
           Quantity: 1
+        - ReagentId: Flavorol
+          Quantity: 4
 # Tastes like sweetness, cake, chocolate.
 
 - type: entity
@@ -407,12 +418,14 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 50
+        maxVol: 70
         reagents:
         - ReagentId: Nutriment
           Quantity: 32
         - ReagentId: Vitamin
           Quantity: 11
+        - ReagentId: Flavorol
+          Quantity: 20
 
 - type: entity
   name: slice of pumpkin-spice cake
@@ -436,6 +449,8 @@
           Quantity: 6.4
         - ReagentId: Vitamin
           Quantity: 2.2
+        - ReagentId: Flavorol
+          Quantity: 4
 # Tastes like sweetness, cake, pumpkin.
 
 - type: entity
@@ -513,7 +528,7 @@
   - type: SolutionContainerManager #TODO Sprinkles
     solutions:
       food:
-        maxVol: 45
+        maxVol: 65
         reagents:
         - ReagentId: Nutriment
           Quantity: 20
@@ -521,7 +536,9 @@
           Quantity: 5
         - ReagentId: Sugar
           Quantity: 15
-
+        - ReagentId: Flavorol
+          Quantity: 20
+          
 - type: entity
   name: slice of vanilla cake
   parent: FoodCakeSliceBase
@@ -546,6 +563,8 @@
           Quantity: 1
         - ReagentId: Sugar
           Quantity: 3
+        - ReagentId: Flavorol
+          Quantity: 4
 # Tastes like sweetness, cake, vanilla.
 
 - type: entity
@@ -565,7 +584,7 @@
   - type: SolutionContainerManager #TODO Sprinkles
     solutions:
       food:
-        maxVol: 45
+        maxVol: 65
         reagents:
         - ReagentId: Nutriment
           Quantity: 20
@@ -573,7 +592,9 @@
           Quantity: 5
         - ReagentId: Sugar
           Quantity: 15
-
+        - ReagentId: Flavorol
+          Quantity: 20
+          
 - type: entity
   name: slice of clown cake
   parent: FoodCakeSliceBase
@@ -598,6 +619,8 @@
           Quantity: 1
         - ReagentId: Sugar
           Quantity: 3
+        - ReagentId: Flavorol
+          Quantity: 4
 # Tastes like sweetness, cake, clown.
 
 - type: entity
@@ -674,7 +697,7 @@
       food:
         maxVol: 48
         reagents:
-        - ReagentId: Nutriment
+        - ReagentId: Flavorol
           Quantity: 48
   - type: Food
     transferAmount: 12
@@ -700,7 +723,7 @@
       food:
         maxVol: 12
         reagents:
-        - ReagentId: Nutriment
+        - ReagentId: Flavorol
           Quantity: 12
   - type: Food
     transferAmount: 3

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/misc.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/misc.yml
@@ -246,6 +246,13 @@
       map: ["pancakes9"]
       visible: false
   - type: Appearance
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 6
+        reagents:
+        - ReagentId: Flavorol
+          Quantity: 5
   - type: Tag
     tags:
     - Pancake
@@ -278,6 +285,13 @@
     - state: pancakesbb3
       map: ["pancakesbb3"]
       visible: false
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 6
+        reagents:
+        - ReagentId: Flavorol
+          Quantity: 5
   - type: Appearance
   - type: Tag
     tags:
@@ -317,7 +331,7 @@
       food:
         maxVol: 6
         reagents:
-        - ReagentId: Nutriment
+        - ReagentId: Flavorol
           Quantity: 5
         - ReagentId: Theobromine
           Quantity: 1
@@ -340,7 +354,7 @@
       food:
         maxVol: 20
         reagents:
-        - ReagentId: Nutriment
+        - ReagentId: Flavorol
           Quantity: 8
         - ReagentId: Vitamin
           Quantity: 1
@@ -360,7 +374,7 @@
       food:
         maxVol: 20
         reagents:
-        - ReagentId: Nutriment
+        - ReagentId: Flavorol
           Quantity: 10
         - ReagentId: Vitamin
           Quantity: 1
@@ -380,7 +394,7 @@
       food:
         maxVol: 20
         reagents:
-        - ReagentId: Nutriment
+        - ReagentId: Flavorol
           Quantity: 10
         - ReagentId: Vitamin
           Quantity: 1
@@ -400,7 +414,7 @@
       food:
         maxVol: 20
         reagents:
-        - ReagentId: Nutriment
+        - ReagentId: Flavorol
           Quantity: 8
         - ReagentId: Vitamin
           Quantity: 2
@@ -429,7 +443,7 @@
       food:
         maxVol: 20
         reagents:
-        - ReagentId: Nutriment
+        - ReagentId: Flavorol
           Quantity: 5
         - ReagentId: Vitamin
           Quantity: 1

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/pie.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/pie.yml
@@ -15,12 +15,14 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 20
+        maxVol: 31
         reagents: #Most of these are this with slight variations, not worth changing until we have the rest of the reagents
         - ReagentId: Nutriment
           Quantity: 11
         - ReagentId: Vitamin
           Quantity: 5
+        - ReagentId: Flavorol
+          Quantity: 11
   - type: SliceableFood
     count: 4
   - type: Tag
@@ -50,6 +52,8 @@
           Quantity: 1.2
         - ReagentId: Vitamin
           Quantity: 1
+        - ReagentId: Flavorol
+          Quantity: 1.5
   - type: Tag
     tags:
     - NoSpinOnThrow
@@ -342,7 +346,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 17
+        maxVol: 23
         reagents:
         - ReagentId: Nutriment
           Quantity: 6
@@ -350,6 +354,8 @@
           Quantity: 3
         - ReagentId: Vitamin
           Quantity: 4
+        - ReagentId: Flavorol
+          Quantity: 6
 # Tastes like pie, mushrooms.
 
 - type: entity
@@ -438,10 +444,12 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 26
+        maxVol: 41
         reagents:
         - ReagentId: Nutriment
           Quantity: 15
         - ReagentId: Theobromine
           Quantity: 2
+        - ReagentId: Flavorol
+          Quantity: 15
 # Tastes like tart, dark chocolate.

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/pizza.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/pizza.yml
@@ -18,9 +18,11 @@
         maxVol: 40
         reagents:
         - ReagentId: Nutriment
-          Quantity: 30
+          Quantity: 15
         - ReagentId: Vitamin
           Quantity: 5
+        - ReagentId: Flavorol
+          Quantity: 15
   - type: SliceableFood
     count: 6
   - type: Item
@@ -48,9 +50,11 @@
         maxVol: 6
         reagents:
         - ReagentId: Nutriment
-          Quantity: 5
+          Quantity: 3
         - ReagentId: Vitamin
           Quantity: 0.8
+        - ReagentId: Flavorol
+          Quantity: 3
   - type: Item
     size: 1
   - type: Tag
@@ -189,6 +193,8 @@
           Quantity: 5
         - ReagentId: Vitamin
           Quantity: 5
+        - ReagentId: Flavorol
+          Quantity: 15
 
 - type: entity
   name: slice of vegetable pizza
@@ -219,7 +225,9 @@
           Quantity: 1
         - ReagentId: Vitamin
           Quantity: 1
-
+        - ReagentId: Flavorol
+          Quantity: 3
+          
 # Tastes like crust, tomato, cheese, carrot.
 
 - type: entity
@@ -239,7 +247,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 50
+        maxVol: 60
         reagents:
         - ReagentId: Nutriment
           Quantity: 27
@@ -247,7 +255,8 @@
           Quantity: 6
         - ReagentId: Omnizine
           Quantity: 9
-
+        - ReagentId: Flavorol
+          Quantity: 15
 
 - type: entity
   name: slice of donk-pocket pizza
@@ -272,6 +281,8 @@
           Quantity: 1
         - ReagentId: Omnizine
           Quantity: 1.5
+        - ReagentId: Flavorol
+          Quantity: 3
 # Tastes like crust, tomato, cheese, meat, laziness.
 
 - type: entity
@@ -294,7 +305,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 50
+        maxVol: 65
         reagents:
         - ReagentId: Nutriment
           Quantity: 25
@@ -302,6 +313,8 @@
           Quantity: 5
         - ReagentId: DoctorsDelight
           Quantity: 6
+        - ReagentId: Flavorol
+          Quantity: 15
 
 - type: entity
   name: slice of dank pizza
@@ -329,6 +342,8 @@
           Quantity: 0.8
         - ReagentId: DoctorsDelight
           Quantity: 1
+        - ReagentId: Flavorol
+          Quantity: 3
 # Tastes like crust, tomato, cheese, meat, satisfaction.
 
 - type: entity
@@ -435,7 +450,9 @@
           Quantity: 10
         - ReagentId: Omnizine
           Quantity: 30
-
+        - ReagentId: Flavorol
+          Quantity: 15
+          
 - type: entity
   name: slice of Arnold's pizza
   parent: FoodPizzaSliceBase
@@ -465,6 +482,8 @@
           Quantity: 1.6
         - ReagentId: Omnizine
           Quantity: 5
+        - ReagentId: Flavorol
+          Quantity: 4
 # Tastes like crust, tomato, cheese, pepperoni, 9 millimeter bullets.
 
 #TODO: Make this do poison damage and make cut pizza slices eventually rot into this.

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/burger.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/burger.yml
@@ -82,13 +82,15 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 20
+        maxVol: 25
         reagents:
         - ReagentId: Nutriment
           Quantity: 2
         - ReagentId: Protein
           Quantity: 6
         - ReagentId: Vitamin
+          Quantity: 6
+        - ReagentId: Flavorol
           Quantity: 6
 # Tastes like bun, grass.
 
@@ -107,12 +109,14 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 30
+        maxVol: 40
         reagents:
         - ReagentId: Nutriment
           Quantity: 19
         - ReagentId: Vitamin
           Quantity: 5
+        - ReagentId: Flavorol
+          Quantity: 10
 # Tastes like bun, bacon.
 
 - type: entity
@@ -130,7 +134,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 15
+        maxVol: 20
         reagents:
         - ReagentId: Nutriment
           Quantity: 3
@@ -138,6 +142,8 @@
           Quantity: 5
         - ReagentId: Vitamin
           Quantity: 2
+        - ReagentId: Flavorol
+          Quantity: 5
 
 - type: entity
   name: bearger
@@ -154,13 +160,15 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 15
+        maxVol: 20
         reagents:
         - ReagentId: Nutriment
           Quantity: 3
         - ReagentId: Protein
           Quantity: 6
         - ReagentId: Vitamin
+          Quantity: 5
+        - ReagentId: Flavorol
           Quantity: 5
 
 - type: entity
@@ -177,12 +185,14 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 33
+        maxVol: 43
         reagents:
         - ReagentId: Nutriment
           Quantity: 17
         - ReagentId: Vitamin
           Quantity: 9
+        - ReagentId: Flavorol
+          Quantity: 10
   - type: Sprite
     state: bigbite
 # Tastes like bun, silver, magic.
@@ -202,13 +212,15 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 20
+        maxVol: 25
         reagents:
         - ReagentId: Nutriment
           Quantity: 6
         - ReagentId: Protein
           Quantity: 6
         - ReagentId: Vitamin
+          Quantity: 5
+        - ReagentId: Flavorol
           Quantity: 5
 # Tastes like bun, brains.
 
@@ -253,7 +265,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 15
+        maxVol: 20
         reagents:
         - ReagentId: Nutriment
           Quantity: 3
@@ -261,6 +273,9 @@
           Quantity: 7
         - ReagentId: Protein
           Quantity: 1
+        - ReagentId: Flavorol
+          Quantity: 5
+          
 # TODO: Make this work.
   # - type: Sprite
   #   state: plate
@@ -286,7 +301,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 15
+        maxVol: 20
         reagents:
         - ReagentId: Nutriment
           Quantity: 3
@@ -296,6 +311,8 @@
           Quantity: 1
         - ReagentId: Mayo
           Quantity: 3
+        - ReagentId: Flavorol
+          Quantity: 5
 # Tastes like bun, chicken.
 
 - type: entity
@@ -313,7 +330,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 15
+        maxVol: 20
         reagents:
         - ReagentId: Nutriment
           Quantity: 4
@@ -321,6 +338,8 @@
           Quantity: 6
         - ReagentId: Vitamin
           Quantity: 6
+        - ReagentId: Flavorol
+          Quantity: 5
 
 - type: entity
   name: corgi burger #curger...
@@ -359,7 +378,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 15
+        maxVol: 20
         reagents:
         - ReagentId: Nutriment
           Quantity: 4
@@ -367,6 +386,8 @@
           Quantity: 5
         - ReagentId: Vitamin
           Quantity: 4
+        - ReagentId: Flavorol
+          Quantity: 5
 
 - type: entity
   name: crazy hamburger # Burger for you euro-cucks
@@ -411,7 +432,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 15
+        maxVol: 20
         reagents:
         - ReagentId: Nutriment
           Quantity: 3
@@ -419,6 +440,8 @@
           Quantity: 7
         - ReagentId: Vitamin
           Quantity: 1
+        - ReagentId: Flavorol
+          Quantity: 5
 # Tastes like bun, duck.
 
 - type: entity
@@ -436,11 +459,13 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 15
+        maxVol: 20
         reagents:
         - ReagentId: Nutriment
           Quantity: 8
         - ReagentId: Licoxide
+          Quantity: 5
+        - ReagentId: Flavorol
           Quantity: 5
 # Tastes like bun, pure electricity.
 
@@ -473,7 +498,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 15
+        maxVol: 20
         reagents:
         - ReagentId: Nutriment
           Quantity: 6
@@ -483,7 +508,8 @@
           Quantity: 5
         - ReagentId: Vitamin
           Quantity: 1
-
+        - ReagentId: Flavorol
+          Quantity: 5
 # Tastes like bun, HEAT.
 
 - type: entity
@@ -501,12 +527,14 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 25
+        maxVol: 30
         reagents:
         - ReagentId: Nutriment
           Quantity: 7
         - ReagentId: Vitamin
           Quantity: 12
+        - ReagentId: Flavorol
+          Quantity: 5
 # Tastes like bun, ectoplasm.
 
 - type: entity
@@ -524,13 +552,15 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 15
+        maxVol: 20
         reagents:
         - ReagentId: Nutriment
           Quantity: 2
         - ReagentId: Protein
           Quantity: 6
         - ReagentId: Vitamin
+          Quantity: 5
+        - ReagentId: Flavorol
           Quantity: 5
 
 - type: entity
@@ -548,7 +578,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 15
+        maxVol: 20
         reagents:
         - ReagentId: Nutriment
           Quantity: 2
@@ -556,6 +586,8 @@
           Quantity: 7
         - ReagentId: Vitamin
           Quantity: 1
+        - ReagentId: Flavorol
+          Quantity: 5
 
 - type: entity
   name: McRib
@@ -572,7 +604,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 15
+        maxVol: 20
         reagents:
         - ReagentId: Nutriment
           Quantity: 2
@@ -582,6 +614,8 @@
           Quantity: 4
         - ReagentId: BbqSauce
           Quantity: 1
+        - ReagentId: Flavorol
+          Quantity: 5
 # Tastes like bun, pork patty.
 
 - type: entity
@@ -609,6 +643,8 @@
           Quantity: 4
         - ReagentId: Nothing
           Quantity: 1
+        - ReagentId: Flavorol
+          Quantity: 5
 # Tastes like  .
 
 - type: entity
@@ -634,6 +670,8 @@
           Quantity: 6
         - ReagentId: Vitamin
           Quantity: 3
+        - ReagentId: Flavorol
+          Quantity: 5
 
 - type: entity
   name: rat burger
@@ -650,7 +688,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 15
+        maxVol: 20
         reagents:
         - ReagentId: Nutriment
           Quantity: 3
@@ -658,6 +696,8 @@
           Quantity: 6
         - ReagentId: Vitamin
           Quantity: 2
+        - ReagentId: Flavorol
+          Quantity: 5
 # Tastes like bun, HEAT.
 
 - type: entity
@@ -699,7 +739,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 15
+        maxVol: 20
         reagents:
         - ReagentId: Nutriment
           Quantity: 4
@@ -707,6 +747,8 @@
           Quantity: 6
         - ReagentId: Vitamin
           Quantity: 4
+        - ReagentId: Flavorol
+          Quantity: 5
 # Tastes like bun, redditors.
 
 - type: entity
@@ -724,7 +766,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 20
+        maxVol: 25
         reagents:
         - ReagentId: Nutriment
           Quantity: 4
@@ -732,6 +774,8 @@
           Quantity: 5
         - ReagentId: Vitamin
           Quantity: 10
+        - ReagentId: Flavorol
+          Quantity: 5
 # Tastes like bun, silver.
 
 - type: entity
@@ -748,16 +792,18 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 55
+        maxVol: 60
         reagents:
         - ReagentId: Nutriment
-          Quantity: 44
+          Quantity: 29
         - ReagentId: Vitamin
           Quantity: 24
         - ReagentId: TableSalt
           Quantity: 5
         - ReagentId: Blackpepper
           Quantity: 5
+        - ReagentId: Flavorol
+          Quantity: 20
   - type: Sprite
     state: superbite
 # Tastes like bun, diabetes.
@@ -777,7 +823,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 15
+        maxVol: 20
         reagents:
         - ReagentId: Nutriment
           Quantity: 3
@@ -785,6 +831,8 @@
           Quantity: 6
         - ReagentId: Vitamin
           Quantity: 3
+        - ReagentId: Flavorol
+          Quantity: 5
 # Tastes like bun, tofu.
 
 - type: entity
@@ -803,13 +851,15 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 15
+        maxVol: 20
         reagents:
         - ReagentId: Nutriment
           Quantity: 3
         - ReagentId: Protein
           Quantity: 6
         - ReagentId: Vitamin
+          Quantity: 5
+        - ReagentId: Flavorol
           Quantity: 5
 # Tastes like bun, acid.
 

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/meals.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/meals.yml
@@ -15,11 +15,12 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 26
+        maxVol: 31
         reagents:
         - ReagentId: Nutriment
-          Quantity: 20
-
+          Quantity: 15
+        - ReagentId: Flavorol
+          Quantity: 10
 # Meals
 
 - type: entity
@@ -117,7 +118,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 15
+        maxVol: 20
         reagents:
         - ReagentId: Nutriment
           Quantity: 6
@@ -125,6 +126,8 @@
           Quantity: 3
         - ReagentId: TableSalt
           Quantity: 1
+        - ReagentId: Flavorol
+          Quantity: 5
 # Tastes like nachos, cheese.
 
 - type: entity
@@ -143,7 +146,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 15
+        maxVol: 20
         reagents:
         - ReagentId: Nutriment
           Quantity: 7
@@ -151,6 +154,8 @@
           Quantity: 8
         - ReagentId: Vitamin
           Quantity: 4
+        - ReagentId: Flavorol
+          Quantity: 5
 # Tastes like nachos, hot pepper.
 
 - type: entity
@@ -189,12 +194,14 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 10
+        maxVol: 15
         reagents:
         - ReagentId: Nutriment
           Quantity: 6
         - ReagentId: Vitamin
           Quantity: 2
+        - ReagentId: Flavorol
+          Quantity: 5
 # Tastes like eggplant, cheese.
 
 - type: entity
@@ -230,12 +237,14 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 15
+        maxVol: 20
         reagents:
         - ReagentId: Nutriment
           Quantity: 6
         - ReagentId: CarpoToxin
           Quantity: 3
+        - ReagentId: Flavorol
+          Quantity: 5
 # Tastes like fish, batter, hot peppers.
 
 - type: entity
@@ -253,12 +262,14 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 15
+        maxVol: 20
         reagents:
         - ReagentId: Nutriment
           Quantity: 6
         - ReagentId: Vitamin
           Quantity: 4
+        - ReagentId: Flavorol
+          Quantity: 5
 # Tastes like meat, cabbage.
 
 - type: entity
@@ -276,11 +287,13 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 15
+        maxVol: 17
         reagents:
         - ReagentId: Nutriment
           Quantity: 2
         - ReagentId: Vitamin
+          Quantity: 5
+        - ReagentId: Flavorol
           Quantity: 5
 # Tastes like meat, salmon.
 
@@ -322,7 +335,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 25
+        maxVol: 30
         reagents:
         - ReagentId: Nutriment
           Quantity: 3
@@ -330,6 +343,8 @@
           Quantity: 10
         - ReagentId: BbqSauce
           Quantity: 10
+        - ReagentId: Flavorol
+          Quantity: 5
 # Tastes like meat, smokey sauce.
 
 - type: entity
@@ -348,12 +363,14 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 15
+        maxVol: 20
         reagents:
         - ReagentId: Nutriment
           Quantity: 6
         - ReagentId: Vitamin
           Quantity: 4
+        - ReagentId: Flavorol
+          Quantity: 5
 # Tastes like eggs, bacon, bun.
 
 - type: entity
@@ -371,10 +388,12 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 10
+        maxVol: 15
         reagents:
         - ReagentId: Nutriment
           Quantity: 9
+        - ReagentId: Flavorol
+          Quantity: 5
 # Tastes like egg, cheese.
 
 - type: entity
@@ -450,7 +469,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 25
+        maxVol: 30
         reagents:
         - ReagentId: Nutriment
           Quantity: 9
@@ -458,6 +477,8 @@
           Quantity: 10
         - ReagentId: Blackpepper
           Quantity: 3
+        - ReagentId: Flavorol
+          Quantity: 5
 # Tastes awesome.
 
 - type: entity
@@ -509,12 +530,14 @@
     - type: SolutionContainerManager
       solutions:
         food:
-          maxVol: 10
+          maxVol: 15
           reagents:
           - ReagentId: Nutriment
             Quantity: 8
           - ReagentId: CapsaicinOil
             Quantity: 6
+          - ReagentId: Flavorol
+            Quantity: 5
 # What do Europeans eat instead of enchiladas? 25.4 millimeter-iladas.
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/noodles.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/noodles.yml
@@ -13,11 +13,12 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 25
+        maxVol: 30
         reagents:
         - ReagentId: Nutriment
-          Quantity: 20
-
+          Quantity: 15
+        - ReagentId: Flavorol
+          Quantity: 10
 # Noodles
 
 - type: entity
@@ -65,12 +66,14 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxvol: 25
+        maxvol: 30
         reagents:
         - ReagentId: Nutriment
-          Quantity: 12
+          Quantity: 7
         - ReagentId: Vitamin
           Quantity: 8
+        - ReagentId: Flavorol
+          Quantity: 10
 # Tastes like pasta, bad humor.
 
 - type: entity
@@ -90,12 +93,14 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxvol: 15
+        maxvol: 20
         reagents:
         - ReagentId: Nutriment
           Quantity: 8
         - ReagentId: Vitamin
           Quantity: 4
+        - ReagentId: Flavorol
+          Quantity: 5
 # Tastes like pasta, meat.
 
 - type: entity
@@ -115,12 +120,14 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxvol: 15
+        maxvol: 20
         reagents:
         - ReagentId: Nutriment
           Quantity: 8
         - ReagentId: Vitamin
           Quantity: 6
+        - ReagentId: Flavorol
+          Quantity: 5
 # Tastes like pasta, meat.
 
 - type: entity
@@ -142,12 +149,14 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxvol: 15
+        maxvol: 26
         reagents:
         - ReagentId: Nutriment
           Quantity: 7
         - ReagentId: Vitamin
           Quantity: 6
+        - ReagentId: Flavorol
+          Quantity: 11
 # Tastes like pasta, tomato.
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/skewer.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/skewer.yml
@@ -12,10 +12,12 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 10
+        maxVol: 20
         reagents:
         - ReagentId: Nutriment
           Quantity: 8
+        - ReagentId: Flavorol
+          Quantity: 10
   - type: Item
     size: 5
 
@@ -114,6 +116,8 @@
           Quantity: 6
         - ReagentId: Vitamin
           Quantity: 2
+        - ReagentId: Flavorol
+          Quantity: 5
 
 - type: entity
   name: double rat kebab
@@ -134,7 +138,9 @@
           Quantity: 12
         - ReagentId: Vitamin
           Quantity: 6
-
+        - ReagentId: Flavorol
+          Quantity: 10
+          
 - type: entity
   name: fiesta kebab
   parent: FoodSkewerBase

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/soup.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/soup.yml
@@ -9,10 +9,12 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 20
+        maxVol: 35
         reagents:
         - ReagentId: Nutriment
           Quantity: 20
+        - ReagentId: Flavorol
+          Quantity: 10
   - type: Sprite
     sprite: Objects/Consumable/Food/bowl.rsi
   - type: DamageOnLand
@@ -76,13 +78,14 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxvol: 15
+        maxvol: 20
         reagents:
         - ReagentId: Nutriment
           Quantity: 8
         - ReagentId: Vitamin
           Quantity: 5
-
+        - ReagentId: Flavorol
+          Quantity: 5
 # Salad
 
 - type: entity
@@ -101,7 +104,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxvol: 15
+        maxvol: 20
         reagents:
         - ReagentId: Nutriment
           Quantity: 8
@@ -109,7 +112,9 @@
           Quantity: 6
         - ReagentId: Omnizine
           Quantity: 8
-
+        - ReagentId: Flavorol
+          Quantity: 5
+          
 - type: entity
   name: herb salad
   parent: FoodBowlBase
@@ -127,13 +132,15 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxvol: 15
+        maxvol: 20
         reagents:
         - ReagentId: Nutriment
           Quantity: 8
         - ReagentId: Vitamin
           Quantity: 2
-
+        - ReagentId: Flavorol
+          Quantity: 5
+          
 - type: entity
   name: valid salad
   parent: FoodBowlBase
@@ -153,7 +160,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxvol: 15
+        maxvol: 25
         reagents:
         - ReagentId: Nutriment
           Quantity: 8
@@ -161,7 +168,9 @@
           Quantity: 2
         - ReagentId: DoctorsDelight
           Quantity: 5
-
+        - ReagentId: Flavorol
+          Quantity: 5
+          
 - type: entity
   name: coleslaw
   parent: FoodBowlBase
@@ -180,7 +189,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxvol: 15
+        maxvol: 20
         reagents:
         - ReagentId: Nutriment
           Quantity: 8
@@ -188,7 +197,9 @@
           Quantity: 2
         - ReagentId: Allicin
           Quantity: 3
-
+        - ReagentId: Flavorol
+          Quantity: 5
+          
 - type: entity
   name: caesar salad
   parent: FoodBowlBase
@@ -208,13 +219,15 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxvol: 15
+        maxvol: 20
         reagents:
         - ReagentId: Nutriment
           Quantity: 8
         - ReagentId: Vitamin
           Quantity: 6
-
+        - ReagentId: Flavorol
+          Quantity: 5
+          
 - type: entity
   name: kimchi salad
   parent: FoodBowlBase
@@ -233,7 +246,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxvol: 15
+        maxvol: 20
         reagents:
         - ReagentId: Nutriment
           Quantity: 8
@@ -241,7 +254,9 @@
           Quantity: 2
         - ReagentId: Allicin
           Quantity: 2
-
+        - ReagentId: Flavorol
+          Quantity: 5
+          
 - type: entity
   name: fruit salad
   parent: FoodBowlBase
@@ -258,13 +273,15 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxvol: 10
+        maxvol: 15
         reagents:
         - ReagentId: Nutriment
           Quantity: 2
         - ReagentId: Vitamin
           Quantity: 4
-
+        - ReagentId: Flavorol
+          Quantity: 5
+          
 - type: entity
   name: jungle salad
   parent: FoodBowlBase
@@ -282,13 +299,15 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxvol: 15
+        maxvol: 20
         reagents:
         - ReagentId: Nutriment
           Quantity: 7
         - ReagentId: Vitamin
           Quantity: 4
-
+        - ReagentId: Flavorol
+          Quantity: 5
+          
 - type: entity
   name: citrus salad
   parent: FoodBowlBase
@@ -306,13 +325,15 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxvol: 38
+        maxvol: 45
         reagents:
         - ReagentId: Nutriment
-          Quantity: 18
+          Quantity: 13
         - ReagentId: Vitamin
           Quantity: 15
-
+        - ReagentId: Flavorol
+          Quantity: 12
+          
 - type: entity
   name: salad of eden
   parent: FoodBowlBase
@@ -338,7 +359,8 @@
           Quantity: 5
         - ReagentId: Omnizine
           Quantity: 5
-
+        - ReagentId: Flavorol
+          Quantity: 5
 # Rice
 
 - type: entity
@@ -396,16 +418,18 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxvol: 40
+        maxvol: 45
         reagents:
         - ReagentId: Nutriment
-          Quantity: 18
+          Quantity: 13
         - ReagentId: Vitamin
           Quantity: 7
         - ReagentId: Dexalin ##This is probably a reference to something but I don't get it
           Quantity: 6.5
         - ReagentId: Epinephrine
           Quantity: 2
+        - ReagentId: Flavorol
+          Quantity: 10
 
 - type: entity
   name: rice pudding
@@ -424,7 +448,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxvol: 25
+        maxvol: 30
         reagents:
         - ReagentId: Nutriment
           Quantity: 9
@@ -433,6 +457,8 @@
         - ReagentId: Milk ##This is probably a reference to something but I don't get it
           Quantity: 5
         - ReagentId: Sugar
+          Quantity: 5
+        - ReagentId: Flavorol
           Quantity: 5
 
 - type: entity
@@ -454,7 +480,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxvol: 12
+        maxvol: 17
         reagents:
         - ReagentId: Nutriment
           Quantity: 5
@@ -462,7 +488,8 @@
           Quantity: 3
         - ReagentId: CapsaicinOil
           Quantity: 2
-
+        - ReagentId: Flavorol
+          Quantity: 5
 # Misc
 
 - type: entity
@@ -482,7 +509,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxvol: 20
+        maxvol: 25
         reagents:
         - ReagentId: Nutriment
           Quantity: 7
@@ -490,7 +517,9 @@
           Quantity: 2
         - ReagentId: Milk
           Quantity: 10
-
+        - ReagentId: Flavorol
+          Quantity: 5
+          
 - type: entity
   name: space liberty duff
   parent: FoodBowlBase
@@ -522,13 +551,14 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxvol: 12
+        maxvol: 17
         reagents:
         - ReagentId: Nutriment
           Quantity: 6
         - ReagentId: Amatoxin
           Quantity: 6
-
+        - ReagentId: Flavorol
+          Quantity: 5
 # Soup
 
 - type: entity
@@ -554,7 +584,9 @@
         - ReagentId: Vitamin
           Quantity: 8
         - ReagentId: Water
-          Quantity: 10
+          Quantity: 5
+        - ReagentId: Flavorol
+          Quantity: 5
 
 - type: entity
   name: slime soup
@@ -579,8 +611,10 @@
         - ReagentId: Vitamin
           Quantity: 5
         - ReagentId: Water
-          Quantity: 10
-
+          Quantity: 5
+        - ReagentId: Flavorol
+          Quantity: 5
+          
 - type: entity
   name: tomato soup
   parent: FoodBowlBase
@@ -598,13 +632,15 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxvol: 12
+        maxvol: 20
         reagents:
         - ReagentId: Nutriment
           Quantity: 3
         - ReagentId: Iron
           Quantity: 10
         - ReagentId: Blood
+          Quantity: 5
+        - ReagentId: Flavorol
           Quantity: 5
 
 - type: entity
@@ -624,7 +660,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxvol: 30
+        maxvol: 35
         reagents:
         - ReagentId: Protein
           Quantity: 9
@@ -632,6 +668,8 @@
           Quantity: 10
         - ReagentId: Vitamin
           Quantity: 7
+        - ReagentId: Flavorol
+          Quantity: 5
 
 - type: entity
   name: clown's tears
@@ -649,7 +687,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxvol: 12
+        maxvol: 30
         reagents:
         - ReagentId: Nutriment
           Quantity: 2
@@ -657,7 +695,9 @@
           Quantity: 9
         - ReagentId: Water
           Quantity: 10
-
+        - ReagentId: Flavorol
+          Quantity: 5
+          
 - type: entity
   name: vegetable soup
   parent: FoodBowlBase
@@ -682,10 +722,12 @@
         - ReagentId: Vitamin
           Quantity: 7
         - ReagentId: Water
-          Quantity: 10
+          Quantity: 5
         - ReagentId: Oculine
           Quantity: 1
-
+        - ReagentId: Flavorol
+          Quantity: 5
+          
 - type: entity
   name: nettle soup
   parent: FoodBowlBase
@@ -702,18 +744,20 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxvol: 12
+        maxvol: 17
         reagents:
         - ReagentId: Nutriment
           Quantity: 5
         - ReagentId: Vitamin
           Quantity: 8
         - ReagentId: Water
-          Quantity: 10
+          Quantity: 5
         - ReagentId: Omnizine
           Quantity: 5
         - ReagentId: Histamine
           Quantity: 0.5
+        - ReagentId: Flavorol
+          Quantity: 5
 
 - type: entity
   name: mystery soup
@@ -745,7 +789,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 20
+        maxVol: 25
         reagents:
           - ReagentId: Nutriment
             Quantity: 8
@@ -755,7 +799,9 @@
             Quantity: 4
           - ReagentId: Allicin
             Quantity: 3
-
+          - ReagentId: Flavorol
+            Quantity: 5
+            
 - type: entity
   name: cold chili
   parent: FoodBowlBase
@@ -779,7 +825,9 @@
             Quantity: 8
           - ReagentId: Vitamin
             Quantity: 4
-
+          - ReagentId: Flavorol
+            Quantity: 5
+            
 - type: entity
   name: chili con carnival
   parent: FoodBowlBase
@@ -799,7 +847,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 20
+        maxVol: 25
         reagents:
           - ReagentId: Nutriment
             Quantity: 6
@@ -809,7 +857,9 @@
             Quantity: 4
           - ReagentId: Allicin
             Quantity: 3
-
+          - ReagentId: Flavorol
+            Quantity: 5
+          
 - type: entity
   name: monkey's delight
   parent: FoodBowlBase
@@ -827,7 +877,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 20
+        maxVol: 25
         reagents:
           - ReagentId: Nutriment
             Quantity: 10
@@ -837,6 +887,8 @@
             Quantity: 1
           - ReagentId: Blackpepper
             Quantity: 1
+          - ReagentId: Flavorol
+            Quantity: 5
 
 - type: entity
   name: tomato soup
@@ -861,8 +913,10 @@
           - ReagentId: Vitamin
             Quantity: 5
           - ReagentId: Water
-            Quantity: 10
-
+            Quantity: 5
+          - ReagentId: Flavorol
+            Quantity: 5
+            
 - type: entity
   name: eyeball soup
   parent: FoodBowlBase
@@ -880,13 +934,15 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 12
+        maxVol: 17
         reagents:
           - ReagentId: Nutriment
             Quantity: 5
           - ReagentId: Vitamin
             Quantity: 3
-
+          - ReagentId: Flavorol
+            Quantity: 5
+            
 - type: entity
   name: miso soup
   parent: FoodBowlBase
@@ -913,8 +969,10 @@
           - ReagentId: Vitamin
             Quantity: 3
           - ReagentId: Water
-            Quantity: 10
-
+            Quantity: 5
+          - ReagentId: Flavorol
+            Quantity: 5
+            
 - type: entity
   name: mushroom soup
   parent: FoodBowlBase
@@ -931,7 +989,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 25
+        maxVol: 30
         reagents:
           - ReagentId: Nutriment
             Quantity: 2
@@ -941,7 +999,9 @@
             Quantity: 5
           - ReagentId: Milk
             Quantity: 5
-
+          - ReagentId: Flavorol
+            Quantity: 5
+            
 - type: entity
   name: beet soup
   parent: FoodBowlBase
@@ -962,7 +1022,9 @@
           - ReagentId: Vitamin
             Quantity: 7
           - ReagentId: Water
-            Quantity: 10
+            Quantity: 5
+          - ReagentId: Flavorol
+            Quantity: 5
 # Tastes like borsch, bortsch, borstch, borsh, borshch, borscht.
 
 - type: entity
@@ -978,12 +1040,14 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 15
+        maxVol: 20
         reagents:
           - ReagentId: Nutriment
             Quantity: 4
           - ReagentId: Vitamin
             Quantity: 6
+          - ReagentId: Flavorol
+            Quantity: 5
 # Tastes like beet.
 
 - type: entity
@@ -1004,15 +1068,17 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 15
+        maxVol: 20
         reagents:
           - ReagentId: Nutriment
-            Quantity: 15
+            Quantity: 10
           - ReagentId: Protein
             Quantity: 5
           - ReagentId: Vitamin
             Quantity: 2
-
+          - ReagentId: Flavorol
+            Quantity: 10
+            
 - type: entity
   name: sweet potato soup
   parent: FoodBowlBase
@@ -1029,11 +1095,13 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 12
+        maxVol: 17
         reagents:
           - ReagentId: Nutriment
             Quantity: 4
           - ReagentId: Vitamin
+            Quantity: 5
+          - ReagentId: Flavorol
             Quantity: 5
 # Tastes like sweet potato.
 
@@ -1053,7 +1121,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 10
+        maxVol: 16
         reagents:
           - ReagentId: Nutriment
             Quantity: 1
@@ -1061,7 +1129,9 @@
             Quantity: 5
           - ReagentId: Allicin
             Quantity: 5
-
+          - ReagentId: Flavorol
+            Quantity: 5
+            
 - type: entity
   name: bisque
   parent: FoodBowlBase
@@ -1078,7 +1148,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 30
+        maxVol: 35
         reagents:
           - ReagentId: Nutriment
             Quantity: 6
@@ -1087,6 +1157,8 @@
           - ReagentId: Protein
             Quantity: 6
           - ReagentId: Water
+            Quantity: 5
+          - ReagentId: Flavorol
             Quantity: 5
 # Tastes like crab.
 
@@ -1107,12 +1179,14 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 10
+        maxVol: 15
         reagents:
           - ReagentId: Nutriment
             Quantity: 3
           - ReagentId: Licoxide
             Quantity: 6
+          - ReagentId: Flavorol
+            Quantity: 5
 
 - type: entity
   name: bungo curry
@@ -1130,7 +1204,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 15
+        maxVol: 30
         reagents:
           - ReagentId: Nutriment
             Quantity: 6
@@ -1138,4 +1212,6 @@
             Quantity: 5
           - ReagentId: CapsaicinOil
             Quantity: 5
+          - ReagentId: Flavorol
+            Quantity: 15
 # Tastes like bungo, hot curry.

--- a/Resources/Prototypes/_NF/Reagents/Consumables/food.yml
+++ b/Resources/Prototypes/_NF/Reagents/Consumables/food.yml
@@ -1,0 +1,32 @@
+﻿- type: reagent
+  id: Flavorol #something magical a chef adds to a dish to make it better tm. Again, not doing a super in depth simulator just adding this to some of the higher end cooked meals to make it 'worth it' to seek out a chef.
+  name: reagent-name-Flavorol
+  group: Foods
+  desc: reagent-desc-nutriment
+  physicalDesc: reagent-physical-desc-opaque
+  flavor: nutriment
+  color: "#775441"
+  metabolisms:
+    Food:
+      metabolismRate: 0.1
+      effects:
+      - !type:MovespeedModifier
+        walkSpeedModifier: 1.15
+        sprintSpeedModifier: 1.15
+      - !type:SatiateHunger
+      - !type:HealthChange #minor health benefit if you eat full meals, helps with the existing 'healthy' vitamins etc. to create a complete and balanced diet.
+        conditions:
+        - !type:ReagentThreshold
+          min: 10
+        damage:
+          types:
+            Poison: -0.2
+            Radiation: -0.2
+      - !type:ModifyBloodLevel
+        amount: .5
+  plantMetabolism:
+  - !type:PlantAdjustNutrition
+    amount: 1
+  - !type:PlantAdjustHealth
+    amount: 0.5
+  pricePerUnit: 10


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
adds flavor

Most of the chef recipes have been updated with Flavorol (tm)

The list is too long here since many items simply inherent bases like pies and cakes and pizza, but essentially eating food that is cooked by chefs will give you a slight speed boost (1.15, weakest so far in the game) for some minutes, and if you eat a full meals worth (generally 3 or more cooked 'dishes'), has a very slight curative effect for blood loss and poison/radiation damage. It is miniscule in comparison to the actual curative chemicals, even compared to iron for blood loss.

:cl: checkraze
 - add: added Flavorol, a new small buff to the complicated chef-created cooked items for adventurers.