### PR TITLE
salvage crate buff

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Crates/salvage.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/salvage.yml
@@ -88,24 +88,251 @@
         prob: 0.01
         #  - Pins
       - id: ClothingNeckLGBTPin
-        prob: 0.025
-        orGroup: LGBTQIAPlusPins
+        orGroup: DripLoot
       - id: ClothingNeckAromanticPin
-        orGroup: LGBTQIAPlusPins
+        orGroup: DripLoot
       - id: ClothingNeckAsexualPin
-        orGroup: LGBTQIAPlusPins
+        orGroup: DripLoot
       - id: ClothingNeckBisexualPin
-        orGroup: LGBTQIAPlusPins
+        orGroup: DripLoot
       - id: ClothingNeckIntersexPin
-        orGroup: LGBTQIAPlusPins
+        orGroup: DripLoot
       - id: ClothingNeckLesbianPin
-        orGroup: LGBTQIAPlusPins
+        orGroup: DripLoot
       - id: ClothingNeckNonBinaryPin
-        orGroup: LGBTQIAPlusPins
+        orGroup: DripLoot
       - id: ClothingNeckPansexualPin
-        orGroup: LGBTQIAPlusPins
+        orGroup: DripLoot
       - id: ClothingNeckTransPin
-        orGroup: LGBTQIAPlusPins
+        orGroup: DripLoot
+      - id: ClothingBeltStorageWaistbag
+        orGroup: DripLoot
+      - id: ClothingBeltBandolier
+        orGroup: DripLoot
+      - id: ClothingBeltSuspenders
+        orGroup: DripLoot
+      - id: ClothingEyesGlassesGar
+        orGroup: DripLoot
+      - id: ClothingEyesGlassesGarOrange
+        orGroup: DripLoot
+      - id: ClothingEyesGlassesGarGiga
+        orGroup: DripLoot
+      - id: ClothingEyesGlasses
+        orGroup: DripLoot
+      - id: ClothingEyesGlassesSunglasses
+        orGroup: DripLoot
+      - id: ClothingEyesEyepatch
+        orGroup: DripLoot
+      - id: ClothingEyesBlindfold
+        orGroup: DripLoot
+      - id: ClothingHandsGlovesColorPurple
+        orGroup: DripLoot
+      - id: ClothingHandsGlovesColorRed
+        orGroup: DripLoot
+      - id: ClothingHandsGlovesColorBlack
+        orGroup: DripLoot
+      - id: ClothingHandsGlovesColorBlue
+        orGroup: DripLoot
+      - id: ClothingHandsGlovesColorBrown
+        orGroup: DripLoot
+      - id: ClothingHandsGlovesColorGray
+        orGroup: DripLoot
+      - id: ClothingHandsGlovesColorGreen
+        orGroup: DripLoot
+      - id: ClothingHandsGlovesColorLightBrown
+        orGroup: DripLoot
+      - id: ClothingHandsGlovesColorOrange
+        orGroup: DripLoot
+      - id: ClothingHandsGlovesColorWhite
+        orGroup: DripLoot
+      - id: ClothingHandsGlovesColorYellowBudget
+        orGroup: DripLoot
+      - id: ClothingHandsGlovesPowerglove
+        orGroup: DripLoot
+      - id: ClothingHandsGlovesRobohands
+        orGroup: DripLoot
+      - id: ClothingHeadHatAnimalCat
+        orGroup: DripLoot
+      - id: ClothingHeadHatAnimalCatBrown
+        orGroup: DripLoot
+      - id: ClothingHeadHatAnimalCatBlack
+        orGroup: DripLoot
+      - id: ClothingHeadHatAnimalHeadslime
+        orGroup: DripLoot
+      - id: ClothingHeadHatAnimalMonkey
+        orGroup: DripLoot
+      - id: ClothingHeadBandBlack
+        orGroup: DripLoot
+      - id: ClothingHeadBandBlue
+        orGroup: DripLoot
+      - id: ClothingHeadBandGrey
+        orGroup: DripLoot
+      - id: ClothingHeadBandBrown
+        orGroup: DripLoot
+      - id: ClothingHeadHatBeaverHat
+        orGroup: DripLoot
+      - id: ClothingHeadHatBeret
+        orGroup: DripLoot
+      - id: ClothingHeadHatCasa
+        orGroup: DripLoot
+      - id: ClothingHeadHatBowlerHat
+        orGroup: DripLoot
+      - id: ClothingHeadHatCardborg
+        orGroup: DripLoot
+      - id: ClothingHeadHatFedoraBrown
+        orGroup: DripLoot
+      - id: ClothingHeadHatFedoraGrey
+        orGroup: DripLoot
+      - id: ClothingHeadHatFez
+        orGroup: DripLoot
+      - id: lothingHeadHatWitch1
+        orGroup: DripLoot
+      - id: ClothingHeadHatPaper
+        orGroup: DripLoot
+      - id: ClothingHeadHatPirate
+        orGroup: DripLoot
+      - id: ClothingHeadHatTophat
+        orGroup: DripLoot
+      - id: ClothingHeadHatUshanka
+        orGroup: DripLoot
+      - id: ClothingHeadHatWitch
+        orGroup: DripLoot
+      - id: ClothingHeadHatTrucker
+        orGroup: DripLoot
+      - id: ClothingHeadFishCap
+        orGroup: DripLoot
+      - id: ClothingHeadSafari
+        orGroup: DripLoot
+      - id: ClothingHeadHatPirateTricord
+        orGroup: DripLoot
+      - id: ClothingHeadHatHoodGoliathCloak
+        orGroup: DripLoot
+      - id: ClothingHeadHatBluesoft
+        orGroup: DripLoot
+      - id: ClothingHeadHatBluesoftFlipped
+        orGroup: DripLoot
+      - id: ClothingHeadHatCorpsoft
+        orGroup: DripLoot
+      - id: ClothingHeadHatCorpsoftFlipped
+        orGroup: DripLoot
+      - id: ClothingHeadHatGreensoft
+        orGroup: DripLoot
+      - id: ClothingHeadHatGreensoftFlipped
+        orGroup: DripLoot
+      - id: ClothingHeadHatGreysoft
+        orGroup: DripLoot
+      - id: ClothingHeadHatGreysoftFlipped
+        orGroup: DripLoot
+      - id: ClothingHeadHatOrangesoft
+        orGroup: DripLoot
+      - id: ClothingHeadHatOrangesoftFlipped
+        orGroup: DripLoot
+      - id: ClothingHeadHatPurplesoft
+        orGroup: DripLoot
+      - id: ClothingHeadHatPurplesoftFlipped
+        orGroup: DripLoot
+      - id: ClothingMaskRat
+        orGroup: DripLoot
+      - id: ClothingMaskFox
+        orGroup: DripLoot
+      - id: ClothingMaskBee
+        orGroup: DripLoot
+      - id: ClothingMaskBear
+        orGroup: DripLoot
+      - id: ClothingMaskRaven
+        orGroup: DripLoot
+      - id: ClothingMaskJackal
+        orGroup: DripLoot
+      - id: ClothingMaskBat
+        orGroup: DripLoot
+      - id: ClothingNeckCloakHerald
+        orGroup: DripLoot
+      - id: ClothingNeckCloakAdmin
+        orGroup: DripLoot
+        prob: 0.5
+      - id: ClothingNeckCloakTrans
+        orGroup: DripLoot
+      - id: ClothingNeckCloakPirateCap
+        orGroup: DripLoot
+        prob: 0.25
+      - id: ClothingNeckHeadphones
+        orGroup: DripLoot
+      - id: ClothingNeckBling
+        orGroup: DripLoot
+      - id: ClothingNeckTieRed
+        orGroup: DripLoot
+      - id: ClothingNeckTieSci
+        orGroup: DripLoot
+      - id: ClothingOuterCoatBomber
+        orGroup: DripLoot
+      - id: ClothingOuterCoatGentle
+        orGroup: DripLoot
+      - id: ClothingOuterCoatJensen
+        orGroup: DripLoot
+      - id: ClothingOuterCoatPirate
+        orGroup: DripLoot
+      - id: ClothingOuterDameDane
+        orGroup: DripLoot
+      - id: ClothingOuterDogi
+        orGroup: DripLoot
+      - id: ClothingOuterHoodieBlack
+        orGroup: DripLoot
+      - id: ClothingOuterHoodieGrey
+        orGroup: DripLoot
+      - id: ClothingOuterCardborg
+        orGroup: DripLoot
+      - id: ClothingOuterGhostSheet
+        orGroup: DripLoot
+      - id: ClothingShoesBootsWork
+        orGroup: DripLoot
+      - id: ClothingShoesBootsLaceup
+        orGroup: DripLoot
+      - id: ClothingShoesColorBlack
+        orGroup: DripLoot
+      - id: ClothingShoesColorBlue
+        orGroup: DripLoot
+      - id: ClothingShoesColorBrown
+        orGroup: DripLoot
+      - id: ClothingShoesColorGreen
+        orGroup: DripLoot
+      - id: ClothingShoesColorOrange
+        orGroup: DripLoot
+      - id: ClothingShoesColorPurple
+        orGroup: DripLoot
+      - id: ClothingShoesColorRed
+        orGroup: DripLoot
+      - id: ClothingShoesColorWhite
+        orGroup: DripLoot
+      - id: ClothingShoesColorYellow
+        orGroup: DripLoot
+      - id: ClothingShoesFlippers
+        orGroup: DripLoot
+      - id: ClothingShoesLeather
+        orGroup: DripLoot
+      - id: ClothingShoesSlippers
+        orGroup: DripLoot
+      - id: ClothingShoeSlippersDuck
+        orGroup: DripLoot
+      - id: ClothingShoesTourist
+        orGroup: DripLoot
+      - id: ClothingShoesDameDane
+        orGroup: DripLoot
+      - id: ClothingUnderSocksBee
+        orGroup: DripLoot
+      - id: ClothingUnderSocksCoder
+        orGroup: DripLoot
+      - id: ClothingUniformJumpsuitKimono
+        orGroup: DripLoot
+      - id: ClothingUniformOveralls
+        orGroup: DripLoot
+      - id: ClothingUniformJumpsuitSafari
+        orGroup: DripLoot
+      - id: ClothingUniformJumpsuitDameDane
+        orGroup: DripLoot
+      - id: ClothingUniformJumpsuitPirate
+        orGroup: DripLoot
+      - id: ClothingUniformJumpsuitCossack
+        orGroup: DripLoot
         # TRAITOR EQUIPMENT (0.01%)
       - id: Telecrystal10
         prob: 0.0001

