### PR TITLE
raise minimum ftl destination size

### DIFF
--- a/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
@@ -73,7 +73,7 @@ public sealed partial class ShuttleSystem
     /// <summary>
     /// Minimum mass for an FTL destination
     /// </summary>
-    public const float FTLDestinationMass = 500f;
+    public const float FTLDestinationMass = 1000f;
 
     private void InitializeFTL()
     {


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
raises the mass requirements on a ftl destination auto-generating so 'large' category ships dont get them on accident but outposts like the main station stil will
