### PR TITLE
Re-balanced engineering goggles and welding mask price

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
@@ -74,6 +74,8 @@
   - type: Clothing
     sprite: Clothing/Eyes/Glasses/meson.rsi
   - type: EyeProtection
+  - type: StaticPrice
+    price: 300
 
 - type: entity
   parent: ClothingEyesBase

--- a/Resources/Prototypes/Entities/Clothing/Head/welding.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/welding.yml
@@ -29,6 +29,8 @@
     tags:
     - HamsterWearable
     - WhitelistChameleon
+  - type: StaticPrice
+    price: 60
 
 - type: entity
   parent: WeldingMaskBase


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
On my little economy balance journey, I've decided to fix multiple prices that make zero sense, same as in #64 here I'm trying to fix some questionable values that lead to empty stock when shift starts.

So, welding mask and engineering googles provide the same function, they protect eyes during welding, googles also protect from some other? Influence that may hurt your eyes.

A welding mask has many disadvantages: it is bulky, takes up a slot that won't let you wear your helmet, can't be used in space, etc. but its default price is $250.
On the other hand, engineering googles: take up a less important slot, provide additional protection, allow you to work welder in space, but for some reason they are basically free, just $75, even while being a more professional equipment.

My suggestion is to increase price for engineering googles higher, closer to other professional equipment (Mag Boots), that way players that just grab them because they are free and convenient might think twice if they really need them, while players that need them for sure will be able to afford them anyway, just as they do with MagBoots(which are 2k).

It should also motivate grabbing welding masks more often instead of using goggles every time.


**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
Old prices:
![image](https://github.com/new-frontiers-14/frontier-station-14/assets/35602029/d83feeda-8c95-47b9-80dc-51b90e943ee8)

New prices:
![image](https://github.com/new-frontiers-14/frontier-station-14/assets/35602029/d9e3df37-c7fd-49e2-8a9b-e6999cad1d68)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: Rebalanced 'engineering goggles' and 'welding mask' prices
