### PR TITLE
Space Traffic Control Part 1

### DIFF
--- a/Content.Client/Shuttles/UI/ShuttleConsoleWindow.xaml
+++ b/Content.Client/Shuttles/UI/ShuttleConsoleWindow.xaml
@@ -18,8 +18,15 @@
                 <controls:StripeBack>
                     <Label Name="DockingPortsLabel" Text="{Loc 'shuttle-console-dock-label'}" HorizontalAlignment="Center"/>
                 </controls:StripeBack>
+                <ScrollContainer
+                    HScrollEnabled="False"
+                    HorizontalExpand="True"
+                    MinSize="100 400"
+                    SizeFlagsStretchRatio="2"
+                    VerticalExpand="True">
                 <BoxContainer Name="DockPorts"
                               Orientation="Vertical"/>
+                </ScrollContainer>
             </BoxContainer>
             <BoxContainer Orientation="Vertical">
                 <controls:StripeBack>

--- a/Content.Client/Shuttles/UI/ShuttleConsoleWindow.xaml.cs
+++ b/Content.Client/Shuttles/UI/ShuttleConsoleWindow.xaml.cs
@@ -198,20 +198,20 @@ public sealed partial class ShuttleConsoleWindow : FancyWindow,
             {
                 var pressed = state.Entity == DockingScreen.ViewedDock;
 
-                string suffix;
+                string name;
+                if (state.Name != null)
+                    name = state.Name;
+                else
+                    name = Loc.GetString("shuttle-console-dock-button", ("suffix", index));
 
                 if (state.Connected)
                 {
-                    suffix = Loc.GetString("shuttle-console-docked", ("index", index));
-                }
-                else
-                {
-                    suffix = $"{index}";
+                    name += " " + Loc.GetString("shuttle-console-docked");
                 }
 
                 var button = new Button()
                 {
-                    Text = Loc.GetString("shuttle-console-dock-button", ("suffix", suffix)),
+                    Text = name,
                     ToggleMode = true,
                     Pressed = pressed,
                     Margin = new Thickness(0f, 1f),

--- a/Content.Server/Shuttles/Components/DockingComponent.cs
+++ b/Content.Server/Shuttles/Components/DockingComponent.cs
@@ -30,6 +30,12 @@ namespace Content.Server.Shuttles.Components
         [ViewVariables(VVAccess.ReadWrite), DataField("highlightedRadarColor")]
         public Color HighlightedRadarColor = Color.Magenta;
 
+        /// <summary>
+        /// Name that is shown on the radar screen for this dock, if any.
+        /// </summary>
+        [ViewVariables(VVAccess.ReadWrite), DataField("name")]
+        public string? Name = null;
+
         [ViewVariables]
         public int PathfindHandle = -1;
     }

--- a/Content.Server/Shuttles/Systems/ShuttleConsoleSystem.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleConsoleSystem.cs
@@ -247,6 +247,7 @@ public sealed partial class ShuttleConsoleSystem : SharedShuttleConsoleSystem
                 Entity = uid,
                 Connected = comp.Docked,
                 Color = comp.RadarColor,
+                Name = comp.Name,
                 HighlightedColor = comp.HighlightedRadarColor,
             };
             result.Add(state);

--- a/Content.Shared/Shuttles/BUIStates/RadarConsoleBoundInterfaceState.cs
+++ b/Content.Shared/Shuttles/BUIStates/RadarConsoleBoundInterfaceState.cs
@@ -45,6 +45,7 @@ public sealed class DockingInterfaceState
     public EntityUid Entity;
     public bool Connected;
     public Color Color;
+    public string? Name;
     public Color HighlightedColor;
 }
 

--- a/Resources/Locale/en-US/headset/headset-component.ftl
+++ b/Resources/Locale/en-US/headset/headset-component.ftl
@@ -5,7 +5,7 @@ examine-headset-default-channel = Use {$prefix} for the default channel ([color=
 
 chat-radio-common = Common
 chat-radio-centcom = CentCom
-chat-radio-command = Command
+chat-radio-command = Traffic Control
 chat-radio-engineering = Engineering
 chat-radio-medical = Medical
 chat-radio-science = Science

--- a/Resources/Locale/en-US/shuttles/console.ftl
+++ b/Resources/Locale/en-US/shuttles/console.ftl
@@ -25,7 +25,7 @@ shuttle-console-linear-velocity = Linear velocity:
 shuttle-console-angular-velocity = Angular velocity:
 
 shuttle-console-dock-label = Docking ports
-shuttle-console-docked = {$index} (Docked)
+shuttle-console-docked = (Docked)
 shuttle-console-dock-button = Dock {$suffix}
 
 shuttle-console-hyperspace-label = FTL destinations

--- a/Resources/Prototypes/Entities/Objects/Devices/encryption_keys.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/encryption_keys.yml
@@ -81,8 +81,8 @@
 - type: entity
   parent: EncryptionKey
   id: EncryptionKeyCommand
-  name: command encryption key
-  description: An encryption key used by crew's bosses.
+  name: traffic control encryption key
+  description: An encryption key for the space traffic control channel.
   components:
   - type: EncryptionKey
     channels:

--- a/Resources/Prototypes/_NF/Catalog/Fills/AstroVend.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/AstroVend.yml
@@ -8,6 +8,7 @@
     AirTank: 10
     HandheldGPSBasic: 15
     RadioHandheld: 15
+    EncryptionKeyCommand: 15
     JetpackMiniFilled: 10
 
 - type: vendingMachineInventory


### PR DESCRIPTION
## About the PR
This adds some nice changes in preparations for having Space Traffic Control.

- Rename "Command" channel to "Traffic Control", put traffic control encryption key in AstroVend
- Allow docking ports to be named. If they are named, they appear in the shuttle console. Otherwise, they use the old dock numbers
- Add a scroll bar to the docking port list so that all the docks are visible on Frontier Station