### PR TITLE
2 new small security vessels

### DIFF
--- a/Resources/Maps/Shuttles/cleric.yml
+++ b/Resources/Maps/Shuttles/cleric.yml
@@ -140,12 +140,6 @@ entities:
       type: Transform
 - proto: BedsheetMedical
   entities:
-  - uid: 4
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 3.5,1.5
-      parent: 1
-      type: Transform
   - uid: 5
     components:
     - rot: 1.5707963267948966 rad
@@ -370,11 +364,11 @@ entities:
       pos: 2.5,0.5
       parent: 1
       type: Transform
-- proto: EmergencyRollerBedSpawnFolded
+- proto: EmergencyRollerBed
   entities:
-  - uid: 36
+  - uid: 4
     components:
-    - pos: 4.4220133,1.5057969
+    - pos: 3.489162,1.4973726
       parent: 1
       type: Transform
 - proto: GeneratorWallmountAPU
@@ -448,11 +442,6 @@ entities:
     - pos: 5.5,1.5
       parent: 1
       type: Transform
-  - uid: 49
-    components:
-    - pos: 3.5,1.5
-      parent: 1
-      type: Transform
 - proto: MedkitCombatFilled
   entities:
   - uid: 50
@@ -512,13 +501,6 @@ entities:
   - uid: 59
     components:
     - pos: 3.5,0.5
-      parent: 1
-      type: Transform
-- proto: StasisBed
-  entities:
-  - uid: 60
-    components:
-    - pos: 5.5,2.5
       parent: 1
       type: Transform
 - proto: SubstationWallBasic

