### PR TITLE
Update carrier into empress

### DIFF
--- a/Resources/Maps/Shuttles/empress.yml
+++ b/Resources/Maps/Shuttles/empress.yml
@@ -30,7 +30,7 @@ entities:
           tiles: XwAAABcAAAA6AAAAOgAAABcAAABfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABcAAAAXAAAAOgAAADoAAAAXAAAAXwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXAAAAFwAAADoAAAA6AAAAFwAAAF8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFwAAABcAAAA6AAAAOgAAABcAAABfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF8AAAAXAAAAOgAAADoAAAAXAAAAXwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXAAAAFwAAADoAAAA6AAAAFwAAAF8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFwAAABcAAAA6AAAAOgAAABcAAABfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABcAAAAXAAAAFwAAABcAAAAXAAAAXwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXAAAAFwAAABcAAAAXAAAAFwAAAF8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFwAAABcAAAAXAAAAFwAAABcAAABfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABcAAAA6AAAAOgAAADoAAAAXAAAAXwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXAAAAOgAAADoAAAA6AAAAFwAAAF8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFwAAABcAAAA6AAAAOgAAABcAAABfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF8AAAAXAAAAFwAAABcAAAAXAAAAXwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABcAAAAXwAAABcAAAAXAAAAFwAAAF8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXAAAABcAAAAXAAAAFwAAABcAAABfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
         0,-2:
           ind: 0,-2
-          tiles: AAAAAAAAAABeAAAAXwAAAF8AAABfAAAAXwAAAF4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABeAAAAXgAAAF8AAABfAAAAXwAAAF8AAABeAAAAXgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABeAAAAXgAAAF8AAABfAAAAXwAAAF8AAABfAAAAXwAAAF4AAABeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXwAAAF8AAABfAAAAXwAAAF8AAABfAAAAXwAAAF8AAABfAAAAXgAAAF4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF8AAABfAAAAXwAAAF8AAABfAAAAXwAAAF8AAAA5AAAAJgAAACYAAABeAAAAXgAAAAAAAAAAAAAAAAAAAAAAAABfAAAAXwAAAF8AAABfAAAAXwAAAF8AAABfAAAAOQAAACYAAAAmAAAAXwAAAF8AAABeAAAAAAAAAAAAAAAAAAAAXwAAAF8AAABfAAAAXwAAAF8AAABfAAAAXwAAAFIAAABSAAAAUgAAAFIAAABSAAAAXwAAAF4AAAAAAAAAAAAAAF8AAABfAAAAXwAAAF8AAABfAAAAXwAAAF8AAABSAAAAUgAAAFIAAABSAAAAUgAAAF8AAABeAAAAAAAAAAAAAABfAAAAXwAAAF8AAABfAAAAXwAAAF8AAABfAAAAUgAAAFIAAABSAAAAUgAAAFIAAABfAAAAXgAAAAAAAAAAAAAAXwAAAF8AAABfAAAAXwAAAF8AAABfAAAAXwAAADkAAAAXAAAAFwAAADkAAABSAAAAFwAAAF4AAAAAAAAAAAAAAF8AAAAXAAAAXwAAAF8AAABfAAAAXwAAAF8AAABSAAAAUgAAAFIAAABSAAAAUgAAAF8AAABeAAAAAAAAAAAAAABfAAAAUgAAAFIAAABSAAAAUgAAAFIAAABSAAAAUgAAAFIAAABSAAAAUgAAAFIAAABfAAAAXgAAAAAAAAAAAAAAXwAAAFIAAABSAAAAUgAAAFIAAABSAAAAUgAAAFIAAABSAAAAUgAAAFIAAABSAAAAXwAAAF4AAAAAAAAAAAAAAF8AAABSAAAAUgAAAFIAAABSAAAAUgAAAFIAAABSAAAAUgAAAFIAAABSAAAAUgAAAF8AAABeAAAAAAAAAAAAAABfAAAAXwAAAF8AAABfAAAAFwAAABcAAABfAAAAXwAAAF8AAABfAAAAXwAAAF8AAABeAAAAAAAAAAAAAAAAAAAAFwAAABcAAAAXAAAAFwAAABcAAABfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          tiles: AAAAAAAAAABeAAAAXwAAAF8AAABfAAAAXwAAAF4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABeAAAAXgAAAF8AAABfAAAAXwAAAF8AAABeAAAAXgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABeAAAAXgAAAF8AAABfAAAAXwAAAF8AAABfAAAAXwAAAF4AAABeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXwAAAF8AAABfAAAAXwAAAF8AAABfAAAAXwAAAF8AAABfAAAAXgAAAF4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF8AAABfAAAAXwAAAF8AAABfAAAAXwAAAF8AAAA5AAAAJgAAACYAAABeAAAAXgAAAAAAAAAAAAAAAAAAAAAAAABfAAAAXwAAAF8AAABfAAAAXwAAAF8AAABfAAAAOQAAACYAAAAmAAAAXwAAAF8AAABeAAAAAAAAAAAAAAAAAAAAXwAAAF8AAABfAAAAXwAAAF8AAABfAAAAXwAAAFIAAABSAAAAUgAAAFIAAABSAAAAXwAAAF4AAAAAAAAAAAAAAF8AAABfAAAAXwAAAF8AAABfAAAAXwAAAF8AAABSAAAAUgAAAFIAAABSAAAAUgAAAF8AAABeAAAAAAAAAAAAAABfAAAAXwAAAF8AAABfAAAAXwAAAF8AAABfAAAAUgAAAFIAAABSAAAAUgAAAFIAAABfAAAAXgAAAAAAAAAAAAAAXwAAAF8AAABfAAAAXwAAAF8AAABfAAAAXwAAADkAAAAXAAAAFwAAADkAAABSAAAAFwAAAF4AAAAAAAAAAAAAAF8AAAAXAAAAXwAAAF8AAABfAAAAXwAAAF8AAABSAAAAUgAAAFIAAABSAAAAUgAAAF8AAABeAAAAAAAAAAAAAABfAAAAUgAAAFIAAABSAAAAUgAAAFIAAABSAAAAUgAAAFIAAABSAAAAUgAAAFIAAABfAAAAXgAAAAAAAAAAAAAAXwAAAFIAAABSAAAAUgAAAFIAAABSAAAAUgAAAFIAAABSAAAAUgAAAFIAAABSAAAAXwAAAF4AAAAAAAAAAAAAACYAAABSAAAAUgAAAFIAAABSAAAAUgAAAFIAAABSAAAAUgAAAFIAAABSAAAAUgAAAF8AAABeAAAAAAAAAAAAAABfAAAAXwAAAF8AAABfAAAAFwAAABcAAABfAAAAXwAAAF8AAABfAAAAXwAAAF8AAABeAAAAAAAAAAAAAAAAAAAAFwAAABcAAAAXAAAAFwAAABcAAABfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
         -1,-2:
           ind: -1,-2
           tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXgAAAF8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXgAAAF8AAABfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXgAAAF8AAABfAAAAXwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF4AAABfAAAAXwAAAF8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABeAAAAXwAAAF8AAABfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABeAAAAXgAAAF8AAABfAAAAXwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXgAAAF4AAABfAAAAXwAAAF8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF4AAABfAAAAGgAAABoAAAAaAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABeAAAAXwAAABoAAAAaAAAAGgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXgAAAF8AAAAaAAAAGgAAABoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABfAAAAGgAAABoAAAAaAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXwAAABoAAAAaAAAAGgAAAA==
