### PR TITLE
tools vends change

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/engivend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/engivend.yml
@@ -1,11 +1,11 @@
 - type: vendingMachineInventory
   id: EngiVendInventory
   startingInventory:
-    ClothingHandsGlovesColorYellow: 8
-    Multitool: 8
+    ClothingHandsGlovesColorYellow: 10
+    Multitool: 10
     ClothingEyesGlassesMeson: 10
     ClothingHeadHatWelding: 6
     InflatableWallStack1: 24
     InflatableDoorStack1: 8
     PowerCellMedium: 15
-    NetworkConfigurator: 15
+#    NetworkConfigurator: 15

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/youtool.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/youtool.yml
@@ -5,17 +5,18 @@
     Crowbar: 15
     Wirecutter: 15
     Wrench: 15
-    Welder: 13
+    Welder: 15
+    NetworkConfigurator: 15
     AppraisalTool: 15
-    ClothingHandsGlovesColorYellowBudget: 30
+    ClothingBeltUtility: 15
+#    ClothingHandsGlovesColorYellowBudget: 30 # Not a single soul buy this.
     CableApcStack: 20
     CableMVStack: 20
     CableHVStack: 20
     FlashlightLantern: 15
     trayScanner: 15
     GasAnalyzer: 15
-    NetworkConfigurator: 13
-    AirlockPainter: 20
+    AirlockPainter: 15
   # Some engineer forgot to take the multitool out the youtool when working on it, happens.
   contrabandInventory:
     Multitool: 5


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Removed the Network Configurator from the EngiVend and added 2 more multi and gloves
Removed the Budget Gloves since not a single soul ever got them, added empty utility belts.
Updated the rest of the items to match the same tool amounts to allow people to "buy" a full kit.

**Media**
![image](https://github.com/new-frontiers-14/frontier-station-14/assets/39403717/6a48c63a-0c7b-49d1-b7fc-af46ca23693f)