--- a/Resources/Maps/Shuttles/cleric.yml
+++ b/Resources/Maps/Shuttles/cleric.yml
@@ -1,0 +1,654 @@
+meta:
+  format: 5
+  postmapinit: false
+tilemap:
+  0: Space
+  83: FloorWhiteDiagonal
+  91: FloorWhitePlastic
+  94: Lattice
+  95: Plating
+entities:
+- proto: ""
+  entities:
+  - uid: 1
+    components:
+    - type: MetaData
+    - pos: -2.515625,0.15625
+      parent: invalid
+      type: Transform
+    - chunks:
+        0,0:
+          ind: 0,0
+          tiles: XwAAAF8AAABfAAAAXwAAAF8AAABfAAAAXwAAAF4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF8AAABbAAAAWwAAAFsAAABbAAAAWwAAAFsAAABfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABfAAAAWwAAAFMAAABTAAAAUwAAAFMAAABbAAAAXwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXgAAAFsAAABbAAAAWwAAAFsAAABbAAAAWwAAAF8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF4AAABeAAAAXwAAAF8AAABfAAAAXwAAAF4AAABeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+      type: MapGrid
+    - type: Broadphase
+    - angularDamping: 0.05
+      linearDamping: 0.05
+      fixedRotation: False
+      bodyType: Dynamic
+      type: Physics
+    - fixtures: {}
+      type: Fixtures
+    - type: OccluderTree
+    - type: SpreaderGrid
+    - type: Shuttle
+    - type: GridPathfinding
+    - gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+      type: Gravity
+    - chunkCollection:
+        version: 2
+        nodes:
+        - node:
+            color: '#B02E26FF'
+            id: BrickTileWhiteCornerNe
+          decals:
+            4: 6,2
+            6: 5,3
+        - node:
+            color: '#B02E26FF'
+            id: BrickTileWhiteCornerNw
+          decals:
+            1: 2,3
+            8: 1,2
+        - node:
+            color: '#B02E26FF'
+            id: BrickTileWhiteCornerSe
+          decals:
+            0: 6,1
+        - node:
+            color: '#B02E26FF'
+            id: BrickTileWhiteInnerNe
+          decals:
+            5: 5,2
+        - node:
+            color: '#B02E26FF'
+            id: BrickTileWhiteInnerNw
+          decals:
+            7: 2,2
+            9: 1,1
+        - node:
+            color: '#B02E26FF'
+            id: BrickTileWhiteLineN
+          decals:
+            2: 3,3
+            3: 4,3
+        - node:
+            color: '#B02E26FF'
+            id: BrickTileWhiteLineS
+          decals:
+            10: 1,1
+            11: 2,1
+            12: 3,1
+            13: 4,1
+            14: 5,1
+      type: DecalGrid
+    - version: 2
+      data:
+        tiles:
+          0,0:
+            0: 65535
+          0,1:
+            0: 15
+          1,0:
+            0: 65535
+          1,1:
+            0: 15
+        uniqueMixes:
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 21.824879
+          - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        chunkSize: 4
+      type: GridAtmosphere
+    - type: GasTileOverlay
+    - type: RadiationGridResistance
+- proto: AirlockGlassShuttle
+  entities:
+  - uid: 2
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 0.5,1.5
+      parent: 1
+      type: Transform
+- proto: APCBasic
+  entities:
+  - uid: 3
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 0.5,2.5
+      parent: 1
+      type: Transform
+- proto: AtmosDeviceFanTiny
+  entities:
+  - uid: 82
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,1.5
+      parent: 1
+      type: Transform
+- proto: BedsheetMedical
+  entities:
+  - uid: 4
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 3.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 5
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 5.5,1.5
+      parent: 1
+      type: Transform
+- proto: CableApcExtension
+  entities:
+  - uid: 6
+    components:
+    - pos: 0.5,2.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 7
+    components:
+    - pos: 1.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 8
+    components:
+    - pos: 1.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 9
+    components:
+    - pos: 2.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 10
+    components:
+    - pos: 3.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 11
+    components:
+    - pos: 4.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 12
+    components:
+    - pos: 5.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 13
+    components:
+    - pos: 6.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 14
+    components:
+    - pos: 7.5,2.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 15
+    components:
+    - pos: 7.5,3.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 16
+    components:
+    - pos: 7.5,1.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 17
+    components:
+    - pos: 7.5,0.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 18
+    components:
+    - pos: 3.5,1.5
+      parent: 1
+      type: Transform
+- proto: CableHV
+  entities:
+  - uid: 19
+    components:
+    - pos: 6.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 20
+    components:
+    - pos: 7.5,3.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 21
+    components:
+    - pos: 7.5,2.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 22
+    components:
+    - pos: 7.5,1.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+- proto: CableMV
+  entities:
+  - uid: 23
+    components:
+    - pos: 7.5,1.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 24
+    components:
+    - pos: 6.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 25
+    components:
+    - pos: 5.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 26
+    components:
+    - pos: 5.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 27
+    components:
+    - pos: 4.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 28
+    components:
+    - pos: 3.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 29
+    components:
+    - pos: 2.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 30
+    components:
+    - pos: 1.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 31
+    components:
+    - pos: 0.5,2.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+- proto: ClothingBeltParamedicFilled
+  entities:
+  - uid: 33
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 32
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: ComputerShuttle
+  entities:
+  - uid: 34
+    components:
+    - pos: 4.5,3.5
+      parent: 1
+      type: Transform
+- proto: CrateMedicalSupplies
+  entities:
+  - uid: 32
+    components:
+    - pos: 1.5,2.5
+      parent: 1
+      type: Transform
+    - air:
+        volume: 200
+        immutable: False
+        temperature: 293.1497
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+      type: EntityStorage
+    - containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 33
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+      type: ContainerContainer
+- proto: DefibrillatorCabinetFilled
+  entities:
+  - uid: 35
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 2.5,0.5
+      parent: 1
+      type: Transform
+- proto: EmergencyRollerBedSpawnFolded
+  entities:
+  - uid: 36
+    components:
+    - pos: 4.4220133,1.5057969
+      parent: 1
+      type: Transform
+- proto: GeneratorWallmountAPU
+  entities:
+  - uid: 37
+    components:
+    - pos: 7.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 38
+    components:
+    - pos: 6.5,3.5
+      parent: 1
+      type: Transform
+- proto: GravityGeneratorMini
+  entities:
+  - uid: 39
+    components:
+    - pos: 6.5,2.5
+      parent: 1
+      type: Transform
+- proto: Grille
+  entities:
+  - uid: 40
+    components:
+    - pos: 4.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 41
+    components:
+    - pos: 3.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 42
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 1.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 43
+    components:
+    - pos: 3.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 44
+    components:
+    - pos: 4.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 45
+    components:
+    - pos: 5.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 46
+    components:
+    - pos: 7.5,2.5
+      parent: 1
+      type: Transform
+- proto: Gyroscope
+  entities:
+  - uid: 47
+    components:
+    - pos: 6.5,4.5
+      parent: 1
+      type: Transform
+- proto: MedicalBed
+  entities:
+  - uid: 48
+    components:
+    - pos: 5.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 49
+    components:
+    - pos: 3.5,1.5
+      parent: 1
+      type: Transform
+- proto: MedkitCombatFilled
+  entities:
+  - uid: 50
+    components:
+    - pos: 3.5313883,3.537047
+      parent: 1
+      type: Transform
+- proto: Poweredlight
+  entities:
+  - uid: 51
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 1.5,1.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+  - uid: 52
+    components:
+    - pos: 6.5,2.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+- proto: ReinforcedWindow
+  entities:
+  - uid: 53
+    components:
+    - pos: 3.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 54
+    components:
+    - pos: 1.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 55
+    components:
+    - pos: 4.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 56
+    components:
+    - pos: 7.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 57
+    components:
+    - pos: 5.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 58
+    components:
+    - pos: 4.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 59
+    components:
+    - pos: 3.5,0.5
+      parent: 1
+      type: Transform
+- proto: StasisBed
+  entities:
+  - uid: 60
+    components:
+    - pos: 5.5,2.5
+      parent: 1
+      type: Transform
+- proto: SubstationWallBasic
+  entities:
+  - uid: 61
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 7.5,1.5
+      parent: 1
+      type: Transform
+- proto: TableGlass
+  entities:
+  - uid: 62
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 3.5,3.5
+      parent: 1
+      type: Transform
+- proto: Thruster
+  entities:
+  - uid: 63
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 7.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 64
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 0.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 65
+    components:
+    - pos: 1.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 66
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 7.5,0.5
+      parent: 1
+      type: Transform
+- proto: WallPlastitanium
+  entities:
+  - uid: 67
+    components:
+    - pos: 0.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 68
+    components:
+    - pos: 0.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 69
+    components:
+    - pos: 6.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 70
+    components:
+    - pos: 7.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 71
+    components:
+    - pos: 7.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 72
+    components:
+    - pos: 1.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 73
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 6.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 74
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 2.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 75
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 2.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 76
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 5.5,4.5
+      parent: 1
+      type: Transform
+- proto: WallPlastitaniumDiagonal
+  entities:
+  - uid: 77
+    components:
+    - pos: 0.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 78
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 2.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 79
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 5.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 80
+    components:
+    - pos: 6.5,1.5
+      parent: 1
+      type: Transform
+- proto: WarpPoint
+  entities:
+  - uid: 81
+    components:
+    - pos: 3.5,2.5
+      parent: 1
+      type: Transform
+    - location: Cleric
+      type: WarpPoint
+...