@@ -39,7 +39,7 @@ entities:
           tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXwAAABoAAAAaAAAAGgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF8AAAAaAAAAGgAAABoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABfAAAAGgAAABoAAAAaAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXwAAABoAAAAaAAAAGgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF8AAABfAAAAXwAAAF8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABfAAAAGgAAABoAAAAaAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXwAAABoAAAAaAAAAGgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF8AAAAaAAAAGgAAABoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABfAAAAXwAAAF8AAABfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXwAAAFwAAABcAAAAXwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF8AAABcAAAAXAAAAF8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABfAAAAXAAAAFwAAABfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXwAAAFwAAABcAAAAFwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF8AAABcAAAAXAAAAFwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABfAAAAXAAAAFwAAABcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXwAAAFwAAABcAAAAXAAAAA==
         -1,0:
           ind: -1,0
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXwAAAFwAAABcAAAAXAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF8AAABcAAAAXAAAAFwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABfAAAAFwAAABcAAAAXAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXwAAABcAAAAXAAAAFwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXgAAAF8AAAAXAAAAFwAAABcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF4AAABfAAAAXAAAAFwAAABcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABeAAAAXgAAABcAAAAXAAAAFwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXgAAAF8AAAAXAAAAFwAAABcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF4AAABeAAAAXwAAABcAAAAXAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXgAAAF8AAAAXAAAAFwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABfAAAAFwAAABcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXgAAAF4AAABfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABeAAAAXgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXwAAABcAAAAXAAAAFwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF8AAAAXAAAAFwAAABcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABfAAAAFwAAABcAAAAXAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXwAAABcAAAAXAAAAFwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXgAAAF8AAAAXAAAAFwAAABcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF4AAABfAAAAXAAAAFwAAABcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABeAAAAXgAAABcAAAAXAAAAFwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXgAAAF8AAAAXAAAAFwAAABcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF4AAABeAAAAXwAAABcAAAAXAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXgAAAF8AAAAXAAAAFwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABfAAAAFwAAABcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXgAAAF4AAABfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABeAAAAXgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
         0,-3:
           ind: 0,-3
           tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXgAAAF4AAABeAAAAXgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
@@ -66,301 +66,307 @@ entities:
             color: '#B02E26FF'
             id: Bot
           decals:
-            64: -1,9
-            65: -1,6
-            108: 1,-19
-            109: 7,-22
-            110: 11,-26
-            111: 7,-26
+            52: -1,9
+            53: -1,6
+            96: 1,-19
+            97: 7,-22
+            98: 11,-26
+            99: 7,-26
         - node:
             color: '#B02E26FF'
             id: BotGreyscale
           decals:
-            62: 0,-4
-            63: 1,-3
+            50: 0,-4
+            51: 1,-3
         - node:
             color: '#B02E26FF'
             id: BotLeft
           decals:
-            66: -2,9
-            67: -2,8
-            68: -3,7
-            69: -3,6
-            70: -2,6
+            54: -2,9
+            55: -2,8
+            56: -3,7
+            57: -3,6
+            58: -2,6
         - node:
             color: '#B02E26FF'
             id: Box
           decals:
-            71: 0,7
+            59: 0,7
         - node:
             color: '#B02E26FF'
             id: BrickTileSteelCornerNe
           decals:
-            27: 4,-9
-            54: 4,-3
-            74: 4,1
+            15: 4,-9
+            42: 4,-3
+            62: 4,1
         - node:
             color: '#B02E26FF'
             id: BrickTileSteelCornerNw
           decals:
-            28: 1,-9
-            75: 2,1
+            16: 1,-9
+            63: 2,1
         - node:
             color: '#B02E26FF'
             id: BrickTileSteelCornerSe
           decals:
-            30: 4,-17
-            58: 4,-7
-            77: 4,-1
+            18: 4,-17
+            46: 4,-7
+            65: 4,-1
         - node:
             color: '#B02E26FF'
             id: BrickTileSteelCornerSw
           decals:
-            29: 1,-17
-            59: 0,-7
-            76: 2,-1
+            17: 1,-17
+            47: 0,-7
+            64: 2,-1
         - node:
             color: '#B02E26FF'
             id: BrickTileSteelLineE
           decals:
-            31: 4,-16
-            32: 4,-15
-            33: 4,-14
-            34: 4,-13
-            35: 4,-12
-            36: 4,-11
-            37: 4,-10
-            55: 4,-6
-            56: 4,-5
-            57: 4,-4
-            80: 4,0
+            19: 4,-16
+            20: 4,-15
+            21: 4,-14
+            22: 4,-13
+            23: 4,-12
+            24: 4,-11
+            25: 4,-10
+            43: 4,-6
+            44: 4,-5
+            45: 4,-4
+            68: 4,0
         - node:
             color: '#B02E26FF'
             id: BrickTileSteelLineN
           decals:
-            38: 2,-9
-            39: 3,-9
-            60: 2,-3
-            61: 3,-3
-            81: 3,1
+            26: 2,-9
+            27: 3,-9
+            48: 2,-3
+            49: 3,-3
+            69: 3,1
         - node:
             color: '#B02E26FF'
             id: BrickTileSteelLineS
           decals:
-            47: 2,-17
-            48: 3,-17
-            49: 3,-7
-            50: 2,-7
-            51: 1,-7
-            79: 3,-1
+            35: 2,-17
+            36: 3,-17
+            37: 3,-7
+            38: 2,-7
+            39: 1,-7
+            67: 3,-1
         - node:
             color: '#B02E26FF'
             id: BrickTileSteelLineW
           decals:
-            40: 1,-10
-            41: 1,-11
-            42: 1,-12
-            43: 1,-13
-            44: 1,-14
-            45: 1,-15
-            46: 1,-16
-            52: 0,-6
-            53: 0,-5
-            78: 2,0
+            28: 1,-10
+            29: 1,-11
+            30: 1,-12
+            31: 1,-13
+            32: 1,-14
+            33: 1,-15
+            34: 1,-16
+            40: 0,-6
+            41: 0,-5
+            66: 2,0
         - node:
             color: '#B02E26FF'
             id: BrickTileWhiteCornerNe
           decals:
-            106: 11,-19
-            113: 11,-24
+            94: 11,-19
+            101: 11,-24
         - node:
             color: '#B02E26FF'
             id: BrickTileWhiteCornerNw
           decals:
-            112: 7,-24
+            100: 7,-24
         - node:
             color: '#B02E26FF'
             id: BrickTileWhiteCornerSe
           decals:
-            105: 11,-22
+            93: 11,-22
         - node:
             color: '#B02E26FF'
             id: BrickTileWhiteCornerSw
           decals:
-            107: 1,-21
+            95: 1,-21
         - node:
             color: '#B02E26FF'
             id: BrickTileWhiteInnerSw
           decals:
-            146: 7,-21
+            134: 7,-21
         - node:
             color: '#B02E26FF'
             id: BrickTileWhiteLineE
           decals:
-            117: 11,-25
-            118: 11,-26
-            128: 11,-21
-            129: 11,-20
+            105: 11,-25
+            106: 11,-26
+            116: 11,-21
+            117: 11,-20
         - node:
             color: '#B02E26FF'
             id: BrickTileWhiteLineN
           decals:
-            114: 8,-24
-            115: 9,-24
-            116: 10,-24
-            130: 1,-19
-            131: 3,-19
-            132: 2,-19
-            133: 4,-19
-            134: 5,-19
-            135: 6,-19
-            136: 7,-19
-            137: 8,-19
-            138: 9,-19
-            139: 10,-19
+            102: 8,-24
+            103: 9,-24
+            104: 10,-24
+            118: 1,-19
+            119: 3,-19
+            120: 2,-19
+            121: 4,-19
+            122: 5,-19
+            123: 6,-19
+            124: 7,-19
+            125: 8,-19
+            126: 9,-19
+            127: 10,-19
         - node:
             color: '#B02E26FF'
             id: BrickTileWhiteLineS
           decals:
-            121: 10,-26
-            122: 11,-26
-            123: 7,-26
-            124: 8,-22
-            125: 7,-22
-            126: 9,-22
-            127: 10,-22
-            140: 2,-21
-            141: 3,-21
-            142: 4,-21
-            143: 5,-21
-            144: 6,-21
+            109: 10,-26
+            110: 11,-26
+            111: 7,-26
+            112: 8,-22
+            113: 7,-22
+            114: 9,-22
+            115: 10,-22
+            128: 2,-21
+            129: 3,-21
+            130: 4,-21
+            131: 5,-21
+            132: 6,-21
         - node:
             color: '#B02E26FF'
             id: BrickTileWhiteLineW
           decals:
-            119: 7,-25
-            120: 7,-26
-            145: 7,-22
-            147: 1,-20
-            148: 1,-19
+            107: 7,-25
+            108: 7,-26
+            133: 7,-22
+            135: 1,-20
+            136: 1,-19
         - node:
             color: '#DE3A3AFF'
             id: Caution
           decals:
             0: 0,10
         - node:
-            color: '#B02E26FF'
+            color: '#B02E2685'
             id: CheckerNESW
           decals:
-            1: -3,2
-            2: -2,3
-            3: -2,2
-            4: -1,2
-            5: 0,2
-            6: 0,3
-            7: -1,3
-            8: -3,3
-            9: -3,4
-            10: -2,4
-            11: -1,4
-            12: 0,4
+            139: -3,4
+            140: -2,4
+            141: -1,4
+            142: 0,4
+            143: -3,3
+            144: -2,3
+            145: -1,3
+            146: 0,3
+            147: -3,2
+            148: -2,2
+            149: -1,2
+            150: 0,2
+            151: -3,1
+            152: -2,1
+            153: -1,1
+            154: -1,0
+            155: -2,0
+            156: -3,0
         - node:
             color: '#B02E26FF'
             id: Delivery
           decals:
-            13: 0,-17
-            14: 0,-11
-            72: 0,11
-            73: -1,10
+            1: 0,-17
+            2: 0,-11
+            60: 0,11
+            61: -1,10
         - node:
             color: '#B02E26FF'
             id: MiniTileSteelBox
           decals:
-            104: 3,0
+            92: 3,0
         - node:
             color: '#B02E26FF'
             id: MiniTileSteelCornerNe
           decals:
-            82: 3,-10
-            102: 3,-4
+            70: 3,-10
+            90: 3,-4
         - node:
             color: '#B02E26FF'
             id: MiniTileSteelCornerNw
           decals:
-            83: 2,-10
-            97: 1,-5
-            98: 2,-4
+            71: 2,-10
+            85: 1,-5
+            86: 2,-4
         - node:
             color: '#B02E26FF'
             id: MiniTileSteelCornerSe
           decals:
-            84: 3,-16
-            99: 3,-6
+            72: 3,-16
+            87: 3,-6
         - node:
             color: '#B02E26FF'
             id: MiniTileSteelCornerSw
           decals:
-            85: 2,-16
-            96: 1,-6
+            73: 2,-16
+            84: 1,-6
         - node:
             color: '#B02E26FF'
             id: MiniTileSteelInnerNw
           decals:
-            100: 2,-5
+            88: 2,-5
         - node:
             color: '#B02E26FF'
             id: MiniTileSteelLineE
           decals:
-            86: 3,-15
-            87: 3,-14
-            88: 3,-13
-            89: 3,-12
-            90: 3,-11
-            101: 3,-5
+            74: 3,-15
+            75: 3,-14
+            76: 3,-13
+            77: 3,-12
+            78: 3,-11
+            89: 3,-5
         - node:
             color: '#B02E26FF'
             id: MiniTileSteelLineS
           decals:
-            103: 2,-6
+            91: 2,-6
         - node:
             color: '#B02E26FF'
             id: MiniTileSteelLineW
           decals:
-            91: 2,-15
-            92: 2,-14
-            93: 2,-13
-            94: 2,-12
-            95: 2,-11
+            79: 2,-15
+            80: 2,-14
+            81: 2,-13
+            82: 2,-12
+            83: 2,-11
         - node:
             color: '#B02E26FF'
             id: WarnLineGreyscaleE
           decals:
-            15: -1,-15
-            16: -1,-14
-            17: -1,-13
-            18: -1,-9
+            3: -1,-15
+            4: -1,-14
+            5: -1,-13
+            6: -1,-9
         - node:
             color: '#B02E26FF'
             id: WarnLineGreyscaleN
           decals:
-            22: -3,-13
-            23: -2,-13
+            10: -3,-13
+            11: -2,-13
         - node:
             color: '#B02E26FF'
             id: WarnLineGreyscaleS
           decals:
-            24: -3,-11
-            25: -2,-11
-            149: 8,-26
-            150: 9,-26
+            12: -3,-11
+            13: -2,-11
+            137: 8,-26
+            138: 9,-26
         - node:
             color: '#B02E26FF'
             id: WarnLineGreyscaleW
           decals:
-            19: -3,-14
-            20: -3,-17
-            21: -3,-20
-            26: -3,-10
+            7: -3,-14
+            8: -3,-17
+            9: -3,-20
+            14: -3,-10
       type: DecalGrid
     - version: 2
       data:
@@ -374,11 +380,13 @@ entities:
           0,1:
             0: 65535
           0,2:
-            0: 65535
+            0: 65471
+            1: 64
           0,3:
             0: 3839
           1,0:
-            0: 65331
+            0: 65315
+            2: 16
           1,1:
             0: 65535
           1,2:
@@ -390,7 +398,8 @@ entities:
           2,1:
             0: 65535
           2,2:
-            0: 65535
+            0: 65531
+            3: 4
           2,3:
             0: 23
           3,0:
@@ -406,7 +415,7 @@ entities:
           0,-8:
             0: 65516
           0,-7:
-            1: 17
+            4: 17
             0: 65518
           0,-6:
             0: 65535
@@ -440,11 +449,12 @@ entities:
             0: 65535
           -1,-7:
             0: 48108
-            2: 17408
+            5: 17408
           -1,-8:
             0: 32768
           -1,-4:
-            0: 65535
+            0: 65533
+            2: 2
           -1,-3:
             0: 65535
           -1,-2:
@@ -470,7 +480,8 @@ entities:
           1,-2:
             0: 13107
           1,-1:
-            0: 13107
+            0: 9011
+            1: 4096
           0,-9:
             0: 32768
           1,-9:
@@ -487,6 +498,51 @@ entities:
           moles:
           - 21.824879
           - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 21.813705
+          - 82.06108
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 21.6852
+          - 81.57766
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 21.785265
+          - 81.954094
           - 0
           - 0
           - 0
