### PR TITLE
cargo_catalog_trim

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_engineering.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_engineering.yml
@@ -54,7 +54,7 @@
     sprite: Objects/Tanks/Jetpacks/blue.rsi
     state: icon
   product: CrateEngineeringJetpack
-  cost: 1000
+  cost: 2000
   category: Engineering
   group: market
 
@@ -64,7 +64,7 @@
     sprite: Objects/Tanks/Jetpacks/mini.rsi
     state: icon
   product: CrateEngineeringMiniJetpack
-  cost: 750
+  cost: 1250
   category: Engineering
   group: market
 

--- a/Resources/Prototypes/Catalog/Cargo/cargo_food.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_food.yml
@@ -18,15 +18,15 @@
   # category: Food
   # group: market
 
-- type: cargoProduct
-  id: FoodCook
-  icon:
-    sprite: Objects/Consumable/Food/ingredients.rsi
-    state: flour-big
-  product: CrateFoodCooking
-  cost: 750
-  category: Food
-  group: market
+# - type: cargoProduct
+  # id: FoodCook
+  # icon:
+    # sprite: Objects/Consumable/Food/ingredients.rsi
+    # state: flour-big
+  # product: CrateFoodCooking
+  # cost: 750
+  # category: Food
+  # group: market
 
 - type: cargoProduct
   id: FoodDinnerware
@@ -38,32 +38,32 @@
   category: Food
   group: market
 
-- type: cargoProduct
-  id: FoodBarSupply
-  icon:
-    sprite: Objects/Consumable/Drinks/beerglass.rsi
-    state: icon
-  product: CrateFoodBarSupply
-  cost: 750
-  category: Food
-  group: market
+# - type: cargoProduct
+  # id: FoodBarSupply
+  # icon:
+    # sprite: Objects/Consumable/Drinks/beerglass.rsi
+    # state: icon
+  # product: CrateFoodBarSupply
+  # cost: 750
+  # category: Food
+  # group: market
 
-- type: cargoProduct
-  id: FoodSoftdrinks
-  icon:
-    sprite: Objects/Consumable/Drinks/beerglass.rsi
-    state: icon
-  product: CrateFoodSoftdrinks
-  cost: 1200
-  category: Food
-  group: market
+# - type: cargoProduct
+  # id: FoodSoftdrinks
+  # icon:
+    # sprite: Objects/Consumable/Drinks/beerglass.rsi
+    # state: icon
+  # product: CrateFoodSoftdrinks
+  # cost: 1200
+  # category: Food
+  # group: market
 
-- type: cargoProduct
-  id: FoodSoftdrinksLarge
-  icon:
-    sprite: Objects/Consumable/Drinks/beerglass.rsi
-    state: icon
-  product: CrateFoodSoftdrinksLarge
-  cost: 2400
-  category: Food
-  group: market
+# - type: cargoProduct
+  # id: FoodSoftdrinksLarge
+  # icon:
+    # sprite: Objects/Consumable/Drinks/beerglass.rsi
+    # state: icon
+  # product: CrateFoodSoftdrinksLarge
+  # cost: 2400
+  # category: Food
+  # group: market

--- a/Resources/Prototypes/Catalog/Cargo/cargo_medical.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_medical.yml
@@ -18,15 +18,15 @@
   category: Medical
   group: market
 
-- type: cargoProduct
-  id: EmergencyBurnKit
-  icon:
-    sprite: Objects/Specific/Medical/firstaidkits.rsi
-    state: burnkit
-  product: CrateEmergencyBurnKit
-  cost: 2100
-  category: Medical
-  group: market
+# - type: cargoProduct
+  # id: EmergencyBurnKit
+  # icon:
+    # sprite: Objects/Specific/Medical/firstaidkits.rsi
+    # state: burnkit
+  # product: CrateEmergencyBurnKit
+  # cost: 2100
+  # category: Medical
+  # group: market
 
 - type: cargoProduct
   id: EmergencyToxinKit
@@ -48,25 +48,25 @@
   category: Medical
   group: market
 
-- type: cargoProduct
-  id: EmergencyBruteKit
-  icon:
-    sprite: Objects/Specific/Medical/firstaidkits.rsi
-    state: brutekit
-  product: CrateEmergencyBruteKit
-  cost: 3600
-  category: Medical
-  group: market
+# - type: cargoProduct
+  # id: EmergencyBruteKit
+  # icon:
+    # sprite: Objects/Specific/Medical/firstaidkits.rsi
+    # state: brutekit
+  # product: CrateEmergencyBruteKit
+  # cost: 3600
+  # category: Medical
+  # group: market
 
-- type: cargoProduct
-  id: EmergencyAdvancedKit
-  icon:
-    sprite: Objects/Specific/Medical/firstaidkits.rsi
-    state: advkit
-  product: CrateEmergencyAdvancedKit
-  cost: 3700
-  category: Medical
-  group: market
+# - type: cargoProduct
+  # id: EmergencyAdvancedKit
+  # icon:
+    # sprite: Objects/Specific/Medical/firstaidkits.rsi
+    # state: advkit
+  # product: CrateEmergencyAdvancedKit
+  # cost: 3700
+  # category: Medical
+  # group: market
 
 - type: cargoProduct
   id: EmergencyRadiationKit