--- a/Resources/Maps/Shuttles/rogue.yml
+++ b/Resources/Maps/Shuttles/rogue.yml
@@ -1,0 +1,700 @@
+meta:
+  format: 5
+  postmapinit: false
+tilemap:
+  0: Space
+  27: FloorDarkMini
+  94: Lattice
+  95: Plating
+entities:
+- proto: ""
+  entities:
+  - uid: 1
+    components:
+    - type: MetaData
+    - pos: -3.59375,-1.71875
+      parent: invalid
+      type: Transform
+    - chunks:
+        0,0:
+          ind: 0,0
+          tiles: XgAAAF4AAABfAAAAGwAAAF8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF4AAABeAAAAGwAAABsAAABfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABeAAAAXgAAAF8AAAAbAAAAXwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXgAAAF4AAABfAAAAGwAAAF8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF4AAABeAAAAXgAAAF8AAABeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABeAAAAXgAAAF4AAABeAAAAXgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXgAAAF4AAABeAAAAXgAAAF4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF4AAABeAAAAXgAAAF4AAABeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+      type: MapGrid
+    - type: Broadphase
+    - angularDamping: 0.05
+      linearDamping: 0.05
+      fixedRotation: False
+      bodyType: Dynamic
+      type: Physics
+    - fixtures: {}
+      type: Fixtures
+    - type: OccluderTree
+    - type: SpreaderGrid
+    - type: Shuttle
+    - type: GridPathfinding
+    - gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+      type: Gravity
+    - chunkCollection:
+        version: 2
+        nodes:
+        - node:
+            color: '#B02E26FF'
+            id: MiniTileSteelEndN
+          decals:
+            0: 3,3
+        - node:
+            color: '#B02E26FF'
+            id: MiniTileSteelEndS
+          decals:
+            1: 3,1
+        - node:
+            color: '#B02E26FF'
+            id: MiniTileSteelLineE
+          decals:
+            2: 3,2
+        - node:
+            color: '#B02E26FF'
+            id: MiniTileSteelLineW
+          decals:
+            3: 3,2
+      type: DecalGrid
+    - version: 2
+      data:
+        tiles:
+          0,0:
+            0: 65535
+          0,1:
+            0: 65535
+          1,0:
+            0: 4369
+          1,1:
+            0: 4369
+        uniqueMixes:
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 21.824879
+          - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        chunkSize: 4
+      type: GridAtmosphere
+    - type: GasTileOverlay
+    - type: RadiationGridResistance
+- proto: AirlockExternal
+  entities:
+  - uid: 86
+    components:
+    - pos: 2.5,1.5
+      parent: 1
+      type: Transform
+- proto: AirlockGlassShuttle
+  entities:
+  - uid: 85
+    components:
+    - pos: 3.5,0.5
+      parent: 1
+      type: Transform
+- proto: APCBasic
+  entities:
+  - uid: 60
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 2.5,0.5
+      parent: 1
+      type: Transform
+- proto: AtmosDeviceFanTiny
+  entities:
+  - uid: 83
+    components:
+    - pos: 2.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 84
+    components:
+    - pos: 3.5,0.5
+      parent: 1
+      type: Transform
+- proto: CableApcExtension
+  entities:
+  - uid: 68
+    components:
+    - pos: 2.5,0.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 69
+    components:
+    - pos: 1.5,0.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 70
+    components:
+    - pos: 0.5,0.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 71
+    components:
+    - pos: 2.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 72
+    components:
+    - pos: 3.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 73
+    components:
+    - pos: 3.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 74
+    components:
+    - pos: 3.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 75
+    components:
+    - pos: 3.5,4.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 76
+    components:
+    - pos: 3.5,5.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 77
+    components:
+    - pos: 4.5,5.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 78
+    components:
+    - pos: 4.5,6.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 79
+    components:
+    - pos: 4.5,7.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 91
+    components:
+    - pos: 3.5,7.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 92
+    components:
+    - pos: 2.5,7.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 93
+    components:
+    - pos: 1.5,7.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 94
+    components:
+    - pos: 0.5,7.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+- proto: CableHV
+  entities:
+  - uid: 61
+    components:
+    - pos: 4.5,3.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 62
+    components:
+    - pos: 4.5,2.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 63
+    components:
+    - pos: 3.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 64
+    components:
+    - pos: 2.5,2.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+- proto: CableMV
+  entities:
+  - uid: 65
+    components:
+    - pos: 2.5,2.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 66
+    components:
+    - pos: 2.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 67
+    components:
+    - pos: 2.5,0.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+- proto: Catwalk
+  entities:
+  - uid: 17
+    components:
+    - pos: 1.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 18
+    components:
+    - pos: 0.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 19
+    components:
+    - pos: 1.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 20
+    components:
+    - pos: 1.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 21
+    components:
+    - pos: 1.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 22
+    components:
+    - pos: 1.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 23
+    components:
+    - pos: 1.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 24
+    components:
+    - pos: 1.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 25
+    components:
+    - pos: 1.5,7.5
+      parent: 1
+      type: Transform
+  - uid: 26
+    components:
+    - pos: 0.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 27
+    components:
+    - pos: 0.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 28
+    components:
+    - pos: 0.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 29
+    components:
+    - pos: 0.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 30
+    components:
+    - pos: 0.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 31
+    components:
+    - pos: 0.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 32
+    components:
+    - pos: 0.5,7.5
+      parent: 1
+      type: Transform
+  - uid: 33
+    components:
+    - pos: 2.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 34
+    components:
+    - pos: 2.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 35
+    components:
+    - pos: 3.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 36
+    components:
+    - pos: 4.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 37
+    components:
+    - pos: 4.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 38
+    components:
+    - pos: 3.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 39
+    components:
+    - pos: 3.5,7.5
+      parent: 1
+      type: Transform
+  - uid: 40
+    components:
+    - pos: 4.5,7.5
+      parent: 1
+      type: Transform
+  - uid: 41
+    components:
+    - pos: 2.5,7.5
+      parent: 1
+      type: Transform
+  - uid: 80
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 2.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 81
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 4.5,4.5
+      parent: 1
+      type: Transform
+- proto: ChairPilotSeat
+  entities:
+  - uid: 87
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 3.5,2.5
+      parent: 1
+      type: Transform
+- proto: ComputerShuttle
+  entities:
+  - uid: 82
+    components:
+    - pos: 3.5,3.5
+      parent: 1
+      type: Transform
+- proto: GeneratorWallmountAPU
+  entities:
+  - uid: 14
+    components:
+    - pos: 4.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 58
+    components:
+    - pos: 4.5,3.5
+      parent: 1
+      type: Transform
+- proto: GravityGeneratorMini
+  entities:
+  - uid: 57
+    components:
+    - pos: 4.5,5.5
+      parent: 1
+      type: Transform
+    missingComponents:
+    - PointLight
+- proto: Grille
+  entities:
+  - uid: 3
+    components:
+    - pos: 4.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 6
+    components:
+    - pos: 2.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 7
+    components:
+    - pos: 3.5,4.5
+      parent: 1
+      type: Transform
+- proto: Gyroscope
+  entities:
+  - uid: 56
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 3.5,5.5
+      parent: 1
+      type: Transform
+- proto: Poweredlight
+  entities:
+  - uid: 16
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 3.5,2.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+    - links:
+      - 95
+      type: DeviceLinkSink
+- proto: PoweredSmallLight
+  entities:
+  - uid: 88
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 1.5,2.5
+      parent: 1
+      type: Transform
+    - links:
+      - 95
+      type: DeviceLinkSink
+  - uid: 89
+    components:
+    - pos: 0.5,6.5
+      parent: 1
+      type: Transform
+    - links:
+      - 95
+      type: DeviceLinkSink
+  - uid: 90
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 1.5,7.5
+      parent: 1
+      type: Transform
+    - links:
+      - 95
+      type: DeviceLinkSink
+- proto: Railing
+  entities:
+  - uid: 45
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 0.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 46
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 0.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 47
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 0.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 48
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 0.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 49
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 0.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 50
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 0.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 51
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 1.5,7.5
+      parent: 1
+      type: Transform
+  - uid: 52
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 3.5,7.5
+      parent: 1
+      type: Transform
+  - uid: 53
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 2.5,7.5
+      parent: 1
+      type: Transform
+- proto: ReinforcedWindow
+  entities:
+  - uid: 5
+    components:
+    - pos: 2.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 13
+    components:
+    - pos: 3.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 15
+    components:
+    - pos: 4.5,1.5
+      parent: 1
+      type: Transform
+- proto: SignalButton
+  entities:
+  - uid: 95
+    components:
+    - pos: 0.5,7.5
+      parent: 1
+      type: Transform
+    - linkedPorts:
+        89:
+        - Pressed: Toggle
+        90:
+        - Pressed: Toggle
+        88:
+        - Pressed: Toggle
+        16:
+        - Pressed: Toggle
+      type: DeviceLinkSource
+- proto: SubstationWallBasic
+  entities:
+  - uid: 59
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 2.5,2.5
+      parent: 1
+      type: Transform
+- proto: Thruster
+  entities:
+  - uid: 43
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 1.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 44
+    components:
+    - pos: 4.5,7.5
+      parent: 1
+      type: Transform
+  - uid: 54
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 0.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 55
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 4.5,6.5
+      parent: 1
+      type: Transform
+- proto: WallPlastitanium
+  entities:
+  - uid: 2
+    components:
+    - pos: 2.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 4
+    components:
+    - pos: 4.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 9
+    components:
+    - pos: 4.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 11
+    components:
+    - pos: 2.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 12
+    components:
+    - pos: 4.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 42
+    components:
+    - pos: 0.5,7.5
+      parent: 1
+      type: Transform
+- proto: WallPlastitaniumDiagonal
+  entities:
+  - uid: 8
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 4.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 10
+    components:
+    - pos: 2.5,4.5
+      parent: 1
+      type: Transform
+- proto: WarpPoint
+  entities:
+  - uid: 96
+    components:
+    - pos: 2.5,5.5
+      parent: 1
+      type: Transform
+    - location: Rogue
+      type: WarpPoint
+...