@@ -621,11 +677,6 @@ entities:
     - pos: 2.5,-7.5
       parent: 1
       type: Transform
-  - uid: 824
-    components:
-    - pos: 1.5,0.5
-      parent: 1
-      type: Transform
   - uid: 825
     components:
     - pos: 3.5,-1.5
@@ -634,6 +685,11 @@ entities:
   - uid: 826
     components:
     - pos: 3.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 1369
+    components:
+    - pos: 1.5,-0.5
       parent: 1
       type: Transform
 - proto: AmeController
@@ -955,21 +1011,29 @@ entities:
   - uid: 1130
     components:
     - rot: 1.5707963267948966 rad
-      pos: -2.5,-1.5
+      pos: -2.5,-2.5
       parent: 1
       type: Transform
     - bodyType: Static
       type: Physics
 - proto: BenchSofaCorpRight
   entities:
-  - uid: 652
+  - uid: 535
     components:
     - rot: 1.5707963267948966 rad
-      pos: -2.5,-2.5
+      pos: -2.5,-3.5
       parent: 1
       type: Transform
     - bodyType: Static
       type: Physics
+- proto: BlockGameArcade
+  entities:
+  - uid: 1350
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -2.5,-16.5
+      parent: 1
+      type: Transform
 - proto: BookshelfFilled
   entities:
   - uid: 899
@@ -977,6 +1041,35 @@ entities:
     - pos: -0.5,-8.5
       parent: 1
       type: Transform
+- proto: BoxBeaker
+  entities:
+  - uid: 1182
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 791
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: BoxBodyBag
+  entities:
+  - uid: 1373
+    components:
+    - pos: 7.522447,-25.48572
+      parent: 1
+      type: Transform
+- proto: BoxDonkSoftBox
+  entities:
+  - uid: 1183
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 658
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
 - proto: BoxLethalshot
   entities:
   - uid: 1194
@@ -1049,6 +1142,15 @@ entities:
       type: DeviceLinkSource
 - proto: Bucket
   entities:
+  - uid: 726
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 725
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
   - uid: 881
     components:
     - flags: InContainer
@@ -2106,6 +2208,11 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
+  - uid: 1366
+    components:
+    - pos: -0.5,7.5
+      parent: 1
+      type: Transform
 - proto: CableApcStack
   entities:
   - uid: 479
@@ -2855,6 +2962,16 @@ entities:
     - pos: 10.5,8.5
       parent: 1
       type: Transform
+  - uid: 1364
+    components:
+    - pos: 9.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 1365
+    components:
+    - pos: 9.5,8.5
+      parent: 1
+      type: Transform
 - proto: CartridgeRocket
   entities:
   - uid: 1154
@@ -2898,6 +3015,53 @@ entities:
     - flags: InContainer
       type: MetaData
     - parent: 1147
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: CartridgeRocketEmp
+  entities:
+  - uid: 1339
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 1201
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 1340
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 1201
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 1341
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 1201
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 1342
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 1201
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 1344
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 1201
       type: Transform
     - canCollide: False
       type: Physics
@@ -3108,18 +3272,24 @@ entities:
       type: Transform
 - proto: ChairPilotSeat
   entities:
-  - uid: 717
+  - uid: 636
     components:
     - rot: 3.141592653589793 rad
-      pos: 4.5,11.5
+      pos: 3.5,11.5
+      parent: 1
+      type: Transform
+  - uid: 1320
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 5.5,11.5
       parent: 1
       type: Transform
 - proto: ChairWood
   entities:
-  - uid: 510
+  - uid: 717
     components:
     - rot: 1.5707963267948966 rad
-      pos: 5.5,9.5
+      pos: 5.5,8.5
       parent: 1
       type: Transform
 - proto: chem_master
@@ -3154,7 +3324,7 @@ entities:
   entities:
   - uid: 867
     components:
-    - pos: 10.537712,-23.356623
+    - pos: 7.4796104,-25.49443
       parent: 1
       type: Transform
 - proto: ClothingBeltSheathFilled
@@ -3205,6 +3375,17 @@ entities:
     - flags: InContainer
       type: MetaData
     - parent: 619
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: ClothingHeadHatPirate
+  entities:
+  - uid: 1264
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 658
       type: Transform
     - canCollide: False
       type: Physics
@@ -3290,6 +3471,51 @@ entities:
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
+- proto: ClothingNeckCloakHos
+  entities:
+  - uid: 877
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 715
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: ClothingNeckCloakPirateCap
+  entities:
+  - uid: 1292
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 658
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: ClothingNeckMantleCMO
+  entities:
+  - uid: 741
+    components:
+    - flags: InContainer
+      name: brigmedic mantle
+      type: MetaData
+    - parent: 158
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: ClothingNeckMantleHOS
+  entities:
+  - uid: 879
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 715
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
 - proto: ClothingOuterArmorCaptainCarapace
   entities:
   - uid: 631
@@ -3313,6 +3539,17 @@ entities:
     - pos: -1.353327,9.403219
       parent: 1
       type: Transform
+- proto: ClothingOuterCoatPirate
+  entities:
+  - uid: 1212
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 658
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
 - proto: ClothingOuterHardsuitBrigmedic
   entities:
   - uid: 307
@@ -3321,6 +3558,36 @@ entities:
       type: MetaData
     - parent: 158
       type: Transform
+    - group:
+      - hoverMessage: ""
+        contextText: verb-examine-group-other
+        icon: /Textures/Interface/examine-star.png
+        components:
+        - Armor
+        - ClothingSpeedModifier
+        entries:
+        - message: >-
+            It provides the following protection:
+
+            - [color=yellow]Blunt[/color] damage reduced by [color=lightblue]20%[/color].
+
+            - [color=yellow]Slash[/color] damage reduced by [color=lightblue]20%[/color].
+
+            - [color=yellow]Piercing[/color] damage reduced by [color=lightblue]25%[/color].
+
+            - [color=yellow]Heat[/color] damage reduced by [color=lightblue]10%[/color].
+
+            - [color=yellow]Caustic[/color] damage reduced by [color=lightblue]80%[/color].
+          priority: 0
+          component: Armor
+        - message: >-
+            This decreases your running speed by [color=yellow]15%[/color].
+
+            This decreases your walking speed by [color=yellow]10%[/color].
+          priority: 0
+          component: ClothingSpeedModifier
+        title: null
+      type: GroupExamine
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
@@ -3558,10 +3825,9 @@ entities:
     - type: InsideEntityStorage
 - proto: ComputerCrewMonitoring
   entities:
-  - uid: 876
+  - uid: 516
     components:
-    - rot: 1.5707963267948966 rad
-      pos: 2.5,10.5
+    - pos: 5.5,12.5
       parent: 1
       type: Transform
   - uid: 1263
@@ -3569,11 +3835,20 @@ entities:
     - pos: 5.5,-18.5
       parent: 1
       type: Transform
+- proto: ComputerId
+  entities:
+  - uid: 1351
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 6.5,10.5
+      parent: 1
+      type: Transform
 - proto: ComputerIFF
   entities:
-  - uid: 863
+  - uid: 426
     components:
-    - pos: 5.5,12.5
+    - rot: 1.5707963267948966 rad
+      pos: 2.5,11.5
       parent: 1
       type: Transform
 - proto: ComputerRadar
@@ -3600,35 +3875,27 @@ entities:
       type: Transform
 - proto: ComputerShuttleSyndie
   entities:
-  - uid: 426
+  - uid: 512
     components:
-    - desc: Used to pilot the security carrier.
+    - desc: Used to pilot the security flagship vessel carrier.
       name: security shuttle console
       type: MetaData
-    - pos: 4.5,12.5
+    - pos: 3.5,12.5
       parent: 1
       type: Transform
 - proto: ComputerStationRecords
   entities:
-  - uid: 348
+  - uid: 517
     components:
     - rot: 1.5707963267948966 rad
-      pos: 2.5,11.5
+      pos: 2.5,10.5
       parent: 1
       type: Transform
 - proto: ComputerSurveillanceCameraMonitor
   entities:
-  - uid: 217
+  - uid: 348
     components:
-    - pos: 3.5,12.5
-      parent: 1
-      type: Transform
-- proto: ComputerTelevision
-  entities:
-  - uid: 533
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -0.5,-2.5
+    - pos: 4.5,12.5
       parent: 1
       type: Transform
 - proto: CrateChemistrySupplies
@@ -3638,6 +3905,35 @@ entities:
     - pos: 7.5,-24.5
       parent: 1
       type: Transform
+    - air:
+        volume: 200
+        immutable: False
+        temperature: 293.1496
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+      type: EntityStorage
+    - containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 1182
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+      type: ContainerContainer
 - proto: CrateEngineeringAMEJar
   entities:
   - uid: 96
@@ -3680,7 +3976,7 @@ entities:
       type: ContainerContainer
 - proto: CrateFoodCooking
   entities:
-  - uid: 739
+  - uid: 725
     components:
     - pos: -2.5,3.5
       parent: 1
@@ -3708,13 +4004,22 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 740
-          - 741
+          - 738
+          - 729
+          - 726
+          - 739
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
           ent: null
       type: ContainerContainer
+- proto: CrateFoodDinnerware
+  entities:
+  - uid: 1363
+    components:
+    - pos: -2.5,1.5
+      parent: 1
+      type: Transform
 - proto: CrateFunBoardGames
   entities:
   - uid: 655
@@ -3734,8 +4039,8 @@ entities:
         immutable: False
         temperature: 293.1496
         moles:
-        - 1.7459903
-        - 6.568249
+        - 1.8856695
+        - 7.0937095
         - 0
         - 0
         - 0
@@ -3752,8 +4057,14 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 661
+          - 1184
+          - 1183
           - 662
+          - 1211
+          - 1212
+          - 1264
+          - 1292
+          - 661
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -3804,13 +4115,6 @@ entities:
     - pos: 7.5,-18.5
       parent: 1
       type: Transform
-- proto: CrateSecuritySupplies
-  entities:
-  - uid: 1201
-    components:
-    - pos: 0.5,7.5
-      parent: 1
-      type: Transform
     - air:
         volume: 200
         immutable: False
@@ -3829,20 +4133,20 @@ entities:
         - 0
         - 0
       type: EntityStorage
-- proto: CrateWeaponSecure
+- proto: CrateSecuritySupplies
   entities:
-  - uid: 1147
+  - uid: 1201
     components:
-    - pos: 0.5,11.5
+    - pos: 0.5,7.5
       parent: 1
       type: Transform
     - air:
         volume: 200
         immutable: False
-        temperature: 293.14948
+        temperature: 293.1496
         moles:
-        - 1.606311
-        - 6.042789
+        - 1.8856695
+        - 7.0937095
         - 0
         - 0
         - 0
@@ -3859,24 +4163,65 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 1159
-          - 1158
-          - 1157
-          - 1156
-          - 1155
-          - 1154
-          - 1148
-          - 1149
-          - 1150
-          - 1151
-          - 1152
-          - 1153
-          - 1160
-          - 1161
-          - 1162
-          - 1163
-          - 1164
+          - 1339
+          - 1340
+          - 1341
+          - 1342
           - 1165
+          - 1343
+          - 1344
+          - 1162
+          - 1160
+          - 1153
+          - 1161
+          - 1163
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+      type: ContainerContainer
+- proto: CrateWeaponSecure
+  entities:
+  - uid: 1147
+    components:
+    - pos: 0.5,11.5
+      parent: 1
+      type: Transform
+    - air:
+        volume: 200
+        immutable: False
+        temperature: 293.14948
+        moles:
+        - 1.8744951
+        - 7.051672
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+      type: EntityStorage
+    - containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 1156
+          - 1157
+          - 1158
+          - 1159
+          - 1152
+          - 1151
+          - 1150
+          - 1149
+          - 1148
+          - 1164
+          - 1154
+          - 1155
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -3902,13 +4247,6 @@ entities:
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-- proto: CrewMonitoringServer
-  entities:
-  - uid: 636
-    components:
-    - pos: 7.5,-25.5
-      parent: 1
-      type: Transform
 - proto: CryoPod
   entities:
   - uid: 750
@@ -3966,13 +4304,6 @@ entities:
     - pos: 9.5,5.5
       parent: 1
       type: Transform
-- proto: DonkpocketBoxSpawner
-  entities:
-  - uid: 1189
-    components:
-    - pos: -0.5,3.5
-      parent: 1
-      type: Transform
 - proto: DresserFilled
   entities:
   - uid: 1202
@@ -4008,7 +4339,7 @@ entities:
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 1147
+    - parent: 1201
       type: Transform
     - canCollide: False
       type: Physics
@@ -4017,7 +4348,7 @@ entities:
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 1147
+    - parent: 1201
       type: Transform
     - canCollide: False
       type: Physics
@@ -4026,7 +4357,7 @@ entities:
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 1147
+    - parent: 1201
       type: Transform
     - canCollide: False
       type: Physics
@@ -4035,7 +4366,7 @@ entities:
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 1147
+    - parent: 1201
       type: Transform
     - canCollide: False
       type: Physics
@@ -4044,7 +4375,7 @@ entities:
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 1147
+    - parent: 1201
       type: Transform
     - canCollide: False
       type: Physics
@@ -4053,7 +4384,7 @@ entities:
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 1147
+    - parent: 1201
       type: Transform
     - canCollide: False
       type: Physics
@@ -4116,9 +4447,16 @@ entities:
     - type: InsideEntityStorage
 - proto: FaxMachineBase
   entities:
-  - uid: 537
+  - uid: 1345
     components:
-    - pos: 6.5,10.5
+    - pos: 6.5,9.5
+      parent: 1
+      type: Transform
+- proto: FigureSpawner
+  entities:
+  - uid: 1353
+    components:
+    - pos: 4.5,11.5
       parent: 1
       type: Transform
 - proto: Firelock
@@ -4165,7 +4503,8 @@ entities:
       type: Transform
   - uid: 550
     components:
-    - pos: 1.5,0.5
+    - rot: -1.5707963267948966 rad
+      pos: 1.5,-0.5
       parent: 1
       type: Transform
   - uid: 551
@@ -4206,6 +4545,28 @@ entities:
       type: Transform
     - fixtures: {}
       type: Fixtures
+- proto: FoamCrossbow
+  entities:
+  - uid: 1211
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 658
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: FoamCutlass
+  entities:
+  - uid: 1184
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 658
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
 - proto: GasFilter
   entities:
   - uid: 756
@@ -5874,6 +6235,12 @@ entities:
       pos: 5.5,-4.5
       parent: 1
       type: Transform