--- a/Resources/Prototypes/Catalog/Cargo/cargo_science.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_science.yml
@@ -8,15 +8,15 @@
   category: Science
   group: market
 
-- type: cargoProduct
-  id: RandomArtifact
-  icon:
-    sprite: Objects/Specific/Xenoarchaeology/xeno_artifacts.rsi
-    state: ano13
-  product: RandomArtifactSpawner
-  cost: 2000
-  category: Science
-  group: market
+# - type: cargoProduct
+  # id: RandomArtifact
+  # icon:
+    # sprite: Objects/Specific/Xenoarchaeology/xeno_artifacts.rsi
+    # state: ano13
+  # product: RandomArtifactSpawner
+  # cost: 2000
+  # category: Science
+  # group: market
 
 - type: cargoProduct
   id: ScienceBiosuit

--- a/Resources/Prototypes/GameRules/cargo_gifts.yml
+++ b/Resources/Prototypes/GameRules/cargo_gifts.yml
@@ -1,88 +1,88 @@
-- type: entity
-  id: GiftsPizzaPartySmall
-  parent: BaseGameRule
-  noSpawn: true
-  components:
-  - type: StationEvent
-    weight: 10
-    startDelay: 10
-    duration: 120
-    earliestStart: 20
-  - type: CargoGiftsRule
-    description: cargo-gift-pizza-small
-    sender: cargo-gift-default-sender
-    dest: cargo-gift-dest-bar
-    gifts:
-      FoodPizzaLarge: 1              # 16 pizzas
-      FoodBarSupply: 1
-      FoodSoftdrinks: 1
-      CrateVendingMachineRestockRobustSoftdrinks: 1
+# - type: entity
+  # id: GiftsPizzaPartySmall
+  # parent: BaseGameRule
+  # noSpawn: true
+  # components:
+  # - type: StationEvent
+    # weight: 10
+    # startDelay: 10
+    # duration: 120
+    # earliestStart: 20
+  # - type: CargoGiftsRule
+    # description: cargo-gift-pizza-small
+    # sender: cargo-gift-default-sender
+    # dest: cargo-gift-dest-bar
+    # gifts:
+      # FoodPizzaLarge: 1              # 16 pizzas
+      # FoodBarSupply: 1
+      # FoodSoftdrinks: 1
+      # CrateVendingMachineRestockRobustSoftdrinks: 1
 
-- type: entity
-  id: GiftsPizzaPartyLarge
-  parent: BaseGameRule
-  noSpawn: true
-  components:
-    - type: StationEvent
-      weight: 6
-      startDelay: 10
-      duration: 240
-      minimumPlayers: 50
-      earliestStart: 40
-    - type: CargoGiftsRule
-      description: cargo-gift-pizza-large
-      sender: cargo-gift-default-sender
-      dest: cargo-gift-dest-bar
-      gifts:
-        FoodPizzaLarge: 4              # 64 pizzas
-        FoodBarSupply: 1
-        FoodSoftdrinksLarge: 1
+# - type: entity
+  # id: GiftsPizzaPartyLarge
+  # parent: BaseGameRule
+  # noSpawn: true
+  # components:
+    # - type: StationEvent
+      # weight: 6
+      # startDelay: 10
+      # duration: 240
+      # minimumPlayers: 50
+      # earliestStart: 40
+    # - type: CargoGiftsRule
+      # description: cargo-gift-pizza-large
+      # sender: cargo-gift-default-sender
+      # dest: cargo-gift-dest-bar
+      # gifts:
+        # FoodPizzaLarge: 4              # 64 pizzas
+        # FoodBarSupply: 1
+        # FoodSoftdrinksLarge: 1
 
-- type: entity
-  id: GiftsEngineering
-  parent: BaseGameRule
-  noSpawn: true
-  components:
-    - type: StationEvent
-      weight: 4
-      startDelay: 10
-      duration: 240
-      earliestStart: 30
-      minimumPlayers: 10
-    - type: CargoGiftsRule
-      description: cargo-gift-eng
-      sender: cargo-gift-default-sender
-      dest: cargo-gift-dest-eng
-      gifts:
-        EngineeringCableBulk: 1
-        AirlockKit: 1
-        MaterialSteel: 1
-        MaterialPlasteel: 1
-        MaterialGlass: 1
-        CrateVendingMachineRestockEngineering: 1
+# - type: entity
+  # id: GiftsEngineering
+  # parent: BaseGameRule
+  # noSpawn: true
+  # components:
+    # - type: StationEvent
+      # weight: 4
+      # startDelay: 10
+      # duration: 240
+      # earliestStart: 30
+      # minimumPlayers: 10
+    # - type: CargoGiftsRule
+      # description: cargo-gift-eng
+      # sender: cargo-gift-default-sender
+      # dest: cargo-gift-dest-eng
+      # gifts:
+        # EngineeringCableBulk: 1
+        # AirlockKit: 1
+        # MaterialSteel: 1
+        # MaterialPlasteel: 1
+        # MaterialGlass: 1
+        # CrateVendingMachineRestockEngineering: 1
 
