### PR TITLE
Rebalanced ChemVend prices

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
@@ -82,7 +82,7 @@
     sprite: Objects/Specific/Service/vending_machine_restock.rsi
     state: base
   product: CrateVendingMachineRestockChemVendFilled
-  cost: 3500
+  cost: 2000
   category: Medical
   group: market
 

--- a/Resources/Prototypes/Entities/Objects/Specific/chemical-containers.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemical-containers.yml
@@ -45,7 +45,7 @@
       maxFillLevels: 6
       fillBaseName: jug
     - type: StaticPrice
-      price: 80
+      price: 10
 
 - type: entity
   parent: Jug


### PR DESCRIPTION
still no infinitechem, but now jugs only cost 100. This means the chemistry crates are more reasonably priced. Also made the chemvend restock cheaper since it was pretty absurdly priced (especially since you have to pay for the jugs still) 