+  - uid: 79
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 1.5,0.5
+      parent: 1
+      type: Transform
   - uid: 94
     components:
     - rot: 1.5707963267948966 rad
@@ -5932,11 +6299,6 @@ entities:
     components:
     - rot: 3.141592653589793 rad
       pos: -2.5,10.5
-      parent: 1
-      type: Transform
-  - uid: 177
-    components:
-    - pos: 1.5,-0.5
       parent: 1
       type: Transform
   - uid: 181
@@ -6197,8 +6559,8 @@ entities:
         immutable: False
         temperature: 293.14935
         moles:
-        - 1.4778061
-        - 5.559366
+        - 1.8642148
+        - 7.0129986
         - 0
         - 0
         - 0
@@ -6215,10 +6577,18 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 1191
-          - 1192
-          - 1193
+          - 150
+          - 354
+          - 298
+          - 504
+          - 510
+          - 513
+          - 537
+          - 676
           - 1194
+          - 1193
+          - 1192
+          - 1191
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -6309,7 +6679,7 @@ entities:
     - pos: 2.5,4.5
       parent: 1
       type: Transform
-    - SecondsUntilStateChange: -6060.2
+    - SecondsUntilStateChange: -19017.852
       state: Closing
       type: Door
   - uid: 582
@@ -6354,6 +6724,12 @@ entities:
       pos: 5.5,-20.5
       parent: 1
       type: Transform
+  - uid: 1370
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 0.5,-18.5
+      parent: 1
+      type: Transform
 - proto: HydroponicsToolClippers
   entities:
   - uid: 671
@@ -6361,6 +6737,15 @@ entities:
     - flags: InContainer
       type: MetaData
     - parent: 669
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 729
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 725
       type: Transform
     - canCollide: False
       type: Physics
@@ -6376,6 +6761,15 @@ entities:
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
+  - uid: 738
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 725
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
 - proto: HydroponicsToolSpade
   entities:
   - uid: 672
@@ -6387,8 +6781,23 @@ entities:
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
+  - uid: 739
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 725
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
 - proto: hydroponicsTray
   entities:
+  - uid: 533
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -2.5,4.5
+      parent: 1
+      type: Transform
   - uid: 663
     components:
     - pos: -2.5,-20.5
@@ -6402,6 +6811,12 @@ entities:
   - uid: 665
     components:
     - pos: -0.5,-20.5
+      parent: 1
+      type: Transform
+  - uid: 721
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -1.5,4.5
       parent: 1
       type: Transform
 - proto: InflatableWallStack
@@ -6471,31 +6886,11 @@ entities:
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-- proto: KitchenKnife
-  entities:
-  - uid: 740
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 739
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
-  - uid: 741
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 739
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
 - proto: KitchenMicrowave
   entities:
-  - uid: 726
+  - uid: 1346
     components:
-    - pos: -0.5,4.5
+    - pos: -0.5,3.5
       parent: 1
       type: Transform
 - proto: KitchenReagentGrinder
@@ -6505,18 +6900,16 @@ entities:
     - pos: 11.5,-23.5
       parent: 1
       type: Transform
+  - uid: 813
+    components:
+    - pos: -0.5,4.5
+      parent: 1
+      type: Transform
 - proto: LampGold
   entities:
   - uid: 902
     components:
     - pos: -2.5069895,-8.18633
-      parent: 1
-      type: Transform
-- proto: LockerBoozeFilled
-  entities:
-  - uid: 729
-    components:
-    - pos: 0.5,3.5
       parent: 1
       type: Transform
 - proto: LockerBrigmedicFilled
@@ -6538,8 +6931,8 @@ entities:
         immutable: False
         temperature: 293.14935
         moles:
-        - 1.3595816
-        - 5.1146173
+        - 1.8943708
+        - 7.126443
         - 0
         - 0
         - 0
@@ -6807,6 +7200,26 @@ entities:
           occludes: True
           ent: null
       type: ContainerContainer
+- proto: MagazineBoxMagnum
+  entities:
+  - uid: 298
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 1190
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 510
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 1190
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
 - proto: MedicalBed
   entities:
   - uid: 807
@@ -6987,14 +7400,15 @@ entities:
     - type: InsideEntityStorage
 - proto: PaperBin10
   entities:
-  - uid: 513
-    components:
-    - pos: 6.5,9.5
-      parent: 1
-      type: Transform
   - uid: 832
     components:
     - pos: 0.5,-6.5
+      parent: 1
+      type: Transform
+  - uid: 1347
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 6.5,8.5
       parent: 1
       type: Transform
 - proto: Pen
@@ -7079,6 +7493,11 @@ entities:
   - uid: 814
     components:
     - pos: 1.5,-12.5
+      parent: 1
+      type: Transform
+  - uid: 1368
+    components:
+    - pos: 0.5,-1.5
       parent: 1
       type: Transform
 - proto: PowerCellRecharger
@@ -7229,14 +7648,6 @@ entities:
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 1264
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 1.5,-19.5
-      parent: 1
-      type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 1265
     components:
     - pos: 9.5,-23.5
@@ -7247,6 +7658,22 @@ entities:
   - uid: 1266
     components:
     - pos: 5.5,-18.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+  - uid: 1372
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 1.5,-20.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+  - uid: 1376
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -0.5,6.5
       parent: 1
       type: Transform
     - enabled: False
@@ -7317,6 +7744,12 @@ entities:
   - uid: 1188
     components:
     - pos: -1.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 1330
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 7.5,-25.5
       parent: 1
       type: Transform
 - proto: RandomInstruments
@@ -7419,11 +7852,6 @@ entities:
       pos: 10.5,-17.5
       parent: 1
       type: Transform
-  - uid: 79
-    components:
-    - pos: 1.5,-0.5
-      parent: 1
-      type: Transform
   - uid: 138
     components:
     - rot: 1.5707963267948966 rad
@@ -7476,12 +7904,6 @@ entities:
     components:
     - rot: 3.141592653589793 rad
       pos: 12.5,-19.5
-      parent: 1
-      type: Transform
-  - uid: 197
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -3.5,3.5
       parent: 1
       type: Transform
   - uid: 209
@@ -7690,31 +8112,43 @@ entities:
       pos: 11.5,-17.5
       parent: 1
       type: Transform
+  - uid: 615
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 1.5,0.5
+      parent: 1
+      type: Transform
   - uid: 728
     components:
     - rot: 1.5707963267948966 rad
       pos: -3.5,-2.5
       parent: 1
       type: Transform
+  - uid: 917
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -3.5,3.5
+      parent: 1
+      type: Transform
 - proto: RubberStampApproved
   entities:
   - uid: 506
     components:
-    - pos: 6.7719097,9.995299
+    - pos: 6.835225,8.438411
       parent: 1
       type: Transform
 - proto: RubberStampDenied
   entities:
   - uid: 496
     components:
-    - pos: 6.542743,10.005716
+    - pos: 6.835225,8.657161
       parent: 1
       type: Transform
 - proto: RubberStampHos
   entities:
   - uid: 499
     components:
-    - pos: 6.3031597,9.995299
+    - pos: 6.210225,8.532161
       parent: 1
       type: Transform
 - proto: SecBreachingHammer
@@ -7802,9 +8236,9 @@ entities:
       type: Transform
 - proto: soda_dispenser
   entities:
-  - uid: 725
+  - uid: 652
     components:
-    - pos: -1.5,4.5
+    - pos: 0.5,3.5
       parent: 1
       type: Transform
 - proto: SpaceCash