--- a/Resources/Prototypes/Catalog/Fills/Crates/salvage.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/salvage.yml
@@ -81,12 +81,12 @@
         prob: 0.001
         #  - Skub
       - id: Skub
-        prob: 0.001
-      - id: ResearchDisk10000
-        prob: 0.001
-      - id: ClothingHeadHatCatEars
         prob: 0.01
-        #  - Pins
+      - id: ResearchDisk10000
+        prob: 0.005
+      - id: ClothingHeadHatCatEars
+        prob: 0.001
+        #  - Drip
       - id: ClothingNeckLGBTPin
         orGroup: DripLoot
       - id: ClothingNeckAromanticPin
@@ -185,7 +185,7 @@
         orGroup: DripLoot
       - id: ClothingHeadHatFez
         orGroup: DripLoot
-      - id: lothingHeadHatWitch1
+      - id: ClothingHeadHatWitch1
         orGroup: DripLoot
       - id: ClothingHeadHatPaper
         orGroup: DripLoot

--- a/Resources/Prototypes/Entities/World/Debris/wrecks.yml
+++ b/Resources/Prototypes/Entities/World/Debris/wrecks.yml
@@ -18,29 +18,39 @@
     - type: SimpleFloorPlanPopulator
       entries:
         Plating:
-          - prob: 3 # Intentional blank.
+          - prob: 3.5 # Intentional blank.
           - id: SalvageMaterialCrateSpawner
