### PR TITLE
Space Traffic Control Part 2

### DIFF
--- a/Content.Client/Shuttles/UI/ShuttleConsoleWindow.xaml.cs
+++ b/Content.Client/Shuttles/UI/ShuttleConsoleWindow.xaml.cs
@@ -181,6 +181,7 @@ public sealed partial class ShuttleConsoleWindow : FancyWindow,
         // We also need to make up some pseudonumber as well for these.
         _docks.Clear();
 
+        docks.Sort(new DockComparer());
         foreach (var dock in docks)
         {
             var grid = _docks.GetOrNew(dock.Coordinates.EntityId);

--- a/Content.Shared/Shuttles/BUIStates/RadarConsoleBoundInterfaceState.cs
+++ b/Content.Shared/Shuttles/BUIStates/RadarConsoleBoundInterfaceState.cs
@@ -49,6 +49,23 @@ public sealed class DockingInterfaceState
     public Color HighlightedColor;
 }
 
+public class DockComparer: IComparer<DockingInterfaceState>
+{
+    public int Compare(DockingInterfaceState? a, DockingInterfaceState? b)
+    {
+        if (a == null)
+            return -1;
+        else if (b == null)
+            return 1;
+        else if (a.Name != null && b.Name != null)
+            return a.Name.CompareTo(b.Name);
+        else if (a.Name != null) // a has a name but b doesn't
+            return 1;
+        else // neither are named, compare by Uid
+            return a.Entity.CompareTo(b.Entity);
+    }
+}
+
 [Serializable, NetSerializable]
 public enum RadarConsoleUiKey : byte
 {

--- a/Resources/Maps/frontier.yml
+++ b/Resources/Maps/frontier.yml
@@ -143,7 +143,7 @@ entities:
           tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXwAAAF8AAABeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
       type: MapGrid
     - type: Broadphase
-    - angularDamping: 0.05
+    - angularDamping: 10000
       linearDamping: 10000
       fixedRotation: False
       bodyType: Dynamic
@@ -151,8 +151,8 @@ entities:
     - fixtures: {}
       type: Fixtures
     - type: OccluderTree
-    - linearDamping: 10000
-      angularDamping: 10000
+    - angularDamping: 10000
+      linearDamping: 10000
       type: Shuttle
     - type: GridPathfinding
     - gravityShakeSound: !type:SoundPathSpecifier
@@ -3207,214 +3207,290 @@ entities:
       pos: -33.5,-25.5
       parent: 2173
       type: Transform
+    - name: 2A
+      type: Docking
   - uid: 2171
     components:
     - rot: -1.5707963267948966 rad
       pos: -33.5,-26.5
       parent: 2173
       type: Transform
+    - name: 2A
+      type: Docking
   - uid: 2172
     components:
     - rot: -1.5707963267948966 rad
       pos: -33.5,-27.5
       parent: 2173
       type: Transform
+    - name: 2A
+      type: Docking
   - uid: 2175
     components:
     - pos: -28.5,-30.5
       parent: 2173
       type: Transform
+    - name: 2B
+      type: Docking
   - uid: 2176
     components:
     - rot: 1.5707963267948966 rad
       pos: -25.5,-27.5
       parent: 2173
       type: Transform
+    - name: 2C
+      type: Docking
   - uid: 2177
     components:
     - rot: 1.5707963267948966 rad
       pos: -25.5,-26.5
       parent: 2173
       type: Transform
+    - name: 2C
+      type: Docking
   - uid: 2178
     components:
     - rot: 1.5707963267948966 rad
       pos: -25.5,-25.5
       parent: 2173
       type: Transform
+    - name: 2C
+      type: Docking
   - uid: 2179
     components:
     - pos: -1.5,-0.5
       parent: 2173
       type: Transform
+    - name: 6
+      type: Docking
   - uid: 2180
     components:
     - pos: 0.5,-0.5
       parent: 2173
       type: Transform
+    - name: 6
+      type: Docking
   - uid: 2181
     components:
     - pos: 27.5,-30.5
       parent: 2173
       type: Transform
+    - name: 3B
+      type: Docking
   - uid: 2182
     components:
     - pos: 28.5,-30.5
       parent: 2173
       type: Transform
+    - name: 3B
+      type: Docking
   - uid: 2183
     components:
     - pos: 29.5,-30.5
       parent: 2173
       type: Transform
+    - name: 3B
+      type: Docking
   - uid: 2184
     components:
     - rot: -1.5707963267948966 rad
       pos: 24.5,-27.5
       parent: 2173
       type: Transform
+    - name: 3A
+      type: Docking
   - uid: 2185
     components:
     - rot: -1.5707963267948966 rad
       pos: 24.5,-26.5
       parent: 2173
       type: Transform
+    - name: 3A
+      type: Docking
   - uid: 2186
     components:
     - rot: -1.5707963267948966 rad
       pos: 24.5,-25.5
       parent: 2173
       type: Transform
+    - name: 3A
+      type: Docking
   - uid: 2187
     components:
     - rot: 1.5707963267948966 rad
       pos: 32.5,-27.5
       parent: 2173
       type: Transform
+    - name: 3C
+      type: Docking
   - uid: 2188
     components:
     - rot: 1.5707963267948966 rad
       pos: 32.5,-26.5
       parent: 2173
       type: Transform
+    - name: 3C
+      type: Docking
   - uid: 2189
     components:
     - rot: 1.5707963267948966 rad
       pos: 32.5,-25.5
       parent: 2173
       type: Transform
+    - name: 3C
+      type: Docking
   - uid: 2190
     components:
     - rot: 1.5707963267948966 rad
       pos: 61.5,1.5
       parent: 2173
       type: Transform
+    - name: 4B
+      type: Docking
   - uid: 2191
     components:
     - rot: 1.5707963267948966 rad
       pos: 61.5,2.5
       parent: 2173
       type: Transform
+    - name: 4B
+      type: Docking
   - uid: 2192
     components:
     - rot: 1.5707963267948966 rad
       pos: 61.5,3.5
       parent: 2173
       type: Transform
+    - name: 4B
+      type: Docking
   - uid: 2193
     components:
     - pos: 58.5,-1.5
       parent: 2173
       type: Transform
+    - name: 4A
+      type: Docking
   - uid: 2194
     components:
     - pos: 57.5,-1.5
       parent: 2173
       type: Transform
+    - name: 4A
+      type: Docking
   - uid: 2195
     components:
     - pos: 56.5,-1.5
       parent: 2173
       type: Transform
+    - name: 4A
+      type: Docking
   - uid: 2196
     components:
     - rot: -1.5707963267948966 rad
       pos: -6.5,43.5
       parent: 2173
       type: Transform
+    - name: 5A
+      type: Docking
   - uid: 2197
     components:
     - rot: -1.5707963267948966 rad
       pos: -6.5,44.5
       parent: 2173
       type: Transform
+    - name: 5A
+      type: Docking
   - uid: 2198
     components:
     - rot: -1.5707963267948966 rad
       pos: -6.5,45.5
       parent: 2173
       type: Transform
+    - name: 5A
+      type: Docking
   - uid: 2199
     components:
     - rot: 1.5707963267948966 rad
       pos: 12.5,53.5
       parent: 2173
       type: Transform
+    - name: 5B
+      type: Docking
   - uid: 2200
     components:
     - rot: 1.5707963267948966 rad
       pos: 12.5,54.5
       parent: 2173
       type: Transform
+    - name: 5B
+      type: Docking
   - uid: 2201
     components:
     - rot: 1.5707963267948966 rad
       pos: 12.5,55.5
       parent: 2173
       type: Transform
+    - name: 5B
+      type: Docking
   - uid: 2202
     components:
     - pos: -57.5,-1.5
       parent: 2173
       type: Transform
+    - name: 1B
+      type: Docking
   - uid: 2203
     components:
     - pos: -58.5,-1.5
       parent: 2173
       type: Transform
+    - name: 1B
+      type: Docking
   - uid: 2204
     components:
     - pos: -59.5,-1.5
       parent: 2173
       type: Transform
+    - name: 1B
+      type: Docking
   - uid: 2205
     components:
     - rot: -1.5707963267948966 rad
       pos: -62.5,1.5
       parent: 2173
       type: Transform
+    - name: 1A
+      type: Docking
   - uid: 2206
     components:
     - rot: -1.5707963267948966 rad
       pos: -62.5,2.5
       parent: 2173
       type: Transform
+    - name: 1A
+      type: Docking
   - uid: 2207
     components:
     - rot: -1.5707963267948966 rad
       pos: -62.5,3.5
       parent: 2173
       type: Transform
+    - name: 1A
+      type: Docking
   - uid: 5801
     components:
     - pos: -29.5,-30.5
       parent: 2173
       type: Transform
+    - name: 2B
+      type: Docking
   - uid: 5805
     components:
     - pos: -30.5,-30.5
       parent: 2173
       type: Transform
+    - name: 2B
+      type: Docking
 - proto: AirlockHeadOfPersonnelGlassLocked
   entities:
   - uid: 4113
@@ -15343,12 +15419,6 @@ entities:
     - pos: -54.5,4.5
       parent: 2173
       type: Transform
-  - uid: 2838
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 12.5,14.5
-      parent: 2173
-      type: Transform
   - uid: 4169
     components:
     - pos: -24.5,4.5
@@ -15398,6 +15468,14 @@ entities:
   - uid: 5742
     components:
     - pos: 43.5,13.5
+      parent: 2173
+      type: Transform
+- proto: ComputerShuttle
+  entities:
+  - uid: 2838
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 12.5,14.5
       parent: 2173
       type: Transform
 - proto: ComputerStationRecords


### PR DESCRIPTION
This is Part 2 of Space Traffic Control. This plots the dock names (from the last part) on the radar console. Then, update Frontier Station's docks to have dock names.
![stc](https://github.com/new-frontiers-14/frontier-station-14/assets/3229565/d4124b2f-04ba-4517-b1ca-de478e152a3e)