@@ -7829,6 +8263,18 @@ entities:
     - pos: 8.793568,3.9148858
       parent: 1
       type: Transform
+- proto: SpacemenFigureSpawner
+  entities:
+  - uid: 1354
+    components:
+    - pos: 1.5,-6.5
+      parent: 1
+      type: Transform
+  - uid: 1374
+    components:
+    - pos: 10.5,-23.5
+      parent: 1
+      type: Transform
 - proto: SpawnMobShiva
   entities:
   - uid: 616
@@ -7838,7 +8284,7 @@ entities:
       type: Transform
 - proto: SpawnPointLatejoin
   entities:
-  - uid: 615
+  - uid: 1349
     components:
     - pos: -1.5,-1.5
       parent: 1
@@ -7874,8 +8320,55 @@ entities:
     - pos: 2.5,-4.5
       parent: 1
       type: Transform
+- proto: SpeedLoaderMagnum
+  entities:
+  - uid: 150
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 1190
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 354
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 1190
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 504
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 1190
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 537
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 1190
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
 - proto: SpeedLoaderMagnumHighVelocity
   entities:
+  - uid: 513
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 1190
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
   - uid: 606
     components:
     - flags: InContainer
@@ -7890,6 +8383,15 @@ entities:
     - flags: InContainer
       type: MetaData
     - parent: 605
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 676
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 1190
       type: Transform
     - canCollide: False
       type: Physics
@@ -7954,11 +8456,6 @@ entities:
       pos: -1.5,-17.5
       parent: 1
       type: Transform
-  - uid: 676
-    components:
-    - pos: -2.5,-16.5
-      parent: 1
-      type: Transform
   - uid: 901
     components:
     - rot: 3.141592653589793 rad
@@ -7967,22 +8464,28 @@ entities:
       type: Transform
 - proto: StoolBar
   entities:
-  - uid: 512
+  - uid: 518
     components:
     - rot: 3.141592653589793 rad
-      pos: -1.5,0.5
+      pos: -2.5,-0.5
       parent: 1
       type: Transform
-  - uid: 516
+  - uid: 723
     components:
     - rot: 3.141592653589793 rad
-      pos: -2.5,0.5
+      pos: -0.5,-0.5
       parent: 1
       type: Transform
-  - uid: 517
+  - uid: 863
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 0.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 876
     components:
     - rot: 3.141592653589793 rad
-      pos: -0.5,0.5
+      pos: -1.5,-0.5
       parent: 1
       type: Transform
 - proto: SubstationBasic
@@ -8004,8 +8507,8 @@ entities:
         immutable: False
         temperature: 293.1497
         moles:
-        - 1.8856695
-        - 7.0937095
+        - 1.8968438
+        - 7.1357465
         - 0
         - 0
         - 0
@@ -8022,10 +8525,11 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 522
-          - 523
-          - 525
+          - 741
           - 307
+          - 525
+          - 523
+          - 522
       type: ContainerContainer
   - uid: 215
     components:
@@ -8037,8 +8541,8 @@ entities:
         immutable: False
         temperature: 293.1497
         moles:
-        - 1.7459903
-        - 6.568249
+        - 1.8856695
+        - 7.0937095
         - 0
         - 0
         - 0
@@ -8070,8 +8574,8 @@ entities:
         immutable: False
         temperature: 293.1496
         moles:
-        - 1.8856695
-        - 7.0937095
+        - 1.8968438
+        - 7.1357465
         - 0
         - 0
         - 0
@@ -8088,10 +8592,12 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 720
-          - 719
+          - 877
           - 527
           - 716
+          - 879
+          - 719
+          - 720
       type: ContainerContainer
   - uid: 883
     components:
@@ -8504,11 +9010,6 @@ entities:
       type: Transform
 - proto: TablePlasmaGlass
   entities:
-  - uid: 504
-    components:
-    - pos: 6.5,10.5
-      parent: 1
-      type: Transform
   - uid: 509
     components:
     - rot: 1.5707963267948966 rad
@@ -8539,8 +9040,27 @@ entities:
     - pos: 4.5,7.5
       parent: 1
       type: Transform
+- proto: TableStone
+  entities:
+  - uid: 217
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 4.5,11.5
+      parent: 1
+      type: Transform
+  - uid: 1367
+    components:
+    - pos: 4.5,10.5
+      parent: 1
+      type: Transform
 - proto: TableWood
   entities:
+  - uid: 536
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 0.5,3.5
+      parent: 1
+      type: Transform
   - uid: 674
     components:
     - rot: 3.141592653589793 rad
@@ -8553,16 +9073,9 @@ entities:
       pos: -2.5,-18.5
       parent: 1
       type: Transform
-  - uid: 722
+  - uid: 724
     components:
-    - rot: 3.141592653589793 rad
-      pos: -1.5,4.5
-      parent: 1
-      type: Transform
-  - uid: 723
-    components:
-    - rot: 3.141592653589793 rad
-      pos: -0.5,4.5
+    - pos: -0.5,4.5
       parent: 1
       type: Transform
   - uid: 742
@@ -8573,22 +9086,27 @@ entities:
       type: Transform
 - proto: TableWoodReinforced
   entities:
-  - uid: 535
+  - uid: 177
     components:
-    - rot: 3.141592653589793 rad
-      pos: -0.5,1.5
+    - pos: -1.5,0.5
       parent: 1
       type: Transform
-  - uid: 536
+  - uid: 197
     components:
-    - rot: 3.141592653589793 rad
-      pos: -2.5,1.5
+    - rot: -1.5707963267948966 rad
+      pos: -2.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 824
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -0.5,1.5
       parent: 1
       type: Transform
   - uid: 1145
     components:
-    - rot: 3.141592653589793 rad
-      pos: -1.5,1.5
+    - rot: -1.5707963267948966 rad
+      pos: -0.5,0.5
       parent: 1
       type: Transform
 - proto: Thruster
@@ -8731,6 +9249,14 @@ entities:
       pos: 13.5,7.5
       parent: 1
       type: Transform
+- proto: ToiletDirtyWater
+  entities:
+  - uid: 1371
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 0.5,-18.5
+      parent: 1
+      type: Transform
 - proto: ToiletEmpty
   entities:
   - uid: 576
@@ -8744,27 +9270,46 @@ entities:
     - pos: 8.5,11.5
       parent: 1
       type: Transform
-- proto: ToyFigurineNukieElite
+- proto: ToySkeleton
   entities:
-  - uid: 150
+  - uid: 1375
     components:
-    - pos: 6.5219097,8.672383
+    - pos: -2.5082126,-18.308739
       parent: 1
       type: Transform
-- proto: ToyFigurineSecurity
+- proto: TrackingImplanter
   entities:
-  - uid: 879
+  - uid: 1336
     components:
-    - pos: 1.5506005,-6.4342585
+    - pos: 7.4263067,-25.42087
+      parent: 1
+      type: Transform
+  - uid: 1337
+    components:
+    - pos: 7.5044317,-25.48337
+      parent: 1
+      type: Transform
+  - uid: 1338
+    components:
+    - pos: 7.5981817,-25.54587
       parent: 1
       type: Transform
 - proto: VendingMachineBooze
   entities:
-  - uid: 724
+  - uid: 1352
     components:
     - flags: SessionSpecific
       type: MetaData
