### PR TITLE
Update default development cvars

### DIFF
--- a/Resources/ConfigPresets/Build/development.toml
+++ b/Resources/ConfigPresets/Build/development.toml
@@ -1,8 +1,7 @@
 ﻿[game]
 # Straight in-game baby
 lobbyenabled = false
-# Dev map for faster loading & convenience
-map = "Dev"
+map = "Frontier"
 role_timers = false
 
 [physics]
@@ -21,4 +20,4 @@ grid_fill = false
 auto_call_time = 0
 emergency = false
 arrivals = false
-shipyard = false
+shipyard = true


### PR DESCRIPTION
Enable shipyard and set the default map and game mode so that new developers contributing to Frontier Station don't get confused why shipyards don't work and on how to set the map and game mode.