### PR TITLE
Better discord notifications

### DIFF
--- a/Content.Server/GameTicking/GameTicker.RoundFlow.cs
+++ b/Content.Server/GameTicking/GameTicker.RoundFlow.cs
@@ -237,6 +237,7 @@ namespace Content.Server.GameTicking
             UpdateLateJoinStatus();
             AnnounceRound();
             UpdateInfoText();
+            RaiseLocalEvent(new RoundStartedEvent(RoundId));
 
 #if EXCEPTION_TOLERANCE
             }
@@ -359,6 +360,7 @@ namespace Content.Server.GameTicking
             RaiseNetworkEvent(new RoundEndMessageEvent(gamemodeTitle, roundEndText, roundDuration, RoundId,
                 listOfPlayerInfoFinal.Length, listOfPlayerInfoFinal, LobbySong,
                 new SoundCollectionSpecifier("RoundEnd").GetSound()));
+            RaiseLocalEvent(new RoundEndedEvent(RoundId, roundDuration));
         }
 
         public void RestartRound()

--- a/Content.Server/Nyanotrasen/GameTicking/RoundEndedEvent.cs
+++ b/Content.Server/Nyanotrasen/GameTicking/RoundEndedEvent.cs
@@ -1,0 +1,13 @@
+﻿namespace Content.Shared.GameTicking;
+
+public sealed class RoundEndedEvent : EntityEventArgs
+{
+    public int RoundId { get; }
+    public TimeSpan RoundDuration { get; }
+
+    public RoundEndedEvent(int roundId, TimeSpan roundDuration)
+    {
+        RoundId = roundId;
+        RoundDuration = roundDuration;
+    }
+}

