### PR TITLE
Bounty Vend

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/pinpointer.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pinpointer.yml
@@ -54,3 +54,15 @@
   - type: Pinpointer
     updateTargetName: true
     canRetarget: true
+  - type: Sprite
+    noRot: True
+    sprite: Objects/Devices/pinpointer.rsi
+    layers:
+    - state: pinpointer_crew
+      map: ["enum.PinpointerLayers.Base"]
+    - state: pinonnull
+      map: ["enum.PinpointerLayers.Screen"]
+      shader: unshaded
+      visible: false
+  - type: StaticPrice
+    price: 150

--- a/Resources/Prototypes/_NF/Catalog/Fills/AstroVend.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/AstroVend.yml
@@ -57,3 +57,17 @@
     ClothingShoesChameleonNoSlips: 8
     ClothingBackpackDuffelSyndicateEVABundle: 12
     BoxHoloparasite: 2
+
+- type: vendingMachineInventory
+  id: BountyVendInventory
+  startingInventory:
+    PinpointerUniversal: 15
+    WeaponGrapplingGun: 10
+    HandheldGPSBasic: 5
+    JetpackMiniFilled:  10
+    WeaponDisabler: 10
+    WeaponEmpEmitter: 10
+    Zipties: 20
+    Flash: 15
+    ClothingEyesGlassesSunglasses: 12
+    ClothingHeadHatHoshat: 4

--- a/Resources/Prototypes/_NF/Entities/Structures/machines.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/machines.yml
@@ -262,3 +262,34 @@
     color: "#ad2c2b"
   - type: MarketModifier
     mod: 50
+    
+- type: entity
+  parent: VendingMachine
+  id: VendingMachineBountyVend
+  name: BountyVend
+  description: Essential gear for the space-men on the go
+  components:
+  - type: Anchorable
+    delay: 999999
+  - type: VendingMachine
+    pack: BountyVendInventory
+    offState: off
+    brokenState: broken
+    normalState: normal-unshaded
+    # ejectState: eject-unshaded  No sprite, see chefvend/dinnerware/BODA/etc for expamples
+  - type: Advertise
+    pack: AstroVendAds
+  - type: Sprite
+    sprite: _NF/Structures/bountyvend.rsi
+    layers:
+    - state: "off"
+      map: ["enum.VendingMachineVisualLayers.Base"]
+    - state: "off"
+      map: ["enum.VendingMachineVisualLayers.BaseUnshaded"]
+      shader: unshaded
+    - state: panel
+      map: ["enum.WiresVisualLayers.MaintenancePanel"]
+  - type: PointLight
+    radius: 1.5
+    energy: 1.6
+    color: "#4b93ad"


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
adds the bounty hunter vending machine. Contains some useful, non-lethal tools for both sec and civilian bounty hunters.  Should only be mapped inside Sec and only in certain capital Sec ships (carrier for one).
