### PR TITLE
buff walk/sprint speed in sec hardsuits

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -169,8 +169,8 @@
     highPressureMultiplier: 0.525
     lowPressureMultiplier: 10000
   - type: ClothingSpeedModifier
-    walkModifier: 0.7
-    sprintModifier: 0.7   
+    walkModifier: 0.8
+    sprintModifier: 0.8   
   - type: Armor
     modifiers:
       coefficients:
@@ -199,8 +199,8 @@
     highPressureMultiplier: 0.3
     lowPressureMultiplier: 5500
   - type: ClothingSpeedModifier
-    walkModifier: 0.8
-    sprintModifier: 0.85
+    walkModifier: 0.9
+    sprintModifier: 0.9
   - type: Armor
     modifiers:
       coefficients:
@@ -226,6 +226,9 @@
   - type: PressureProtection
     highPressureMultiplier: 0.525
     lowPressureMultiplier: 10000
+  - type: ClothingSpeedModifier
+    walkModifier: 0.8
+    sprintModifier: 0.8
   - type: Armor
     modifiers:
       coefficients:
@@ -380,8 +383,8 @@
     highPressureMultiplier: 0.45
     lowPressureMultiplier: 10000
   - type: ClothingSpeedModifier
-    walkModifier: 0.75
-    sprintModifier: 0.75
+    walkModifier: 0.8
+    sprintModifier: 0.8
   - type: Armor
     modifiers:
       coefficients:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR

Reduced the walk spedd debuff of all sec hardsuits to 20% and 10% for the brigmedic one.


:cl:
- tweak: Security hardsuits are now made with lighter materials

