### PR TITLE
Puppets are not longer "alive"

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/puppet.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/puppet.yml
@@ -19,9 +19,6 @@
   - type: TypingIndicator
     proto: robot
   - type: Actions
-  - type: MobState
-    allowedStates:
-      - Alive
   - type: MeleeWeapon
     hidden: true
     soundHit:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR

Fixes issue where puppets would not let you sell the ship because they had the MobState component as Alive, now with it removed they aren't automatically ghost role, they now need to be manually added the ghost role by the admins.


**Changelog**


:cl:

- fix: You can sell ships with puppets inside of them.
