### PR TITLE
Vend change

### DIFF
--- a/Content.Server/VendingMachines/VendingMachineSystem.cs
+++ b/Content.Server/VendingMachines/VendingMachineSystem.cs
@@ -84,10 +84,10 @@ namespace Content.Server.VendingMachines
                     continue;
                 }
 
-                price += entry.Amount * _pricing.GetEstimatedPrice(proto);
+                price += entry.Amount; //* _pricing.GetEstimatedPrice(proto); Removed this to make machine price without the items worth.
             }
 
-            args.Price += price;
+            //args.Price += price; Removed this to also make the machine price without the amount of items worth.
         }
 
         protected override void OnComponentInit(EntityUid uid, VendingMachineComponent component, ComponentInit args)

--- a/Content.Server/VendingMachines/VendingMachineSystem.cs
+++ b/Content.Server/VendingMachines/VendingMachineSystem.cs
@@ -421,10 +421,10 @@ namespace Content.Server.VendingMachines
                 var entry = GetEntry(uid, item.ID, item.Type, vendComponent);
                 if (entry != null)
                     entry.Amount--;
-                EjectItem(uid, vendComponent, forceEject);
+                //EjectItem(uid, vendComponent, forceEject); // Stop vending machine from giving free items
             }
-            else
-                TryEjectVendorItem(uid, item.Type, item.ID, throwItem, 0, vendComponent);
+            //else
+            //TryEjectVendorItem(uid, item.Type, item.ID, throwItem, 0, vendComponent); // Stop vending machine from giving free items
         }
 
         private void EjectItem(EntityUid uid, VendingMachineComponent? vendComponent = null, bool forceEject = false)

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -87,7 +87,7 @@
   - type: SentienceTarget
     flavorKind: station-event-random-sentience-flavor-mechanical
   - type: StaticPrice
-    price: 100
+    price: 1000
   - type: Appearance
   - type: WiresVisuals
   - type: MarketModifier


### PR DESCRIPTION
## About the PR
The action to eject machine items is disabled,
Multitool, EMP, Player controlled or damage to vend machines will not drop any items.
Machines worth is now static of 1000 and will ignore any content in it.