--- a/Content.Server/Nyanotrasen/RoundNotifications/RoundNotificationsSystem.cs
+++ b/Content.Server/Nyanotrasen/RoundNotifications/RoundNotificationsSystem.cs
@@ -1,0 +1,179 @@
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Content.Shared.CCVar;
+using Content.Server.Maps;
+using Content.Shared.GameTicking;
+using Robust.Shared;
+using Robust.Shared.Configuration;
+
+namespace Content.Server.Nyanotrasen.RoundNotifications;
+
+/// <summary>
+/// Listen game events and send notifications to Discord
+/// </summary>
+public sealed class RoundNotificationsSystem : EntitySystem
+{
+    [Dependency] private readonly IConfigurationManager _config = default!;
+    [Dependency] private readonly IGameMapManager _gameMapManager = default!;
+
+    private ISawmill _sawmill = default!;
+    private readonly HttpClient _httpClient = new();
+
+    private string _webhookUrl = String.Empty;
+    private string _roleId = String.Empty;
+    private bool _roundStartOnly;
+    private string _serverName = string.Empty;
+
+    /// <inheritdoc/>
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<RoundRestartCleanupEvent>(OnRoundRestart);
+        SubscribeLocalEvent<RoundStartedEvent>(OnRoundStarted);
+        SubscribeLocalEvent<RoundEndedEvent>(OnRoundEnded);
+
+        _config.OnValueChanged(CCVars.DiscordRoundWebhook, value => _webhookUrl = value, true);
+        _config.OnValueChanged(CCVars.DiscordRoundRoleId, value => _roleId = value, true);
+        _config.OnValueChanged(CCVars.DiscordRoundStartOnly, value => _roundStartOnly = value, true);
+        _config.OnValueChanged(CVars.GameHostName, OnServerNameChanged, true);
+
+        _sawmill = IoCManager.Resolve<ILogManager>().GetSawmill("notifications");
+    }
+
+    private void OnServerNameChanged(string obj)
+    {
+        _serverName = obj;
+    }
+
+    private void OnRoundRestart(RoundRestartCleanupEvent e)
+    {
+        if (String.IsNullOrEmpty(_webhookUrl))
+            return;
+
+        var text = Loc.GetString("discord-round-new");
+
+        SendDiscordMessage(text, true, 0x91B2C7);
+    }
+
+    private void OnRoundStarted(RoundStartedEvent e)
+    {
+        if (String.IsNullOrEmpty(_webhookUrl))
+            return;
+
+        var map = _gameMapManager.GetSelectedMap();
+        var mapName = map?.MapName ?? Loc.GetString("discord-round-unknown-map");
+        var text = Loc.GetString("discord-round-start",
+            ("id", e.RoundId),
+            ("map", mapName));
+
+        SendDiscordMessage(text, false);
+    }
+
+    private void OnRoundEnded(RoundEndedEvent e)
+    {
+        if (String.IsNullOrEmpty(_webhookUrl) || _roundStartOnly)
+            return;
+
+        var text = Loc.GetString("discord-round-end",
+            ("id", e.RoundId),
+            ("hours", Math.Truncate(e.RoundDuration.TotalHours)),
+            ("minutes", e.RoundDuration.Minutes),
+            ("seconds", e.RoundDuration.Seconds));
+
+        SendDiscordMessage(text, false, 0xB22B27);
+    }
+
+    private async void SendDiscordMessage(string text, bool ping = false, int color = 0x41F097)
+    {
+
+        // Limit server name to 1500 characters, in case someone tries to be a little funny
+        var serverName = _serverName[..Math.Min(_serverName.Length, 1500)];
+        var message = "";
+        if (!String.IsNullOrEmpty(_roleId) && ping)
+            message = $"<@&{_roleId}>";
+
+        // Build the embed
+        var payload = new WebhookPayload
+        {
+            Message = message,
+            Embeds = new List<Embed>
+            {
+                new()
+                {
+                    Title = Loc.GetString("discord-round-title"),
+                    Description = text,
+                    Color = color,
+                    Footer = new EmbedFooter
+                    {
+                        Text = $"{serverName}"
+                    },
+                },
+            },
+        };
+        if (!String.IsNullOrEmpty(_roleId) && ping)
+            payload.AllowedMentions = new Dictionary<string, string[]> {{ "roles", new []{ _roleId } }};
+
+        var request = await _httpClient.PostAsync($"{_webhookUrl}?wait=true",
+            new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json"));
+
+        var content = await request.Content.ReadAsStringAsync();
+        if (!request.IsSuccessStatusCode)
+        {
+            _sawmill.Log(LogLevel.Error,
+                $"Discord returned bad status code when posting message: {request.StatusCode}\nResponse: {content}");
+            return;
+        }
+    }
+
+// https://discord.com/developers/docs/resources/channel#message-object-message-structure
+    private struct WebhookPayload
+    {
+        [JsonPropertyName("username")] public string? Username { get; set; } = null;
+
+        [JsonPropertyName("avatar_url")] public string? AvatarUrl { get; set; } = null;
+
+        [JsonPropertyName("content")] public string Message { get; set; } = "";
+
+        [JsonPropertyName("embeds")] public List<Embed>? Embeds { get; set; } = null;
+
+        [JsonPropertyName("allowed_mentions")]
+        public Dictionary<string, string[]> AllowedMentions { get; set; } =
+            new()
+            {
+                { "parse", Array.Empty<string>() },
+            };
+
+        public WebhookPayload()
+        {
+        }
+    }
+
+// https://discord.com/developers/docs/resources/channel#embed-object-embed-structure
+    private struct Embed
+    {
+        [JsonPropertyName("title")] public string Title { get; set; } = "";
+
+        [JsonPropertyName("description")] public string Description { get; set; } = "";
+
+        [JsonPropertyName("color")] public int Color { get; set; } = 0;
+
+        [JsonPropertyName("footer")] public EmbedFooter? Footer { get; set; } = null;
+
+        public Embed()
+        {
+        }
+    }
+
+// https://discord.com/developers/docs/resources/channel#embed-object-embed-footer-structure
+    private struct EmbedFooter
+    {
+        [JsonPropertyName("text")] public string Text { get; set; } = "";
+
+        [JsonPropertyName("icon_url")] public string? IconUrl { get; set; }
+
+        public EmbedFooter()
+        {
+        }
+    }
+}

