### PR TITLE
Re-balanced vending food and drinks prices

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks.yml
@@ -2154,6 +2154,8 @@
     tags:
     - Trash
   - type: SpaceGarbage
+  - type: StaticPrice
+    price: 7.5
 
 - type: entity
   parent: DrinkRamen

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_bottles.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_bottles.yml
@@ -41,6 +41,8 @@
         acts: [ "Destruction" ]
   - type: TrashOnEmpty
     solution: drink
+  - type: StaticPrice
+    price: 16
 
 - type: entity
   parent: DrinkBottleBaseFull
@@ -416,6 +418,8 @@
   - type: Drink
   - type: Sprite
     sprite: Objects/Consumable/Drinks/limejuice.rsi
+  - type: StaticPrice
+    price: 13
 
 - type: entity
   parent: DrinkBottleBaseFull
@@ -433,6 +437,8 @@
   - type: Drink
   - type: Sprite
     sprite: Objects/Consumable/Drinks/orangejuice.rsi
+  - type: StaticPrice
+    price: 13
 
 - type: entity
   parent: DrinkBottleBaseFull
@@ -450,6 +456,8 @@
   - type: Drink
   - type: Sprite
     sprite: Objects/Consumable/Drinks/tomatojuice.rsi
+  - type: StaticPrice
+    price: 13
 
 - type: entity
   parent: DrinkBottleBaseFull

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cans.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cans.yml
@@ -56,6 +56,8 @@
   - type: PhysicalComposition
     materialComposition:
       Steel: 50 #reduce, reuse, recycle
+  - type: StaticPrice
+    price: 5.5
 
 - type: entity
   parent: DrinkCanBaseFull

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cups.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cups.yml
@@ -38,6 +38,8 @@
       types:
         Blunt: 0
   - type: ItemCooldown
+  - type: StaticPrice
+    price: 4.5
 
 - type: entity
   parent: DrinkBaseCup

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_flasks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_flasks.yml
@@ -29,7 +29,7 @@
   - type: TrashOnEmpty
     solution: drink
   - type: StaticPrice
-    price: 12
+    price: 12.5
 
 - type: entity
   parent: DrinkBase

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_flasks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_flasks.yml
@@ -28,6 +28,8 @@
           Quantity: 50
   - type: TrashOnEmpty
     solution: drink
+  - type: StaticPrice
+    price: 12
 
 - type: entity
   parent: DrinkBase

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/donut.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/donut.yml
@@ -22,6 +22,8 @@
   - type: Item
     sprite: Objects/Consumable/Food/Baked/donut.rsi
     size: 1
+  - type: StaticPrice
+    price: 12
 # Tastes like donut.
 
 # The sprinkles are now an overlay, so you can put them on any donut! If we really

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/condiments.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/condiments.yml
@@ -36,7 +36,7 @@
   # Since this one is closed, the only way to insert liquid is with a syringe.
   - type: InjectableSolution
     solution: food
-  # Note NOT refillable. 
+  # Note NOT refillable.
   # It be a shame if it turned out ALL drinks were ALWAYS refillable.... ffs.
   # Well its fixed now, but I want to share my pain.
   - type: SolutionContainerManager
@@ -52,6 +52,8 @@
   - type: PhysicalComposition
     materialComposition:
       Plastic: 50
+  - type: StaticPrice
+    price: 4.5
 
 - type: entity
   parent: BaseFoodCondimentPacket

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/snacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/snacks.yml
@@ -19,6 +19,8 @@
     sprite: Objects/Consumable/Food/snacks.rsi
     heldPrefix: packet
     size: 3
+  - type: StaticPrice
+    price: 7.5
 # Snacks
 
 # "Snacks" means food in a packet. Down the line this stuff can have multiple
@@ -90,6 +92,8 @@
       - id: FoodSnackChocolateBar
     sound:
       path: /Audio/Effects/unwrap.ogg
+  - type: StaticPrice
+    price: 7.5
 
 - type: entity
   name: chocolate bar
@@ -304,6 +308,8 @@
       - id: FoodSnackNutribrickOpen
     sound:
       path: /Audio/Effects/unwrap.ogg
+  - type: StaticPrice
+    price: 7
 
 - type: entity
   id: FoodSnackNutribrickOpen
@@ -342,6 +348,8 @@
       - id: FoodSnackMREBrownieOpen
     sound:
       path: /Audio/Effects/unwrap.ogg
+  - type: StaticPrice
+    price: 7
 
 
 - type: entity


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Food and drink prices never made much sense, why would a can of soda cost more than a hard suit or some engineering tool?

I think they should be more accessible, so players run through them faster and start seeking Kitchen ships, or buy more Vending refills instead

In this update:
Can drinks are $55
Cup drinks are $45
Snacks are $75
Donuts are $60
Condiments are $45
MRE snacks are $70

Booze-o-Mat fix:
Alcohol drinks are $80
Juices are $65
Water cans are $27

(Non-drink wares of Booze-o-Mat are going to be re-priced in different pull request)

Prices are a little different for variation, hopefully they make more sense

As a bonus consequence, now you can sell some of the trash left after Vending food and drinks for a very small price, which would definitely help keep the station cleaner
**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
New prices:
![image](https://github.com/new-frontiers-14/frontier-station-14/assets/35602029/8f00f0b9-a3f3-4324-b15c-116e34463bf8)
![image](https://github.com/new-frontiers-14/frontier-station-14/assets/35602029/dacb10de-80ce-4550-8e6d-3cf3032a8950)
![image](https://github.com/new-frontiers-14/frontier-station-14/assets/35602029/587b8b7a-52b2-4038-865a-1d1f27aa7a4d)
![image](https://github.com/new-frontiers-14/frontier-station-14/assets/35602029/a3134414-a723-4568-81d1-3f75554e887b)
![image](https://github.com/new-frontiers-14/frontier-station-14/assets/35602029/b86d3714-d632-4025-ac3e-58f3143dcfbf)
![image](https://github.com/new-frontiers-14/frontier-station-14/assets/35602029/471adcd8-d3ce-4212-877c-ef739b34766c)


- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- tweak: Changed prices for most vending machines food
- fix: now some of the trash, such as empty cans, can be sold to get rid of it

