### PR TITLE
Reduces boom xeno artifact effect, no spacing

### DIFF
--- a/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
+++ b/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
@@ -534,9 +534,10 @@
   - type: Explosive
     deleteAfterExplosion: false
     explosionType: Default
-    totalIntensity: 500
+    totalIntensity: 300
     intensitySlope: 2.5
     maxIntensity: 50
+    canCreateVacuum: false
 
 - type: artifactEffect
   id: EffectSingulo


### PR DESCRIPTION
After playing a round as research and getting a big hole in the ship twice, well, I made this PR. That's pretty much it :P

My idea was to make it rarer, but I underestimated how obvious that would be so just no removing plating and a slightly weaker explosion will make it more manageable hopefully
