### PR TITLE
Any languages names

### DIFF
--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -1396,7 +1396,7 @@ namespace Content.Shared.CCVar
         /// Restricts IC character names to alphanumeric chars.
         /// </summary>
         public static readonly CVarDef<bool> RestrictedNames =
-            CVarDef.Create("ic.restricted_names", false, CVar.SERVER | CVar.REPLICATED);
+            CVarDef.Create("ic.restricted_names", true, CVar.SERVER | CVar.REPLICATED);
 
         /// <summary>
         /// Allows flavor text (character descriptions)

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -1396,7 +1396,7 @@ namespace Content.Shared.CCVar
         /// Restricts IC character names to alphanumeric chars.
         /// </summary>
         public static readonly CVarDef<bool> RestrictedNames =
-            CVarDef.Create("ic.restricted_names", true, CVar.SERVER | CVar.REPLICATED);
+            CVarDef.Create("ic.restricted_names", false, CVar.SERVER | CVar.REPLICATED);
 
         /// <summary>
         /// Allows flavor text (character descriptions)

--- a/Content.Shared/Preferences/HumanoidCharacterProfile.cs
+++ b/Content.Shared/Preferences/HumanoidCharacterProfile.cs
@@ -417,7 +417,15 @@ namespace Content.Shared.Preferences
             var configManager = IoCManager.Resolve<IConfigurationManager>();
             if (configManager.GetCVar(CCVars.RestrictedNames))
             {
-                name = Regex.Replace(name, @"[^A-Z,a-z,0-9, -]", string.Empty);
+                name = Regex.Replace(name, @"[^\u0041-\u005A,\u0061-\u007A,\u00C0-\u00D6,\u00D8-\u00F6,\u00F8-\u00FF,\u0100-\u017F, -]", string.Empty);
+                /*
+                 * 0041-005A  Basic Latin: Uppercase Latin Alphabet
+                 * 0061-007A  Basic Latin: Lowercase Latin Alphabet
+                 * 00C0-00D6  Latin-1 Supplement: Letters I
+                 * 00D8-00F6  Latin-1 Supplement: Letters II
+                 * 00F8-00FF  Latin-1 Supplement: Letters III
+                 * 0100-017F  Latin Extended A: European Latin
+                 */
             }
 
             if (configManager.GetCVar(CCVars.ICNameCase))


### PR DESCRIPTION
## About the PR

New frontiers is also popular in non-English speaking countries, so why not make more diversity of languages? For rp situations it is useful when a player plays a Spaniard, Italian, Russian. For forks it will make less problems in translation, they will not need to customize support for names in other languages.

**Media**

![изображение](https://github.com/new-frontiers-14/frontier-station-14/assets/42233446/2abb064b-c219-412e-8083-8818abcbf703)
![изображение](https://github.com/new-frontiers-14/frontier-station-14/assets/42233446/ab8ff861-6d55-47ef-b966-f88f94102ffe)
![изображение](https://github.com/new-frontiers-14/frontier-station-14/assets/42233446/29e23a48-5dd2-42de-9f59-9210570abce3)


- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

:cl:
- tweak: Names on any languages!