-- type: entity
-  id: GiftsVendingRestock
-  parent: BaseGameRule
-  noSpawn: true
-  components:
-    - type: StationEvent
-      weight: 4
-      startDelay: 10
-      duration: 120
-      minimumPlayers: 40
-      earliestStart: 30
-    - type: CargoGiftsRule
-      description: cargo-gift-vending
-      sender: cargo-gift-default-sender
-      dest: cargo-gift-dest-supp
-      gifts:
-        CrateVendingMachineRestockHotDrinks: 3
-        CrateVendingMachineRestockBooze: 1
-        CrateVendingMachineRestockNutriMax: 1
-        CrateVendingMachineRestockRobustSoftdrinks: 2
-        CrateVendingMachineRestockVendomat: 1
-        CrateVendingMachineRestockGetmoreChocolateCorp: 1
+# - type: entity
+  # id: GiftsVendingRestock
+  # parent: BaseGameRule
+  # noSpawn: true
+  # components:
+    # - type: StationEvent
+      # weight: 4
+      # startDelay: 10
+      # duration: 120
+      # minimumPlayers: 40
+      # earliestStart: 30
+    # - type: CargoGiftsRule
+      # description: cargo-gift-vending
+      # sender: cargo-gift-default-sender
+      # dest: cargo-gift-dest-supp
+      # gifts:
+        # CrateVendingMachineRestockHotDrinks: 3
+        # CrateVendingMachineRestockBooze: 1
+        # CrateVendingMachineRestockNutriMax: 1
+        # CrateVendingMachineRestockRobustSoftdrinks: 2
+        # CrateVendingMachineRestockVendomat: 1
+        # CrateVendingMachineRestockGetmoreChocolateCorp: 1
 
 - type: entity
   id: GiftsJanitor
@@ -168,43 +168,43 @@
         EmergencyBurnKit: 1
         EmergencyBruteKit: 1
 
-- type: entity
-  id: GiftsSecurityGuns
-  parent: BaseGameRule
-  noSpawn: true
-  components:
-    - type: StationEvent
-      weight: 2
-      startDelay: 10
-      duration: 120
-      earliestStart: 20
-      minimumPlayers: 50
-    - type: CargoGiftsRule
-      description: cargo-gift-security-guns
-      sender: cargo-gift-default-sender
-      dest: cargo-gift-dest-sec
-      gifts:
-        CrateSecurityArmor: 3
-        ArmorySmg: 1
-        ArmoryShotgun: 1
-        ArmoryLaser: 1
+# - type: entity
+  # id: GiftsSecurityGuns
+  # parent: BaseGameRule
+  # noSpawn: true
+  # components:
+    # - type: StationEvent
+      # weight: 2
+      # startDelay: 10
+      # duration: 120
+      # earliestStart: 20
+      # minimumPlayers: 50
+    # - type: CargoGiftsRule
+      # description: cargo-gift-security-guns
+      # sender: cargo-gift-default-sender
+      # dest: cargo-gift-dest-sec
+      # gifts:
+        # CrateSecurityArmor: 3
+        # ArmorySmg: 1
+        # ArmoryShotgun: 1
+        # ArmoryLaser: 1
 
-- type: entity
-  id: GiftsSecurityRiot
-  parent: BaseGameRule
-  noSpawn: true
-  components:
-    - type: StationEvent
-      weight: 4
-      startDelay: 10
-      duration: 120
-      earliestStart: 20
-      minimumPlayers: 50
-    - type: CargoGiftsRule
-      description: cargo-gift-security-riot
-      sender: cargo-gift-default-sender
-      dest: cargo-gift-dest-sec
-      gifts:
-        SecurityRiot: 2
-        CrateRestraints: 2
-        CrateSecurityNonlethal: 2
+# - type: entity
+  # id: GiftsSecurityRiot
+  # parent: BaseGameRule
+  # noSpawn: true
+  # components:
+    # - type: StationEvent
+      # weight: 4
+      # startDelay: 10
+      # duration: 120
+      # earliestStart: 20
+      # minimumPlayers: 50
+    # - type: CargoGiftsRule
+      # description: cargo-gift-security-riot
+      # sender: cargo-gift-default-sender
+      # dest: cargo-gift-dest-sec
+      # gifts:
+        # SecurityRiot: 2
+        # CrateRestraints: 2
+        # CrateSecurityNonlethal: 2


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->

trims some stuff that was available in the catalog that dont make sense like some of the food crates that are actually just rewards for rng events, or artifacts. In theory, we are the ones on the frontier selling the artifacts to the stations etc.