-    - pos: -2.5,4.5
+    - pos: -2.5,2.5
+      parent: 1
+      type: Transform
+- proto: VendingMachineBountyVend
+  entities:
+  - uid: 1189
+    components:
+    - flags: SessionSpecific
+      type: MetaData
+    - pos: 2.5,-2.5
       parent: 1
       type: Transform
 - proto: VendingMachineChemicals
@@ -8778,20 +9323,11 @@ entities:
       type: Transform
 - proto: VendingMachineCigs
   entities:
-  - uid: 721
+  - uid: 722
     components:
     - flags: SessionSpecific
       type: MetaData
-    - pos: -0.5,-1.5
-      parent: 1
-      type: Transform
-- proto: VendingMachineDonut
-  entities:
-  - uid: 813
-    components:
-    - flags: SessionSpecific
-      type: MetaData
-    - pos: 0.5,-1.5
+    - pos: -0.5,-2.5
       parent: 1
       type: Transform
 - proto: VendingMachineMedical
@@ -8814,11 +9350,11 @@ entities:
       type: Transform
 - proto: VendingMachineSecDrobe
   entities:
-  - uid: 518
+  - uid: 1321
     components:
     - flags: SessionSpecific
       type: MetaData
-    - pos: 2.5,-2.5
+    - pos: 4.5,5.5
       parent: 1
       type: Transform
 - proto: VendingMachineTankDispenserEVA
@@ -9402,12 +9938,6 @@ entities:
     - pos: 5.5,-21.5
       parent: 1
       type: Transform
-  - uid: 354
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 0.5,-18.5
-      parent: 1
-      type: Transform
   - uid: 358
     components:
     - rot: -1.5707963267948966 rad
@@ -9632,6 +10162,12 @@ entities:
     - pos: -2.5,8.5
       parent: 1
       type: Transform
+  - uid: 1356
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 1.5,-18.5
+      parent: 1
+      type: Transform
 - proto: WallPlastitaniumDiagonal
   entities:
   - uid: 111
@@ -9701,12 +10237,6 @@ entities:
   - uid: 278
     components:
     - pos: -3.5,8.5
-      parent: 1
-      type: Transform
-  - uid: 298
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 1.5,-18.5
       parent: 1
       type: Transform
   - uid: 365
@@ -9813,6 +10343,12 @@ entities:
       pos: 2.5,7.5
       parent: 1
       type: Transform
+  - uid: 1348
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 1.5,-19.5
+      parent: 1
+      type: Transform
 - proto: WallPlastitaniumIndestructible
   entities:
   - uid: 233
@@ -9880,7 +10416,7 @@ entities:
     - pos: 4.5,4.5
       parent: 1
       type: Transform
-    - location: Carrier
+    - location: Empress
       type: WarpPoint
 - proto: WaterTankFull
   entities:
@@ -9908,21 +10444,28 @@ entities:
       pos: 4.5,-10.5
       parent: 1
       type: Transform
+- proto: WeaponEmpEmitter
+  entities:
+  - uid: 1358
+    components:
+    - pos: -2.4186845,7.6908584
+      parent: 1
+      type: Transform
+  - uid: 1359
+    components:
+    - pos: -2.4343095,7.8158584
+      parent: 1
+      type: Transform
 - proto: WeaponLaserCarbine
   entities:
-  - uid: 1182
+  - uid: 1357
     components:
-    - pos: -2.4627018,7.2469687
+    - pos: -2.4811845,7.1439834
       parent: 1
       type: Transform
-  - uid: 1183
+  - uid: 1361
     components:
-    - pos: -2.4470768,7.4188437
-      parent: 1
-      type: Transform
-  - uid: 1184
-    components:
-    - pos: -2.4783268,7.6844687
+    - pos: -2.4811845,7.3783584
       parent: 1
       type: Transform
 - proto: WeaponLauncherRocket
@@ -9936,21 +10479,29 @@ entities:
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
+- proto: WeaponLauncherRocketEmp
+  entities:
+  - uid: 1343
+    components:
+    - flags: InContainer
+      desc: A modified ancient rocket-propelled grenade launcher with EMP loaded charges.
+      name: EMP-RPG-7
+      type: MetaData
+    - parent: 1201
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
 - proto: WeaponPistolMk58
   entities:
-  - uid: 877
+  - uid: 1377
     components:
-    - pos: -1.5658212,8.674228
+    - pos: -1.3093095,8.409609
       parent: 1
       type: Transform
-  - uid: 1211
+  - uid: 1378
     components:
-    - pos: -1.3939462,8.517978
-      parent: 1
-      type: Transform
-  - uid: 1212
-    components:
-    - pos: -1.2064462,8.392978
+    - pos: -1.1530595,8.268984
       parent: 1
       type: Transform
 - proto: WeaponPulsePistol
@@ -9975,6 +10526,18 @@ entities:
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
+- proto: WeaponRevolverInspector
+  entities:
+  - uid: 1360
+    components:
+    - pos: -1.5905595,8.690859
+      parent: 1
+      type: Transform
+  - uid: 1362
+    components:
+    - pos: -1.4499345,8.550234
+      parent: 1
+      type: Transform
 - proto: WeaponRifleLecter
   entities:
   - uid: 1170
@@ -10032,9 +10595,10 @@ entities:
     - pos: 8.5,10.5
       parent: 1
       type: Transform
-  - uid: 738
+  - uid: 1355
     components:
-    - pos: 0.5,1.5
+    - rot: 1.5707963267948966 rad
+      pos: -0.5,-18.5
       parent: 1
       type: Transform
 - proto: WindoorSecureArmoryLocked
@@ -10056,6 +10620,12 @@ entities:
     components:
     - rot: -1.5707963267948966 rad
       pos: -0.5,-5.5
+      parent: 1
+      type: Transform
+  - uid: 740
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,1.5
       parent: 1
       type: Transform
 - proto: WindowReinforcedDirectional

--- a/Resources/Prototypes/_NF/Shipyard/empress.yml
+++ b/Resources/Prototypes/_NF/Shipyard/empress.yml
@@ -1,23 +1,23 @@
 - type: vessel
-  id: Carrier
-  name: NT Carrier
+  id: Empress
+  name: NT Empress
   description: A large patrol vessel capable of carrying up to 3 smaller faster attack ships. the flagship vessel of security.
   price: 110200
   category: Large
   group: Security
-  shuttlePath: /Maps/Shuttles/carrier.yml
+  shuttlePath: /Maps/Shuttles/empress.yml
 
 - type: gameMap
-  id: Carrier
-  mapName: 'NT Carrier'
-  mapPath: /Maps/Shuttles/carrier.yml
+  id: Empress
+  mapName: 'NT Empress'
+  mapPath: /Maps/Shuttles/empress.yml
   minPlayers: 0
   stations:
-    Carrier:
+    Empress:
       stationProto: StandardFrontierVessel
       components:
         - type: StationNameSetup
-          mapNameTemplate: '{0} Carrier {1}'
+          mapNameTemplate: '{0} Empress {1}'
           nameGenerator:
             !type:NanotrasenNameGenerator
             prefixCreator: '14'


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR

Renamed carrier into Empress, monarch of the space, expanded the kitchen a little, added ID Computer to its bridge, some extra drip added, added 1 extra EMP-RPG with its ammo and 2 EMP guns to the armory, now perma has a toilet too (very important) and removed the crew-monitor server since it will use the frontier station central crew monitor server. 


:cl:

- tweak: Renamed the carrier into the empress plus fixed more of its functionality. 