--- a/Resources/Prototypes/_NF/Shipyard/cleric.yml
+++ b/Resources/Prototypes/_NF/Shipyard/cleric.yml
@@ -1,0 +1,27 @@
+- type: vessel
+  id: Cleric
+  name: NT Cleric
+  description: Small support vessel used for emergency rescues and first aid.
+  price: 10500 #Appraisal is 10200
+  category: Small
+  group: Security #Should be only available at a cruiser custom shipyard TODO
+  shuttlePath: /Maps/Shuttles/cleric.yml
+
+- type: gameMap
+  id: Cleric
+  mapName: 'NT Cleric'
+  mapPath: /Maps/Shuttles/cleric.yml
+  minPlayers: 0
+  stations:
+    Cleric:
+      stationProto: StandardFrontierVessel
+      components:
+        - type: StationNameSetup
+          mapNameTemplate: '{0} Cleric {1}'
+          nameGenerator:
+            !type:NanotrasenNameGenerator
+            prefixCreator: '14'
+        - type: StationJobs
+          overflowJobs: []
+          availableJobs:
+            Passenger: [ 0, 0 ]

--- a/Resources/Prototypes/_NF/Shipyard/cleric.yml
+++ b/Resources/Prototypes/_NF/Shipyard/cleric.yml
@@ -2,7 +2,7 @@
   id: Cleric
   name: NT Cleric
   description: Small support vessel used for emergency rescues and first aid.