--- a/Content.Server/_NF/GameRule/NfAdventureRuleSystem.cs
+++ b/Content.Server/_NF/GameRule/NfAdventureRuleSystem.cs
@@ -214,6 +214,8 @@ public sealed class NfAdventureRuleSystem : GameRuleSystem<AdventureRuleComponen
     {
         Logger.InfoS("discord", message);
         String _webhookUrl = _configurationManager.GetCVar(CCVars.DiscordLeaderboardWebhook);
+        if (_webhookUrl == string.Empty)
+            return;
 
         var payload = new WebhookPayload
         {

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -323,12 +323,6 @@ namespace Content.Shared.CCVar
             CVarDef.Create("discord.ahelp_webhook", string.Empty, CVar.SERVERONLY);
 
         /// <summary>
-        /// URL of the Discord webhook which will relay all round end messages.
-        /// </summary>
-        public static readonly CVarDef<string> DiscordEndRoundWebhook =
-            CVarDef.Create("discord.end_round_webhook", string.Empty, CVar.SERVERONLY);
-
-        /// <summary>
         /// The server icon to use in the Discord ahelp embed footer.
         /// Valid values are specified at https://discord.com/developers/docs/resources/channel#embed-object-embed-footer-structure.
         /// </summary>
@@ -340,6 +334,30 @@ namespace Content.Shared.CCVar
         /// </summary>
         public static readonly CVarDef<string> DiscordAHelpAvatar =
             CVarDef.Create("discord.ahelp_avatar", string.Empty, CVar.SERVERONLY);
+
+        /// <summary>
+        ///     URL of the Discord webhook which will send round status notifications.
+        /// </summary>
+        public static readonly CVarDef<string> DiscordRoundWebhook =
+            CVarDef.Create("discord.round_webhook", string.Empty, CVar.SERVERONLY);
+
+        /// <summary>
+        ///     Discord ID of role which will be pinged on new round start message.
+        /// </summary>
+        public static readonly CVarDef<string> DiscordRoundRoleId =
+            CVarDef.Create("discord.round_roleid", string.Empty, CVar.SERVERONLY);
+
+        /// <summary>
+        ///     Send notifications only about a new round begins.
+        /// </summary>
+        public static readonly CVarDef<bool> DiscordRoundStartOnly =
+            CVarDef.Create("discord.round_start_only", true, CVar.SERVERONLY);
+
+        /// <summary>
+        /// URL of the Discord webhook which will relay all round end messages.
+        /// </summary>
+        public static readonly CVarDef<string> DiscordLeaderboardWebhook =
+            CVarDef.Create("discord.leaderboard_webhook", string.Empty, CVar.SERVERONLY);
 
         /*
          * Suspicion

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -351,7 +351,7 @@ namespace Content.Shared.CCVar
         ///     Send notifications only about a new round begins.
         /// </summary>
         public static readonly CVarDef<bool> DiscordRoundStartOnly =
-            CVarDef.Create("discord.round_start_only", true, CVar.SERVERONLY);
+            CVarDef.Create("discord.round_start_only", false, CVar.SERVERONLY);
 
         /// <summary>
         /// URL of the Discord webhook which will relay all round end messages.

--- a/Content.Shared/GameTicking/RoundRestartedEvent.cs
+++ b/Content.Shared/GameTicking/RoundRestartedEvent.cs
@@ -1,0 +1,15 @@
+﻿using Robust.Shared.Serialization;
+
+namespace Content.Shared.GameTicking
+{
+    [Serializable, NetSerializable]
+    public sealed class RoundStartedEvent : EntityEventArgs
+    {
+        public int RoundId { get; }
+
+        public RoundStartedEvent(int roundId)
+        {
+            RoundId = roundId;
+        }
+    }
+}

--- a/Resources/Locale/en-US/round-notifications/notifications.ftl
+++ b/Resources/Locale/en-US/round-notifications/notifications.ftl
@@ -1,0 +1,4 @@
+﻿discord-round-new = A new round is starting!
+discord-round-start = Round #{ $id } on map "{ $map }" has started.
+discord-round-end = Round #{ $id } has ended. It lasted for {$hours} hours, {$minutes} minutes, and {$seconds} seconds.
+discord-round-title = Round Notification


### PR DESCRIPTION
## About the PR
Notifications about the start of a round have been added, this is useful as the rounds in the frontier are very long, also notifications from the galactic bank have been made in the form of embed messages.

Also if i start talk about discord, here mine - Gados#1923

**Media**
![изображение](https://github.com/new-frontiers-14/frontier-station-14/assets/42233446/4c9fc2a5-072f-4723-92a7-a5da251b68e1)
Better use separeted channels for round notifications and bank leaderboard.
Reminder: NEVER PUT WEBHOOK URL IN GIT REPOSITORY!

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl:
- add: Round notification!
- tweak: Make bank notifications embed!