-            prob: .6
+            prob: 0.6
           - id: RandomArtifactSpawner20
-            prob: .4
+            prob: 0.3
           - id: SalvageCanisterSpawner
             prob: 0.3
           - id: SalvageMobSpawner
-            prob: 0.8
+            prob: 0.3
+          - id: SpawnMobBearSalvage
+            prob: 0.02
+          - id: SpawnMobSpiderSalvage
+            prob: 0.02
+          - id: SpawnMobKangarooSalvage
+            prob: 0.02
+          - id: SpawnMobSmallPurpleSnake
+            prob: 0.03
+          - id: SpawnMobPurpleSnake
+            prob: 0.02
           - id: TableFrame
-            prob: 0.1
+            prob: 0.2
           - id: RandomBox
-            prob: 0.1
+            prob: 0.2
           - id: Girder
-            prob: 1.5
+            prob: 1.7
           - id: WallSolid
             prob: 1.5
           - id: Grille
-            prob: 0.5
+            prob: 0.4
         Lattice:
           - prob: 2
           - id: Grille
-            prob: 0.2
+            prob: 0.3
           - id: SalvageMaterialCrateSpawner
             prob: 0.3
           - id: SalvageCanisterSpawner
@@ -70,7 +80,17 @@
           - id: SalvageCanisterSpawner
             prob: 0.2
           - id: SalvageMobSpawner
-            prob: 0.8
+            prob: 0.3
+          - id: SpawnMobBearSalvage
+            prob: 0.02
+          - id: SpawnMobSpiderSalvage
+            prob: 0.02
+          - id: SpawnMobKangarooSalvage
+            prob: 0.02
+          - id: SpawnMobSmallPurpleSnake
+            prob: 0.03
+          - id: SpawnMobPurpleSnake
+            prob: 0.02
     - type: GCAbleObject
       queue: SpaceDebris
     - type: IFF


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
changes the lgbtq+ pins to be a wide range of various drip now. value shouldnt change overall but the variety should, including items probably not obtainable yet etc.  The salvage crate loot list in general, and in fact all procgen/rng loot tables in general could really use a pass for more interesting loot tables.

This adds strictly vanilla items and hasnt added any outside codebase drip yet.  Also pretty generic, mostly maints-loot level drip type stuff with maybe a few fun odds and ends.