-  price: 10500 #Appraisal is 10200
+  price: 10800 #Appraisal is 10500
   category: Small
   group: Security #Should be only available at a cruiser custom shipyard TODO
   shuttlePath: /Maps/Shuttles/cleric.yml

--- a/Resources/Prototypes/_NF/Shipyard/rogue.yml
+++ b/Resources/Prototypes/_NF/Shipyard/rogue.yml
@@ -1,0 +1,27 @@
+- type: vessel
+  id: Rogue
+  name: NT Rogue
+  description: Small assault vessel with a toggle for going dark in deep space.
+  price: 8200 #the appraisal is 7941$
+  category: Small
+  group: Security #Should be only available at a cruiser custom shipyard TODO
+  shuttlePath: /Maps/Shuttles/rogue.yml
+
+- type: gameMap
+  id: Rogue
+  mapName: 'NT Rogue'
+  mapPath: /Maps/Shuttles/rogue.yml
+  minPlayers: 0
+  stations:
+    Rogue:
+      stationProto: StandardFrontierVessel
+      components:
+        - type: StationNameSetup
+          mapNameTemplate: '{0} Rogue {1}'
+          nameGenerator:
+            !type:NanotrasenNameGenerator
+            prefixCreator: '14'
+        - type: StationJobs
+          overflowJobs: []
+          availableJobs:
+            Passenger: [ 0, 0 ]


### PR DESCRIPTION
## About the PR
<!-- What does it change? What other things could this impact? -->

Adds the other 2 small security ships for use in the carrier, Cleric and Rogue

**Media**

>Cleric
![20230726_235317](https://github.com/new-frontiers-14/frontier-station-14/assets/80334192/79f3ce6f-0c4e-4571-a7a6-23869c4b1292)

>Rogue Light/Dark mode
![20230727_123645](https://github.com/new-frontiers-14/frontier-station-14/assets/80334192/b32a3a1b-e368-4906-810a-3184c4abebe7)
![20230727_123653](https://github.com/new-frontiers-14/frontier-station-14/assets/80334192/c5beca25-a0ad-4eea-8e7b-32aee4e02edc)


- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


**Changelog**


:cl:
- add: 2 new security small ships, Cleric and Rogue.
