### PR TITLE
nerf heavy armor

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -127,13 +127,14 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.2
-        Slash: 0.2
-        Piercing: 0.2
-        Heat: 0.5
-        Radiation: 0
+        Blunt: 0.6
+        Slash: 0.6
+        Piercing: 0.5
+        Heat: 0.7
         Caustic: 0.75
   - type: GroupExamine
+  - type: ExplosionResistance
+    damageCoefficient: 0.7
 
 - type: entity
   parent: ClothingOuterArmorHeavy


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

Nerfs Heavy Armor, ideally the solution would be to change the rewards given in the expeditions, but for now this will help to mitigate the fact that you can freely get an armor better then the deathsquad one without any significant speed slowdown, it will still be a good armor and reward but wont have use in space because its not insulated to the cold or pressure it.

***The old stats***
>80% Blunt
>80% Slash
>80% Piercing
>50% Heat
>100% Radiation lmao
>15% Caustic

***New stats***
>40% Blunt
>40% Slash
>50% Piercing
>30% Heat
>Removed radiation resistance.
>15% Caustic
>30% Explotion Resistance Added

**Changelog**

:cl:

- tweak: Nerfs Heavy armor

