### PR TITLE
Security Ship Line-up Alterations, Prowler Intro, Trident Retirement, and more!

### DIFF
--- a/Resources/Maps/Shuttles/marauder.yml
+++ b/Resources/Maps/Shuttles/marauder.yml
@@ -32,13 +32,13 @@ entities:
           tiles: FwAAARcAAAJIAAAASAAAAF8AAAA8AAAAAAAAAAAAAAAAAAAAAAAAADwAAABfAAAAXwAAAF8AAAA8AAAAAAAAABcAAAMXAAADXwAAAF8AAABfAAAAPAAAAAAAAAAAAAAAAAAAAAAAAAA8AAAAPAAAADwAAAA8AAAAPAAAAAAAAAAXAAADFwAAAkgAAABIAAAAXwAAADwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADwAAAA8AAAAPAAAAAAAAAAAAAAAFwAAARcAAAJIAAAASAAAAEgAAAA8AAAAPAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABcAAAIXAAABXwAAAF8AAABfAAAAPAAAADwAAAA8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXAAABXwAAAE8AAABPAAAATwAAAE8AAAA8AAAAPAAAADwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFwAAAV8AAABPAAAATwAAAE8AAAAXAAADXwAAAF8AAAA8AAAAPAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABcAAABfAAAATwAAAE8AAABPAAAAFwAAAhcAAAMXAAABNAAAADwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXAAABXwAAAE8AAABPAAAATwAAABcAAAMXAAAAFwAAAF8AAAA8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFwAAAk8AAABPAAAATwAAAE8AAAAXAAACFwAAARcAAAI0AAAAPAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABcAAAMXAAADFwAAAhcAAAIXAAAAFwAAAxcAAABfAAAAPAAAADwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXAAABXwAAAF0AAABdAAAAFwAAAT0AAAA9AAAAPAAAADwAAAA8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFwAAABcAAAFdAAAAXQAAABcAAAE9AAAAPAAAADwAAAA8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABcAAAEXAAACXQAAAF0AAAAXAAADPAAAADwAAAA8AAAAPAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXAAADFwAAAF0AAABdAAAAXQAAADwAAAA8AAAAPAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGwAAAxsAAANdAAAAXQAAADwAAAA8AAAAPAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
         0,-1:
           ind: 0,-1
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXgAAAF8AAAA0AAAANAAAADQAAAA0AAAANAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF4AAABfAAAANAAAADQAAAA0AAAANAAAADQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AAAAXwAAADQAAAA0AAAANAAAADQAAAA0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AAAAPAAAAF8AAAAXAAADFwAAAl8AAABfAAAAXwAAAF8AAAA0AAAAXwAAADwAAAA8AAAAPAAAADwAAAA8AAAAPAAAADwAAABfAAAAFwAAAhcAAAIXAAACXwAAAAAAAAA0AAAANAAAADQAAAA8AAAAPAAAADwAAAA8AAAAPAAAADwAAABfAAAAXwAAABcAAAIXAAABFwAAAl8AAAAAAAAAXwAAAF8AAABfAAAAPAAAADwAAAA8AAAAPAAAADwAAAAXAAADFwAAAxcAAAAXAAADFwAAABcAAANfAAAAAAAAABcAAAEXAAAAFwAAAhcAAAMXAAABFwAAAxcAAAEXAAAAFwAAAxcAAAIXAAACFwAAAhcAAAMXAAACXwAAAAAAAAAXAAAAFwAAAhcAAAMXAAACFwAAARcAAAAXAAABFwAAAhcAAAIXAAAAXwAAAF8AAABfAAAAXwAAAF8AAAAAAAAAFwAAAxcAAAEXAAABFwAAAhcAAAAXAAADFwAAABcAAAM8AAAAPAAAAF8AAABfAAAAXwAAAF8AAABfAAAAAAAAACkAAAAwAAAAMAAAADAAAAAwAAAAMAAAABcAAAM8AAAAPAAAAAAAAABfAAAAXgAAAF4AAABeAAAAXwAAAAAAAABFAAAAMAAAADAAAAAwAAAAMAAAADAAAAA8AAAAPAAAAAAAAAAAAAAAXwAAAF8AAABfAAAAXwAAAF8AAAAAAAAARQAAAzAAAAAwAAAAMAAAADAAAAA8AAAAPAAAADwAAAAAAAAAAAAAAF8AAABfAAAAXgAAAF8AAABfAAAAAAAAAEUAAAIwAAAAMAAAADAAAABfAAAAPAAAADwAAAAAAAAAAAAAAAAAAABfAAAAXwAAAF4AAABfAAAAXwAAAAAAAAAXAAABFwAAAl8AAABfAAAAXwAAADwAAAAAAAAAAAAAAAAAAAAAAAAAXwAAAF8AAABfAAAAXwAAAF8AAAAAAAAAFwAAABcAAAJIAAAASAAAAEgAAAA8AAAAAAAAAAAAAAAAAAAAAAAAAF8AAABeAAAAXgAAAF4AAABfAAAAAAAAAA==
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXgAAAF8AAAA0AAAANAAAADQAAAA0AAAANAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF4AAABfAAAANAAAADQAAAA0AAAANAAAADQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AAAAXwAAADQAAAA0AAAANAAAADQAAAA0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AAAAPAAAAF8AAAA0AAAAFwAAAl8AAABfAAAAXwAAAF8AAAA0AAAAXwAAADwAAAA8AAAAPAAAADwAAAA8AAAAPAAAADwAAABfAAAAFwAAAhcAAAIXAAACXwAAAAAAAAA0AAAANAAAADQAAAA8AAAAPAAAADwAAAA8AAAAPAAAADwAAABfAAAAXwAAABcAAAIXAAABFwAAAl8AAAAAAAAAXwAAADQAAABfAAAAPAAAADwAAAA8AAAAPAAAADwAAAAXAAADFwAAAxcAAAAXAAADFwAAABcAAANfAAAAAAAAABcAAAEXAAAAFwAAAhcAAAMXAAABFwAAAxcAAAEXAAAAFwAAAxcAAAIXAAACFwAAAhcAAAMXAAACXwAAAAAAAAAXAAAAFwAAAhcAAAMXAAACFwAAARcAAAAXAAABFwAAAhcAAAIXAAAAXwAAAF8AAABfAAAAXwAAAF8AAAAAAAAAFwAAAxcAAAEXAAABFwAAAhcAAAAXAAADFwAAABcAAAM8AAAAPAAAAF8AAABfAAAAXwAAAF8AAABfAAAAAAAAACkAAAAwAAAAMAAAADAAAAAwAAAAMAAAABcAAAM8AAAAPAAAAAAAAABfAAAAXgAAAF4AAABeAAAAXwAAAAAAAABFAAAAMAAAADAAAAAwAAAAMAAAADAAAAA8AAAAPAAAAAAAAAAAAAAAXwAAAF8AAABfAAAAXwAAAF8AAAAAAAAARQAAAzAAAAAwAAAAMAAAADAAAAA8AAAAPAAAADwAAAAAAAAAAAAAAF8AAABfAAAAXgAAAF8AAABfAAAAAAAAAEUAAAIwAAAAMAAAADAAAABfAAAAPAAAADwAAAAAAAAAAAAAAAAAAABfAAAAXwAAAF4AAABfAAAAXwAAAAAAAAAXAAABFwAAAl8AAABfAAAAXwAAADwAAAAAAAAAAAAAAAAAAAAAAAAAXwAAAF8AAABfAAAAXwAAAF8AAAAAAAAAFwAAABcAAAJIAAAASAAAAEgAAAA8AAAAAAAAAAAAAAAAAAAAAAAAAF8AAABeAAAAXgAAAF4AAABfAAAAAAAAAA==
         -1,0:
           ind: -1,0
           tiles: AAAAAAAAAAA8AAAAXwAAAF8AAABfAAAAPAAAAAAAAAAAAAAAAAAAAAAAAAA8AAAAXwAAABcAAAIXAAAAFwAAAgAAAAAAAAAAPAAAADwAAAA8AAAAPAAAADwAAAAAAAAAAAAAAAAAAAAAAAAAPAAAAF8AAAAXAAABFwAAAhcAAAMAAAAAAAAAAAAAAAA8AAAAPAAAADwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADwAAABfAAAAFwAAABcAAAAXAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADwAAAA8AAAAXwAAABcAAAAXAAAAFwAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADwAAAA8AAAAPAAAABcAAAAXAAAAFwAAABcAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADwAAAA8AAAAPAAAAFIAAABSAAAAUgAAAlIAAAAXAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADwAAAA8AAAAXwAAABcAAAMXAAADUgAAAFIAAABSAAAAUgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AAAAFwAAAk8AAABPAAAAFwAAAlIAAABSAAAAUgAAABcAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPAAAABcAAAJPAAAATwAAAE8AAABSAAAAUgAAAFIAAAAXAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADwAAAAXAAACTwAAAE8AAABPAAAAFwAAABcAAAMXAAADFwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AAAAPAAAAF8AAABfAAAAXwAAABcAAAIXAAABFwAAARcAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPAAAADwAAAA0AAAANAAAADQAAAAXAAACFwAAAhcAAAMXAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AAAAPAAAADwAAAA8AAAAFwAAAxcAAAIXAAABFwAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPAAAADwAAAA8AAAAPAAAABcAAAIXAAAAFwAAABcAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AAAAPAAAADwAAAAXAAAAFwAAABcAAAAXAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADwAAAA8AAAAFwAAABcAAAAXAAAAGwAAAw==
         -1,-1:
           ind: -1,-1
-          tiles: AAAAADQAAAA0AAAANAAAADQAAAA0AAAAXwAAAF4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA0AAAANAAAADQAAAA0AAAANAAAAF8AAABeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAANAAAADQAAAA0AAAANAAAADQAAABfAAAAPAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF8AAABfAAAAXwAAABcAAAMXAAAAXwAAADwAAAA8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXwAAABcAAAIXAAAAFwAAAF8AAAA8AAAAPAAAADwAAAA8AAAAPAAAADwAAAA8AAAAXwAAADQAAAAAAAAAAAAAAF8AAAAXAAACFwAAABcAAAFfAAAAXwAAADwAAAA8AAAAPAAAADwAAAA8AAAAPAAAADQAAAA0AAAAAAAAAAAAAABfAAAAFwAAARcAAAAXAAADFwAAABcAAAAXAAACPAAAADwAAAA8AAAAPAAAADwAAABfAAAAXwAAAAAAAAAAAAAAXwAAABcAAAAXAAAAFwAAABcAAAAXAAAAFwAAABcAAAEXAAABFwAAABcAAAMXAAABFwAAAxcAAAAAAAAAAAAAAF8AAABfAAAAXwAAAF8AAABfAAAAFwAAABcAAAEXAAADFwAAAxcAAAEXAAADFwAAAhcAAAAXAAACAAAAAAAAAABfAAAAXwAAAF8AAABfAAAAXwAAADwAAAA8AAAAFwAAARcAAAAXAAADFwAAAhcAAAAXAAABFwAAAwAAAAAAAAAAXwAAAF4AAABeAAAAXgAAAF8AAAAAAAAAPAAAADwAAAAXAAADRQAAAEUAAABFAAADKQAAACkAAAAAAAAAAAAAAF8AAABfAAAAXwAAAF8AAABfAAAAAAAAAAAAAAA8AAAAPAAAAEUAAABFAAACRQAAAUUAAAJFAAABAAAAAAAAAABfAAAAXwAAAF4AAABfAAAAXwAAAAAAAAAAAAAAPAAAADwAAAA8AAAAFwAAA0UAAAJFAAABRQAAAgAAAAAAAAAAXwAAAF8AAABeAAAAXwAAAF8AAAAAAAAAAAAAAAAAAAA8AAAAPAAAAF8AAABFAAABRQAAAEUAAAMAAAAAAAAAAF8AAABfAAAAXwAAAF8AAABfAAAAAAAAAAAAAAAAAAAAAAAAADwAAABfAAAAFwAAAhcAAAIXAAAAAAAAAAAAAABfAAAAXgAAAF4AAABeAAAAXwAAAAAAAAAAAAAAAAAAAAAAAAA8AAAAXwAAABcAAAAXAAABFwAAAQ==
+          tiles: AAAAADQAAAA0AAAANAAAADQAAAA0AAAAXwAAAF4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA0AAAANAAAADQAAAA0AAAANAAAAF8AAABeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAANAAAADQAAAA0AAAANAAAADQAAABfAAAAPAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF8AAABfAAAAXwAAABcAAAM0AAAAXwAAADwAAAA8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXwAAABcAAAIXAAAAFwAAAF8AAAA8AAAAPAAAADwAAAA8AAAAPAAAADwAAAA8AAAAXwAAADQAAAAAAAAAAAAAAF8AAAAXAAACFwAAABcAAAFfAAAAXwAAADwAAAA8AAAAPAAAADwAAAA8AAAAPAAAADQAAAA0AAAAAAAAAAAAAABfAAAAFwAAARcAAAAXAAADFwAAABcAAAAXAAACPAAAADwAAAA8AAAAPAAAADwAAABfAAAANAAAAAAAAAAAAAAAXwAAABcAAAAXAAAAFwAAABcAAAAXAAAAFwAAABcAAAEXAAABFwAAABcAAAMXAAABFwAAAxcAAAAAAAAAAAAAAF8AAABfAAAAXwAAAF8AAABfAAAAFwAAABcAAAEXAAADFwAAAxcAAAEXAAADFwAAAhcAAAAXAAACAAAAAAAAAABfAAAAXwAAAF8AAABfAAAAXwAAADwAAAA8AAAAFwAAARcAAAAXAAADFwAAAhcAAAAXAAABFwAAAwAAAAAAAAAAXwAAAF4AAABeAAAAXgAAAF8AAAAAAAAAPAAAADwAAAAXAAADRQAAAEUAAABFAAADKQAAACkAAAAAAAAAAAAAAF8AAABfAAAAXwAAAF8AAABfAAAAAAAAAAAAAAA8AAAAPAAAAEUAAABFAAACRQAAAUUAAAJFAAABAAAAAAAAAABfAAAAXwAAAF4AAABfAAAAXwAAAAAAAAAAAAAAPAAAADwAAAA8AAAAFwAAA0UAAAJFAAABRQAAAgAAAAAAAAAAXwAAAF8AAABeAAAAXwAAAF8AAAAAAAAAAAAAAAAAAAA8AAAAPAAAAF8AAABFAAABRQAAAEUAAAMAAAAAAAAAAF8AAABfAAAAXwAAAF8AAABfAAAAAAAAAAAAAAAAAAAAAAAAADwAAABfAAAAFwAAAhcAAAIXAAAAAAAAAAAAAABfAAAAXgAAAF4AAABeAAAAXwAAAAAAAAAAAAAAAAAAAAAAAAA8AAAAXwAAABcAAAAXAAABFwAAAQ==
         -1,-2:
           ind: -1,-2
           tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AAAAPAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPAAAADwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPAAAADwAAAA8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPAAAADwAAAA8AAAAPAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPAAAADwAAAA8AAAAPAAAADwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADwAAAA8AAAAPAAAADwAAAA8AAAAXgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF8AAABfAAAANAAAADQAAAA0AAAAXwAAAF4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
@@ -75,39 +75,39 @@ entities:
             color: '#FFFFFFFF'
             id: Bot
           decals:
-            34: -3,0
-            35: -3,-1
-            36: -2,-1
+            21: -3,0
+            22: -3,-1
+            23: -2,-1
         - node:
             color: '#FFFFFFFF'
             id: BrickTileSteelCornerNw
           decals:
-            31: -2,-6
+            18: -2,-6
         - node:
             color: '#FFFFFFFF'
             id: BrickTileSteelLineN
           decals:
-            32: -1,-6
-            33: 0,-6
+            19: -1,-6
+            20: 0,-6
         - node:
             color: '#E97F004C'
             id: BrickTileWhiteLineE
           decals:
-            46: 1,0
-            48: 1,2
+            32: 1,0
+            33: 1,2
         - node:
             color: '#B4B4B4FF'
             id: CheckerNESW
           decals:
-            19: 1,-6
+            17: 1,-6
         - node:
             color: '#6FB2FB9B'
             id: CheckerNWSE
           decals:
-            51: -2,5
-            52: -3,5
-            53: -4,5
-            54: -5,5
+            34: -2,5
+            35: -3,5
+            36: -4,5
+            37: -5,5
         - node:
             color: '#B4000049'
             id: CheckerNWSE
@@ -116,7 +116,6 @@ entities:
             1: -3,12
             2: -4,12
             3: -4,11
-            4: -5,11
             5: -2,11
             6: -3,11
             7: -4,10
@@ -133,37 +132,37 @@ entities:
             color: '#FFFFFFFF'
             id: StandClear
           decals:
-            39: -12,-18
-            40: 12,-18
+            26: -12,-18
+            27: 12,-18
         - node:
             angle: 1.5707963267948966 rad
             color: '#FFFFFFFF'
             id: StandClear
           decals:
-            38: 3,-11
+            25: 3,-11
         - node:
             angle: 4.71238898038469 rad
             color: '#FFFFFFFF'
             id: StandClear
           decals:
-            37: -3,-11
+            24: -3,-11
         - node:
             color: '#FFFFFFFF'
             id: WarnLineE
           decals:
-            41: -14,-14
-            42: -14,-16
+            28: -14,-14
+            29: -14,-16
         - node:
             color: '#FFFFFFFF'
             id: WarnLineS
           decals:
-            43: 14,-16
-            44: 14,-14
+            30: 14,-16
+            31: 14,-14
         - node:
             color: '#FFFFFFFF'
             id: b
           decals:
-            55: -1.8067541,0.85464954
+            38: -1.8067541,0.85464954
       type: DecalGrid
     - version: 2
       data:
@@ -179,9 +178,12 @@ entities:
           1,0:
             0: 29491
           1,1:
-            0: 65535
+            0: 32767
+            1: 32768
           1,2:
-            0: 65535
+            0: 65399
+            2: 8
+            3: 128
           1,3:
             0: 32767
           2,1:
@@ -318,6 +320,51 @@ entities:
           - 0
           - 0
           - 0
+        - volume: 2500
+          temperature: 293.14993
+          moles:
+          - 18.472576
+          - 69.49208
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.14996
+          moles:
+          - 21.556696
+          - 81.09423
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 21.6852
+          - 81.57766
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
         chunkSize: 4
       type: GridAtmosphere
     - type: GasTileOverlay
@@ -326,149 +373,149 @@ entities:
       type: BecomesStation
 - proto: AirlockArmoryGlassLocked
   entities:
-  - uid: 1465
+  - uid: 2
     components:
     - pos: -0.5,2.5
       parent: 1
       type: Transform
 - proto: AirlockAtmospherics
   entities:
-  - uid: 2
+  - uid: 3
     components:
     - pos: -4.5,9.5
       parent: 1
       type: Transform
 - proto: AirlockBrigLocked
   entities:
-  - uid: 36
+  - uid: 4
     components:
     - pos: 0.5,-1.5
       parent: 1
       type: Transform
-  - uid: 37
+  - uid: 5
     components:
     - pos: 10.5,-8.5
       parent: 1
       type: Transform
-  - uid: 38
+  - uid: 6
     components:
     - pos: -10.5,-12.5
       parent: 1
       type: Transform
-  - uid: 39
+  - uid: 7
     components:
     - pos: -9.5,-8.5
       parent: 1
       type: Transform
-  - uid: 40
+  - uid: 8
     components:
     - pos: 11.5,-12.5
       parent: 1
       type: Transform
-  - uid: 41
+  - uid: 9
     components:
     - pos: -0.5,0.5
       parent: 1
       type: Transform
-  - uid: 42
+  - uid: 10
     components:
     - pos: -2.5,-6.5
       parent: 1
       type: Transform
 - proto: AirlockCaptainLocked
   entities:
-  - uid: 450
+  - uid: 11
     components:
     - pos: 1.5,12.5
       parent: 1
       type: Transform
-  - uid: 1186
+  - uid: 12
     components:
     - pos: 4.5,11.5
       parent: 1
       type: Transform
 - proto: AirlockEngineering
   entities:
-  - uid: 4
+  - uid: 13
     components:
     - pos: 1.5,9.5
       parent: 1
       type: Transform
 - proto: AirlockExternal
   entities:
-  - uid: 16
+  - uid: 14
     components:
     - pos: 12.5,-16.5
       parent: 1
       type: Transform
-  - uid: 17
+  - uid: 15
     components:
     - pos: -11.5,-16.5
       parent: 1
       type: Transform
-  - uid: 268
+  - uid: 16
     components:
     - pos: -6.5,11.5
       parent: 1
       type: Transform
 - proto: AirlockExternalGlass
   entities:
-  - uid: 18
+  - uid: 17
     components:
     - rot: 1.5707963267948966 rad
       pos: -12.5,-13.5
       parent: 1
       type: Transform
-  - uid: 19
+  - uid: 18
     components:
     - rot: 1.5707963267948966 rad
       pos: -12.5,-15.5
       parent: 1
       type: Transform
-  - uid: 20
+  - uid: 19
     components:
     - rot: 1.5707963267948966 rad
       pos: 13.5,-13.5
       parent: 1
       type: Transform
-  - uid: 21
+  - uid: 20
     components:
     - rot: 1.5707963267948966 rad
       pos: 13.5,-15.5
       parent: 1
       type: Transform
-  - uid: 22
+  - uid: 21
     components:
     - rot: 1.5707963267948966 rad
       pos: -0.5,-9.5
       parent: 1
       type: Transform
-  - uid: 23
+  - uid: 22
     components:
     - rot: 1.5707963267948966 rad
       pos: 1.5,-9.5
       parent: 1
       type: Transform
-  - uid: 24
+  - uid: 23
     components:
     - rot: 3.141592653589793 rad
       pos: 2.5,-10.5
       parent: 1
       type: Transform
-  - uid: 25
+  - uid: 24
     components:
     - rot: 3.141592653589793 rad
       pos: -1.5,-10.5
       parent: 1
       type: Transform
-  - uid: 504
+  - uid: 25
     components:
     - pos: -4.5,11.5
       parent: 1
       type: Transform
 - proto: AirlockFreezer
   entities:
-  - uid: 27
+  - uid: 26
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,-6.5
@@ -476,50 +523,50 @@ entities:
       type: Transform
 - proto: AirlockGlassShuttle
   entities:
-  - uid: 28
+  - uid: 27
     components:
     - rot: -1.5707963267948966 rad
       pos: -14.5,-13.5
       parent: 1
       type: Transform
-  - uid: 29
+  - uid: 28
     components:
     - rot: -1.5707963267948966 rad
       pos: -14.5,-15.5
       parent: 1
       type: Transform
-  - uid: 30
+  - uid: 29
     components:
     - rot: 1.5707963267948966 rad
       pos: 15.5,-13.5
       parent: 1
       type: Transform
-  - uid: 31
+  - uid: 30
     components:
     - rot: 1.5707963267948966 rad
       pos: 15.5,-15.5
       parent: 1
       type: Transform
-  - uid: 32
+  - uid: 31
     components:
     - pos: -0.5,-11.5
       parent: 1
       type: Transform
-  - uid: 33
+  - uid: 32
     components:
     - pos: 1.5,-11.5
       parent: 1
       type: Transform
 - proto: AirlockMedicalGlass
   entities:
-  - uid: 880
+  - uid: 33
     components:
     - pos: -1.5,8.5
       parent: 1
       type: Transform
 - proto: AirlockSecurity
   entities:
-  - uid: 35
+  - uid: 34
     components:
     - rot: -1.5707963267948966 rad
       pos: -0.5,11.5
@@ -527,7 +574,7 @@ entities:
       type: Transform
 - proto: AmeController
   entities:
-  - uid: 43
+  - uid: 35
     components:
     - pos: 2.5,8.5
       parent: 1
@@ -538,65 +585,65 @@ entities:
         AmeFuel: !type:ContainerSlot
           showEnts: False
           occludes: True
-          ent: 44
+          ent: 36
       type: ContainerContainer
 - proto: AmeJar
   entities:
-  - uid: 44
+  - uid: 36
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 43
+    - parent: 35
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 46
+  - uid: 38
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 45
+    - parent: 37
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: AmeShielding
   entities:
-  - uid: 47
+  - uid: 39
     components:
     - pos: 2.5,5.5
       parent: 1
       type: Transform
-  - uid: 48
+  - uid: 40
     components:
     - pos: 3.5,5.5
       parent: 1
       type: Transform
-  - uid: 49
+  - uid: 41
     components:
     - pos: 4.5,5.5
       parent: 1
       type: Transform
-  - uid: 50
+  - uid: 42
     components:
     - pos: 2.5,6.5
       parent: 1
       type: Transform
-  - uid: 51
+  - uid: 43
     components:
     - pos: 4.5,7.5
       parent: 1
       type: Transform
-  - uid: 52
+  - uid: 44
     components:
     - pos: 4.5,6.5
       parent: 1
       type: Transform
-  - uid: 53
+  - uid: 45
     components:
     - pos: 2.5,7.5
       parent: 1
       type: Transform
-  - uid: 54
+  - uid: 46
     components:
     - pos: 3.5,6.5
       parent: 1
@@ -604,202 +651,202 @@ entities:
     - radius: 2
       enabled: True
       type: PointLight
-  - uid: 55
+  - uid: 47
     components:
     - pos: 3.5,7.5
       parent: 1
       type: Transform
 - proto: APCBasicEmpImmune
   entities:
-  - uid: 57
+  - uid: 48
     components:
     - rot: 1.5707963267948966 rad
       pos: -0.5,13.5
       parent: 1
       type: Transform
-  - uid: 58
+  - uid: 49
     components:
     - pos: -4.5,-6.5
       parent: 1
       type: Transform
-  - uid: 59
+  - uid: 50
     components:
     - pos: 5.5,-6.5
       parent: 1
       type: Transform
-  - uid: 1176
+  - uid: 51
     components:
     - rot: 1.5707963267948966 rad
       pos: -0.5,5.5
       parent: 1
       type: Transform
-  - uid: 1377
+  - uid: 52
     components:
     - pos: 5.5,10.5
       parent: 1
       type: Transform
 - proto: AtmosDeviceFanTiny
   entities:
-  - uid: 62
+  - uid: 53
     components:
     - rot: 3.141592653589793 rad
       pos: -1.5,-10.5
       parent: 1
       type: Transform
-  - uid: 63
+  - uid: 54
     components:
     - rot: 3.141592653589793 rad
       pos: 2.5,-10.5
       parent: 1
       type: Transform
-  - uid: 64
+  - uid: 55
     components:
     - pos: -0.5,-11.5
       parent: 1
       type: Transform
-  - uid: 65
+  - uid: 56
     components:
     - pos: 15.5,-15.5
       parent: 1
       type: Transform
-  - uid: 66
+  - uid: 57
     components:
     - pos: -11.5,-16.5
       parent: 1
       type: Transform
-  - uid: 67
+  - uid: 58
     components:
     - pos: -14.5,-15.5
       parent: 1
       type: Transform
-  - uid: 68
+  - uid: 59
     components:
     - pos: -14.5,-13.5
       parent: 1
       type: Transform
-  - uid: 69
+  - uid: 60
     components:
     - pos: 15.5,-13.5
       parent: 1
       type: Transform
-  - uid: 70
+  - uid: 61
     components:
     - pos: 12.5,-16.5
       parent: 1
       type: Transform
-  - uid: 71
+  - uid: 62
     components:
     - pos: 1.5,-11.5
       parent: 1
       type: Transform
-  - uid: 618
+  - uid: 63
     components:
     - pos: -6.5,11.5
       parent: 1
       type: Transform
 - proto: BannerSecurity
   entities:
-  - uid: 73
+  - uid: 64
     components:
     - pos: 10.5,-17.5
       parent: 1
       type: Transform
-  - uid: 74
+  - uid: 65
     components:
     - pos: -9.5,-17.5
       parent: 1
       type: Transform
 - proto: BarSign
   entities:
-  - uid: 75
+  - uid: 66
     components:
     - pos: -1.5,-1.5
       parent: 1
       type: Transform
 - proto: Bed
   entities:
-  - uid: 77
+  - uid: 67
     components:
     - pos: 3.5,2.5
       parent: 1
       type: Transform
-  - uid: 78
+  - uid: 68
     components:
     - pos: 3.5,0.5
       parent: 1
       type: Transform
-  - uid: 80
+  - uid: 69
     components:
     - pos: -12.5,-10.5
       parent: 1
       type: Transform
-  - uid: 81
+  - uid: 70
     components:
     - pos: -12.5,-11.5
       parent: 1
       type: Transform
-  - uid: 82
+  - uid: 71
     components:
     - pos: 13.5,-11.5
       parent: 1
       type: Transform
-  - uid: 83
+  - uid: 72
     components:
     - pos: 13.5,-10.5
       parent: 1
       type: Transform
-  - uid: 546
+  - uid: 73
     components:
     - pos: 2.5,13.5
       parent: 1
       type: Transform
 - proto: BedsheetBrigmedic
   entities:
-  - uid: 596
+  - uid: 74
     components:
     - pos: -2.5,6.5
       parent: 1
       type: Transform
 - proto: BedsheetHOS
   entities:
-  - uid: 1494
+  - uid: 75
     components:
     - pos: 2.5,13.5
       parent: 1
       type: Transform
 - proto: BedsheetOrange
   entities:
-  - uid: 90
+  - uid: 76
     components:
     - pos: 3.5,0.5
       parent: 1
       type: Transform
-  - uid: 91
+  - uid: 77
     components:
     - pos: 3.5,2.5
       parent: 1
       type: Transform
 - proto: BedsheetRed
   entities:
-  - uid: 92
+  - uid: 78
     components:
     - rot: 1.5707963267948966 rad
       pos: -12.5,-11.5
       parent: 1
       type: Transform
-  - uid: 93
+  - uid: 79
     components:
     - rot: 1.5707963267948966 rad
       pos: -12.5,-10.5
       parent: 1
       type: Transform
-  - uid: 94
+  - uid: 80
     components:
     - rot: 1.5707963267948966 rad
       pos: 13.5,-11.5
       parent: 1
       type: Transform
-  - uid: 95
+  - uid: 81
     components:
     - rot: 1.5707963267948966 rad
       pos: 13.5,-10.5
@@ -807,7 +854,7 @@ entities:
       type: Transform
 - proto: BenchSteelLeft
   entities:
-  - uid: 100
+  - uid: 82
     components:
     - rot: -1.5707963267948966 rad
       pos: -0.5,-2.5
@@ -815,7 +862,7 @@ entities:
       type: Transform
     - bodyType: Static
       type: Physics
-  - uid: 101
+  - uid: 83
     components:
     - rot: 1.5707963267948966 rad
       pos: -2.5,-3.5
@@ -825,7 +872,7 @@ entities:
       type: Physics
 - proto: BenchSteelRight
   entities:
-  - uid: 102
+  - uid: 84
     components:
     - rot: -1.5707963267948966 rad
       pos: -0.5,-3.5
@@ -833,7 +880,7 @@ entities:
       type: Transform
     - bodyType: Static
       type: Physics
-  - uid: 103
+  - uid: 85
     components:
     - rot: 1.5707963267948966 rad
       pos: -2.5,-2.5
@@ -843,2298 +890,2345 @@ entities:
       type: Physics
 - proto: BlastDoor
   entities:
-  - uid: 534
+  - uid: 86
     components:
     - pos: -5.5,11.5
       parent: 1
       type: Transform
     - links:
-      - 269
+      - 1115
       type: DeviceLinkSink
 - proto: BlastDoorOpen
   entities:
-  - uid: 105
+  - uid: 87
     components:
     - pos: -13.5,-13.5
       parent: 1
       type: Transform
     - links:
-      - 1102
+      - 1120
       type: DeviceLinkSink
-  - uid: 106
+  - uid: 88
     components:
     - pos: -13.5,-15.5
       parent: 1
       type: Transform
     - links:
-      - 1102
+      - 1120
       type: DeviceLinkSink
-  - uid: 107
+  - uid: 89
     components:
     - pos: 14.5,-15.5
       parent: 1
       type: Transform
     - links:
-      - 1103
+      - 1121
       type: DeviceLinkSink
-  - uid: 108
+  - uid: 90
     components:
     - pos: 14.5,-13.5
       parent: 1
       type: Transform
     - links:
-      - 1103
+      - 1121
       type: DeviceLinkSink
+- proto: BoxBeanbag
+  entities:
+  - uid: 900
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 893
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: BoxLethalshot
+  entities:
+  - uid: 896
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 893
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: BoxShellTranquilizer
+  entities:
+  - uid: 894
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 893
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: BoxShotgunIncendiary
+  entities:
+  - uid: 897
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 893
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: BoxShotgunSlug
+  entities:
+  - uid: 898
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 893
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
 - proto: BrigTimer
   entities:
-  - uid: 110
+  - uid: 91
     components:
     - rot: 3.141592653589793 rad
       pos: 1.5,4.5
       parent: 1
       type: Transform
     - linkedPorts:
-        1501:
+        1524:
         - Start: Close
         - Timer: AutoClose
         - Timer: Open
       type: DeviceLinkSource
-  - uid: 111
+  - uid: 92
     components:
     - rot: 3.141592653589793 rad
       pos: 1.5,1.5
       parent: 1
       type: Transform
     - linkedPorts:
-        1502:
+        1525:
         - Start: Close
         - Timer: AutoClose
         - Timer: Open
       type: DeviceLinkSource
 - proto: CableApcExtension
   entities:
-  - uid: 61
+  - uid: 93
     components:
     - pos: 5.5,10.5
       parent: 1
       type: Transform
-  - uid: 109
+  - uid: 94
     components:
     - pos: 4.5,15.5
       parent: 1
       type: Transform
-  - uid: 112
+  - uid: 95
     components:
     - pos: 12.5,-6.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 113
+  - uid: 96
     components:
     - pos: -9.5,-7.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 114
+  - uid: 97
     components:
     - pos: -4.5,-6.5
       parent: 1
       type: Transform
-  - uid: 115
+  - uid: 98
     components:
     - pos: -4.5,-7.5
       parent: 1
       type: Transform
-  - uid: 116
+  - uid: 99
     components:
     - pos: -4.5,-8.5
       parent: 1
       type: Transform
-  - uid: 117
+  - uid: 100
     components:
     - pos: -5.5,-8.5
       parent: 1
       type: Transform
-  - uid: 118
+  - uid: 101
     components:
     - pos: -6.5,-8.5
       parent: 1
       type: Transform
-  - uid: 119
+  - uid: 102
     components:
     - pos: -7.5,-8.5
       parent: 1
       type: Transform
-  - uid: 120
+  - uid: 103
     components:
     - pos: -8.5,-8.5
       parent: 1
       type: Transform
-  - uid: 121
+  - uid: 104
     components:
     - pos: -9.5,-8.5
       parent: 1
       type: Transform
-  - uid: 122
+  - uid: 105
     components:
     - pos: -10.5,-8.5
       parent: 1
       type: Transform
-  - uid: 123
+  - uid: 106
     components:
     - pos: -11.5,-8.5
       parent: 1
       type: Transform
-  - uid: 124
+  - uid: 107
     components:
     - pos: -9.5,-6.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 125
+  - uid: 108
     components:
     - pos: -9.5,-5.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 126
+  - uid: 109
     components:
     - pos: -9.5,-4.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 127
+  - uid: 110
     components:
     - pos: -9.5,-3.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 128
+  - uid: 111
     components:
     - pos: -9.5,-2.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 129
+  - uid: 112
     components:
     - pos: -9.5,-1.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 130
+  - uid: 113
     components:
     - pos: 10.5,-7.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 131
+  - uid: 114
     components:
     - pos: -12.5,-8.5
       parent: 1
       type: Transform
-  - uid: 132
+  - uid: 115
     components:
     - pos: -13.5,-8.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 133
+  - uid: 116
     components:
     - pos: -13.5,-7.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 134
+  - uid: 117
     components:
     - pos: -13.5,-6.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 135
+  - uid: 118
     components:
     - pos: -13.5,-5.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 136
+  - uid: 119
     components:
     - pos: -13.5,-4.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 137
+  - uid: 120
     components:
     - pos: -13.5,-3.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 138
+  - uid: 121
     components:
     - pos: -13.5,-2.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 139
+  - uid: 122
     components:
     - pos: -13.5,-1.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 140
+  - uid: 123
     components:
     - pos: -13.5,-0.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 141
+  - uid: 124
     components:
     - pos: -13.5,0.5
       parent: 1
       type: Transform
-  - uid: 142
+  - uid: 125
     components:
     - pos: -12.5,0.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 143
+  - uid: 126
     components:
     - pos: -11.5,0.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 144
+  - uid: 127
     components:
     - pos: 5.5,-6.5
       parent: 1
       type: Transform
-  - uid: 145
+  - uid: 128
     components:
     - pos: 5.5,-7.5
       parent: 1
       type: Transform
-  - uid: 146
+  - uid: 129
     components:
     - pos: 5.5,-8.5
       parent: 1
       type: Transform
-  - uid: 147
+  - uid: 130
     components:
     - pos: 5.5,-8.5
       parent: 1
       type: Transform
-  - uid: 148
+  - uid: 131
     components:
     - pos: 6.5,-8.5
       parent: 1
       type: Transform
-  - uid: 149
+  - uid: 132
     components:
     - pos: 7.5,-8.5
       parent: 1
       type: Transform
-  - uid: 150
+  - uid: 133
     components:
     - pos: 8.5,-8.5
       parent: 1
       type: Transform
-  - uid: 151
+  - uid: 134
     components:
     - pos: 9.5,-8.5
       parent: 1
       type: Transform
-  - uid: 152
+  - uid: 135
     components:
     - pos: 10.5,-8.5
       parent: 1
       type: Transform
-  - uid: 153
+  - uid: 136
     components:
     - pos: 11.5,-8.5
       parent: 1
       type: Transform
-  - uid: 154
+  - uid: 137
     components:
     - pos: 12.5,-8.5
       parent: 1
       type: Transform
-  - uid: 155
+  - uid: 138
     components:
     - pos: 10.5,-6.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 156
+  - uid: 139
     components:
     - pos: 10.5,-5.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 157
+  - uid: 140
     components:
     - pos: 10.5,-4.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 158
+  - uid: 141
     components:
     - pos: 10.5,-3.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 159
+  - uid: 142
     components:
     - pos: 10.5,-2.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 160
+  - uid: 143
     components:
     - pos: 10.5,-1.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 161
+  - uid: 144
     components:
     - pos: 10.5,-0.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 162
+  - uid: 145
     components:
     - pos: 10.5,0.5
       parent: 1
       type: Transform
-  - uid: 163
+  - uid: 146
     components:
     - pos: 11.5,0.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 164
+  - uid: 147
     components:
     - pos: -11.5,-15.5
       parent: 1
       type: Transform
-  - uid: 165
+  - uid: 148
     components:
     - pos: 13.5,-8.5
       parent: 1
       type: Transform
-  - uid: 166
+  - uid: 149
     components:
     - pos: 14.5,-8.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 167
+  - uid: 150
     components:
     - pos: 14.5,-7.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 168
+  - uid: 151
     components:
     - pos: 14.5,-6.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 169
+  - uid: 152
     components:
     - pos: 14.5,-5.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 170
+  - uid: 153
     components:
     - pos: 14.5,-4.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 171
+  - uid: 154
     components:
     - pos: 14.5,-3.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 172
+  - uid: 155
     components:
     - pos: 14.5,-2.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 173
+  - uid: 156
     components:
     - pos: 14.5,-1.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 174
+  - uid: 157
     components:
     - pos: 14.5,-0.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 175
+  - uid: 158
     components:
     - pos: -3.5,-7.5
       parent: 1
       type: Transform
-  - uid: 176
+  - uid: 159
     components:
     - pos: -2.5,-7.5
       parent: 1
       type: Transform
-  - uid: 177
+  - uid: 160
     components:
     - pos: -1.5,-7.5
       parent: 1
       type: Transform
-  - uid: 178
+  - uid: 161
     components:
     - pos: -0.5,-7.5
       parent: 1
       type: Transform
-  - uid: 179
+  - uid: 162
     components:
     - pos: 0.5,-7.5
       parent: 1
       type: Transform
-  - uid: 180
+  - uid: 163
     components:
     - pos: 1.5,-7.5
       parent: 1
       type: Transform
-  - uid: 181
+  - uid: 164
     components:
     - pos: 2.5,-7.5
       parent: 1
       type: Transform
-  - uid: 182
+  - uid: 165
     components:
     - pos: 3.5,-7.5
       parent: 1
       type: Transform
-  - uid: 183
+  - uid: 166
     components:
     - pos: 4.5,-7.5
       parent: 1
       type: Transform
-  - uid: 184
+  - uid: 167
     components:
     - pos: 0.5,-6.5
       parent: 1
       type: Transform
-  - uid: 185
+  - uid: 168
     components:
     - pos: 0.5,-5.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 186
+  - uid: 169
     components:
     - pos: 0.5,-4.5
       parent: 1
       type: Transform
-  - uid: 187
+  - uid: 170
     components:
     - pos: 0.5,-3.5
       parent: 1
       type: Transform
-  - uid: 188
+  - uid: 171
     components:
     - pos: 0.5,-2.5
       parent: 1
       type: Transform
-  - uid: 189
+  - uid: 172
     components:
     - pos: 0.5,-8.5
       parent: 1
       type: Transform
-  - uid: 190
+  - uid: 173
     components:
     - pos: 0.5,-9.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 191
+  - uid: 174
     components:
     - pos: 0.5,-10.5
       parent: 1
       type: Transform
-  - uid: 192
+  - uid: 175
     components:
     - pos: 0.5,-11.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 193
+  - uid: 176
     components:
     - pos: -0.5,-9.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
-  - uid: 194
+  - uid: 177
     components:
     - pos: -1.5,-9.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 195
+  - uid: 178
     components:
     - pos: -2.5,-9.5
       parent: 1
       type: Transform
-  - uid: 196
+  - uid: 179
     components:
     - pos: 1.5,-9.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
-  - uid: 197
+  - uid: 180
     components:
     - pos: 2.5,-9.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 198
+  - uid: 181
     components:
     - pos: 3.5,-9.5
       parent: 1
       type: Transform
-  - uid: 199
+  - uid: 182
     components:
     - pos: 12.5,-9.5
       parent: 1
       type: Transform
-  - uid: 200
+  - uid: 183
     components:
     - pos: 12.5,-10.5
       parent: 1
       type: Transform
-  - uid: 201
+  - uid: 184
     components:
     - pos: 12.5,-11.5
       parent: 1
       type: Transform
-  - uid: 202
+  - uid: 185
     components:
     - pos: 12.5,-12.5
       parent: 1
       type: Transform
-  - uid: 203
+  - uid: 186
     components:
     - pos: 12.5,-13.5
       parent: 1
       type: Transform
-  - uid: 204
+  - uid: 187
     components:
     - pos: 12.5,-14.5
       parent: 1
       type: Transform
-  - uid: 205
+  - uid: 188
     components:
     - pos: 12.5,-15.5
       parent: 1
       type: Transform
-  - uid: 206
+  - uid: 189
     components:
     - pos: 13.5,-14.5
       parent: 1
       type: Transform
-  - uid: 207
+  - uid: 190
     components:
     - pos: 14.5,-14.5
       parent: 1
       type: Transform
-  - uid: 208
+  - uid: 191
     components:
     - pos: -11.5,-9.5
       parent: 1
       type: Transform
-  - uid: 209
+  - uid: 192
     components:
     - pos: -11.5,-10.5
       parent: 1
       type: Transform
-  - uid: 210
+  - uid: 193
     components:
     - pos: -11.5,-11.5
       parent: 1
       type: Transform
-  - uid: 211
+  - uid: 194
     components:
     - pos: -11.5,-12.5
       parent: 1
       type: Transform
-  - uid: 212
+  - uid: 195
     components:
     - pos: -11.5,-13.5
       parent: 1
       type: Transform
-  - uid: 213
+  - uid: 196
     components:
     - pos: -11.5,-14.5
       parent: 1
       type: Transform
-  - uid: 214
+  - uid: 197
     components:
     - pos: -12.5,-14.5
       parent: 1
       type: Transform
-  - uid: 215
+  - uid: 198
     components:
     - pos: -13.5,-14.5
       parent: 1
       type: Transform
-  - uid: 216
+  - uid: 199
     components:
     - pos: -11.5,-16.5
       parent: 1
       type: Transform
-  - uid: 217
+  - uid: 200
     components:
     - pos: -11.5,-17.5
       parent: 1
       type: Transform
-  - uid: 218
+  - uid: 201
     components:
     - pos: -11.5,-18.5
       parent: 1
       type: Transform
-  - uid: 219
+  - uid: 202
     components:
     - pos: 12.5,-16.5
       parent: 1
       type: Transform
-  - uid: 220
+  - uid: 203
     components:
     - pos: 12.5,-17.5
       parent: 1
       type: Transform
-  - uid: 221
+  - uid: 204
     components:
     - pos: 12.5,-18.5
       parent: 1
       type: Transform
-  - uid: 222
+  - uid: 205
     components:
     - pos: -10.5,-11.5
       parent: 1
       type: Transform
-  - uid: 223
+  - uid: 206
     components:
     - pos: -9.5,-11.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 224
+  - uid: 207
     components:
     - pos: -8.5,-11.5
       parent: 1
       type: Transform
-  - uid: 225
+  - uid: 208
     components:
     - pos: -7.5,-11.5
       parent: 1
       type: Transform
-  - uid: 226
+  - uid: 209
     components:
     - pos: -6.5,-11.5
       parent: 1
       type: Transform
-  - uid: 227
+  - uid: 210
     components:
     - pos: -5.5,-11.5
       parent: 1
       type: Transform
-  - uid: 228
+  - uid: 211
     components:
     - pos: -4.5,-11.5
       parent: 1
       type: Transform
-  - uid: 229
+  - uid: 212
     components:
     - pos: -3.5,-11.5
       parent: 1
       type: Transform
-  - uid: 230
+  - uid: 213
     components:
     - pos: -2.5,-11.5
       parent: 1
       type: Transform
-  - uid: 231
+  - uid: 214
     components:
     - pos: -1.5,-11.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 232
+  - uid: 215
     components:
     - pos: -0.5,-11.5
       parent: 1
       type: Transform
-  - uid: 233
+  - uid: 216
     components:
     - pos: 0.5,-11.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 234
+  - uid: 217
     components:
     - pos: 1.5,-11.5
       parent: 1
       type: Transform
-  - uid: 235
+  - uid: 218
     components:
     - pos: 2.5,-11.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 236
+  - uid: 219
     components:
     - pos: 3.5,-11.5
       parent: 1
       type: Transform
-  - uid: 237
+  - uid: 220
     components:
     - pos: 4.5,-11.5
       parent: 1
       type: Transform
-  - uid: 238
+  - uid: 221
     components:
     - pos: 5.5,-11.5
       parent: 1
       type: Transform
-  - uid: 239
+  - uid: 222
     components:
     - pos: 6.5,-11.5
       parent: 1
       type: Transform
-  - uid: 240
+  - uid: 223
     components:
     - pos: 7.5,-11.5
       parent: 1
       type: Transform
-  - uid: 241
+  - uid: 224
     components:
     - pos: 8.5,-11.5
       parent: 1
       type: Transform
-  - uid: 242
+  - uid: 225
     components:
     - pos: 9.5,-11.5
       parent: 1
       type: Transform
-  - uid: 243
+  - uid: 226
     components:
     - pos: 10.5,-11.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 244
+  - uid: 227
     components:
     - pos: 11.5,-11.5
       parent: 1
       type: Transform
-  - uid: 245
+  - uid: 228
     components:
     - pos: 0.5,-1.5
       parent: 1
       type: Transform
-  - uid: 246
+  - uid: 229
     components:
     - pos: 0.5,-0.5
       parent: 1
       type: Transform
-  - uid: 247
+  - uid: 230
     components:
     - pos: 0.5,0.5
       parent: 1
       type: Transform
-  - uid: 248
+  - uid: 231
     components:
     - pos: 0.5,1.5
       parent: 1
       type: Transform
-  - uid: 249
+  - uid: 232
     components:
     - pos: 0.5,2.5
       parent: 1
       type: Transform
-  - uid: 250
+  - uid: 233
     components:
     - pos: 0.5,3.5
       parent: 1
       type: Transform
-  - uid: 251
+  - uid: 234
     components:
     - pos: -0.5,3.5
       parent: 1
       type: Transform
-  - uid: 252
+  - uid: 235
     components:
     - pos: 0.5,4.5
       parent: 1
       type: Transform
-  - uid: 253
+  - uid: 236
     components:
     - pos: 0.5,5.5
       parent: 1
       type: Transform
-  - uid: 254
+  - uid: 237
     components:
     - pos: 0.5,6.5
       parent: 1
       type: Transform
-  - uid: 255
+  - uid: 238
     components:
     - pos: 0.5,7.5
       parent: 1
       type: Transform
-  - uid: 256
+  - uid: 239
     components:
     - pos: 0.5,8.5
       parent: 1
       type: Transform
-  - uid: 257
+  - uid: 240
     components:
     - pos: 0.5,9.5
       parent: 1
       type: Transform
-  - uid: 258
+  - uid: 241
     components:
     - pos: 0.5,10.5
       parent: 1
       type: Transform
-  - uid: 259
+  - uid: 242
     components:
     - pos: 0.5,11.5
       parent: 1
       type: Transform
-  - uid: 260
+  - uid: 243
     components:
     - pos: 0.5,12.5
       parent: 1
       type: Transform
-  - uid: 261
+  - uid: 244
     components:
     - pos: 0.5,13.5
       parent: 1
       type: Transform
-  - uid: 262
+  - uid: 245
     components:
     - pos: 0.5,14.5
       parent: 1
       type: Transform
-  - uid: 263
+  - uid: 246
     components:
     - pos: 0.5,15.5
       parent: 1
       type: Transform
-  - uid: 264
+  - uid: 247
     components:
     - pos: 0.5,16.5
       parent: 1
       type: Transform
-  - uid: 265
+  - uid: 248
     components:
     - pos: 0.5,17.5
       parent: 1
       type: Transform
-  - uid: 266
+  - uid: 249
     components:
     - pos: -0.5,13.5
       parent: 1
       type: Transform
-  - uid: 267
+  - uid: 250
     components:
     - pos: -0.5,15.5
       parent: 1
       type: Transform
-  - uid: 270
+  - uid: 251
     components:
     - pos: 1.5,9.5
       parent: 1
       type: Transform
-  - uid: 271
+  - uid: 252
     components:
     - pos: 2.5,9.5
       parent: 1
       type: Transform
-  - uid: 272
+  - uid: 253
     components:
     - pos: 3.5,9.5
       parent: 1
       type: Transform
-  - uid: 273
+  - uid: 254
     components:
     - pos: 4.5,9.5
       parent: 1
       type: Transform
-  - uid: 274
+  - uid: 255
     components:
     - pos: 5.5,9.5
       parent: 1
       type: Transform
-  - uid: 275
+  - uid: 256
     components:
     - pos: 6.5,9.5
       parent: 1
       type: Transform
-  - uid: 276
+  - uid: 257
     components:
     - pos: 5.5,15.5
       parent: 1
       type: Transform
-  - uid: 277
+  - uid: 258
     components:
     - pos: -0.5,8.5
       parent: 1
       type: Transform
-  - uid: 278
+  - uid: 259
     components:
     - pos: -1.5,8.5
       parent: 1
       type: Transform
-  - uid: 279
+  - uid: 260
     components:
     - pos: 1.5,12.5
       parent: 1
       type: Transform
-  - uid: 280
+  - uid: 261
     components:
     - pos: -3.5,8.5
       parent: 1
       type: Transform
-  - uid: 281
+  - uid: 262
     components:
     - pos: -4.5,8.5
       parent: 1
       type: Transform
-  - uid: 282
+  - uid: 263
     components:
     - pos: -5.5,8.5
       parent: 1
       type: Transform
-  - uid: 283
+  - uid: 264
     components:
     - pos: -6.5,8.5
       parent: 1
       type: Transform
-  - uid: 284
+  - uid: 265
     components:
     - pos: -0.5,11.5
       parent: 1
       type: Transform
-  - uid: 285
+  - uid: 266
     components:
     - pos: -1.5,11.5
       parent: 1
       type: Transform
-  - uid: 286
+  - uid: 267
     components:
     - pos: -2.5,11.5
       parent: 1
       type: Transform
-  - uid: 287
+  - uid: 268
     components:
     - pos: -3.5,11.5
       parent: 1
       type: Transform
-  - uid: 288
+  - uid: 269
     components:
     - pos: -4.5,11.5
       parent: 1
       type: Transform
-  - uid: 289
+  - uid: 270
     components:
     - pos: -5.5,11.5
       parent: 1
       type: Transform
-  - uid: 290
+  - uid: 271
     components:
     - pos: -2.5,14.5
       parent: 1
       type: Transform
-  - uid: 291
+  - uid: 272
     components:
     - pos: -2.5,13.5
       parent: 1
       type: Transform
-  - uid: 293
+  - uid: 273
     components:
     - pos: 1.5,14.5
       parent: 1
       type: Transform
-  - uid: 294
+  - uid: 274
     components:
     - pos: 2.5,14.5
       parent: 1
       type: Transform
-  - uid: 295
+  - uid: 275
     components:
     - pos: 3.5,14.5
       parent: 1
       type: Transform
-  - uid: 296
+  - uid: 276
     components:
     - pos: 4.5,14.5
       parent: 1
       type: Transform
-  - uid: 297
+  - uid: 277
     components:
     - pos: 6.5,8.5
       parent: 1
       type: Transform
-  - uid: 298
+  - uid: 278
     components:
     - pos: 6.5,7.5
       parent: 1
       type: Transform
-  - uid: 299
+  - uid: 279
     components:
     - pos: 7.5,8.5
       parent: 1
       type: Transform
-  - uid: 300
+  - uid: 280
     components:
     - pos: 8.5,8.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 301
+  - uid: 281
     components:
     - pos: 3.5,8.5
       parent: 1
       type: Transform
-  - uid: 302
+  - uid: 282
     components:
     - pos: 3.5,7.5
       parent: 1
       type: Transform
-  - uid: 303
+  - uid: 283
     components:
     - pos: 3.5,6.5
       parent: 1
       type: Transform
-  - uid: 304
+  - uid: 284
     components:
     - pos: 3.5,5.5
       parent: 1
       type: Transform
-  - uid: 305
+  - uid: 285
     components:
     - pos: 3.5,4.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 306
+  - uid: 286
     components:
     - pos: 3.5,3.5
       parent: 1
       type: Transform
-  - uid: 307
+  - uid: 287
     components:
     - pos: 3.5,2.5
       parent: 1
       type: Transform
-  - uid: 308
+  - uid: 288
     components:
     - pos: 3.5,1.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 309
+  - uid: 289
     components:
     - pos: 3.5,0.5
       parent: 1
       type: Transform
-  - uid: 310
+  - uid: 290
     components:
     - pos: 3.5,-0.5
       parent: 1
       type: Transform
-  - uid: 311
+  - uid: 291
     components:
     - pos: 3.5,-1.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 312
+  - uid: 292
     components:
     - pos: 3.5,-2.5
       parent: 1
       type: Transform
-  - uid: 313
+  - uid: 293
     components:
     - pos: 3.5,-3.5
       parent: 1
       type: Transform
-  - uid: 314
+  - uid: 294
     components:
     - pos: 3.5,-4.5
       parent: 1
       type: Transform
-  - uid: 315
+  - uid: 295
     components:
     - pos: 3.5,-5.5
       parent: 1
       type: Transform
-  - uid: 316
+  - uid: 296
     components:
     - pos: 3.5,-6.5
       parent: 1
       type: Transform
-  - uid: 317
+  - uid: 297
     components:
     - pos: -2.5,-6.5
       parent: 1
       type: Transform
-  - uid: 318
+  - uid: 298
     components:
     - pos: -2.5,-5.5
       parent: 1
       type: Transform
-  - uid: 319
+  - uid: 299
     components:
     - pos: -2.5,-4.5
       parent: 1
       type: Transform
-  - uid: 320
+  - uid: 300
     components:
     - pos: -2.5,-3.5
       parent: 1
       type: Transform
-  - uid: 321
+  - uid: 301
     components:
     - pos: -2.5,-2.5
       parent: 1
       type: Transform
-  - uid: 322
+  - uid: 302
     components:
     - pos: -2.5,-1.5
       parent: 1
       type: Transform
-  - uid: 323
+  - uid: 303
     components:
     - pos: -2.5,-0.5
       parent: 1
       type: Transform
-  - uid: 324
+  - uid: 304
     components:
     - pos: -2.5,0.5
       parent: 1
       type: Transform
-  - uid: 325
+  - uid: 305
     components:
     - pos: -2.5,1.5
       parent: 1
       type: Transform
-  - uid: 326
+  - uid: 306
     components:
     - pos: -2.5,2.5
       parent: 1
       type: Transform
-  - uid: 327
+  - uid: 307
     components:
     - pos: -2.5,3.5
       parent: 1
       type: Transform
-  - uid: 328
+  - uid: 308
     components:
     - pos: -2.5,4.5
       parent: 1
       type: Transform
-  - uid: 329
+  - uid: 309
     components:
     - pos: -2.5,5.5
       parent: 1
       type: Transform
-  - uid: 330
+  - uid: 310
     components:
     - pos: -2.5,6.5
       parent: 1
       type: Transform
-  - uid: 331
+  - uid: 311
     components:
     - pos: -2.5,7.5
       parent: 1
       type: Transform
-  - uid: 332
+  - uid: 312
     components:
     - pos: -2.5,8.5
       parent: 1
       type: Transform
-  - uid: 333
+  - uid: 313
     components:
     - pos: -2.5,9.5
       parent: 1
       type: Transform
-  - uid: 334
+  - uid: 314
     components:
     - pos: -2.5,10.5
       parent: 1
       type: Transform
-  - uid: 335
+  - uid: 315
     components:
     - pos: 2.5,12.5
       parent: 1
       type: Transform
-  - uid: 336
+  - uid: 316
     components:
     - pos: 3.5,12.5
       parent: 1
       type: Transform
-  - uid: 337
+  - uid: 317
     components:
     - pos: 4.5,12.5
       parent: 1
       type: Transform
-  - uid: 338
+  - uid: 318
     components:
     - pos: 5.5,12.5
       parent: 1
       type: Transform
-  - uid: 339
+  - uid: 319
     components:
     - pos: -1.5,20.5
       parent: 1
       type: Transform
-  - uid: 340
+  - uid: 320
     components:
     - pos: 5.5,11.5
       parent: 1
       type: Transform
-  - uid: 341
+  - uid: 321
     components:
     - pos: 12.5,-7.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 342
+  - uid: 322
     components:
     - pos: 12.5,-5.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 343
+  - uid: 323
     components:
     - pos: 12.5,-4.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 344
+  - uid: 324
     components:
     - pos: 12.5,-3.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 345
+  - uid: 325
     components:
     - pos: 12.5,-2.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 346
+  - uid: 326
     components:
     - pos: 12.5,-1.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 347
+  - uid: 327
     components:
     - pos: 12.5,-0.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 348
+  - uid: 328
     components:
     - pos: 12.5,0.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 349
+  - uid: 329
     components:
     - pos: -11.5,-7.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 350
+  - uid: 330
     components:
     - pos: -11.5,-6.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 351
+  - uid: 331
     components:
     - pos: -11.5,-5.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 352
+  - uid: 332
     components:
     - pos: -11.5,-4.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 353
+  - uid: 333
     components:
     - pos: -11.5,-3.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 354
+  - uid: 334
     components:
     - pos: -11.5,-2.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 355
+  - uid: 335
     components:
     - pos: -11.5,-1.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 356
+  - uid: 336
     components:
     - pos: -11.5,-0.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 357
+  - uid: 337
     components:
     - pos: -11.5,0.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 358
+  - uid: 338
     components:
     - pos: 0.5,18.5
       parent: 1
       type: Transform
-  - uid: 359
+  - uid: 339
     components:
     - pos: 0.5,19.5
       parent: 1
       type: Transform
-  - uid: 360
+  - uid: 340
     components:
     - pos: -0.5,5.5
       parent: 1
       type: Transform
-  - uid: 361
+  - uid: 341
     components:
     - pos: 0.5,21.5
       parent: 1
       type: Transform
-  - uid: 501
+  - uid: 342
     components:
     - pos: -0.5,20.5
       parent: 1
       type: Transform
-  - uid: 853
+  - uid: 343
     components:
     - pos: 1.5,17.5
       parent: 1
       type: Transform
-  - uid: 884
+  - uid: 344
     components:
     - pos: -1.5,17.5
       parent: 1
       type: Transform
-  - uid: 886
+  - uid: 345
     components:
     - pos: -0.5,17.5
       parent: 1
       type: Transform
-  - uid: 979
+  - uid: 346
     components:
     - pos: -2.5,12.5
       parent: 1
       type: Transform
-  - uid: 1092
+  - uid: 347
     components:
     - pos: 2.5,17.5
       parent: 1
       type: Transform
-  - uid: 1219
+  - uid: 348
     components:
     - pos: 0.5,20.5
       parent: 1
       type: Transform
-  - uid: 1226
+  - uid: 349
     components:
     - pos: 1.5,20.5
       parent: 1
       type: Transform
-  - uid: 1257
+  - uid: 350
     components:
     - pos: -2.5,15.5
       parent: 1
       type: Transform
-  - uid: 1258
+  - uid: 351
     components:
     - pos: -3.5,15.5
       parent: 1
       type: Transform
-  - uid: 1306
+  - uid: 352
     components:
     - pos: 2.5,20.5
       parent: 1
       type: Transform
 - proto: CableApcStack
   entities:
-  - uid: 363
+  - uid: 354
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 362
+    - parent: 353
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: CableHV
   entities:
-  - uid: 368
+  - uid: 359
     components:
     - pos: 2.5,8.5
       parent: 1
       type: Transform
-  - uid: 369
+  - uid: 360
     components:
     - pos: 3.5,8.5
       parent: 1
       type: Transform
-  - uid: 370
+  - uid: 361
     components:
     - pos: 4.5,8.5
       parent: 1
       type: Transform
-  - uid: 371
+  - uid: 362
     components:
     - pos: 3.5,9.5
       parent: 1
       type: Transform
-  - uid: 372
+  - uid: 363
     components:
     - pos: 2.5,9.5
       parent: 1
       type: Transform
-  - uid: 373
+  - uid: 364
     components:
     - pos: 4.5,9.5
       parent: 1
       type: Transform
-  - uid: 374
+  - uid: 365
     components:
     - pos: 2.5,10.5
       parent: 1
       type: Transform
-  - uid: 375
+  - uid: 366
     components:
     - pos: 1.5,9.5
       parent: 1
       type: Transform
-  - uid: 376
+  - uid: 367
     components:
     - pos: 0.5,9.5
       parent: 1
       type: Transform
-  - uid: 377
+  - uid: 368
     components:
     - pos: 0.5,8.5
       parent: 1
       type: Transform
-  - uid: 378
+  - uid: 369
     components:
     - pos: 0.5,7.5
       parent: 1
       type: Transform
-  - uid: 379
+  - uid: 370
     components:
     - pos: 0.5,6.5
       parent: 1
       type: Transform
-  - uid: 380
+  - uid: 371
     components:
     - pos: 0.5,5.5
       parent: 1
       type: Transform
-  - uid: 381
+  - uid: 372
     components:
     - pos: 0.5,4.5
       parent: 1
       type: Transform
-  - uid: 382
+  - uid: 373
     components:
     - pos: 0.5,3.5
       parent: 1
       type: Transform
-  - uid: 383
+  - uid: 374
     components:
     - pos: 0.5,2.5
       parent: 1
       type: Transform
-  - uid: 384
+  - uid: 375
     components:
     - pos: 0.5,1.5
       parent: 1
       type: Transform
-  - uid: 385
+  - uid: 376
     components:
     - pos: -0.5,1.5
       parent: 1
       type: Transform
-  - uid: 386
+  - uid: 377
     components:
     - pos: -1.5,1.5
       parent: 1
       type: Transform
-  - uid: 387
+  - uid: 378
     components:
     - pos: -2.5,1.5
       parent: 1
       type: Transform
-  - uid: 388
+  - uid: 379
     components:
     - pos: 10.5,-10.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 389
+  - uid: 380
     components:
     - pos: 0.5,10.5
       parent: 1
       type: Transform
-  - uid: 390
+  - uid: 381
     components:
     - pos: 0.5,11.5
       parent: 1
       type: Transform
-  - uid: 391
+  - uid: 382
     components:
     - pos: 0.5,12.5
       parent: 1
       type: Transform
-  - uid: 392
+  - uid: 383
     components:
     - pos: 0.5,13.5
       parent: 1
       type: Transform
-  - uid: 393
+  - uid: 384
     components:
     - pos: 0.5,14.5
       parent: 1
       type: Transform
-  - uid: 394
+  - uid: 385
     components:
     - pos: 0.5,15.5
       parent: 1
       type: Transform
-  - uid: 395
+  - uid: 386
     components:
     - pos: 0.5,16.5
       parent: 1
       type: Transform
-  - uid: 396
+  - uid: 387
     components:
     - pos: 0.5,17.5
       parent: 1
       type: Transform
-  - uid: 397
+  - uid: 388
     components:
     - pos: 0.5,18.5
       parent: 1
       type: Transform
-  - uid: 400
+  - uid: 389
     components:
     - pos: -0.5,16.5
       parent: 1
       type: Transform
-  - uid: 401
+  - uid: 390
     components:
     - pos: -1.5,16.5
       parent: 1
       type: Transform
-  - uid: 402
+  - uid: 391
     components:
     - pos: -2.5,16.5
       parent: 1
       type: Transform
-  - uid: 403
+  - uid: 392
     components:
     - pos: 1.5,16.5
       parent: 1
       type: Transform
-  - uid: 404
+  - uid: 393
     components:
     - pos: 2.5,16.5
       parent: 1
       type: Transform
-  - uid: 405
+  - uid: 394
     components:
     - pos: 3.5,16.5
       parent: 1
       type: Transform
-  - uid: 406
+  - uid: 395
     components:
     - pos: 0.5,0.5
       parent: 1
       type: Transform
-  - uid: 407
+  - uid: 396
     components:
     - pos: 0.5,-0.5
       parent: 1
       type: Transform
-  - uid: 408
+  - uid: 397
     components:
     - pos: 0.5,-1.5
       parent: 1
       type: Transform
-  - uid: 409
+  - uid: 398
     components:
     - pos: 0.5,-2.5
       parent: 1
       type: Transform
-  - uid: 410
+  - uid: 399
     components:
     - pos: 0.5,-3.5
       parent: 1
       type: Transform
-  - uid: 411
+  - uid: 400
     components:
     - pos: 0.5,-4.5
       parent: 1
       type: Transform
-  - uid: 412
+  - uid: 401
     components:
     - pos: 0.5,-5.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 413
+  - uid: 402
     components:
     - pos: 0.5,-6.5
       parent: 1
       type: Transform
-  - uid: 414
+  - uid: 403
     components:
     - pos: 0.5,-7.5
       parent: 1
       type: Transform
-  - uid: 415
+  - uid: 404
     components:
     - pos: 0.5,-8.5
       parent: 1
       type: Transform
-  - uid: 416
+  - uid: 405
     components:
     - pos: 0.5,-9.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 417
+  - uid: 406
     components:
     - pos: -0.5,-9.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
-  - uid: 418
+  - uid: 407
     components:
     - pos: -1.5,-9.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 419
+  - uid: 408
     components:
     - pos: -2.5,-9.5
       parent: 1
       type: Transform
-  - uid: 420
+  - uid: 409
     components:
     - pos: -3.5,-9.5
       parent: 1
       type: Transform
-  - uid: 421
+  - uid: 410
     components:
     - pos: -4.5,-9.5
       parent: 1
       type: Transform
-  - uid: 422
+  - uid: 411
     components:
     - pos: -5.5,-9.5
       parent: 1
       type: Transform
-  - uid: 423
+  - uid: 412
     components:
     - pos: -6.5,-9.5
       parent: 1
       type: Transform
-  - uid: 424
+  - uid: 413
     components:
     - pos: -7.5,-9.5
       parent: 1
       type: Transform
-  - uid: 425
+  - uid: 414
     components:
     - pos: -8.5,-9.5
       parent: 1
       type: Transform
-  - uid: 426
+  - uid: 415
     components:
     - pos: -9.5,-9.5
       parent: 1
       type: Transform
-  - uid: 427
+  - uid: 416
     components:
     - pos: -9.5,-10.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 428
+  - uid: 417
     components:
     - pos: -9.5,-11.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 429
+  - uid: 418
     components:
     - pos: -9.5,-12.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 430
+  - uid: 419
     components:
     - pos: -9.5,-13.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 431
+  - uid: 420
     components:
     - pos: -9.5,-14.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 432
+  - uid: 421
     components:
     - pos: -9.5,-15.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 433
+  - uid: 422
     components:
     - pos: -9.5,-16.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 434
+  - uid: 423
     components:
     - pos: 1.5,-9.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
-  - uid: 435
+  - uid: 424
     components:
     - pos: 2.5,-9.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 436
+  - uid: 425
     components:
     - pos: 3.5,-9.5
       parent: 1
       type: Transform
-  - uid: 437
+  - uid: 426
     components:
     - pos: 4.5,-9.5
       parent: 1
       type: Transform
-  - uid: 438
+  - uid: 427
     components:
     - pos: 5.5,-9.5
       parent: 1
       type: Transform
-  - uid: 439
+  - uid: 428
     components:
     - pos: 6.5,-9.5
       parent: 1
       type: Transform
-  - uid: 440
+  - uid: 429
     components:
     - pos: 7.5,-9.5
       parent: 1
       type: Transform
-  - uid: 441
+  - uid: 430
     components:
     - pos: 8.5,-9.5
       parent: 1
       type: Transform
-  - uid: 442
+  - uid: 431
     components:
     - pos: 9.5,-9.5
       parent: 1
       type: Transform
-  - uid: 443
+  - uid: 432
     components:
     - pos: 10.5,-9.5
       parent: 1
       type: Transform
-  - uid: 444
+  - uid: 433
     components:
     - pos: 10.5,-11.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 445
+  - uid: 434
     components:
     - pos: 10.5,-12.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 446
+  - uid: 435
     components:
     - pos: 10.5,-13.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 447
+  - uid: 436
     components:
     - pos: 10.5,-14.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 448
+  - uid: 437
     components:
     - pos: 10.5,-15.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 449
+  - uid: 438
     components:
     - pos: 10.5,-16.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 582
+  - uid: 439
     components:
     - pos: 2.5,16.5
       parent: 1
       type: Transform
-  - uid: 840
+  - uid: 440
     components:
     - pos: 1.5,16.5
       parent: 1
       type: Transform
-  - uid: 1093
+  - uid: 441
     components:
     - pos: -0.5,20.5
       parent: 1
       type: Transform
-  - uid: 1094
+  - uid: 442
     components:
     - pos: 0.5,19.5
       parent: 1
       type: Transform
-  - uid: 1095
+  - uid: 443
     components:
     - pos: 0.5,20.5
       parent: 1
       type: Transform
-  - uid: 1101
+  - uid: 444
     components:
     - pos: 1.5,20.5
       parent: 1
       type: Transform
 - proto: CableHVStack
   entities:
-  - uid: 364
+  - uid: 355
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 362
+    - parent: 353
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: CableMV
   entities:
-  - uid: 60
+  - uid: 445
     components:
     - pos: -0.5,5.5
       parent: 1
       type: Transform
-  - uid: 452
+  - uid: 446
     components:
     - pos: 2.5,10.5
       parent: 1
       type: Transform
-  - uid: 453
+  - uid: 447
     components:
     - pos: 2.5,9.5
       parent: 1
       type: Transform
-  - uid: 454
+  - uid: 448
     components:
     - pos: 1.5,9.5
       parent: 1
       type: Transform
-  - uid: 455
+  - uid: 449
     components:
     - pos: 0.5,9.5
       parent: 1
       type: Transform
-  - uid: 456
+  - uid: 450
     components:
     - pos: -2.5,1.5
       parent: 1
       type: Transform
-  - uid: 457
+  - uid: 451
     components:
     - pos: -1.5,1.5
       parent: 1
       type: Transform
-  - uid: 458
+  - uid: 452
     components:
     - pos: -0.5,1.5
       parent: 1
       type: Transform
-  - uid: 459
+  - uid: 453
     components:
     - pos: 0.5,1.5
       parent: 1
       type: Transform
-  - uid: 460
+  - uid: 454
     components:
     - pos: 0.5,2.5
       parent: 1
       type: Transform
-  - uid: 461
+  - uid: 455
     components:
     - pos: 0.5,3.5
       parent: 1
       type: Transform
-  - uid: 462
+  - uid: 456
     components:
     - pos: 0.5,4.5
       parent: 1
       type: Transform
-  - uid: 463
+  - uid: 457
     components:
     - pos: 0.5,5.5
       parent: 1
       type: Transform
-  - uid: 464
+  - uid: 458
     components:
     - pos: 0.5,6.5
       parent: 1
       type: Transform
-  - uid: 465
+  - uid: 459
     components:
     - pos: 0.5,7.5
       parent: 1
       type: Transform
-  - uid: 466
+  - uid: 460
     components:
     - pos: 0.5,8.5
       parent: 1
       type: Transform
-  - uid: 467
+  - uid: 461
     components:
     - pos: 4.5,8.5
       parent: 1
       type: Transform
-  - uid: 468
+  - uid: 462
     components:
     - pos: 4.5,9.5
       parent: 1
       type: Transform
-  - uid: 469
+  - uid: 463
     components:
     - pos: 3.5,9.5
       parent: 1
       type: Transform
-  - uid: 470
+  - uid: 464
     components:
     - pos: 0.5,10.5
       parent: 1
       type: Transform
-  - uid: 471
+  - uid: 465
     components:
     - pos: 0.5,11.5
       parent: 1
       type: Transform
-  - uid: 472
+  - uid: 466
     components:
     - pos: 0.5,12.5
       parent: 1
       type: Transform
-  - uid: 473
+  - uid: 467
     components:
     - pos: 0.5,13.5
       parent: 1
       type: Transform
-  - uid: 474
+  - uid: 468
     components:
     - pos: -0.5,13.5
       parent: 1
       type: Transform
-  - uid: 475
+  - uid: 469
     components:
     - pos: 0.5,0.5
       parent: 1
       type: Transform
-  - uid: 476
+  - uid: 470
     components:
     - pos: 0.5,-0.5
       parent: 1
       type: Transform
-  - uid: 477
+  - uid: 471
     components:
     - pos: 0.5,-1.5
       parent: 1
       type: Transform
-  - uid: 478
+  - uid: 472
     components:
     - pos: 0.5,-2.5
       parent: 1
       type: Transform
-  - uid: 479
+  - uid: 473
     components:
     - pos: 0.5,-3.5
       parent: 1
       type: Transform
-  - uid: 480
+  - uid: 474
     components:
     - pos: 0.5,-4.5
       parent: 1
       type: Transform
-  - uid: 481
+  - uid: 475
     components:
     - pos: 0.5,-5.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 482
+  - uid: 476
     components:
     - pos: 0.5,-6.5
       parent: 1
       type: Transform
-  - uid: 483
+  - uid: 477
     components:
     - pos: 0.5,-7.5
       parent: 1
       type: Transform
-  - uid: 484
+  - uid: 478
     components:
     - pos: 1.5,-7.5
       parent: 1
       type: Transform
-  - uid: 485
+  - uid: 479
     components:
     - pos: 2.5,-7.5
       parent: 1
       type: Transform
-  - uid: 486
+  - uid: 480
     components:
     - pos: 3.5,-7.5
       parent: 1
       type: Transform
-  - uid: 487
+  - uid: 481
     components:
     - pos: 4.5,-7.5
       parent: 1
       type: Transform
-  - uid: 488
+  - uid: 482
     components:
     - pos: 5.5,-7.5
       parent: 1
       type: Transform
-  - uid: 489
+  - uid: 483
     components:
     - pos: 5.5,-6.5
       parent: 1
       type: Transform
-  - uid: 490
+  - uid: 484
     components:
     - pos: -0.5,-7.5
       parent: 1
       type: Transform
-  - uid: 491
+  - uid: 485
     components:
     - pos: -1.5,-7.5
       parent: 1
       type: Transform
-  - uid: 492
+  - uid: 486
     components:
     - pos: -2.5,-7.5
       parent: 1
       type: Transform
-  - uid: 493
+  - uid: 487
     components:
     - pos: -3.5,-7.5
       parent: 1
       type: Transform
-  - uid: 494
+  - uid: 488
     components:
     - pos: -4.5,-7.5
       parent: 1
       type: Transform
-  - uid: 495
+  - uid: 489
     components:
     - pos: -4.5,-6.5
       parent: 1
       type: Transform
-  - uid: 496
+  - uid: 490
     components:
     - pos: -0.5,3.5
       parent: 1
       type: Transform
-  - uid: 497
+  - uid: 491
     components:
     - pos: 0.5,14.5
       parent: 1
       type: Transform
-  - uid: 498
+  - uid: 492
     components:
     - pos: 1.5,15.5
       parent: 1
       type: Transform
-  - uid: 500
+  - uid: 493
     components:
     - pos: 5.5,9.5
       parent: 1
       type: Transform
-  - uid: 502
+  - uid: 494
     components:
     - pos: 5.5,10.5
       parent: 1
       type: Transform
-  - uid: 503
+  - uid: 495
     components:
     - pos: -0.5,15.5
       parent: 1
       type: Transform
-  - uid: 506
+  - uid: 496
     components:
     - pos: 2.5,15.5
       parent: 1
       type: Transform
-  - uid: 507
+  - uid: 497
     components:
     - pos: 0.5,15.5
       parent: 1
       type: Transform
-  - uid: 1144
+  - uid: 498
     components:
     - pos: 2.5,16.5
       parent: 1
       type: Transform
 - proto: CableMVStack
   entities:
-  - uid: 365
+  - uid: 356
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 362
+    - parent: 353
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: CableTerminal
   entities:
-  - uid: 508
+  - uid: 499
     components:
     - rot: 3.141592653589793 rad
       pos: 3.5,9.5
@@ -3142,89 +3236,89 @@ entities:
       type: Transform
 - proto: Carpet
   entities:
-  - uid: 1005
+  - uid: 500
     components:
     - pos: 2.5,15.5
       parent: 1
       type: Transform
-  - uid: 1044
+  - uid: 501
     components:
     - pos: 2.5,14.5
       parent: 1
       type: Transform
-  - uid: 1133
+  - uid: 502
     components:
     - pos: 3.5,14.5
       parent: 1
       type: Transform
-  - uid: 1137
+  - uid: 503
     components:
     - pos: 3.5,15.5
       parent: 1
       type: Transform
-  - uid: 1237
+  - uid: 504
     components:
     - pos: 4.5,14.5
       parent: 1
       type: Transform
 - proto: CartridgeRocket
   entities:
-  - uid: 862
+  - uid: 506
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 861
+    - parent: 505
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 863
+  - uid: 507
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 861
+    - parent: 505
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 865
+  - uid: 508
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 861
+    - parent: 505
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: CartridgeRocketEmp
   entities:
-  - uid: 864
+  - uid: 509
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 861
+    - parent: 505
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 866
+  - uid: 510
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 861
+    - parent: 505
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: ChairPilotSeat
   entities:
-  - uid: 538
+  - uid: 512
     components:
     - rot: 3.141592653589793 rad
       pos: 1.5,18.5
       parent: 1
       type: Transform
-  - uid: 589
+  - uid: 513
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,18.5
@@ -3232,21 +3326,21 @@ entities:
       type: Transform
 - proto: chem_master
   entities:
-  - uid: 523
+  - uid: 514
     components:
     - pos: -3.5,7.5
       parent: 1
       type: Transform
 - proto: ClosetBombFilled
   entities:
-  - uid: 1234
+  - uid: 515
     components:
     - pos: 6.5,8.5
       parent: 1
       type: Transform
 - proto: ClosetWall
   entities:
-  - uid: 45
+  - uid: 37
     components:
     - pos: 3.5,10.5
       parent: 1
@@ -3274,9 +3368,9 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 46
+          - 38
       type: ContainerContainer
-  - uid: 362
+  - uid: 353
     components:
     - pos: 4.5,10.5
       parent: 1
@@ -3304,32 +3398,32 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 366
-          - 364
-          - 363
-          - 367
-          - 365
+          - 357
+          - 355
+          - 354
+          - 358
+          - 356
       type: ContainerContainer
 - proto: ClosetWallEmergencyFilledRandom
   entities:
-  - uid: 524
+  - uid: 516
     components:
     - pos: 11.5,-7.5
       parent: 1
       type: Transform
-  - uid: 525
+  - uid: 517
     components:
     - pos: -10.5,-7.5
       parent: 1
       type: Transform
 - proto: ClosetWallFireFilledRandom
   entities:
-  - uid: 526
+  - uid: 518
     components:
     - pos: 1.5,-6.5
       parent: 1
       type: Transform
-  - uid: 527
+  - uid: 519
     components:
     - rot: 1.5707963267948966 rad
       pos: -0.5,12.5
@@ -3337,306 +3431,306 @@ entities:
       type: Transform
 - proto: ClothingBackpackDuffelSurgeryFilled
   entities:
-  - uid: 85
+  - uid: 521
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 84
+    - parent: 520
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: ClothingBeltSheathFilled
   entities:
-  - uid: 11
+  - uid: 523
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 5
+    - parent: 522
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: ClothingEyesGlassesSunglasses
   entities:
-  - uid: 1513
+  - uid: 533
     components:
     - pos: 3.4467783,-3.382914
       parent: 1
       type: Transform
 - proto: ClothingHeadHatChef
   entities:
-  - uid: 531
+  - uid: 534
     components:
     - pos: 2.9483314,-2.1550899
       parent: 1
       type: Transform
 - proto: ClothingHeadHelmetRiot
   entities:
-  - uid: 1097
+  - uid: 535
     components:
     - pos: 6.3127594,7.522749
       parent: 1
       type: Transform
-  - uid: 1154
+  - uid: 536
     components:
     - pos: 6.6252594,7.803999
       parent: 1
       type: Transform
-  - uid: 1170
+  - uid: 537
     components:
     - pos: 6.4846344,7.710249
       parent: 1
       type: Transform
 - proto: ClothingNeckCloakCapFormal
   entities:
-  - uid: 8
+  - uid: 524
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 5
+    - parent: 522
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: ClothingNeckMantleCap
   entities:
-  - uid: 15
+  - uid: 525
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 5
+    - parent: 522
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: ClothingNeckMantleHOS
   entities:
-  - uid: 9
+  - uid: 526
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 5
+    - parent: 522
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: ClothingOuterArmorCaptainCarapace
   entities:
-  - uid: 14
+  - uid: 527
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 5
+    - parent: 522
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: ClothingOuterArmorReflective
   entities:
-  - uid: 6
+  - uid: 528
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 5
+    - parent: 522
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: ClothingOuterArmorRiot
   entities:
-  - uid: 26
+  - uid: 538
     components:
     - pos: 6.436035,7.438429
       parent: 1
       type: Transform
-  - uid: 1155
+  - uid: 539
     components:
     - pos: 6.279785,7.297804
       parent: 1
       type: Transform
-  - uid: 1161
+  - uid: 540
     components:
     - pos: 6.70166,7.594679
       parent: 1
       type: Transform
 - proto: ClothingOuterCoatHyenhSweater
   entities:
-  - uid: 13
+  - uid: 529
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 5
+    - parent: 522
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: ClothingOuterJacketChef
   entities:
-  - uid: 533
+  - uid: 541
     components:
     - pos: 2.9327064,-2.4832149
       parent: 1
       type: Transform
 - proto: ClothingShoesColorOrange
   entities:
-  - uid: 892
+  - uid: 543
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 891
+    - parent: 542
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 895
+  - uid: 544
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 891
+    - parent: 542
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 897
+  - uid: 545
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 891
+    - parent: 542
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 899
+  - uid: 546
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 891
+    - parent: 542
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 901
+  - uid: 552
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 900
+    - parent: 551
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 902
+  - uid: 553
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 900
+    - parent: 551
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 903
+  - uid: 554
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 900
+    - parent: 551
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 904
+  - uid: 555
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 900
+    - parent: 551
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: ClothingUniformJumpskirtPrisoner
   entities:
-  - uid: 894
+  - uid: 547
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 891
+    - parent: 542
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 896
+  - uid: 548
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 891
+    - parent: 542
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 906
+  - uid: 556
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 900
+    - parent: 551
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 908
+  - uid: 557
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 900
+    - parent: 551
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: ClothingUniformJumpsuitPrisoner
   entities:
-  - uid: 893
+  - uid: 549
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 891
+    - parent: 542
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 898
+  - uid: 550
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 891
+    - parent: 542
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 905
+  - uid: 558
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 900
+    - parent: 551
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 907
+  - uid: 559
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 900
+    - parent: 551
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: ComfyChair
   entities:
-  - uid: 522
+  - uid: 560
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,14.5
       parent: 1
       type: Transform
-  - uid: 1517
+  - uid: 561
     components:
     - rot: 1.5707963267948966 rad
       pos: -1.5,4.5
@@ -3644,7 +3738,7 @@ entities:
       type: Transform
 - proto: ComputerCrewMonitoring
   entities:
-  - uid: 600
+  - uid: 562
     components:
     - rot: 1.5707963267948966 rad
       pos: -1.5,17.5
@@ -3652,42 +3746,42 @@ entities:
       type: Transform
 - proto: ComputerCriminalRecords
   entities:
-  - uid: 598
+  - uid: 563
     components:
     - rot: -1.5707963267948966 rad
       pos: 2.5,17.5
       parent: 1
       type: Transform
-  - uid: 1250
+  - uid: 564
     components:
     - rot: 1.5707963267948966 rad
       pos: -2.5,3.5
       parent: 1
       type: Transform
-- proto: ComputerIFFSyndicate
+- proto: ComputerIFF
   entities:
-  - uid: 398
+  - uid: 565
     components:
     - pos: 0.5,19.5
       parent: 1
       type: Transform
 - proto: ComputerRadar
   entities:
-  - uid: 919
+  - uid: 566
     components:
     - pos: -0.5,19.5
       parent: 1
       type: Transform
 - proto: ComputerShuttle
   entities:
-  - uid: 399
+  - uid: 567
     components:
     - pos: 1.5,19.5
       parent: 1
       type: Transform
 - proto: ComputerStationRecords
   entities:
-  - uid: 514
+  - uid: 568
     components:
     - rot: 1.5707963267948966 rad
       pos: 2.5,14.5
@@ -3695,7 +3789,7 @@ entities:
       type: Transform
 - proto: ComputerSurveillanceCameraMonitor
   entities:
-  - uid: 912
+  - uid: 569
     components:
     - rot: 1.5707963267948966 rad
       pos: -2.5,2.5
@@ -3703,21 +3797,21 @@ entities:
       type: Transform
 - proto: CrateChemistrySupplies
   entities:
-  - uid: 541
+  - uid: 570
     components:
     - pos: -2.5,0.5
       parent: 1
       type: Transform
 - proto: CrateFoodCooking
   entities:
-  - uid: 542
+  - uid: 571
     components:
     - pos: -1.5,-0.5
       parent: 1
       type: Transform
 - proto: CrateHydroponicsSeeds
   entities:
-  - uid: 543
+  - uid: 572
     components:
     - pos: -2.5,-0.5
       parent: 1
@@ -3745,7 +3839,7 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 544
+          - 573
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -3753,7 +3847,7 @@ entities:
       type: ContainerContainer
 - proto: DefibrillatorCabinetFilled
   entities:
-  - uid: 1073
+  - uid: 574
     components:
     - rot: -1.5707963267948966 rad
       pos: -0.5,7.5
@@ -3761,226 +3855,226 @@ entities:
       type: Transform
 - proto: DisposalPipe
   entities:
-  - uid: 547
+  - uid: 575
     components:
     - pos: 2.5,-6.5
       parent: 1
       type: Transform
-  - uid: 548
+  - uid: 576
     components:
     - pos: 2.5,-7.5
       parent: 1
       type: Transform
-  - uid: 549
+  - uid: 577
     components:
     - pos: 2.5,-8.5
       parent: 1
       type: Transform
-  - uid: 550
+  - uid: 578
     components:
     - pos: 2.5,-9.5
       parent: 1
       type: Transform
-  - uid: 551
+  - uid: 579
     components:
     - pos: 2.5,-10.5
       parent: 1
       type: Transform
-  - uid: 552
+  - uid: 580
     components:
     - pos: 2.5,-11.5
       parent: 1
       type: Transform
 - proto: DisposalTrunk
   entities:
-  - uid: 553
+  - uid: 581
     components:
     - pos: 2.5,-5.5
       parent: 1
       type: Transform
 - proto: DisposalUnit
   entities:
-  - uid: 554
+  - uid: 582
     components:
     - pos: 2.5,-5.5
       parent: 1
       type: Transform
 - proto: EmergencyLight
   entities:
-  - uid: 555
+  - uid: 583
     components:
     - pos: 13.5,-17.5
       parent: 1
       type: Transform
-  - uid: 556
+  - uid: 584
     components:
     - rot: -1.5707963267948966 rad
       pos: 0.5,1.5
       parent: 1
       type: Transform
-  - uid: 557
+  - uid: 585
     components:
     - rot: 1.5707963267948966 rad
       pos: 0.5,7.5
       parent: 1
       type: Transform
-  - uid: 558
+  - uid: 586
     components:
     - rot: -1.5707963267948966 rad
       pos: 0.5,11.5
       parent: 1
       type: Transform
-  - uid: 560
+  - uid: 587
     components:
     - rot: -1.5707963267948966 rad
       pos: -1.5,12.5
       parent: 1
       type: Transform
-  - uid: 561
+  - uid: 588
     components:
     - rot: -1.5707963267948966 rad
       pos: -5.5,7.5
       parent: 1
       type: Transform
-  - uid: 562
+  - uid: 589
     components:
     - rot: 3.141592653589793 rad
       pos: 4.5,11.5
       parent: 1
       type: Transform
-  - uid: 563
+  - uid: 590
     components:
     - rot: 1.5707963267948966 rad
       pos: 6.5,8.5
       parent: 1
       type: Transform
-  - uid: 564
+  - uid: 591
     components:
     - pos: 3.5,9.5
       parent: 1
       type: Transform
-  - uid: 565
+  - uid: 592
     components:
     - pos: 6.5,-7.5
       parent: 1
       type: Transform
-  - uid: 566
+  - uid: 593
     components:
     - pos: -5.5,-7.5
       parent: 1
       type: Transform
-  - uid: 567
+  - uid: 594
     components:
     - rot: -1.5707963267948966 rad
       pos: -2.5,-11.5
       parent: 1
       type: Transform
-  - uid: 568
+  - uid: 595
     components:
     - rot: 1.5707963267948966 rad
       pos: 3.5,-11.5
       parent: 1
       type: Transform
-  - uid: 569
+  - uid: 596
     components:
     - pos: -12.5,-17.5
       parent: 1
       type: Transform
-  - uid: 570
+  - uid: 597
     components:
     - rot: -1.5707963267948966 rad
       pos: -10.5,-10.5
       parent: 1
       type: Transform
-  - uid: 571
+  - uid: 598
     components:
     - rot: 1.5707963267948966 rad
       pos: 11.5,-10.5
       parent: 1
       type: Transform
-  - uid: 572
+  - uid: 599
     components:
     - rot: 3.141592653589793 rad
       pos: 12.5,2.5
       parent: 1
       type: Transform
-  - uid: 573
+  - uid: 600
     components:
     - rot: 1.5707963267948966 rad
       pos: 9.5,8.5
       parent: 1
       type: Transform
-  - uid: 574
+  - uid: 601
     components:
     - rot: -1.5707963267948966 rad
       pos: -8.5,8.5
       parent: 1
       type: Transform
-  - uid: 575
+  - uid: 602
     components:
     - rot: -1.5707963267948966 rad
       pos: -4.5,1.5
       parent: 1
       type: Transform
-  - uid: 576
+  - uid: 603
     components:
     - rot: 1.5707963267948966 rad
       pos: 5.5,1.5
       parent: 1
       type: Transform
-  - uid: 577
+  - uid: 604
     components:
     - rot: 3.141592653589793 rad
       pos: -11.5,2.5
       parent: 1
       type: Transform
-  - uid: 578
+  - uid: 605
     components:
     - pos: 3.5,-2.5
       parent: 1
       type: Transform
-  - uid: 579
+  - uid: 606
     components:
     - rot: 1.5707963267948966 rad
       pos: -2.5,-3.5
       parent: 1
       type: Transform
-  - uid: 580
+  - uid: 607
     components:
     - rot: -1.5707963267948966 rad
       pos: -1.5,-0.5
       parent: 1
       type: Transform
-  - uid: 641
+  - uid: 608
     components:
     - pos: -2.5,4.5
       parent: 1
       type: Transform
-  - uid: 1128
+  - uid: 609
     components:
     - rot: 1.5707963267948966 rad
       pos: -3.5,10.5
       parent: 1
       type: Transform
-  - uid: 1166
+  - uid: 610
     components:
     - rot: -1.5707963267948966 rad
       pos: -3.5,18.5
       parent: 1
       type: Transform
-  - uid: 1189
+  - uid: 611
     components:
     - rot: -1.5707963267948966 rad
       pos: 1.5,18.5
       parent: 1
       type: Transform
-  - uid: 1224
+  - uid: 612
     components:
     - rot: 1.5707963267948966 rad
       pos: -0.5,18.5
       parent: 1
       type: Transform
-  - uid: 1519
+  - uid: 613
     components:
     - rot: 1.5707963267948966 rad
       pos: 4.5,18.5
@@ -3988,69 +4082,69 @@ entities:
       type: Transform
 - proto: EncryptionKeyCommand
   entities:
-  - uid: 537
+  - uid: 614
     components:
     - pos: -0.46291542,19.523981
       parent: 1
       type: Transform
-  - uid: 539
+  - uid: 615
     components:
     - pos: 1.5214596,19.477106
       parent: 1
       type: Transform
 - proto: EnergySword
   entities:
-  - uid: 12
+  - uid: 530
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 5
+    - parent: 522
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: ExtinguisherCabinetFilled
   entities:
-  - uid: 591
+  - uid: 616
     components:
     - pos: -0.5,1.5
       parent: 1
       type: Transform
-  - uid: 592
+  - uid: 617
     components:
     - pos: 6.5,-6.5
       parent: 1
       type: Transform
-  - uid: 593
+  - uid: 618
     components:
     - pos: -5.5,-6.5
       parent: 1
       type: Transform
-  - uid: 594
+  - uid: 619
     components:
     - pos: -9.5,-9.5
       parent: 1
       type: Transform
-  - uid: 595
+  - uid: 620
     components:
     - pos: 10.5,-9.5
       parent: 1
       type: Transform
-  - uid: 597
+  - uid: 621
     components:
     - pos: -5.5,6.5
       parent: 1
       type: Transform
 - proto: FaxMachineBase
   entities:
-  - uid: 509
+  - uid: 622
     components:
     - pos: 2.5,15.5
       parent: 1
       type: Transform
     - name: Marauder Captain
       type: FaxMachine
-  - uid: 1182
+  - uid: 623
     components:
     - pos: 0.5,18.5
       parent: 1
@@ -4059,115 +4153,115 @@ entities:
       type: FaxMachine
 - proto: FirelockGlass
   entities:
-  - uid: 601
+  - uid: 624
     components:
     - rot: -1.5707963267948966 rad
       pos: 0.5,10.5
       parent: 1
       type: Transform
-  - uid: 602
+  - uid: 625
     components:
     - pos: 0.5,7.5
       parent: 1
       type: Transform
-  - uid: 603
+  - uid: 626
     components:
     - pos: -1.5,-8.5
       parent: 1
       type: Transform
-  - uid: 604
+  - uid: 627
     components:
     - pos: 2.5,-8.5
       parent: 1
       type: Transform
-  - uid: 605
+  - uid: 628
     components:
     - pos: -7.5,-8.5
       parent: 1
       type: Transform
-  - uid: 606
+  - uid: 629
     components:
     - pos: 8.5,-8.5
       parent: 1
       type: Transform
-  - uid: 607
+  - uid: 630
     components:
     - pos: -9.5,-8.5
       parent: 1
       type: Transform
-  - uid: 608
+  - uid: 631
     components:
     - pos: -10.5,-12.5
       parent: 1
       type: Transform
-  - uid: 609
+  - uid: 632
     components:
     - pos: 10.5,-8.5
       parent: 1
       type: Transform
-  - uid: 610
+  - uid: 633
     components:
     - pos: 11.5,-12.5
       parent: 1
       type: Transform
-  - uid: 611
+  - uid: 634
     components:
     - pos: -2.5,-6.5
       parent: 1
       type: Transform
-  - uid: 612
+  - uid: 635
     components:
     - pos: 3.5,-6.5
       parent: 1
       type: Transform
-  - uid: 613
+  - uid: 636
     components:
     - pos: 0.5,-1.5
       parent: 1
       type: Transform
-  - uid: 614
+  - uid: 637
     components:
     - pos: -0.5,0.5
       parent: 1
       type: Transform
-  - uid: 615
+  - uid: 638
     components:
     - pos: -0.5,2.5
       parent: 1
       type: Transform
-  - uid: 616
+  - uid: 639
     components:
     - pos: -0.5,11.5
       parent: 1
       type: Transform
-  - uid: 617
+  - uid: 640
     components:
     - pos: 1.5,9.5
       parent: 1
       type: Transform
-  - uid: 619
+  - uid: 641
     components:
     - pos: 0.5,1.5
       parent: 1
       type: Transform
-  - uid: 620
+  - uid: 642
     components:
     - pos: 0.5,4.5
       parent: 1
       type: Transform
-  - uid: 1327
+  - uid: 643
     components:
     - pos: 2.5,-7.5
       parent: 1
       type: Transform
-  - uid: 1490
+  - uid: 644
     components:
     - pos: -1.5,-7.5
       parent: 1
       type: Transform
 - proto: FloorDrain
   entities:
-  - uid: 528
+  - uid: 645
     components:
     - pos: 6.5,11.5
       parent: 1
@@ -4176,14 +4270,14 @@ entities:
       type: Fixtures
 - proto: GasDualPortVentPump
   entities:
-  - uid: 621
+  - uid: 646
     components:
     - pos: 0.5,9.5
       parent: 1
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 622
+  - uid: 647
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,13.5
@@ -4191,14 +4285,14 @@ entities:
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 623
+  - uid: 648
     components:
     - pos: 0.5,6.5
       parent: 1
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 624
+  - uid: 649
     components:
     - rot: -1.5707963267948966 rad
       pos: 0.5,2.5
@@ -4206,7 +4300,7 @@ entities:
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 625
+  - uid: 650
     components:
     - rot: -1.5707963267948966 rad
       pos: 0.5,0.5
@@ -4214,7 +4308,7 @@ entities:
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 644
+  - uid: 651
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,12.5
@@ -4224,7 +4318,7 @@ entities:
       type: AmbientSound
 - proto: GasMixer
   entities:
-  - uid: 627
+  - uid: 652
     components:
     - pos: -5.5,8.5
       parent: 1
@@ -4233,7 +4327,7 @@ entities:
       type: AtmosPipeColor
 - proto: GasPassiveVent
   entities:
-  - uid: 628
+  - uid: 653
     components:
     - rot: 3.141592653589793 rad
       pos: -6.5,5.5
@@ -4243,7 +4337,7 @@ entities:
       type: AtmosPipeColor
 - proto: GasPipeBend
   entities:
-  - uid: 629
+  - uid: 654
     components:
     - rot: 3.141592653589793 rad
       pos: -5.5,7.5
@@ -4251,21 +4345,21 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 630
+  - uid: 655
     components:
     - pos: -5.5,10.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 631
+  - uid: 656
     components:
     - pos: -4.5,9.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 632
+  - uid: 657
     components:
     - rot: 3.141592653589793 rad
       pos: -4.5,8.5
@@ -4273,7 +4367,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 633
+  - uid: 658
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,5.5
@@ -4281,7 +4375,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 634
+  - uid: 659
     components:
     - pos: 1.5,5.5
       parent: 1
@@ -4290,7 +4384,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 635
+  - uid: 660
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,5.5
@@ -4298,14 +4392,14 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 636
+  - uid: 661
     components:
     - pos: 0.5,5.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 637
+  - uid: 662
     components:
     - pos: 12.5,-7.5
       parent: 1
@@ -4314,7 +4408,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 638
+  - uid: 663
     components:
     - rot: 1.5707963267948966 rad
       pos: -11.5,-7.5
@@ -4324,18 +4418,18 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 642
+  - uid: 664
     components:
     - rot: 3.141592653589793 rad
       pos: -5.5,9.5
       parent: 1
       type: Transform
-  - uid: 643
+  - uid: 665
     components:
     - pos: -5.5,9.5
       parent: 1
       type: Transform
-  - uid: 646
+  - uid: 666
     components:
     - rot: 1.5707963267948966 rad
       pos: -6.5,10.5
@@ -4343,7 +4437,7 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 809
+  - uid: 667
     components:
     - rot: -1.5707963267948966 rad
       pos: 4.5,12.5
@@ -4351,77 +4445,77 @@ entities:
       type: Transform
 - proto: GasPipeFourway
   entities:
-  - uid: 647
+  - uid: 668
     components:
     - pos: -0.5,11.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 648
+  - uid: 669
     components:
     - pos: 0.5,-7.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 649
+  - uid: 670
     components:
     - pos: 0.5,7.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 650
+  - uid: 671
     components:
     - pos: 0.5,12.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 651
+  - uid: 672
     components:
     - pos: -0.5,8.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 652
+  - uid: 673
     components:
     - pos: 1.5,2.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 653
+  - uid: 674
     components:
     - pos: 0.5,-4.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 654
+  - uid: 675
     components:
     - pos: 1.5,-2.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 655
+  - uid: 676
     components:
     - pos: 0.5,-0.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 656
+  - uid: 677
     components:
     - pos: 0.5,3.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 657
+  - uid: 678
     components:
     - pos: 1.5,0.5
       parent: 1
@@ -4430,13 +4524,13 @@ entities:
       type: AtmosPipeColor
 - proto: GasPipeStraight
   entities:
-  - uid: 512
+  - uid: 679
     components:
     - rot: 3.141592653589793 rad
       pos: 4.5,13.5
       parent: 1
       type: Transform
-  - uid: 658
+  - uid: 680
     components:
     - rot: -1.5707963267948966 rad
       pos: 1.5,8.5
@@ -4446,7 +4540,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 659
+  - uid: 681
     components:
     - rot: 1.5707963267948966 rad
       pos: 4.5,8.5
@@ -4454,7 +4548,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 660
+  - uid: 682
     components:
     - rot: -1.5707963267948966 rad
       pos: 0.5,8.5
@@ -4462,7 +4556,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 661
+  - uid: 683
     components:
     - rot: 1.5707963267948966 rad
       pos: 5.5,8.5
@@ -4470,7 +4564,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 662
+  - uid: 684
     components:
     - rot: 1.5707963267948966 rad
       pos: 3.5,8.5
@@ -4478,21 +4572,21 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 663
+  - uid: 685
     components:
     - pos: -0.5,10.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 664
+  - uid: 686
     components:
     - pos: -0.5,9.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 665
+  - uid: 687
     components:
     - rot: 1.5707963267948966 rad
       pos: -0.5,-7.5
@@ -4500,7 +4594,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 666
+  - uid: 688
     components:
     - rot: -1.5707963267948966 rad
       pos: 0.5,-2.5
@@ -4508,7 +4602,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 667
+  - uid: 689
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,-1.5
@@ -4516,7 +4610,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 668
+  - uid: 690
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,-3.5
@@ -4524,7 +4618,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 669
+  - uid: 691
     components:
     - rot: -1.5707963267948966 rad
       pos: -0.5,2.5
@@ -4532,7 +4626,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 670
+  - uid: 692
     components:
     - rot: 3.141592653589793 rad
       pos: -6.5,6.5
@@ -4542,7 +4636,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 671
+  - uid: 693
     components:
     - rot: 3.141592653589793 rad
       pos: -6.5,8.5
@@ -4550,7 +4644,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 672
+  - uid: 694
     components:
     - rot: 1.5707963267948966 rad
       pos: -4.5,7.5
@@ -4558,7 +4652,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 673
+  - uid: 695
     components:
     - rot: 1.5707963267948966 rad
       pos: -3.5,7.5
@@ -4566,7 +4660,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 674
+  - uid: 696
     components:
     - rot: 1.5707963267948966 rad
       pos: -2.5,7.5
@@ -4574,7 +4668,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 675
+  - uid: 697
     components:
     - rot: 1.5707963267948966 rad
       pos: -0.5,7.5
@@ -4582,7 +4676,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 676
+  - uid: 698
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,0.5
@@ -4590,7 +4684,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 677
+  - uid: 699
     components:
     - rot: 1.5707963267948966 rad
       pos: 1.5,7.5
@@ -4600,7 +4694,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 678
+  - uid: 700
     components:
     - rot: 1.5707963267948966 rad
       pos: 2.5,7.5
@@ -4608,7 +4702,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 679
+  - uid: 701
     components:
     - rot: 1.5707963267948966 rad
       pos: 4.5,7.5
@@ -4616,7 +4710,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 680
+  - uid: 702
     components:
     - rot: 1.5707963267948966 rad
       pos: 5.5,7.5
@@ -4624,7 +4718,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 681
+  - uid: 703
     components:
     - rot: 3.141592653589793 rad
       pos: 3.5,8.5
@@ -4632,7 +4726,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 682
+  - uid: 704
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,8.5
@@ -4640,7 +4734,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 683
+  - uid: 705
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,10.5
@@ -4648,7 +4742,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 684
+  - uid: 706
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,11.5
@@ -4656,7 +4750,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 685
+  - uid: 707
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,14.5
@@ -4664,7 +4758,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 686
+  - uid: 708
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,15.5
@@ -4672,7 +4766,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 687
+  - uid: 709
     components:
     - rot: 1.5707963267948966 rad
       pos: -2.5,8.5
@@ -4680,14 +4774,14 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 688
+  - uid: 710
     components:
     - pos: -0.5,7.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 689
+  - uid: 711
     components:
     - rot: -1.5707963267948966 rad
       pos: -0.5,12.5
@@ -4695,7 +4789,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 690
+  - uid: 712
     components:
     - rot: -1.5707963267948966 rad
       pos: -1.5,12.5
@@ -4703,7 +4797,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 691
+  - uid: 713
     components:
     - rot: -1.5707963267948966 rad
       pos: 1.5,12.5
@@ -4711,7 +4805,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 692
+  - uid: 714
     components:
     - rot: -1.5707963267948966 rad
       pos: 2.5,12.5
@@ -4719,49 +4813,49 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 693
+  - uid: 715
     components:
     - pos: 1.5,4.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 694
+  - uid: 716
     components:
     - pos: -0.5,6.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 695
+  - uid: 717
     components:
     - pos: 0.5,4.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 696
+  - uid: 718
     components:
     - pos: 1.5,3.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 697
+  - uid: 719
     components:
     - pos: 1.5,1.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 698
+  - uid: 720
     components:
     - pos: 1.5,-0.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 699
+  - uid: 721
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,-2.5
@@ -4769,7 +4863,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 700
+  - uid: 722
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,-5.5
@@ -4779,7 +4873,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 701
+  - uid: 723
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,-6.5
@@ -4787,7 +4881,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 702
+  - uid: 724
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,1.5
@@ -4795,7 +4889,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 703
+  - uid: 725
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,2.5
@@ -4803,7 +4897,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 704
+  - uid: 726
     components:
     - rot: -1.5707963267948966 rad
       pos: -1.5,2.5
@@ -4811,7 +4905,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 705
+  - uid: 727
     components:
     - rot: -1.5707963267948966 rad
       pos: -1.5,7.5
@@ -4819,7 +4913,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 706
+  - uid: 728
     components:
     - rot: -1.5707963267948966 rad
       pos: -1.5,8.5
@@ -4827,7 +4921,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 707
+  - uid: 729
     components:
     - rot: 1.5707963267948966 rad
       pos: -1.5,-7.5
@@ -4835,7 +4929,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 708
+  - uid: 730
     components:
     - rot: 1.5707963267948966 rad
       pos: -2.5,-7.5
@@ -4843,7 +4937,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 709
+  - uid: 731
     components:
     - rot: 1.5707963267948966 rad
       pos: -3.5,-7.5
@@ -4851,7 +4945,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 710
+  - uid: 732
     components:
     - rot: 1.5707963267948966 rad
       pos: -5.5,-7.5
@@ -4859,7 +4953,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 711
+  - uid: 733
     components:
     - rot: 1.5707963267948966 rad
       pos: 1.5,-7.5
@@ -4867,7 +4961,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 712
+  - uid: 734
     components:
     - rot: 1.5707963267948966 rad
       pos: 2.5,-7.5
@@ -4875,7 +4969,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 713
+  - uid: 735
     components:
     - rot: 1.5707963267948966 rad
       pos: 3.5,-7.5
@@ -4883,7 +4977,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 714
+  - uid: 736
     components:
     - rot: 1.5707963267948966 rad
       pos: 4.5,-7.5
@@ -4891,7 +4985,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 715
+  - uid: 737
     components:
     - rot: 1.5707963267948966 rad
       pos: 6.5,-7.5
@@ -4899,49 +4993,49 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 716
+  - uid: 738
     components:
     - pos: 1.5,-1.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 717
+  - uid: 739
     components:
     - pos: 1.5,-3.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 718
+  - uid: 740
     components:
     - pos: 1.5,-4.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 719
+  - uid: 741
     components:
     - pos: 1.5,-5.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 720
+  - uid: 742
     components:
     - pos: 1.5,-6.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 721
+  - uid: 743
     components:
     - pos: 1.5,-7.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 722
+  - uid: 744
     components:
     - rot: -1.5707963267948966 rad
       pos: 2.5,-8.5
@@ -4949,7 +5043,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 723
+  - uid: 745
     components:
     - rot: -1.5707963267948966 rad
       pos: 0.5,-8.5
@@ -4957,7 +5051,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 724
+  - uid: 746
     components:
     - rot: 1.5707963267948966 rad
       pos: 3.5,-8.5
@@ -4965,7 +5059,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 725
+  - uid: 747
     components:
     - rot: 1.5707963267948966 rad
       pos: 5.5,-8.5
@@ -4973,7 +5067,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 726
+  - uid: 748
     components:
     - rot: 1.5707963267948966 rad
       pos: 6.5,-8.5
@@ -4981,7 +5075,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 727
+  - uid: 749
     components:
     - rot: 1.5707963267948966 rad
       pos: 7.5,-8.5
@@ -4989,7 +5083,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 728
+  - uid: 750
     components:
     - rot: 1.5707963267948966 rad
       pos: 8.5,-8.5
@@ -4997,7 +5091,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 729
+  - uid: 751
     components:
     - rot: 1.5707963267948966 rad
       pos: 9.5,-8.5
@@ -5005,7 +5099,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 730
+  - uid: 752
     components:
     - rot: 1.5707963267948966 rad
       pos: 10.5,-8.5
@@ -5013,7 +5107,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 731
+  - uid: 753
     components:
     - rot: 1.5707963267948966 rad
       pos: -1.5,-8.5
@@ -5021,7 +5115,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 732
+  - uid: 754
     components:
     - rot: 1.5707963267948966 rad
       pos: -2.5,-8.5
@@ -5029,7 +5123,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 733
+  - uid: 755
     components:
     - rot: 1.5707963267948966 rad
       pos: -4.5,-8.5
@@ -5037,7 +5131,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 734
+  - uid: 756
     components:
     - rot: 1.5707963267948966 rad
       pos: -5.5,-8.5
@@ -5045,7 +5139,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 735
+  - uid: 757
     components:
     - rot: 1.5707963267948966 rad
       pos: -6.5,-8.5
@@ -5053,7 +5147,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 736
+  - uid: 758
     components:
     - rot: 1.5707963267948966 rad
       pos: -7.5,-8.5
@@ -5061,7 +5155,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 737
+  - uid: 759
     components:
     - rot: 1.5707963267948966 rad
       pos: -8.5,-8.5
@@ -5069,7 +5163,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 738
+  - uid: 760
     components:
     - rot: 1.5707963267948966 rad
       pos: -9.5,-8.5
@@ -5077,7 +5171,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 739
+  - uid: 761
     components:
     - rot: 1.5707963267948966 rad
       pos: -6.5,-7.5
@@ -5085,7 +5179,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 740
+  - uid: 762
     components:
     - rot: 1.5707963267948966 rad
       pos: -7.5,-7.5
@@ -5093,7 +5187,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 741
+  - uid: 763
     components:
     - rot: 1.5707963267948966 rad
       pos: -8.5,-7.5
@@ -5101,7 +5195,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 742
+  - uid: 764
     components:
     - rot: 1.5707963267948966 rad
       pos: -9.5,-7.5
@@ -5111,7 +5205,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 743
+  - uid: 765
     components:
     - rot: 1.5707963267948966 rad
       pos: -10.5,-7.5
@@ -5121,7 +5215,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 744
+  - uid: 766
     components:
     - rot: 1.5707963267948966 rad
       pos: 7.5,-7.5
@@ -5129,7 +5223,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 745
+  - uid: 767
     components:
     - rot: 1.5707963267948966 rad
       pos: 8.5,-7.5
@@ -5137,7 +5231,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 746
+  - uid: 768
     components:
     - rot: 1.5707963267948966 rad
       pos: 9.5,-7.5
@@ -5145,7 +5239,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 747
+  - uid: 769
     components:
     - rot: 1.5707963267948966 rad
       pos: 10.5,-7.5
@@ -5155,7 +5249,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 748
+  - uid: 770
     components:
     - rot: 1.5707963267948966 rad
       pos: 11.5,-7.5
@@ -5165,49 +5259,49 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 749
+  - uid: 771
     components:
     - pos: -11.5,-8.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 750
+  - uid: 772
     components:
     - pos: -11.5,-9.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 751
+  - uid: 773
     components:
     - pos: -11.5,-10.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 752
+  - uid: 774
     components:
     - pos: 12.5,-8.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 753
+  - uid: 775
     components:
     - pos: 12.5,-9.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 754
+  - uid: 776
     components:
     - pos: 12.5,-10.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 755
+  - uid: 777
     components:
     - rot: -1.5707963267948966 rad
       pos: -0.5,-2.5
@@ -5215,7 +5309,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 756
+  - uid: 778
     components:
     - rot: -1.5707963267948966 rad
       pos: 1.5,-4.5
@@ -5223,7 +5317,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 757
+  - uid: 779
     components:
     - rot: -1.5707963267948966 rad
       pos: 2.5,-4.5
@@ -5231,7 +5325,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 758
+  - uid: 780
     components:
     - rot: -1.5707963267948966 rad
       pos: -0.5,-4.5
@@ -5239,7 +5333,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 759
+  - uid: 781
     components:
     - rot: -1.5707963267948966 rad
       pos: -1.5,-4.5
@@ -5247,7 +5341,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 761
+  - uid: 782
     components:
     - rot: -1.5707963267948966 rad
       pos: 0.5,11.5
@@ -5255,7 +5349,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 762
+  - uid: 783
     components:
     - rot: -1.5707963267948966 rad
       pos: 1.5,11.5
@@ -5265,7 +5359,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 763
+  - uid: 784
     components:
     - rot: 3.141592653589793 rad
       pos: 2.5,12.5
@@ -5273,7 +5367,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 764
+  - uid: 785
     components:
     - rot: 1.5707963267948966 rad
       pos: -1.5,11.5
@@ -5281,212 +5375,30 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 765
+  - uid: 786
     components:
     - pos: -0.5,12.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 766
+  - uid: 787
     components:
     - pos: -0.5,14.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 767
+  - uid: 788
     components:
     - pos: -0.5,13.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 768
-    components:
-    - pos: 12.5,-12.5
-      parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 769
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 11.5,-9.5
-      parent: 1
-      type: Transform
-    - color: '#0055CCFF'
-      type: AtmosPipeColor
-  - uid: 770
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 11.5,-10.5
-      parent: 1
-      type: Transform
-    - color: '#0055CCFF'
-      type: AtmosPipeColor
-  - uid: 771
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 11.5,-11.5
-      parent: 1
-      type: Transform
-    - color: '#0055CCFF'
-      type: AtmosPipeColor
-  - uid: 772
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 11.5,-12.5
-      parent: 1
-      type: Transform
-    - color: '#0055CCFF'
-      type: AtmosPipeColor
-  - uid: 773
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 11.5,-13.5
-      parent: 1
-      type: Transform
-    - color: '#0055CCFF'
-      type: AtmosPipeColor
-  - uid: 774
-    components:
-    - pos: -11.5,-12.5
-      parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 775
-    components:
-    - rot: 3.141592653589793 rad
-      pos: -10.5,-9.5
-      parent: 1
-      type: Transform
-    - color: '#0055CCFF'
-      type: AtmosPipeColor
-  - uid: 776
-    components:
-    - rot: 3.141592653589793 rad
-      pos: -10.5,-10.5
-      parent: 1
-      type: Transform
-    - color: '#0055CCFF'
-      type: AtmosPipeColor
-  - uid: 777
-    components:
-    - rot: 3.141592653589793 rad
-      pos: -10.5,-11.5
-      parent: 1
-      type: Transform
-    - color: '#0055CCFF'
-      type: AtmosPipeColor
-  - uid: 778
-    components:
-    - rot: 3.141592653589793 rad
-      pos: -10.5,-12.5
-      parent: 1
-      type: Transform
-    - color: '#0055CCFF'
-      type: AtmosPipeColor
-  - uid: 779
-    components:
-    - rot: 3.141592653589793 rad
-      pos: -10.5,-13.5
-      parent: 1
-      type: Transform
-    - color: '#0055CCFF'
-      type: AtmosPipeColor
-  - uid: 780
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -0.5,-0.5
-      parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 781
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -0.5,0.5
-      parent: 1
-      type: Transform
-    - color: '#0055CCFF'
-      type: AtmosPipeColor
-  - uid: 782
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 1.5,3.5
-      parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 783
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 1.5,-0.5
-      parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 784
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -0.5,3.5
-      parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 785
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -1.5,3.5
-      parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 786
-    components:
-    - pos: -6.5,9.5
-      parent: 1
-      type: Transform
-  - uid: 796
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -3.5,8.5
-      parent: 1
-      type: Transform
-  - uid: 1301
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 2.5,13.5
-      parent: 1
-      type: Transform
-- proto: GasPipeTJunction
-  entities:
-  - uid: 645
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 2.5,11.5
-      parent: 1
-      type: Transform
-  - uid: 787
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 2.5,8.5
-      parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 788
-    components:
-    - pos: -4.5,-7.5
-      parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
   - uid: 789
     components:
-    - pos: 5.5,-7.5
+    - pos: 12.5,-12.5
       parent: 1
       type: Transform
     - color: '#990000FF'
@@ -5494,14 +5406,15 @@ entities:
   - uid: 790
     components:
     - rot: 3.141592653589793 rad
-      pos: 4.5,-8.5
+      pos: 11.5,-9.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 791
     components:
-    - pos: 11.5,-8.5
+    - rot: 3.141592653589793 rad
+      pos: 11.5,-10.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
@@ -5509,7 +5422,7 @@ entities:
   - uid: 792
     components:
     - rot: 3.141592653589793 rad
-      pos: -0.5,-8.5
+      pos: 11.5,-11.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
@@ -5517,22 +5430,30 @@ entities:
   - uid: 793
     components:
     - rot: 3.141592653589793 rad
-      pos: -3.5,-8.5
+      pos: 11.5,-12.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 794
     components:
-    - pos: -10.5,-8.5
+    - rot: 3.141592653589793 rad
+      pos: 11.5,-13.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 795
     components:
+    - pos: -11.5,-12.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 796
+    components:
     - rot: 3.141592653589793 rad
-      pos: 3.5,7.5
+      pos: -10.5,-9.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
@@ -5540,12 +5461,185 @@ entities:
   - uid: 797
     components:
     - rot: 3.141592653589793 rad
-      pos: 1.5,-8.5
+      pos: -10.5,-10.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 798
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -10.5,-11.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 799
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -10.5,-12.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 800
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -10.5,-13.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 801
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -0.5,-0.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 802
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -0.5,0.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 803
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 1.5,3.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 804
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 1.5,-0.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 805
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -0.5,3.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 806
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -1.5,3.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 807
+    components:
+    - pos: -6.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 808
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -3.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 809
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 2.5,13.5
+      parent: 1
+      type: Transform
+- proto: GasPipeTJunction
+  entities:
+  - uid: 810
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 2.5,11.5
+      parent: 1
+      type: Transform
+  - uid: 811
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 2.5,8.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 812
+    components:
+    - pos: -4.5,-7.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 813
+    components:
+    - pos: 5.5,-7.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 814
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 4.5,-8.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 815
+    components:
+    - pos: 11.5,-8.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 816
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -0.5,-8.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 817
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -3.5,-8.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 818
+    components:
+    - pos: -10.5,-8.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 819
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 3.5,7.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 820
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 1.5,-8.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 821
     components:
     - rot: 1.5707963267948966 rad
       pos: -11.5,-11.5
@@ -5553,7 +5647,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 799
+  - uid: 822
     components:
     - rot: -1.5707963267948966 rad
       pos: 12.5,-11.5
@@ -5563,13 +5657,13 @@ entities:
       type: AtmosPipeColor
 - proto: GasPort
   entities:
-  - uid: 800
+  - uid: 823
     components:
     - rot: 1.5707963267948966 rad
       pos: -6.5,8.5
       parent: 1
       type: Transform
-  - uid: 802
+  - uid: 824
     components:
     - rot: 1.5707963267948966 rad
       pos: -6.5,9.5
@@ -5577,7 +5671,7 @@ entities:
       type: Transform
 - proto: GasValve
   entities:
-  - uid: 804
+  - uid: 825
     components:
     - rot: 3.141592653589793 rad
       pos: -6.5,7.5
@@ -5591,14 +5685,14 @@ entities:
       type: AtmosPipeColor
 - proto: GasVentPump
   entities:
-  - uid: 532
+  - uid: 826
     components:
     - pos: 4.5,14.5
       parent: 1
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 805
+  - uid: 827
     components:
     - pos: 0.5,16.5
       parent: 1
@@ -5607,7 +5701,7 @@ entities:
       type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 806
+  - uid: 828
     components:
     - rot: 1.5707963267948966 rad
       pos: -2.5,12.5
@@ -5617,7 +5711,7 @@ entities:
       type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 807
+  - uid: 829
     components:
     - pos: 3.5,9.5
       parent: 1
@@ -5626,7 +5720,7 @@ entities:
       type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 808
+  - uid: 830
     components:
     - rot: -1.5707963267948966 rad
       pos: 6.5,7.5
@@ -5636,7 +5730,7 @@ entities:
       type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 810
+  - uid: 831
     components:
     - rot: -1.5707963267948966 rad
       pos: 2.5,-2.5
@@ -5646,7 +5740,7 @@ entities:
       type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 811
+  - uid: 832
     components:
     - rot: 1.5707963267948966 rad
       pos: -1.5,-2.5
@@ -5656,7 +5750,7 @@ entities:
       type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 812
+  - uid: 833
     components:
     - pos: -3.5,-7.5
       parent: 1
@@ -5665,7 +5759,7 @@ entities:
       type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 813
+  - uid: 834
     components:
     - pos: 4.5,-7.5
       parent: 1
@@ -5674,7 +5768,7 @@ entities:
       type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 814
+  - uid: 835
     components:
     - pos: -0.5,-7.5
       parent: 1
@@ -5683,7 +5777,7 @@ entities:
       type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 815
+  - uid: 836
     components:
     - rot: -1.5707963267948966 rad
       pos: 12.5,-8.5
@@ -5693,7 +5787,7 @@ entities:
       type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 816
+  - uid: 837
     components:
     - rot: 1.5707963267948966 rad
       pos: -11.5,-8.5
@@ -5703,7 +5797,7 @@ entities:
       type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 817
+  - uid: 838
     components:
     - rot: 1.5707963267948966 rad
       pos: -2.5,2.5
@@ -5713,7 +5807,7 @@ entities:
       type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 818
+  - uid: 839
     components:
     - rot: 1.5707963267948966 rad
       pos: -1.5,0.5
@@ -5723,7 +5817,7 @@ entities:
       type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 819
+  - uid: 840
     components:
     - rot: -1.5707963267948966 rad
       pos: 2.5,0.5
@@ -5733,7 +5827,7 @@ entities:
       type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 820
+  - uid: 841
     components:
     - rot: -1.5707963267948966 rad
       pos: 2.5,2.5
@@ -5743,7 +5837,7 @@ entities:
       type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 821
+  - uid: 842
     components:
     - rot: 3.141592653589793 rad
       pos: -10.5,-14.5
@@ -5753,7 +5847,7 @@ entities:
       type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 822
+  - uid: 843
     components:
     - rot: 3.141592653589793 rad
       pos: 11.5,-14.5
@@ -5765,14 +5859,14 @@ entities:
       type: AtmosPipeColor
 - proto: GasVentScrubber
   entities:
-  - uid: 505
+  - uid: 844
     components:
     - pos: 2.5,14.5
       parent: 1
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 530
+  - uid: 845
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,11.5
@@ -5780,7 +5874,7 @@ entities:
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 823
+  - uid: 846
     components:
     - pos: 2.5,9.5
       parent: 1
@@ -5789,7 +5883,7 @@ entities:
       type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 824
+  - uid: 847
     components:
     - rot: -1.5707963267948966 rad
       pos: 6.5,8.5
@@ -5799,7 +5893,7 @@ entities:
       type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 825
+  - uid: 848
     components:
     - rot: 1.5707963267948966 rad
       pos: -2.5,11.5
@@ -5809,7 +5903,7 @@ entities:
       type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 826
+  - uid: 849
     components:
     - pos: -0.5,15.5
       parent: 1
@@ -5818,7 +5912,7 @@ entities:
       type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 827
+  - uid: 850
     components:
     - rot: 1.5707963267948966 rad
       pos: -2.5,-4.5
@@ -5828,7 +5922,7 @@ entities:
       type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 828
+  - uid: 851
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,-4.5
@@ -5838,7 +5932,7 @@ entities:
       type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 829
+  - uid: 852
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,-8.5
@@ -5848,7 +5942,7 @@ entities:
       type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 830
+  - uid: 853
     components:
     - rot: 3.141592653589793 rad
       pos: -4.5,-8.5
@@ -5858,7 +5952,7 @@ entities:
       type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 831
+  - uid: 854
     components:
     - rot: 3.141592653589793 rad
       pos: 5.5,-8.5
@@ -5868,7 +5962,7 @@ entities:
       type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 832
+  - uid: 855
     components:
     - rot: 1.5707963267948966 rad
       pos: 11.5,-11.5
@@ -5878,7 +5972,7 @@ entities:
       type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 833
+  - uid: 856
     components:
     - rot: 3.141592653589793 rad
       pos: 12.5,-13.5
@@ -5888,7 +5982,7 @@ entities:
       type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 834
+  - uid: 857
     components:
     - rot: 3.141592653589793 rad
       pos: -11.5,-13.5
@@ -5898,7 +5992,7 @@ entities:
       type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 835
+  - uid: 858
     components:
     - rot: -1.5707963267948966 rad
       pos: -10.5,-11.5
@@ -5908,7 +6002,7 @@ entities:
       type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 836
+  - uid: 859
     components:
     - rot: 1.5707963267948966 rad
       pos: -2.5,3.5
@@ -5918,7 +6012,7 @@ entities:
       type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 837
+  - uid: 860
     components:
     - rot: 1.5707963267948966 rad
       pos: -1.5,-0.5
@@ -5928,7 +6022,7 @@ entities:
       type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 838
+  - uid: 861
     components:
     - rot: -1.5707963267948966 rad
       pos: 2.5,3.5
@@ -5938,7 +6032,7 @@ entities:
       type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 839
+  - uid: 862
     components:
     - rot: -1.5707963267948966 rad
       pos: 2.5,-0.5
@@ -5950,112 +6044,112 @@ entities:
       type: AtmosPipeColor
 - proto: GeneratorWallmountAPU
   entities:
-  - uid: 517
+  - uid: 863
     components:
     - pos: 1.5,16.5
       parent: 1
       type: Transform
 - proto: GravityGeneratorMini
   entities:
-  - uid: 841
+  - uid: 864
     components:
     - pos: 5.5,5.5
       parent: 1
       type: Transform
 - proto: Grille
   entities:
-  - uid: 842
+  - uid: 865
     components:
     - pos: 6.5,-9.5
       parent: 1
       type: Transform
-  - uid: 843
+  - uid: 866
     components:
     - pos: -6.5,-9.5
       parent: 1
       type: Transform
-  - uid: 844
+  - uid: 867
     components:
     - pos: -5.5,-9.5
       parent: 1
       type: Transform
-  - uid: 845
+  - uid: 868
     components:
     - pos: -4.5,-9.5
       parent: 1
       type: Transform
-  - uid: 846
+  - uid: 869
     components:
     - pos: -3.5,-9.5
       parent: 1
       type: Transform
-  - uid: 847
+  - uid: 870
     components:
     - pos: 4.5,-9.5
       parent: 1
       type: Transform
-  - uid: 848
+  - uid: 871
     components:
     - rot: 1.5707963267948966 rad
       pos: 10.5,-13.5
       parent: 1
       type: Transform
-  - uid: 849
+  - uid: 872
     components:
     - pos: 7.5,-9.5
       parent: 1
       type: Transform
-  - uid: 855
+  - uid: 873
     components:
     - pos: 5.5,-9.5
       parent: 1
       type: Transform
-  - uid: 856
+  - uid: 874
     components:
     - rot: 1.5707963267948966 rad
       pos: -9.5,-13.5
       parent: 1
       type: Transform
-  - uid: 857
+  - uid: 875
     components:
     - rot: 1.5707963267948966 rad
       pos: -9.5,-14.5
       parent: 1
       type: Transform
-  - uid: 858
+  - uid: 876
     components:
     - rot: 1.5707963267948966 rad
       pos: -9.5,-15.5
       parent: 1
       type: Transform
-  - uid: 859
+  - uid: 877
     components:
     - rot: 1.5707963267948966 rad
       pos: 10.5,-14.5
       parent: 1
       type: Transform
-  - uid: 860
+  - uid: 878
     components:
     - rot: 1.5707963267948966 rad
       pos: 10.5,-15.5
       parent: 1
       type: Transform
-  - uid: 1053
+  - uid: 879
     components:
     - pos: 1.5,20.5
       parent: 1
       type: Transform
-  - uid: 1054
+  - uid: 880
     components:
     - pos: 0.5,20.5
       parent: 1
       type: Transform
-  - uid: 1055
+  - uid: 881
     components:
     - pos: -0.5,20.5
       parent: 1
       type: Transform
-  - uid: 1518
+  - uid: 882
     components:
     - rot: 1.5707963267948966 rad
       pos: -0.5,3.5
@@ -6063,7 +6157,7 @@ entities:
       type: Transform
 - proto: GunSafe
   entities:
-  - uid: 861
+  - uid: 505
     components:
     - name: rpg safe
       type: MetaData
@@ -6075,8 +6169,8 @@ entities:
         immutable: False
         temperature: 293.1496
         moles:
-        - 1.7459903
-        - 6.568249
+        - 1.8856695
+        - 7.0937095
         - 0
         - 0
         - 0
@@ -6093,31 +6187,62 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 867
-          - 866
-          - 865
-          - 864
-          - 863
-          - 862
+          - 506
+          - 507
+          - 509
+          - 508
+          - 510
+          - 511
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
           ent: null
       type: ContainerContainer
-- proto: GunSafeShotgunEnforcer
-  entities:
-  - uid: 1049
+  - uid: 883
     components:
-    - pos: 7.5,7.5
+    - pos: 7.5,8.5
       parent: 1
       type: Transform
-- proto: GunSafeSubMachineGunWt550
-  entities:
-  - uid: 584
+    - air:
+        volume: 200
+        immutable: False
+        temperature: 293.14963
+        moles:
+        - 1.8744951
+        - 7.051672
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+      type: EntityStorage
+    - containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 884
+          - 885
+          - 886
+          - 887
+          - 888
+          - 889
+          - 890
+          - 891
+          - 892
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+      type: ContainerContainer
+  - uid: 893
     components:
-    - name: smg safe
-      type: MetaData
-    - pos: 7.5,8.5
+    - pos: 7.5,7.5
       parent: 1
       type: Transform
     - air:
@@ -6143,10 +6268,14 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 585
-          - 586
-          - 587
-          - 588
+          - 894
+          - 895
+          - 896
+          - 897
+          - 898
+          - 899
+          - 900
+          - 901
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -6154,180 +6283,180 @@ entities:
       type: ContainerContainer
 - proto: Gyroscope
   entities:
-  - uid: 868
+  - uid: 902
     components:
     - pos: 11.5,-6.5
       parent: 1
       type: Transform
-  - uid: 869
+  - uid: 903
     components:
     - pos: 13.5,-6.5
       parent: 1
       type: Transform
-  - uid: 870
+  - uid: 904
     components:
     - pos: -12.5,-6.5
       parent: 1
       type: Transform
-  - uid: 871
+  - uid: 905
     components:
     - pos: -10.5,-6.5
       parent: 1
       type: Transform
 - proto: HighSecArmoryLocked
   entities:
-  - uid: 872
+  - uid: 906
     components:
     - pos: 5.5,9.5
       parent: 1
       type: Transform
 - proto: HighSecDoor
   entities:
-  - uid: 535
+  - uid: 907
     components:
     - pos: 0.5,16.5
       parent: 1
       type: Transform
 - proto: HospitalCurtainsOpen
   entities:
-  - uid: 529
+  - uid: 908
     components:
     - pos: 6.5,11.5
       parent: 1
       type: Transform
-  - uid: 874
+  - uid: 909
     components:
     - rot: -1.5707963267948966 rad
       pos: -12.5,-11.5
       parent: 1
       type: Transform
-  - uid: 875
+  - uid: 910
     components:
     - rot: -1.5707963267948966 rad
       pos: -12.5,-10.5
       parent: 1
       type: Transform
-  - uid: 878
+  - uid: 911
     components:
     - rot: -1.5707963267948966 rad
       pos: 13.5,-11.5
       parent: 1
       type: Transform
-  - uid: 879
+  - uid: 912
     components:
     - rot: -1.5707963267948966 rad
       pos: 13.5,-10.5
       parent: 1
       type: Transform
-  - uid: 928
+  - uid: 913
     components:
     - pos: 2.5,13.5
       parent: 1
       type: Transform
-  - uid: 1187
+  - uid: 914
     components:
     - pos: -8.5,-7.5
       parent: 1
       type: Transform
-  - uid: 1188
+  - uid: 915
     components:
     - pos: 9.5,-7.5
       parent: 1
       type: Transform
 - proto: HydroponicsToolClippers
   entities:
-  - uid: 544
+  - uid: 573
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 543
+    - parent: 572
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: hydroponicsTray
   entities:
-  - uid: 883
+  - uid: 916
     components:
     - pos: 5.5,-5.5
       parent: 1
       type: Transform
-  - uid: 1340
+  - uid: 917
     components:
     - pos: 5.5,-4.5
       parent: 1
       type: Transform
 - proto: IntercomCommand
   entities:
-  - uid: 1052
+  - uid: 918
     components:
     - pos: -1.5,18.5
       parent: 1
       type: Transform
 - proto: IntercomSecurity
   entities:
-  - uid: 599
+  - uid: 919
     components:
     - pos: 2.5,18.5
       parent: 1
       type: Transform
-  - uid: 887
+  - uid: 920
     components:
     - pos: 1.5,-2.5
       parent: 1
       type: Transform
 - proto: JetpackCaptainFilled
   entities:
-  - uid: 7
+  - uid: 531
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 5
+    - parent: 522
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: JetpackSecurityFilled
   entities:
-  - uid: 876
+  - uid: 921
     components:
     - pos: -3.6663017,14.740974
       parent: 1
       type: Transform
-  - uid: 1009
+  - uid: 922
     components:
     - pos: -3.3225517,14.444099
       parent: 1
       type: Transform
-  - uid: 1130
+  - uid: 923
     components:
     - pos: -3.4944267,14.600349
       parent: 1
       type: Transform
 - proto: KitchenMicrowave
   entities:
-  - uid: 888
+  - uid: 924
     components:
     - pos: 3.5,-2.5
       parent: 1
       type: Transform
 - proto: KitchenReagentGrinder
   entities:
-  - uid: 1240
+  - uid: 925
     components:
     - pos: 4.5,-3.5
       parent: 1
       type: Transform
 - proto: LargeBeaker
   entities:
-  - uid: 1368
+  - uid: 926
     components:
     - pos: 4.1920414,-3.347478
       parent: 1
       type: Transform
 - proto: LockerBrigmedicFilled
   entities:
-  - uid: 84
+  - uid: 520
     components:
     - pos: -3.5,6.5
       parent: 1
@@ -6355,7 +6484,7 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 85
+          - 521
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -6363,7 +6492,7 @@ entities:
       type: ContainerContainer
 - proto: LockerEvidence
   entities:
-  - uid: 891
+  - uid: 542
     components:
     - pos: 1.5,0.5
       parent: 1
@@ -6391,20 +6520,20 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 892
-          - 893
-          - 894
-          - 895
-          - 896
-          - 897
-          - 898
-          - 899
+          - 543
+          - 549
+          - 547
+          - 544
+          - 548
+          - 545
+          - 550
+          - 546
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
           ent: null
       type: ContainerContainer
-  - uid: 900
+  - uid: 551
     components:
     - pos: 1.5,2.5
       parent: 1
@@ -6432,14 +6561,14 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 901
-          - 902
-          - 903
-          - 904
-          - 905
-          - 906
-          - 907
-          - 908
+          - 552
+          - 553
+          - 554
+          - 555
+          - 558
+          - 556
+          - 559
+          - 557
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -6447,7 +6576,7 @@ entities:
       type: ContainerContainer
 - proto: LockerHeadOfSecurityFilledHardsuit
   entities:
-  - uid: 5
+  - uid: 522
     components:
     - pos: 4.5,14.5
       parent: 1
@@ -6475,16 +6604,16 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 9
-          - 8
-          - 7
-          - 6
-          - 10
-          - 11
-          - 12
-          - 13
-          - 14
-          - 15
+          - 526
+          - 524
+          - 531
+          - 528
+          - 532
+          - 523
+          - 530
+          - 529
+          - 527
+          - 525
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -6492,35 +6621,35 @@ entities:
       type: ContainerContainer
 - proto: LockerSecurityFilled
   entities:
-  - uid: 76
+  - uid: 927
     components:
     - pos: -12.5,-8.5
       parent: 1
       type: Transform
-  - uid: 97
+  - uid: 928
     components:
     - pos: -12.5,-9.5
       parent: 1
       type: Transform
-  - uid: 99
+  - uid: 929
     components:
     - pos: 13.5,-9.5
       parent: 1
       type: Transform
-  - uid: 881
+  - uid: 930
     components:
     - pos: 13.5,-8.5
       parent: 1
       type: Transform
 - proto: LockerWallMedicalFilled
   entities:
-  - uid: 885
+  - uid: 931
     components:
     - rot: 1.5707963267948966 rad
       pos: -4.5,6.5
       parent: 1
       type: Transform
-  - uid: 1504
+  - uid: 932
     components:
     - rot: 1.5707963267948966 rad
       pos: -3.5,3.5
@@ -6528,101 +6657,117 @@ entities:
       type: Transform
 - proto: LockerWardenFilledHardsuit
   entities:
-  - uid: 1264
+  - uid: 933
     components:
     - pos: -2.5,4.5
       parent: 1
       type: Transform
 - proto: M_Emp
   entities:
-  - uid: 1152
+  - uid: 934
     components:
     - pos: -3.5,13.5
       parent: 1
       type: Transform
-- proto: MagazinePistolSubMachineGunHighVelocity
+- proto: MagazinePistolSubMachineGunTopMounted
   entities:
-  - uid: 585
+  - uid: 884
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 584
+    - parent: 883
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 587
+  - uid: 885
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 584
+    - parent: 883
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-- proto: MagazinePistolSubMachineGunRubber
-  entities:
-  - uid: 586
+  - uid: 888
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 584
+    - parent: 883
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 588
+  - uid: 889
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 584
+    - parent: 883
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 890
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 883
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 891
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 883
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: MedicalBed
   entities:
-  - uid: 1134
+  - uid: 935
     components:
     - pos: -2.5,6.5
       parent: 1
       type: Transform
 - proto: MedkitAdvancedFilled
   entities:
-  - uid: 910
+  - uid: 936
     components:
     - pos: -3.4508133,8.415087
       parent: 1
       type: Transform
-  - uid: 1304
+  - uid: 937
     components:
     - pos: -2.5133133,8.399462
       parent: 1
       type: Transform
 - proto: Mirror
   entities:
-  - uid: 1231
+  - uid: 938
     components:
     - pos: 6.5,12.5
       parent: 1
       type: Transform
 - proto: NitrogenCanister
   entities:
-  - uid: 917
+  - uid: 939
     components:
     - pos: -6.5,9.5
       parent: 1
       type: Transform
 - proto: OxygenCanister
   entities:
-  - uid: 918
+  - uid: 940
     components:
     - pos: -6.5,8.5
       parent: 1
       type: Transform
 - proto: PaperBin10
   entities:
-  - uid: 1071
+  - uid: 941
     components:
     - rot: 1.5707963267948966 rad
       pos: 3.5,15.5
@@ -6630,38 +6775,38 @@ entities:
       type: Transform
 - proto: PortableFlasher
   entities:
-  - uid: 921
+  - uid: 942
     components:
     - pos: 14.5,-14.5
       parent: 1
       type: Transform
-  - uid: 922
+  - uid: 943
     components:
     - pos: 0.5,-10.5
       parent: 1
       type: Transform
-  - uid: 923
+  - uid: 944
     components:
     - pos: -13.5,-14.5
       parent: 1
       type: Transform
 - proto: PortableScrubber
   entities:
-  - uid: 924
+  - uid: 945
     components:
     - pos: -5.5,7.5
       parent: 1
       type: Transform
 - proto: PosterContrabandFunPolice
   entities:
-  - uid: 925
+  - uid: 946
     components:
     - pos: 1.5,-5.5
       parent: 1
       type: Transform
 - proto: PosterLegit12Gauge
   entities:
-  - uid: 926
+  - uid: 947
     components:
     - rot: 3.141592653589793 rad
       pos: 7.5,10.5
@@ -6669,59 +6814,59 @@ entities:
       type: Transform
 - proto: PosterLegitEnlist
   entities:
-  - uid: 927
+  - uid: 948
     components:
     - pos: -1.5,-6.5
       parent: 1
       type: Transform
 - proto: PosterLegitIonRifle
   entities:
-  - uid: 1185
+  - uid: 949
     components:
     - pos: -5.5,-5.5
       parent: 1
       type: Transform
 - proto: PosterLegitObey
   entities:
-  - uid: 929
+  - uid: 950
     components:
     - pos: 3.5,1.5
       parent: 1
       type: Transform
 - proto: PosterLegitWalk
   entities:
-  - uid: 931
+  - uid: 951
     components:
     - pos: 1.5,6.5
       parent: 1
       type: Transform
 - proto: PottedPlantRandom
   entities:
-  - uid: 932
+  - uid: 952
     components:
     - pos: -1.5,-5.5
       parent: 1
       type: Transform
-  - uid: 933
+  - uid: 953
     components:
     - pos: -0.5,-5.5
       parent: 1
       type: Transform
-  - uid: 934
+  - uid: 954
     components:
     - pos: 0.5,-5.5
       parent: 1
       type: Transform
 - proto: PowerCellRecharger
   entities:
-  - uid: 1278
+  - uid: 955
     components:
     - pos: -1.5,6.5
       parent: 1
       type: Transform
 - proto: Poweredlight
   entities:
-  - uid: 292
+  - uid: 956
     components:
     - rot: 1.5707963267948966 rad
       pos: -3.5,12.5
@@ -6729,7 +6874,7 @@ entities:
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 499
+  - uid: 957
     components:
     - rot: -1.5707963267948966 rad
       pos: -1.5,10.5
@@ -6737,14 +6882,14 @@ entities:
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 935
+  - uid: 958
     components:
     - pos: 12.5,-13.5
       parent: 1
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 936
+  - uid: 959
     components:
     - rot: 1.5707963267948966 rad
       pos: 0.5,1.5
@@ -6752,7 +6897,7 @@ entities:
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 937
+  - uid: 960
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,-8.5
@@ -6760,7 +6905,7 @@ entities:
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 938
+  - uid: 961
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,-5.5
@@ -6768,14 +6913,14 @@ entities:
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 939
+  - uid: 962
     components:
     - pos: -11.5,-13.5
       parent: 1
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 940
+  - uid: 963
     components:
     - rot: -1.5707963267948966 rad
       pos: 0.5,6.5
@@ -6783,7 +6928,7 @@ entities:
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 941
+  - uid: 964
     components:
     - rot: 1.5707963267948966 rad
       pos: 0.5,12.5
@@ -6791,21 +6936,21 @@ entities:
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 944
+  - uid: 965
     components:
     - pos: 2.5,9.5
       parent: 1
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 945
+  - uid: 966
     components:
     - pos: 7.5,9.5
       parent: 1
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 946
+  - uid: 967
     components:
     - rot: 3.141592653589793 rad
       pos: -2.5,2.5
@@ -6813,7 +6958,7 @@ entities:
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 947
+  - uid: 968
     components:
     - rot: 3.141592653589793 rad
       pos: 11.5,-15.5
@@ -6821,7 +6966,7 @@ entities:
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 948
+  - uid: 969
     components:
     - rot: 3.141592653589793 rad
       pos: -10.5,-15.5
@@ -6829,35 +6974,35 @@ entities:
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 949
+  - uid: 970
     components:
     - pos: -4.5,-7.5
       parent: 1
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 950
+  - uid: 971
     components:
     - pos: 2.5,-2.5
       parent: 1
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 951
+  - uid: 972
     components:
     - pos: 5.5,-7.5
       parent: 1
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 952
+  - uid: 973
     components:
     - pos: -6.5,9.5
       parent: 1
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 953
+  - uid: 974
     components:
     - pos: 0.5,-10.5
       parent: 1
@@ -6866,7 +7011,7 @@ entities:
       type: AmbientSound
 - proto: PoweredlightColoredRed
   entities:
-  - uid: 56
+  - uid: 975
     components:
     - rot: 1.5707963267948966 rad
       pos: 6.5,15.5
@@ -6874,14 +7019,14 @@ entities:
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 513
+  - uid: 976
     components:
     - pos: 3.5,15.5
       parent: 1
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 520
+  - uid: 977
     components:
     - rot: 3.141592653589793 rad
       pos: 2.5,21.5
@@ -6889,7 +7034,7 @@ entities:
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 540
+  - uid: 978
     components:
     - rot: -1.5707963267948966 rad
       pos: -5.5,15.5
@@ -6897,14 +7042,14 @@ entities:
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 954
+  - uid: 979
     components:
     - pos: 3.5,-10.5
       parent: 1
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 955
+  - uid: 980
     components:
     - rot: -1.5707963267948966 rad
       pos: 9.5,-12.5
@@ -6912,7 +7057,7 @@ entities:
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 956
+  - uid: 981
     components:
     - rot: 1.5707963267948966 rad
       pos: -8.5,-12.5
@@ -6920,28 +7065,28 @@ entities:
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 957
+  - uid: 982
     components:
     - pos: -2.5,-10.5
       parent: 1
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 958
+  - uid: 983
     components:
     - pos: -10.5,-17.5
       parent: 1
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 959
+  - uid: 984
     components:
     - pos: 11.5,-17.5
       parent: 1
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 962
+  - uid: 985
     components:
     - rot: 1.5707963267948966 rad
       pos: 9.5,9.5
@@ -6949,7 +7094,7 @@ entities:
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 963
+  - uid: 986
     components:
     - rot: -1.5707963267948966 rad
       pos: -8.5,9.5
@@ -6957,7 +7102,7 @@ entities:
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 965
+  - uid: 987
     components:
     - rot: -1.5707963267948966 rad
       pos: -4.5,1.5
@@ -6965,7 +7110,7 @@ entities:
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 966
+  - uid: 988
     components:
     - rot: 1.5707963267948966 rad
       pos: 5.5,1.5
@@ -6973,7 +7118,7 @@ entities:
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 967
+  - uid: 989
     components:
     - rot: 3.141592653589793 rad
       pos: 8.5,-5.5
@@ -6981,7 +7126,7 @@ entities:
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 968
+  - uid: 990
     components:
     - rot: 3.141592653589793 rad
       pos: -7.5,-5.5
@@ -6989,7 +7134,7 @@ entities:
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 1151
+  - uid: 991
     components:
     - rot: 3.141592653589793 rad
       pos: -1.5,21.5
@@ -6999,7 +7144,7 @@ entities:
       type: AmbientSound
 - proto: PoweredlightLED
   entities:
-  - uid: 970
+  - uid: 992
     components:
     - rot: -1.5707963267948966 rad
       pos: -10.5,-9.5
@@ -7007,7 +7152,7 @@ entities:
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 971
+  - uid: 993
     components:
     - rot: 1.5707963267948966 rad
       pos: 11.5,-9.5
@@ -7017,134 +7162,134 @@ entities:
       type: AmbientSound
 - proto: PoweredLightPostSmallRed
   entities:
-  - uid: 972
+  - uid: 994
     components:
     - pos: 0.5,21.5
       parent: 1
       type: Transform
 - proto: PoweredSmallLight
   entities:
-  - uid: 87
+  - uid: 995
     components:
     - rot: 1.5707963267948966 rad
       pos: -3.5,14.5
       parent: 1
       type: Transform
-  - uid: 583
+  - uid: 996
     components:
     - rot: -1.5707963267948966 rad
       pos: 5.5,12.5
       parent: 1
       type: Transform
-  - uid: 909
+  - uid: 997
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,17.5
       parent: 1
       type: Transform
-  - uid: 942
+  - uid: 998
     components:
     - rot: 1.5707963267948966 rad
       pos: -3.5,6.5
       parent: 1
       type: Transform
-  - uid: 973
+  - uid: 999
     components:
     - rot: -1.5707963267948966 rad
       pos: -13.5,-14.5
       parent: 1
       type: Transform
-  - uid: 974
+  - uid: 1000
     components:
     - rot: 1.5707963267948966 rad
       pos: 14.5,-14.5
       parent: 1
       type: Transform
-  - uid: 975
+  - uid: 1001
     components:
     - rot: 1.5707963267948966 rad
       pos: 0.5,3.5
       parent: 1
       type: Transform
-  - uid: 976
+  - uid: 1002
     components:
     - rot: -1.5707963267948966 rad
       pos: -1.5,-0.5
       parent: 1
       type: Transform
-  - uid: 980
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -3.5,-4.5
-      parent: 1
-      type: Transform
-  - uid: 981
+  - uid: 1003
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,-5.5
       parent: 1
       type: Transform
-  - uid: 982
+  - uid: 1004
     components:
     - rot: -1.5707963267948966 rad
       pos: 0.5,-2.5
       parent: 1
       type: Transform
-  - uid: 983
+  - uid: 1005
     components:
     - rot: 3.141592653589793 rad
       pos: 2.5,-5.5
       parent: 1
       type: Transform
-  - uid: 984
+  - uid: 1006
     components:
     - rot: 3.141592653589793 rad
       pos: 5.5,-5.5
       parent: 1
       type: Transform
-  - uid: 985
+  - uid: 1007
     components:
     - rot: 1.5707963267948966 rad
       pos: 0.5,-0.5
       parent: 1
       type: Transform
-  - uid: 1113
+  - uid: 1008
     components:
     - pos: -3.5,4.5
       parent: 1
       type: Transform
-  - uid: 1138
+  - uid: 1009
     components:
     - rot: 3.141592653589793 rad
       pos: 1.5,17.5
       parent: 1
       type: Transform
-  - uid: 1342
+  - uid: 1010
     components:
     - rot: -1.5707963267948966 rad
       pos: -1.5,3.5
       parent: 1
       type: Transform
-  - uid: 1374
+  - uid: 1011
     components:
     - rot: 3.141592653589793 rad
       pos: 9.5,-8.5
       parent: 1
       type: Transform
-  - uid: 1383
+  - uid: 1012
     components:
     - rot: 3.141592653589793 rad
       pos: -8.5,-8.5
       parent: 1
       type: Transform
+  - uid: 1536
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -3.5,-5.5
+      parent: 1
+      type: Transform
 - proto: Rack
   entities:
-  - uid: 986
+  - uid: 1013
     components:
     - pos: 6.5,7.5
       parent: 1
       type: Transform
-  - uid: 1148
+  - uid: 1014
     components:
     - rot: 3.141592653589793 rad
       pos: -3.5,14.5
@@ -7152,318 +7297,318 @@ entities:
       type: Transform
 - proto: Railing
   entities:
-  - uid: 86
+  - uid: 1015
     components:
     - rot: 3.141592653589793 rad
       pos: 13.5,-10.5
       parent: 1
       type: Transform
-  - uid: 877
+  - uid: 1016
     components:
     - rot: 3.141592653589793 rad
       pos: 13.5,-10.5
       parent: 1
       type: Transform
-  - uid: 988
+  - uid: 1017
     components:
     - rot: -1.5707963267948966 rad
       pos: 10.5,-21.5
       parent: 1
       type: Transform
-  - uid: 989
+  - uid: 1018
     components:
     - rot: -1.5707963267948966 rad
       pos: 10.5,-20.5
       parent: 1
       type: Transform
-  - uid: 990
+  - uid: 1019
     components:
     - rot: -1.5707963267948966 rad
       pos: 10.5,-19.5
       parent: 1
       type: Transform
-  - uid: 991
+  - uid: 1020
     components:
     - rot: -1.5707963267948966 rad
       pos: 10.5,-18.5
       parent: 1
       type: Transform
-  - uid: 992
+  - uid: 1021
     components:
     - rot: -1.5707963267948966 rad
       pos: 10.5,-17.5
       parent: 1
       type: Transform
-  - uid: 993
+  - uid: 1022
     components:
     - rot: 1.5707963267948966 rad
       pos: 11.5,-21.5
       parent: 1
       type: Transform
-  - uid: 994
+  - uid: 1023
     components:
     - rot: 1.5707963267948966 rad
       pos: 14.5,-17.5
       parent: 1
       type: Transform
-  - uid: 995
+  - uid: 1024
     components:
     - rot: -1.5707963267948966 rad
       pos: -10.5,-21.5
       parent: 1
       type: Transform
-  - uid: 996
+  - uid: 1025
     components:
     - rot: -1.5707963267948966 rad
       pos: -13.5,-17.5
       parent: 1
       type: Transform
-  - uid: 997
+  - uid: 1026
     components:
     - rot: 1.5707963267948966 rad
       pos: -9.5,-21.5
       parent: 1
       type: Transform
-  - uid: 998
+  - uid: 1027
     components:
     - rot: 1.5707963267948966 rad
       pos: -9.5,-20.5
       parent: 1
       type: Transform
-  - uid: 999
+  - uid: 1028
     components:
     - rot: 1.5707963267948966 rad
       pos: -9.5,-19.5
       parent: 1
       type: Transform
-  - uid: 1000
+  - uid: 1029
     components:
     - rot: 1.5707963267948966 rad
       pos: -9.5,-18.5
       parent: 1
       type: Transform
-  - uid: 1001
+  - uid: 1030
     components:
     - rot: 1.5707963267948966 rad
       pos: -9.5,-17.5
       parent: 1
       type: Transform
-  - uid: 1002
+  - uid: 1031
     components:
     - pos: -2.5,-11.5
       parent: 1
       type: Transform
-  - uid: 1003
+  - uid: 1032
     components:
     - rot: 1.5707963267948966 rad
       pos: 12.5,-11.5
       parent: 1
       type: Transform
-  - uid: 1004
+  - uid: 1033
     components:
     - rot: 1.5707963267948966 rad
       pos: 12.5,-10.5
       parent: 1
       type: Transform
-  - uid: 1007
+  - uid: 1034
     components:
     - rot: -1.5707963267948966 rad
       pos: -11.5,-11.5
       parent: 1
       type: Transform
-  - uid: 1008
+  - uid: 1035
     components:
     - rot: -1.5707963267948966 rad
       pos: -11.5,-10.5
       parent: 1
       type: Transform
-  - uid: 1010
+  - uid: 1036
     components:
     - rot: 3.141592653589793 rad
       pos: -12.5,-10.5
       parent: 1
       type: Transform
-  - uid: 1011
+  - uid: 1037
     components:
     - pos: 5.5,-11.5
       parent: 1
       type: Transform
-  - uid: 1012
+  - uid: 1038
     components:
     - pos: -4.5,-11.5
       parent: 1
       type: Transform
-  - uid: 1013
+  - uid: 1039
     components:
     - pos: -5.5,-11.5
       parent: 1
       type: Transform
-  - uid: 1014
+  - uid: 1040
     components:
     - pos: -3.5,-11.5
       parent: 1
       type: Transform
-  - uid: 1015
+  - uid: 1041
     components:
     - pos: 4.5,-11.5
       parent: 1
       type: Transform
-  - uid: 1016
+  - uid: 1042
     components:
     - pos: 3.5,-11.5
       parent: 1
       type: Transform
-  - uid: 1017
+  - uid: 1043
     components:
     - pos: -6.5,-11.5
       parent: 1
       type: Transform
-  - uid: 1018
+  - uid: 1044
     components:
     - pos: 6.5,-11.5
       parent: 1
       type: Transform
-  - uid: 1019
+  - uid: 1045
     components:
     - pos: 7.5,-11.5
       parent: 1
       type: Transform
 - proto: RailingCorner
   entities:
-  - uid: 1020
+  - uid: 1046
     components:
     - pos: 11.5,-22.5
       parent: 1
       type: Transform
-  - uid: 1021
+  - uid: 1047
     components:
     - rot: -1.5707963267948966 rad
       pos: 10.5,-22.5
       parent: 1
       type: Transform
-  - uid: 1022
+  - uid: 1048
     components:
     - pos: 12.5,-20.5
       parent: 1
       type: Transform
-  - uid: 1023
+  - uid: 1049
     components:
     - pos: 13.5,-19.5
       parent: 1
       type: Transform
-  - uid: 1024
+  - uid: 1050
     components:
     - pos: 14.5,-18.5
       parent: 1
       type: Transform
-  - uid: 1025
+  - uid: 1051
     components:
     - pos: -9.5,-22.5
       parent: 1
       type: Transform
-  - uid: 1026
+  - uid: 1052
     components:
     - rot: -1.5707963267948966 rad
       pos: -10.5,-22.5
       parent: 1
       type: Transform
-  - uid: 1027
+  - uid: 1053
     components:
     - rot: -1.5707963267948966 rad
       pos: -11.5,-20.5
       parent: 1
       type: Transform
-  - uid: 1028
+  - uid: 1054
     components:
     - rot: -1.5707963267948966 rad
       pos: -12.5,-19.5
       parent: 1
       type: Transform
-  - uid: 1029
+  - uid: 1055
     components:
     - rot: -1.5707963267948966 rad
       pos: -13.5,-18.5
       parent: 1
       type: Transform
-  - uid: 1030
+  - uid: 1056
     components:
     - rot: -1.5707963267948966 rad
       pos: 8.5,-12.5
       parent: 1
       type: Transform
-  - uid: 1031
+  - uid: 1057
     components:
     - rot: -1.5707963267948966 rad
       pos: 9.5,-13.5
       parent: 1
       type: Transform
-  - uid: 1032
+  - uid: 1058
     components:
     - pos: -7.5,-12.5
       parent: 1
       type: Transform
-  - uid: 1033
+  - uid: 1059
     components:
     - pos: -8.5,-13.5
       parent: 1
       type: Transform
 - proto: RailingCornerSmall
   entities:
-  - uid: 1034
+  - uid: 1060
     components:
     - rot: 3.141592653589793 rad
       pos: 11.5,-20.5
       parent: 1
       type: Transform
-  - uid: 1035
+  - uid: 1061
     components:
     - rot: 3.141592653589793 rad
       pos: 12.5,-19.5
       parent: 1
       type: Transform
-  - uid: 1036
+  - uid: 1062
     components:
     - rot: 3.141592653589793 rad
       pos: 13.5,-18.5
       parent: 1
       type: Transform
-  - uid: 1037
+  - uid: 1063
     components:
     - rot: 1.5707963267948966 rad
       pos: -12.5,-18.5
       parent: 1
       type: Transform
-  - uid: 1038
+  - uid: 1064
     components:
     - rot: 1.5707963267948966 rad
       pos: -11.5,-19.5
       parent: 1
       type: Transform
-  - uid: 1039
+  - uid: 1065
     components:
     - rot: 1.5707963267948966 rad
       pos: -10.5,-20.5
       parent: 1
       type: Transform
-  - uid: 1040
+  - uid: 1066
     components:
     - rot: 1.5707963267948966 rad
       pos: 9.5,-12.5
       parent: 1
       type: Transform
-  - uid: 1041
+  - uid: 1067
     components:
     - rot: 1.5707963267948966 rad
       pos: 8.5,-11.5
       parent: 1
       type: Transform
-  - uid: 1042
+  - uid: 1068
     components:
     - rot: 3.141592653589793 rad
       pos: -7.5,-11.5
       parent: 1
       type: Transform
-  - uid: 1043
+  - uid: 1069
     components:
     - rot: 3.141592653589793 rad
       pos: -8.5,-12.5
@@ -7471,131 +7616,131 @@ entities:
       type: Transform
 - proto: RandomPosterLegit
   entities:
-  - uid: 1045
+  - uid: 1070
     components:
     - pos: -0.5,10.5
       parent: 1
       type: Transform
-  - uid: 1046
+  - uid: 1071
     components:
     - pos: 1.5,10.5
       parent: 1
       type: Transform
-  - uid: 1047
+  - uid: 1072
     components:
     - pos: 1.5,8.5
       parent: 1
       type: Transform
 - proto: RandomVendingDrinks
   entities:
-  - uid: 1370
+  - uid: 1073
     components:
     - pos: -4.5,-4.5
       parent: 1
       type: Transform
 - proto: RandomVendingSnacks
   entities:
-  - uid: 1486
+  - uid: 1074
     components:
     - pos: -4.5,-5.5
       parent: 1
       type: Transform
 - proto: ReinforcedPlasmaWindow
   entities:
-  - uid: 640
+  - uid: 1075
     components:
     - pos: 0.5,20.5
       parent: 1
       type: Transform
-  - uid: 1236
+  - uid: 1076
     components:
     - pos: 1.5,20.5
       parent: 1
       type: Transform
-  - uid: 1239
+  - uid: 1077
     components:
     - pos: -0.5,20.5
       parent: 1
       type: Transform
 - proto: ReinforcedWindow
   entities:
-  - uid: 1056
+  - uid: 1078
     components:
     - pos: 7.5,-9.5
       parent: 1
       type: Transform
-  - uid: 1057
+  - uid: 1079
     components:
     - pos: -3.5,-9.5
       parent: 1
       type: Transform
-  - uid: 1058
+  - uid: 1080
     components:
     - pos: -5.5,-9.5
       parent: 1
       type: Transform
-  - uid: 1059
+  - uid: 1081
     components:
     - pos: -4.5,-9.5
       parent: 1
       type: Transform
-  - uid: 1060
+  - uid: 1082
     components:
     - pos: 4.5,-9.5
       parent: 1
       type: Transform
-  - uid: 1061
+  - uid: 1083
     components:
     - pos: 6.5,-9.5
       parent: 1
       type: Transform
-  - uid: 1062
+  - uid: 1084
     components:
     - pos: -6.5,-9.5
       parent: 1
       type: Transform
-  - uid: 1063
+  - uid: 1085
     components:
     - rot: 1.5707963267948966 rad
       pos: -9.5,-13.5
       parent: 1
       type: Transform
-  - uid: 1064
+  - uid: 1086
     components:
     - rot: 1.5707963267948966 rad
       pos: -9.5,-14.5
       parent: 1
       type: Transform
-  - uid: 1065
+  - uid: 1087
     components:
     - rot: 1.5707963267948966 rad
       pos: -9.5,-15.5
       parent: 1
       type: Transform
-  - uid: 1066
+  - uid: 1088
     components:
     - rot: 1.5707963267948966 rad
       pos: 10.5,-13.5
       parent: 1
       type: Transform
-  - uid: 1067
+  - uid: 1089
     components:
     - rot: 1.5707963267948966 rad
       pos: 10.5,-14.5
       parent: 1
       type: Transform
-  - uid: 1068
+  - uid: 1090
     components:
     - rot: 1.5707963267948966 rad
       pos: 10.5,-15.5
       parent: 1
       type: Transform
-  - uid: 1069
+  - uid: 1091
     components:
     - pos: 5.5,-9.5
       parent: 1
       type: Transform
-  - uid: 1473
+  - uid: 1092
     components:
     - rot: 1.5707963267948966 rad
       pos: -0.5,3.5
@@ -7603,283 +7748,283 @@ entities:
       type: Transform
 - proto: SecBreachingHammer
   entities:
-  - uid: 521
+  - uid: 1093
     components:
     - pos: 6.669895,7.457632
       parent: 1
       type: Transform
-  - uid: 1074
+  - uid: 1094
     components:
     - pos: 6.5276413,7.5730324
       parent: 1
       type: Transform
 - proto: ShuttersNormal
   entities:
-  - uid: 850
+  - uid: 1095
     components:
     - pos: 1.5,20.5
       parent: 1
       type: Transform
     - links:
-      - 104
+      - 1114
       type: DeviceLinkSink
-  - uid: 851
+  - uid: 1096
     components:
     - pos: 0.5,20.5
       parent: 1
       type: Transform
     - links:
-      - 104
+      - 1114
       type: DeviceLinkSink
-  - uid: 852
+  - uid: 1097
     components:
     - pos: -0.5,20.5
       parent: 1
       type: Transform
     - links:
-      - 104
+      - 1114
       type: DeviceLinkSink
-  - uid: 1076
+  - uid: 1098
     components:
     - pos: -9.5,-13.5
       parent: 1
       type: Transform
     - links:
-      - 1099
+      - 1118
       type: DeviceLinkSink
-  - uid: 1077
+  - uid: 1099
     components:
     - pos: 7.5,-9.5
       parent: 1
       type: Transform
     - links:
-      - 1098
+      - 1117
       type: DeviceLinkSink
-  - uid: 1078
+  - uid: 1100
     components:
     - pos: 6.5,-9.5
       parent: 1
       type: Transform
     - links:
-      - 1098
+      - 1117
       type: DeviceLinkSink
-  - uid: 1079
+  - uid: 1101
     components:
     - pos: 5.5,-9.5
       parent: 1
       type: Transform
     - links:
-      - 1098
+      - 1117
       type: DeviceLinkSink
-  - uid: 1080
+  - uid: 1102
     components:
     - pos: 4.5,-9.5
       parent: 1
       type: Transform
     - links:
-      - 1098
+      - 1117
       type: DeviceLinkSink
-  - uid: 1081
+  - uid: 1103
     components:
     - pos: -3.5,-9.5
       parent: 1
       type: Transform
     - links:
-      - 1098
+      - 1117
       type: DeviceLinkSink
-  - uid: 1082
+  - uid: 1104
     components:
     - pos: -4.5,-9.5
       parent: 1
       type: Transform
     - links:
-      - 1098
+      - 1117
       type: DeviceLinkSink
-  - uid: 1083
+  - uid: 1105
     components:
     - pos: -5.5,-9.5
       parent: 1
       type: Transform
     - links:
-      - 1098
+      - 1117
       type: DeviceLinkSink
-  - uid: 1084
+  - uid: 1106
     components:
     - pos: -6.5,-9.5
       parent: 1
       type: Transform
     - links:
-      - 1098
+      - 1117
       type: DeviceLinkSink
-  - uid: 1085
+  - uid: 1107
     components:
     - pos: -9.5,-14.5
       parent: 1
       type: Transform
     - links:
-      - 1099
+      - 1118
       type: DeviceLinkSink
-  - uid: 1086
+  - uid: 1108
     components:
     - pos: -9.5,-15.5
       parent: 1
       type: Transform
     - links:
-      - 1099
+      - 1118
       type: DeviceLinkSink
-  - uid: 1087
+  - uid: 1109
     components:
     - pos: 10.5,-15.5
       parent: 1
       type: Transform
     - links:
-      - 1100
+      - 1119
       type: DeviceLinkSink
-  - uid: 1088
+  - uid: 1110
     components:
     - pos: 10.5,-14.5
       parent: 1
       type: Transform
     - links:
-      - 1100
+      - 1119
       type: DeviceLinkSink
-  - uid: 1089
+  - uid: 1111
     components:
     - pos: 10.5,-13.5
       parent: 1
       type: Transform
     - links:
-      - 1100
+      - 1119
       type: DeviceLinkSink
 - proto: ShuttersNormalOpen
   entities:
-  - uid: 1090
+  - uid: 1112
     components:
     - rot: -1.5707963267948966 rad
       pos: 1.5,-4.5
       parent: 1
       type: Transform
     - links:
-      - 1048
+      - 1116
       type: DeviceLinkSink
-  - uid: 1091
+  - uid: 1113
     components:
     - rot: -1.5707963267948966 rad
       pos: 1.5,-3.5
       parent: 1
       type: Transform
     - links:
-      - 1048
+      - 1116
       type: DeviceLinkSink
 - proto: SignalButton
   entities:
-  - uid: 104
+  - uid: 1114
     components:
     - pos: -0.5,16.5
       parent: 1
       type: Transform
     - linkedPorts:
-        852:
+        1097:
         - Pressed: Toggle
-        851:
+        1096:
         - Pressed: Toggle
-        850:
+        1095:
         - Pressed: Toggle
       type: DeviceLinkSource
-  - uid: 269
+  - uid: 1115
     components:
     - pos: -4.5,10.5
       parent: 1
       type: Transform
     - linkedPorts:
-        534:
+        86:
         - Pressed: Toggle
       type: DeviceLinkSource
-  - uid: 1048
+  - uid: 1116
     components:
     - pos: 5.5,-3.5
       parent: 1
       type: Transform
     - linkedPorts:
-        1090:
+        1112:
         - Pressed: Toggle
-        1091:
+        1113:
         - Pressed: Toggle
       type: DeviceLinkSource
-  - uid: 1098
+  - uid: 1117
     components:
     - pos: 0.5,-6.5
       parent: 1
       type: Transform
     - linkedPorts:
-        1081:
+        1103:
         - Pressed: Toggle
-        1082:
+        1104:
         - Pressed: Toggle
-        1083:
+        1105:
         - Pressed: Toggle
-        1084:
+        1106:
         - Pressed: Toggle
-        1080:
+        1102:
         - Pressed: Toggle
-        1079:
+        1101:
         - Pressed: Toggle
-        1078:
+        1100:
         - Pressed: Toggle
-        1077:
+        1099:
         - Pressed: Toggle
       type: DeviceLinkSource
-  - uid: 1099
+  - uid: 1118
     components:
     - pos: -9.5,-10.5
       parent: 1
       type: Transform
     - linkedPorts:
-        1076:
+        1098:
         - Pressed: Toggle
-        1085:
+        1107:
         - Pressed: Toggle
-        1086:
+        1108:
         - Pressed: Toggle
       type: DeviceLinkSource
-  - uid: 1100
+  - uid: 1119
     components:
     - pos: 10.5,-10.5
       parent: 1
       type: Transform
     - linkedPorts:
-        1089:
+        1111:
         - Pressed: Toggle
-        1088:
+        1110:
         - Pressed: Toggle
-        1087:
+        1109:
         - Pressed: Toggle
       type: DeviceLinkSource
-  - uid: 1102
+  - uid: 1120
     components:
     - pos: -11.5,-12.5
       parent: 1
       type: Transform
     - linkedPorts:
-        105:
+        87:
         - Pressed: Toggle
-        106:
+        88:
         - Pressed: Toggle
       type: DeviceLinkSource
-  - uid: 1103
+  - uid: 1121
     components:
     - pos: 12.5,-12.5
       parent: 1
       type: Transform
     - linkedPorts:
-        108:
+        90:
         - Pressed: Toggle
-        107:
+        89:
         - Pressed: Toggle
       type: DeviceLinkSource
 - proto: SignArmory
   entities:
-  - uid: 1104
+  - uid: 1122
     components:
     - rot: -1.5707963267948966 rad
       pos: 5.5,8.5
@@ -7887,28 +8032,28 @@ entities:
       type: Transform
 - proto: SignAtmos
   entities:
-  - uid: 1105
+  - uid: 1123
     components:
     - pos: -4.5,8.5
       parent: 1
       type: Transform
 - proto: SignBridge
   entities:
-  - uid: 1106
+  - uid: 1124
     components:
     - pos: -0.5,15.5
       parent: 1
       type: Transform
 - proto: SignCargo
   entities:
-  - uid: 1107
+  - uid: 1125
     components:
     - pos: -0.5,-0.5
       parent: 1
       type: Transform
 - proto: SignDisposalSpace
   entities:
-  - uid: 1108
+  - uid: 1126
     components:
     - rot: 1.5707963267948966 rad
       pos: 2.5,-6.5
@@ -7916,19 +8061,19 @@ entities:
       type: Transform
 - proto: SignEngine
   entities:
-  - uid: 1109
+  - uid: 1127
     components:
     - pos: 12.5,-7.5
       parent: 1
       type: Transform
-  - uid: 1110
+  - uid: 1128
     components:
     - pos: -11.5,-7.5
       parent: 1
       type: Transform
 - proto: SignEVA
   entities:
-  - uid: 1112
+  - uid: 1129
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,-9.5
@@ -7936,56 +8081,56 @@ entities:
       type: Transform
 - proto: SignMedical
   entities:
-  - uid: 1111
+  - uid: 1130
     components:
     - pos: -0.5,9.5
       parent: 1
       type: Transform
 - proto: SignSecurity
   entities:
-  - uid: 1114
+  - uid: 1131
     components:
     - rot: 1.5707963267948966 rad
       pos: -14.5,-14.5
       parent: 1
       type: Transform
-  - uid: 1115
+  - uid: 1132
     components:
     - rot: 1.5707963267948966 rad
       pos: 15.5,-14.5
       parent: 1
       type: Transform
-  - uid: 1116
+  - uid: 1133
     components:
     - rot: 1.5707963267948966 rad
       pos: 14.5,-2.5
       parent: 1
       type: Transform
-  - uid: 1117
+  - uid: 1134
     components:
     - rot: 1.5707963267948966 rad
       pos: -13.5,-2.5
       parent: 1
       type: Transform
-  - uid: 1118
+  - uid: 1135
     components:
     - rot: 1.5707963267948966 rad
       pos: 0.5,-11.5
       parent: 1
       type: Transform
-  - uid: 1119
+  - uid: 1136
     components:
     - pos: -9.5,-2.5
       parent: 1
       type: Transform
-  - uid: 1120
+  - uid: 1137
     components:
     - pos: 10.5,-2.5
       parent: 1
       type: Transform
 - proto: Sink
   entities:
-  - uid: 1050
+  - uid: 1138
     components:
     - rot: 3.141592653589793 rad
       pos: 5.5,11.5
@@ -7993,167 +8138,167 @@ entities:
       type: Transform
 - proto: SinkWide
   entities:
-  - uid: 72
+  - uid: 1139
     components:
     - pos: 6.5,11.5
       parent: 1
       type: Transform
-  - uid: 1122
+  - uid: 1140
     components:
     - rot: 3.141592653589793 rad
       pos: 4.5,-5.5
       parent: 1
       type: Transform
-  - uid: 1123
+  - uid: 1141
     components:
     - rot: 3.141592653589793 rad
       pos: 3.5,-0.5
       parent: 1
       type: Transform
-  - uid: 1124
+  - uid: 1142
     components:
     - pos: 3.5,3.5
       parent: 1
       type: Transform
 - proto: SMESBasic
   entities:
-  - uid: 1125
+  - uid: 1143
     components:
     - pos: 3.5,8.5
       parent: 1
       type: Transform
 - proto: soda_dispenser
   entities:
-  - uid: 1126
+  - uid: 1144
     components:
     - pos: 2.5,-2.5
       parent: 1
       type: Transform
 - proto: SpawnPointBrigmedic
   entities:
-  - uid: 1512
+  - uid: 1145
     components:
     - pos: -2.5,6.5
       parent: 1
       type: Transform
 - proto: SpawnPointChef
   entities:
-  - uid: 1511
+  - uid: 1146
     components:
     - pos: 2.5,-3.5
       parent: 1
       type: Transform
 - proto: SpawnPointLatejoin
   entities:
-  - uid: 1514
+  - uid: 1147
     components:
     - pos: -3.5,-5.5
       parent: 1
       type: Transform
-  - uid: 1515
+  - uid: 1148
     components:
     - pos: -3.5,-4.5
       parent: 1
       type: Transform
 - proto: SpawnPointSecurityOfficer
   entities:
-  - uid: 1131
+  - uid: 1149
     components:
     - pos: 12.5,-11.5
       parent: 1
       type: Transform
-  - uid: 1132
+  - uid: 1150
     components:
     - pos: 12.5,-10.5
       parent: 1
       type: Transform
-  - uid: 1135
+  - uid: 1151
     components:
     - pos: -11.5,-10.5
       parent: 1
       type: Transform
-  - uid: 1136
+  - uid: 1152
     components:
     - pos: -11.5,-11.5
       parent: 1
       type: Transform
 - proto: SpawnPointWarden
   entities:
-  - uid: 1516
+  - uid: 1153
     components:
     - pos: -1.5,3.5
       parent: 1
       type: Transform
 - proto: StationMap
   entities:
-  - uid: 1140
+  - uid: 1154
     components:
     - pos: -3.5,-3.5
       parent: 1
       type: Transform
 - proto: SubstationBasic
   entities:
-  - uid: 1141
+  - uid: 1155
     components:
     - pos: 4.5,8.5
       parent: 1
       type: Transform
 - proto: SubstationWallBasic
   entities:
-  - uid: 518
+  - uid: 1156
     components:
     - pos: 2.5,16.5
       parent: 1
       type: Transform
-  - uid: 1142
+  - uid: 1157
     components:
     - pos: -2.5,1.5
       parent: 1
       type: Transform
-  - uid: 1143
+  - uid: 1158
     components:
     - pos: 2.5,10.5
       parent: 1
       type: Transform
 - proto: SuitStorageEVAEmergency
   entities:
-  - uid: 1145
+  - uid: 1159
     components:
     - pos: -0.5,-7.5
       parent: 1
       type: Transform
-  - uid: 1146
+  - uid: 1160
     components:
     - pos: 1.5,-7.5
       parent: 1
       type: Transform
 - proto: SuitStorageSec
   entities:
-  - uid: 79
+  - uid: 1161
     components:
     - pos: -2.5,15.5
       parent: 1
       type: Transform
-  - uid: 96
+  - uid: 1162
     components:
     - pos: -1.5,15.5
       parent: 1
       type: Transform
-  - uid: 1129
+  - uid: 1163
     components:
     - pos: -3.5,15.5
       parent: 1
       type: Transform
 - proto: SurveillanceCameraRouterSecurity
   entities:
-  - uid: 88
+  - uid: 1164
     components:
     - pos: -3.5,4.5
       parent: 1
       type: Transform
 - proto: SurveillanceCameraSecurity
   entities:
-  - uid: 1150
+  - uid: 1165
     components:
     - rot: 1.5707963267948966 rad
       pos: -3.5,18.5
@@ -8164,7 +8309,7 @@ entities:
       nameSet: True
       id: Port 1
       type: SurveillanceCamera
-  - uid: 1153
+  - uid: 1166
     components:
     - rot: -1.5707963267948966 rad
       pos: -6.5,-7.5
@@ -8175,7 +8320,7 @@ entities:
       nameSet: True
       id: Hallway [LEFT]
       type: SurveillanceCamera
-  - uid: 1156
+  - uid: 1167
     components:
     - rot: 3.141592653589793 rad
       pos: 1.5,3.5
@@ -8186,7 +8331,7 @@ entities:
       nameSet: True
       id: Cell 1
       type: SurveillanceCamera
-  - uid: 1157
+  - uid: 1168
     components:
     - rot: 1.5707963267948966 rad
       pos: -1.5,-0.5
@@ -8197,7 +8342,7 @@ entities:
       nameSet: True
       id: Storage
       type: SurveillanceCamera
-  - uid: 1158
+  - uid: 1169
     components:
     - rot: 1.5707963267948966 rad
       pos: 7.5,-7.5
@@ -8208,7 +8353,7 @@ entities:
       nameSet: True
       id: Hallway [RIGHT]
       type: SurveillanceCamera
-  - uid: 1160
+  - uid: 1170
     components:
     - rot: 3.141592653589793 rad
       pos: 6.5,9.5
@@ -8219,7 +8364,7 @@ entities:
       nameSet: True
       id: Armory
       type: SurveillanceCamera
-  - uid: 1163
+  - uid: 1171
     components:
     - pos: 1.5,-0.5
       parent: 1
@@ -8229,7 +8374,7 @@ entities:
       nameSet: True
       id: Cell 2
       type: SurveillanceCamera
-  - uid: 1165
+  - uid: 1172
     components:
     - rot: 1.5707963267948966 rad
       pos: -8.5,8.5
@@ -8240,7 +8385,7 @@ entities:
       nameSet: True
       id: Port 2
       type: SurveillanceCamera
-  - uid: 1167
+  - uid: 1173
     components:
     - rot: 3.141592653589793 rad
       pos: 12.5,-13.5
@@ -8251,7 +8396,7 @@ entities:
       nameSet: True
       id: Docking port [RIGHT]
       type: SurveillanceCamera
-  - uid: 1168
+  - uid: 1174
     components:
     - rot: 3.141592653589793 rad
       pos: -11.5,-13.5
@@ -8262,7 +8407,7 @@ entities:
       nameSet: True
       id: Docking port [LEFT]
       type: SurveillanceCamera
-  - uid: 1169
+  - uid: 1175
     components:
     - rot: -1.5707963267948966 rad
       pos: 4.5,18.5
@@ -8273,7 +8418,7 @@ entities:
       nameSet: True
       id: Starboard 1
       type: SurveillanceCamera
-  - uid: 1171
+  - uid: 1176
     components:
     - rot: 1.5707963267948966 rad
       pos: 5.5,-5.5
@@ -8284,7 +8429,7 @@ entities:
       nameSet: True
       id: Kitchen
       type: SurveillanceCamera
-  - uid: 1172
+  - uid: 1177
     components:
     - pos: -0.5,-5.5
       parent: 1
@@ -8294,7 +8439,7 @@ entities:
       nameSet: True
       id: Lunch room
       type: SurveillanceCamera
-  - uid: 1520
+  - uid: 1178
     components:
     - rot: 1.5707963267948966 rad
       pos: -1.5,9.5
@@ -8305,7 +8450,7 @@ entities:
       nameSet: True
       id: EVA port room
       type: SurveillanceCamera
-  - uid: 1521
+  - uid: 1179
     components:
     - rot: 3.141592653589793 rad
       pos: -12.5,-17.5
@@ -8316,7 +8461,7 @@ entities:
       nameSet: True
       id: Port 3
       type: SurveillanceCamera
-  - uid: 1522
+  - uid: 1180
     components:
     - rot: 3.141592653589793 rad
       pos: 13.5,-17.5
@@ -8327,7 +8472,7 @@ entities:
       nameSet: True
       id: Starboard 3
       type: SurveillanceCamera
-  - uid: 1523
+  - uid: 1181
     components:
     - rot: -1.5707963267948966 rad
       pos: 9.5,8.5
@@ -8340,13 +8485,13 @@ entities:
       type: SurveillanceCamera
 - proto: Table
   entities:
-  - uid: 1174
+  - uid: 1182
     components:
     - rot: 1.5707963267948966 rad
       pos: -1.5,-3.5
       parent: 1
       type: Transform
-  - uid: 1175
+  - uid: 1183
     components:
     - rot: 1.5707963267948966 rad
       pos: -1.5,-2.5
@@ -8354,30 +8499,30 @@ entities:
       type: Transform
 - proto: TableCounterMetal
   entities:
-  - uid: 98
+  - uid: 1184
     components:
     - pos: -1.5,6.5
       parent: 1
       type: Transform
-  - uid: 1006
+  - uid: 1185
     components:
     - rot: 1.5707963267948966 rad
       pos: -3.5,8.5
       parent: 1
       type: Transform
-  - uid: 1072
+  - uid: 1186
     components:
     - rot: 1.5707963267948966 rad
       pos: -2.5,8.5
       parent: 1
       type: Transform
-  - uid: 1177
+  - uid: 1187
     components:
     - rot: 1.5707963267948966 rad
       pos: 1.5,-3.5
       parent: 1
       type: Transform
-  - uid: 1178
+  - uid: 1188
     components:
     - rot: 1.5707963267948966 rad
       pos: 1.5,-4.5
@@ -8385,44 +8530,44 @@ entities:
       type: Transform
 - proto: TableReinforced
   entities:
-  - uid: 515
+  - uid: 1189
     components:
     - pos: 2.5,15.5
       parent: 1
       type: Transform
-  - uid: 590
+  - uid: 1190
     components:
     - pos: 0.5,18.5
       parent: 1
       type: Transform
-  - uid: 882
+  - uid: 1191
     components:
     - pos: 3.5,-3.5
       parent: 1
       type: Transform
-  - uid: 987
+  - uid: 1192
     components:
     - pos: -0.5,4.5
       parent: 1
       type: Transform
-  - uid: 1181
+  - uid: 1193
     components:
     - rot: -1.5707963267948966 rad
       pos: 2.5,-2.5
       parent: 1
       type: Transform
-  - uid: 1183
+  - uid: 1194
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,-2.5
       parent: 1
       type: Transform
-  - uid: 1184
+  - uid: 1195
     components:
     - pos: 4.5,-3.5
       parent: 1
       type: Transform
-  - uid: 1305
+  - uid: 1196
     components:
     - rot: 1.5707963267948966 rad
       pos: 3.5,15.5
@@ -8430,161 +8575,161 @@ entities:
       type: Transform
 - proto: Thruster
   entities:
-  - uid: 1190
+  - uid: 1197
     components:
     - pos: 12.5,-6.5
       parent: 1
       type: Transform
-  - uid: 1191
+  - uid: 1198
     components:
     - pos: -11.5,-6.5
       parent: 1
       type: Transform
-  - uid: 1192
+  - uid: 1199
     components:
     - rot: 3.141592653589793 rad
       pos: -12.5,-4.5
       parent: 1
       type: Transform
-  - uid: 1193
+  - uid: 1200
     components:
     - rot: 3.141592653589793 rad
       pos: -11.5,-4.5
       parent: 1
       type: Transform
-  - uid: 1194
+  - uid: 1201
     components:
     - rot: 3.141592653589793 rad
       pos: -10.5,-4.5
       parent: 1
       type: Transform
-  - uid: 1195
-    components:
-    - pos: -11.5,-1.5
-      parent: 1
-      type: Transform
-  - uid: 1196
-    components:
-    - rot: 3.141592653589793 rad
-      pos: -11.5,0.5
-      parent: 1
-      type: Transform
-  - uid: 1197
-    components:
-    - pos: -12.5,-1.5
-      parent: 1
-      type: Transform
-  - uid: 1198
-    components:
-    - pos: -10.5,-1.5
-      parent: 1
-      type: Transform
-  - uid: 1199
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -12.5,-2.5
-      parent: 1
-      type: Transform
-  - uid: 1200
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -12.5,-3.5
-      parent: 1
-      type: Transform
-  - uid: 1201
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -10.5,-2.5
-      parent: 1
-      type: Transform
   - uid: 1202
     components:
-    - rot: 1.5707963267948966 rad
-      pos: -10.5,-3.5
+    - pos: -11.5,-1.5
       parent: 1
       type: Transform
   - uid: 1203
     components:
     - rot: 3.141592653589793 rad
-      pos: 12.5,0.5
+      pos: -11.5,0.5
       parent: 1
       type: Transform
   - uid: 1204
     components:
-    - pos: 11.5,-1.5
+    - pos: -12.5,-1.5
       parent: 1
       type: Transform
   - uid: 1205
     components:
-    - pos: 12.5,-1.5
+    - pos: -10.5,-1.5
       parent: 1
       type: Transform
   - uid: 1206
     components:
-    - pos: 13.5,-1.5
+    - rot: -1.5707963267948966 rad
+      pos: -12.5,-2.5
       parent: 1
       type: Transform
   - uid: 1207
     components:
     - rot: -1.5707963267948966 rad
-      pos: 11.5,-2.5
+      pos: -12.5,-3.5
       parent: 1
       type: Transform
   - uid: 1208
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 11.5,-3.5
+    - rot: 1.5707963267948966 rad
+      pos: -10.5,-2.5
       parent: 1
       type: Transform
   - uid: 1209
     components:
     - rot: 1.5707963267948966 rad
-      pos: 13.5,-2.5
+      pos: -10.5,-3.5
       parent: 1
       type: Transform
   - uid: 1210
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 12.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 1211
+    components:
+    - pos: 11.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 1212
+    components:
+    - pos: 12.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 1213
+    components:
+    - pos: 13.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 1214
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 11.5,-2.5
+      parent: 1
+      type: Transform
+  - uid: 1215
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 11.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 1216
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 13.5,-2.5
+      parent: 1
+      type: Transform
+  - uid: 1217
     components:
     - rot: 1.5707963267948966 rad
       pos: 13.5,-3.5
       parent: 1
       type: Transform
-  - uid: 1211
+  - uid: 1218
     components:
     - rot: 3.141592653589793 rad
       pos: 11.5,-4.5
       parent: 1
       type: Transform
-  - uid: 1212
+  - uid: 1219
     components:
     - rot: 3.141592653589793 rad
       pos: 12.5,-4.5
       parent: 1
       type: Transform
-  - uid: 1213
+  - uid: 1220
     components:
     - rot: 3.141592653589793 rad
       pos: 13.5,-4.5
       parent: 1
       type: Transform
-  - uid: 1214
+  - uid: 1221
     components:
     - rot: 3.141592653589793 rad
       pos: -12.5,0.5
       parent: 1
       type: Transform
-  - uid: 1215
+  - uid: 1222
     components:
     - rot: 3.141592653589793 rad
       pos: -10.5,0.5
       parent: 1
       type: Transform
-  - uid: 1216
+  - uid: 1223
     components:
     - rot: 3.141592653589793 rad
       pos: 11.5,0.5
       parent: 1
       type: Transform
-  - uid: 1217
+  - uid: 1224
     components:
     - rot: 3.141592653589793 rad
       pos: 13.5,0.5
@@ -8592,46 +8737,46 @@ entities:
       type: Transform
 - proto: ToiletEmpty
   entities:
-  - uid: 977
+  - uid: 1225
     components:
     - pos: 9.5,-7.5
       parent: 1
       type: Transform
-  - uid: 978
+  - uid: 1226
     components:
     - pos: -8.5,-7.5
       parent: 1
       type: Transform
-  - uid: 1070
+  - uid: 1227
     components:
     - pos: 5.5,12.5
       parent: 1
       type: Transform
 - proto: ToolboxElectricalTurretFilled
   entities:
-  - uid: 366
+  - uid: 357
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 362
+    - parent: 353
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: ToolboxMechanicalFilled
   entities:
-  - uid: 367
+  - uid: 358
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 362
+    - parent: 353
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: VendingMachineDetDrobe
   entities:
-  - uid: 1218
+  - uid: 1228
     components:
     - flags: SessionSpecific
       type: MetaData
@@ -8640,7 +8785,7 @@ entities:
       type: Transform
 - proto: VendingMachineSec
   entities:
-  - uid: 1254
+  - uid: 1229
     components:
     - flags: SessionSpecific
       type: MetaData
@@ -8649,7 +8794,7 @@ entities:
       type: Transform
 - proto: VendingMachineSecDrobe
   entities:
-  - uid: 1220
+  - uid: 1230
     components:
     - flags: SessionSpecific
       type: MetaData
@@ -8658,14 +8803,14 @@ entities:
       type: Transform
 - proto: VendingMachineTankDispenserEVA
   entities:
-  - uid: 1221
+  - uid: 1231
     components:
     - flags: SessionSpecific
       type: MetaData
     - pos: -5.5,-7.5
       parent: 1
       type: Transform
-  - uid: 1222
+  - uid: 1232
     components:
     - flags: SessionSpecific
       type: MetaData
@@ -8674,13 +8819,13 @@ entities:
       type: Transform
 - proto: WallmountTelescreen
   entities:
-  - uid: 920
+  - uid: 1233
     components:
     - rot: 1.5707963267948966 rad
       pos: -1.5,19.5
       parent: 1
       type: Transform
-  - uid: 1179
+  - uid: 1234
     components:
     - rot: -1.5707963267948966 rad
       pos: 2.5,19.5
@@ -8688,432 +8833,432 @@ entities:
       type: Transform
 - proto: WallmountTelescreenFrame
   entities:
-  - uid: 1225
+  - uid: 1235
     components:
     - pos: -3.5,-2.5
       parent: 1
       type: Transform
 - proto: WallPlastitanium
   entities:
-  - uid: 3
+  - uid: 1236
     components:
     - pos: 4.5,13.5
       parent: 1
       type: Transform
-  - uid: 34
+  - uid: 1237
     components:
     - pos: -3.5,5.5
       parent: 1
       type: Transform
-  - uid: 89
+  - uid: 1238
     components:
     - rot: -1.5707963267948966 rad
       pos: -6.5,12.5
       parent: 1
       type: Transform
-  - uid: 510
+  - uid: 1239
     components:
     - pos: 7.5,11.5
       parent: 1
       type: Transform
-  - uid: 511
+  - uid: 1240
     components:
     - pos: 4.5,12.5
       parent: 1
       type: Transform
-  - uid: 536
+  - uid: 1241
     components:
     - pos: 2.5,16.5
       parent: 1
       type: Transform
-  - uid: 545
+  - uid: 1242
     components:
     - pos: -1.5,19.5
       parent: 1
       type: Transform
-  - uid: 559
+  - uid: 1243
     components:
     - pos: -0.5,16.5
       parent: 1
       type: Transform
-  - uid: 581
+  - uid: 1244
     components:
     - pos: -1.5,20.5
       parent: 1
       type: Transform
-  - uid: 639
+  - uid: 1245
     components:
     - rot: -1.5707963267948966 rad
       pos: -4.5,14.5
       parent: 1
       type: Transform
-  - uid: 760
+  - uid: 1246
     components:
     - rot: -1.5707963267948966 rad
       pos: 5.5,14.5
       parent: 1
       type: Transform
-  - uid: 801
+  - uid: 1247
     components:
     - pos: 3.5,18.5
       parent: 1
       type: Transform
-  - uid: 803
+  - uid: 1248
     components:
     - pos: -2.5,18.5
       parent: 1
       type: Transform
-  - uid: 854
+  - uid: 1249
     components:
     - rot: -1.5707963267948966 rad
       pos: -2.5,16.5
       parent: 1
       type: Transform
-  - uid: 873
+  - uid: 1250
     components:
     - pos: 1.5,15.5
       parent: 1
       type: Transform
-  - uid: 911
+  - uid: 1251
     components:
     - rot: 1.5707963267948966 rad
       pos: -4.5,15.5
       parent: 1
       type: Transform
-  - uid: 913
+  - uid: 1252
     components:
     - pos: -1.5,5.5
       parent: 1
       type: Transform
-  - uid: 914
+  - uid: 1253
     components:
     - pos: -4.5,5.5
       parent: 1
       type: Transform
-  - uid: 930
+  - uid: 1254
     components:
     - pos: -0.5,5.5
-      parent: 1
-      type: Transform
-  - uid: 943
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 4.5,15.5
-      parent: 1
-      type: Transform
-  - uid: 964
-    components:
-    - pos: -5.5,12.5
-      parent: 1
-      type: Transform
-  - uid: 969
-    components:
-    - pos: 6.5,12.5
-      parent: 1
-      type: Transform
-  - uid: 1096
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 3.5,16.5
-      parent: 1
-      type: Transform
-  - uid: 1127
-    components:
-    - pos: 1.5,14.5
-      parent: 1
-      type: Transform
-  - uid: 1139
-    components:
-    - pos: -1.5,16.5
-      parent: 1
-      type: Transform
-  - uid: 1147
-    components:
-    - rot: 3.141592653589793 rad
-      pos: -0.5,14.5
-      parent: 1
-      type: Transform
-  - uid: 1149
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -4.5,12.5
-      parent: 1
-      type: Transform
-  - uid: 1159
-    components:
-    - pos: -4.5,13.5
-      parent: 1
-      type: Transform
-  - uid: 1162
-    components:
-    - pos: 2.5,19.5
-      parent: 1
-      type: Transform
-  - uid: 1164
-    components:
-    - pos: 5.5,13.5
-      parent: 1
-      type: Transform
-  - uid: 1173
-    components:
-    - pos: -2.5,5.5
-      parent: 1
-      type: Transform
-  - uid: 1180
-    components:
-    - pos: 1.5,16.5
-      parent: 1
-      type: Transform
-  - uid: 1227
-    components:
-    - pos: -6.5,10.5
-      parent: 1
-      type: Transform
-  - uid: 1228
-    components:
-    - pos: -5.5,10.5
-      parent: 1
-      type: Transform
-  - uid: 1229
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -5.5,6.5
-      parent: 1
-      type: Transform
-  - uid: 1230
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -6.5,6.5
-      parent: 1
-      type: Transform
-  - uid: 1232
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 5.5,15.5
-      parent: 1
-      type: Transform
-  - uid: 1235
-    components:
-    - pos: -0.5,15.5
-      parent: 1
-      type: Transform
-  - uid: 1241
-    components:
-    - pos: -7.5,9.5
-      parent: 1
-      type: Transform
-  - uid: 1242
-    components:
-    - pos: 1.5,13.5
-      parent: 1
-      type: Transform
-  - uid: 1243
-    components:
-    - pos: -7.5,7.5
-      parent: 1
-      type: Transform
-  - uid: 1244
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 8.5,8.5
-      parent: 1
-      type: Transform
-  - uid: 1245
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 8.5,9.5
-      parent: 1
-      type: Transform
-  - uid: 1246
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 8.5,7.5
-      parent: 1
-      type: Transform
-  - uid: 1247
-    components:
-    - pos: -7.5,8.5
-      parent: 1
-      type: Transform
-  - uid: 1248
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 1.5,4.5
-      parent: 1
-      type: Transform
-  - uid: 1249
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -4.5,7.5
-      parent: 1
-      type: Transform
-  - uid: 1251
-    components:
-    - pos: 1.5,10.5
       parent: 1
       type: Transform
   - uid: 1255
     components:
     - rot: -1.5707963267948966 rad
-      pos: -4.5,10.5
+      pos: 4.5,15.5
       parent: 1
       type: Transform
   - uid: 1256
     components:
-    - rot: 1.5707963267948966 rad
-      pos: 1.5,11.5
+    - pos: -5.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 1257
+    components:
+    - pos: 6.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 1258
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 3.5,16.5
       parent: 1
       type: Transform
   - uid: 1259
     components:
-    - pos: 4.5,10.5
+    - pos: 1.5,14.5
       parent: 1
       type: Transform
   - uid: 1260
     components:
-    - rot: 1.5707963267948966 rad
-      pos: 1.5,8.5
+    - pos: -1.5,16.5
       parent: 1
       type: Transform
   - uid: 1261
     components:
-    - rot: 1.5707963267948966 rad
-      pos: 1.5,7.5
+    - rot: 3.141592653589793 rad
+      pos: -0.5,14.5
       parent: 1
       type: Transform
   - uid: 1262
     components:
-    - rot: 1.5707963267948966 rad
-      pos: 1.5,6.5
+    - rot: -1.5707963267948966 rad
+      pos: -4.5,12.5
       parent: 1
       type: Transform
   - uid: 1263
     components:
-    - rot: 1.5707963267948966 rad
-      pos: 1.5,5.5
+    - pos: -4.5,13.5
+      parent: 1
+      type: Transform
+  - uid: 1264
+    components:
+    - pos: 2.5,19.5
+      parent: 1
+      type: Transform
+  - uid: 1265
+    components:
+    - pos: 5.5,13.5
       parent: 1
       type: Transform
   - uid: 1266
     components:
-    - rot: 1.5707963267948966 rad
-      pos: -4.5,6.5
+    - pos: -2.5,5.5
       parent: 1
       type: Transform
   - uid: 1267
     components:
-    - pos: 2.5,20.5
+    - pos: 1.5,16.5
       parent: 1
       type: Transform
   - uid: 1268
     components:
-    - pos: -0.5,12.5
+    - pos: -6.5,10.5
       parent: 1
       type: Transform
   - uid: 1269
     components:
-    - pos: -0.5,13.5
+    - pos: -5.5,10.5
       parent: 1
       type: Transform
   - uid: 1270
     components:
-    - pos: -0.5,6.5
+    - rot: -1.5707963267948966 rad
+      pos: -5.5,6.5
       parent: 1
       type: Transform
   - uid: 1271
     components:
-    - rot: 1.5707963267948966 rad
-      pos: -0.5,7.5
+    - rot: -1.5707963267948966 rad
+      pos: -6.5,6.5
       parent: 1
       type: Transform
   - uid: 1272
     components:
     - rot: 1.5707963267948966 rad
-      pos: -0.5,8.5
+      pos: 5.5,15.5
       parent: 1
       type: Transform
   - uid: 1273
     components:
-    - rot: 3.141592653589793 rad
-      pos: -0.5,10.5
+    - pos: -0.5,15.5
       parent: 1
       type: Transform
   - uid: 1274
     components:
-    - rot: 3.141592653589793 rad
-      pos: -0.5,9.5
+    - pos: -7.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 1275
+    components:
+    - pos: 1.5,13.5
       parent: 1
       type: Transform
   - uid: 1276
     components:
-    - pos: 2.5,10.5
+    - pos: -7.5,7.5
       parent: 1
       type: Transform
   - uid: 1277
     components:
-    - pos: 3.5,10.5
+    - rot: 1.5707963267948966 rad
+      pos: 8.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 1278
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 8.5,9.5
       parent: 1
       type: Transform
   - uid: 1279
     components:
-    - rot: -1.5707963267948966 rad
-      pos: -3.5,3.5
+    - rot: 1.5707963267948966 rad
+      pos: 8.5,7.5
       parent: 1
       type: Transform
   - uid: 1280
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 5.5,4.5
+    - pos: -7.5,8.5
       parent: 1
       type: Transform
   - uid: 1281
     components:
     - rot: -1.5707963267948966 rad
-      pos: -4.5,4.5
+      pos: 1.5,4.5
       parent: 1
       type: Transform
   - uid: 1282
     components:
     - rot: 1.5707963267948966 rad
-      pos: -4.5,8.5
+      pos: -4.5,7.5
       parent: 1
       type: Transform
   - uid: 1283
     components:
-    - rot: 1.5707963267948966 rad
-      pos: -2.5,17.5
+    - pos: 1.5,10.5
       parent: 1
       type: Transform
   - uid: 1284
     components:
-    - rot: 1.5707963267948966 rad
-      pos: -1.5,18.5
+    - rot: -1.5707963267948966 rad
+      pos: -4.5,10.5
       parent: 1
       type: Transform
   - uid: 1285
     components:
     - rot: 1.5707963267948966 rad
-      pos: 2.5,18.5
+      pos: 1.5,11.5
       parent: 1
       type: Transform
   - uid: 1286
     components:
-    - rot: 1.5707963267948966 rad
-      pos: 3.5,17.5
+    - pos: 4.5,10.5
       parent: 1
       type: Transform
   - uid: 1287
     components:
     - rot: 1.5707963267948966 rad
-      pos: -5.5,5.5
+      pos: 1.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 1288
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 1.5,7.5
+      parent: 1
+      type: Transform
+  - uid: 1289
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 1.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 1290
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 1.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 1291
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -4.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 1292
+    components:
+    - pos: 2.5,20.5
+      parent: 1
+      type: Transform
+  - uid: 1293
+    components:
+    - pos: -0.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 1294
+    components:
+    - pos: -0.5,13.5
+      parent: 1
+      type: Transform
+  - uid: 1295
+    components:
+    - pos: -0.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 1296
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -0.5,7.5
+      parent: 1
+      type: Transform
+  - uid: 1297
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -0.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 1298
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -0.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 1299
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -0.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 1300
+    components:
+    - pos: 2.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 1301
+    components:
+    - pos: 3.5,10.5
       parent: 1
       type: Transform
   - uid: 1302
     components:
     - rot: -1.5707963267948966 rad
-      pos: -3.5,16.5
+      pos: -3.5,3.5
       parent: 1
       type: Transform
   - uid: 1303
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 5.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 1304
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -4.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 1305
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -4.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 1306
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -2.5,17.5
+      parent: 1
+      type: Transform
+  - uid: 1307
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -1.5,18.5
+      parent: 1
+      type: Transform
+  - uid: 1308
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 2.5,18.5
+      parent: 1
+      type: Transform
+  - uid: 1309
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 3.5,17.5
+      parent: 1
+      type: Transform
+  - uid: 1310
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -5.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 1311
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -3.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 1312
     components:
     - rot: -1.5707963267948966 rad
       pos: 4.5,16.5
@@ -9121,177 +9266,177 @@ entities:
       type: Transform
 - proto: WallPlastitaniumDiagonal
   entities:
-  - uid: 451
+  - uid: 1313
     components:
     - rot: -1.5707963267948966 rad
       pos: 4.5,17.5
       parent: 1
       type: Transform
-  - uid: 516
+  - uid: 1314
     components:
     - rot: -1.5707963267948966 rad
       pos: 7.5,12.5
       parent: 1
       type: Transform
-  - uid: 626
+  - uid: 1315
     components:
     - pos: -2.5,19.5
       parent: 1
       type: Transform
-  - uid: 961
+  - uid: 1316
     components:
     - rot: -1.5707963267948966 rad
       pos: 5.5,16.5
       parent: 1
       type: Transform
-  - uid: 1051
+  - uid: 1317
     components:
     - pos: -5.5,13.5
       parent: 1
       type: Transform
-  - uid: 1121
+  - uid: 1318
     components:
     - pos: -4.5,16.5
       parent: 1
       type: Transform
-  - uid: 1252
+  - uid: 1319
     components:
     - pos: -3.5,17.5
       parent: 1
       type: Transform
-  - uid: 1253
+  - uid: 1320
     components:
     - rot: -1.5707963267948966 rad
       pos: 6.5,13.5
       parent: 1
       type: Transform
-  - uid: 1275
+  - uid: 1321
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,19.5
       parent: 1
       type: Transform
-  - uid: 1288
+  - uid: 1322
     components:
     - rot: 1.5707963267948966 rad
       pos: -5.5,4.5
       parent: 1
       type: Transform
-  - uid: 1289
+  - uid: 1323
     components:
     - rot: -1.5707963267948966 rad
       pos: -9.5,1.5
       parent: 1
       type: Transform
-  - uid: 1290
+  - uid: 1324
     components:
     - rot: 3.141592653589793 rad
       pos: 8.5,6.5
       parent: 1
       type: Transform
-  - uid: 1291
+  - uid: 1325
     components:
     - rot: -1.5707963267948966 rad
       pos: 8.5,10.5
       parent: 1
       type: Transform
-  - uid: 1292
+  - uid: 1326
     components:
     - pos: -6.5,-5.5
       parent: 1
       type: Transform
-  - uid: 1293
+  - uid: 1327
     components:
     - rot: 1.5707963267948966 rad
       pos: 8.5,-10.5
       parent: 1
       type: Transform
-  - uid: 1294
+  - uid: 1328
     components:
     - rot: 3.141592653589793 rad
       pos: -7.5,-10.5
       parent: 1
       type: Transform
-  - uid: 1295
+  - uid: 1329
     components:
     - rot: -1.5707963267948966 rad
       pos: 7.5,-5.5
       parent: 1
       type: Transform
-  - uid: 1296
+  - uid: 1330
     components:
     - pos: -7.5,10.5
       parent: 1
       type: Transform
-  - uid: 1297
+  - uid: 1331
     components:
     - rot: 1.5707963267948966 rad
       pos: -7.5,6.5
       parent: 1
       type: Transform
-  - uid: 1298
+  - uid: 1332
     components:
     - rot: 3.141592653589793 rad
       pos: -8.5,-11.5
       parent: 1
       type: Transform
-  - uid: 1299
+  - uid: 1333
     components:
     - rot: 1.5707963267948966 rad
       pos: 9.5,-11.5
       parent: 1
       type: Transform
-  - uid: 1300
+  - uid: 1334
     components:
     - pos: -13.5,1.5
       parent: 1
       type: Transform
-  - uid: 1307
+  - uid: 1335
     components:
     - pos: -4.5,-2.5
       parent: 1
       type: Transform
-  - uid: 1308
+  - uid: 1336
     components:
     - rot: -1.5707963267948966 rad
       pos: 5.5,-2.5
       parent: 1
       type: Transform
-  - uid: 1309
+  - uid: 1337
     components:
     - rot: 3.141592653589793 rad
       pos: 5.5,3.5
       parent: 1
       type: Transform
-  - uid: 1310
+  - uid: 1338
     components:
     - rot: 1.5707963267948966 rad
       pos: -4.5,3.5
       parent: 1
       type: Transform
-  - uid: 1311
+  - uid: 1339
     components:
     - pos: -5.5,-3.5
       parent: 1
       type: Transform
-  - uid: 1312
+  - uid: 1340
     components:
     - rot: -1.5707963267948966 rad
       pos: 6.5,-3.5
       parent: 1
       type: Transform
-  - uid: 1313
+  - uid: 1341
     components:
     - pos: 10.5,1.5
       parent: 1
       type: Transform
-  - uid: 1314
+  - uid: 1342
     components:
     - rot: -1.5707963267948966 rad
       pos: 14.5,1.5
       parent: 1
       type: Transform
-  - uid: 1315
+  - uid: 1343
     components:
     - rot: 3.141592653589793 rad
       pos: 6.5,4.5
@@ -9299,962 +9444,962 @@ entities:
       type: Transform
 - proto: WallPlastitaniumIndestructible
   entities:
-  - uid: 960
+  - uid: 1344
     components:
     - pos: 6.5,10.5
       parent: 1
       type: Transform
-  - uid: 1316
+  - uid: 1345
     components:
     - pos: 6.5,5.5
       parent: 1
       type: Transform
-  - uid: 1317
+  - uid: 1346
     components:
     - rot: 3.141592653589793 rad
       pos: -12.5,1.5
       parent: 1
       type: Transform
-  - uid: 1318
+  - uid: 1347
     components:
     - rot: 3.141592653589793 rad
       pos: -9.5,0.5
       parent: 1
       type: Transform
-  - uid: 1319
+  - uid: 1348
     components:
     - rot: 3.141592653589793 rad
       pos: -13.5,0.5
       parent: 1
       type: Transform
-  - uid: 1320
+  - uid: 1349
     components:
     - rot: 3.141592653589793 rad
       pos: -10.5,1.5
       parent: 1
       type: Transform
-  - uid: 1321
+  - uid: 1350
     components:
     - rot: 3.141592653589793 rad
       pos: 14.5,0.5
       parent: 1
       type: Transform
-  - uid: 1322
+  - uid: 1351
     components:
     - rot: 1.5707963267948966 rad
       pos: 13.5,1.5
       parent: 1
       type: Transform
-  - uid: 1323
+  - uid: 1352
     components:
     - rot: 3.141592653589793 rad
       pos: 10.5,0.5
       parent: 1
       type: Transform
-  - uid: 1324
+  - uid: 1353
     components:
     - rot: 1.5707963267948966 rad
       pos: 11.5,1.5
       parent: 1
       type: Transform
-  - uid: 1325
+  - uid: 1354
     components:
     - pos: 4.5,-0.5
       parent: 1
       type: Transform
-  - uid: 1326
-    components:
-    - pos: 4.5,3.5
-      parent: 1
-      type: Transform
-  - uid: 1328
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 1.5,-5.5
-      parent: 1
-      type: Transform
-  - uid: 1329
-    components:
-    - pos: -4.5,-3.5
-      parent: 1
-      type: Transform
-  - uid: 1330
-    components:
-    - pos: -5.5,-4.5
-      parent: 1
-      type: Transform
-  - uid: 1331
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 9.5,-6.5
-      parent: 1
-      type: Transform
-  - uid: 1332
-    components:
-    - pos: 5.5,-3.5
-      parent: 1
-      type: Transform
-  - uid: 1333
-    components:
-    - pos: 6.5,-4.5
-      parent: 1
-      type: Transform
-  - uid: 1334
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 8.5,-6.5
-      parent: 1
-      type: Transform
-  - uid: 1335
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -3.5,1.5
-      parent: 1
-      type: Transform
-  - uid: 1336
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -3.5,0.5
-      parent: 1
-      type: Transform
-  - uid: 1337
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -3.5,-0.5
-      parent: 1
-      type: Transform
-  - uid: 1338
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -3.5,2.5
-      parent: 1
-      type: Transform
-  - uid: 1339
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -3.5,-1.5
-      parent: 1
-      type: Transform
-  - uid: 1341
-    components:
-    - pos: -3.5,-2.5
-      parent: 1
-      type: Transform
-  - uid: 1343
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 5.5,-6.5
-      parent: 1
-      type: Transform
-  - uid: 1344
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 8.5,-9.5
-      parent: 1
-      type: Transform
-  - uid: 1345
-    components:
-    - pos: -9.5,-9.5
-      parent: 1
-      type: Transform
-  - uid: 1346
-    components:
-    - pos: -1.5,-6.5
-      parent: 1
-      type: Transform
-  - uid: 1347
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 6.5,-5.5
-      parent: 1
-      type: Transform
-  - uid: 1348
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 7.5,-6.5
-      parent: 1
-      type: Transform
-  - uid: 1349
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 8.5,-7.5
-      parent: 1
-      type: Transform
-  - uid: 1350
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 9.5,-9.5
-      parent: 1
-      type: Transform
-  - uid: 1351
-    components:
-    - pos: 10.5,-9.5
-      parent: 1
-      type: Transform
-  - uid: 1352
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 4.5,-2.5
-      parent: 1
-      type: Transform
-  - uid: 1353
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 4.5,-1.5
-      parent: 1
-      type: Transform
-  - uid: 1354
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 4.5,0.5
-      parent: 1
-      type: Transform
   - uid: 1355
     components:
-    - rot: 3.141592653589793 rad
-      pos: 4.5,1.5
+    - pos: 4.5,3.5
       parent: 1
       type: Transform
   - uid: 1356
     components:
     - rot: 3.141592653589793 rad
-      pos: 4.5,2.5
+      pos: 1.5,-5.5
       parent: 1
       type: Transform
   - uid: 1357
     components:
-    - pos: 4.5,4.5
+    - pos: -4.5,-3.5
       parent: 1
       type: Transform
   - uid: 1358
     components:
-    - pos: -3.5,-6.5
+    - pos: -5.5,-4.5
       parent: 1
       type: Transform
   - uid: 1359
     components:
-    - pos: -4.5,-6.5
+    - rot: 3.141592653589793 rad
+      pos: 9.5,-6.5
       parent: 1
       type: Transform
   - uid: 1360
     components:
-    - rot: 1.5707963267948966 rad
-      pos: 1.5,-6.5
+    - pos: 5.5,-3.5
       parent: 1
       type: Transform
   - uid: 1361
     components:
-    - pos: 2.5,-9.5
+    - pos: 6.5,-4.5
       parent: 1
       type: Transform
   - uid: 1362
     components:
-    - pos: 2.5,-6.5
+    - rot: 3.141592653589793 rad
+      pos: 8.5,-6.5
       parent: 1
       type: Transform
   - uid: 1363
     components:
-    - pos: -1.5,-9.5
+    - rot: -1.5707963267948966 rad
+      pos: -3.5,1.5
       parent: 1
       type: Transform
   - uid: 1364
     components:
-    - pos: 6.5,-6.5
+    - rot: -1.5707963267948966 rad
+      pos: -3.5,0.5
       parent: 1
       type: Transform
   - uid: 1365
     components:
-    - pos: -5.5,-6.5
+    - rot: -1.5707963267948966 rad
+      pos: -3.5,-0.5
       parent: 1
       type: Transform
   - uid: 1366
     components:
-    - rot: 3.141592653589793 rad
-      pos: -2.5,-9.5
+    - rot: -1.5707963267948966 rad
+      pos: -3.5,2.5
       parent: 1
       type: Transform
   - uid: 1367
     components:
-    - rot: 3.141592653589793 rad
-      pos: 3.5,-9.5
+    - rot: -1.5707963267948966 rad
+      pos: -3.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 1368
+    components:
+    - pos: -3.5,-2.5
       parent: 1
       type: Transform
   - uid: 1369
     components:
+    - rot: 1.5707963267948966 rad
+      pos: 5.5,-6.5
+      parent: 1
+      type: Transform
+  - uid: 1370
+    components:
     - rot: 3.141592653589793 rad
-      pos: -3.5,-3.5
+      pos: 8.5,-9.5
       parent: 1
       type: Transform
   - uid: 1371
     components:
-    - rot: 3.141592653589793 rad
-      pos: -5.5,-5.5
+    - pos: -9.5,-9.5
       parent: 1
       type: Transform
   - uid: 1372
     components:
-    - rot: 3.141592653589793 rad
-      pos: -6.5,-6.5
+    - pos: -1.5,-6.5
       parent: 1
       type: Transform
   - uid: 1373
     components:
     - rot: 3.141592653589793 rad
-      pos: -7.5,-7.5
+      pos: 6.5,-5.5
+      parent: 1
+      type: Transform
+  - uid: 1374
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 7.5,-6.5
       parent: 1
       type: Transform
   - uid: 1375
     components:
     - rot: 3.141592653589793 rad
-      pos: 6.5,6.5
+      pos: 8.5,-7.5
       parent: 1
       type: Transform
   - uid: 1376
     components:
     - rot: 3.141592653589793 rad
-      pos: 7.5,6.5
+      pos: 9.5,-9.5
+      parent: 1
+      type: Transform
+  - uid: 1377
+    components:
+    - pos: 10.5,-9.5
       parent: 1
       type: Transform
   - uid: 1378
     components:
     - rot: 3.141592653589793 rad
-      pos: 7.5,10.5
+      pos: 4.5,-2.5
       parent: 1
       type: Transform
   - uid: 1379
     components:
-    - pos: 5.5,6.5
+    - rot: 3.141592653589793 rad
+      pos: 4.5,-1.5
       parent: 1
       type: Transform
   - uid: 1380
     components:
-    - pos: 5.5,10.5
+    - rot: 3.141592653589793 rad
+      pos: 4.5,0.5
       parent: 1
       type: Transform
   - uid: 1381
     components:
-    - rot: 1.5707963267948966 rad
-      pos: -0.5,-6.5
+    - rot: 3.141592653589793 rad
+      pos: 4.5,1.5
       parent: 1
       type: Transform
   - uid: 1382
     components:
-    - rot: -1.5707963267948966 rad
-      pos: -9.5,-10.5
+    - rot: 3.141592653589793 rad
+      pos: 4.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 1383
+    components:
+    - pos: 4.5,4.5
       parent: 1
       type: Transform
   - uid: 1384
     components:
-    - rot: 3.141592653589793 rad
-      pos: -7.5,-9.5
+    - pos: -3.5,-6.5
       parent: 1
       type: Transform
   - uid: 1385
     components:
-    - rot: 3.141592653589793 rad
-      pos: -9.5,-7.5
+    - pos: -4.5,-6.5
       parent: 1
       type: Transform
   - uid: 1386
     components:
-    - rot: 3.141592653589793 rad
-      pos: -9.5,-6.5
+    - rot: 1.5707963267948966 rad
+      pos: 1.5,-6.5
       parent: 1
       type: Transform
   - uid: 1387
     components:
-    - rot: 3.141592653589793 rad
-      pos: -9.5,-5.5
+    - pos: 2.5,-9.5
       parent: 1
       type: Transform
   - uid: 1388
     components:
-    - rot: 3.141592653589793 rad
-      pos: -9.5,-4.5
+    - pos: 2.5,-6.5
       parent: 1
       type: Transform
   - uid: 1389
     components:
-    - rot: 3.141592653589793 rad
-      pos: -9.5,-3.5
+    - pos: -1.5,-9.5
       parent: 1
       type: Transform
   - uid: 1390
     components:
-    - rot: 3.141592653589793 rad
-      pos: -9.5,-2.5
+    - pos: 6.5,-6.5
       parent: 1
       type: Transform
   - uid: 1391
     components:
-    - rot: 3.141592653589793 rad
-      pos: -9.5,-1.5
+    - pos: -5.5,-6.5
       parent: 1
       type: Transform
   - uid: 1392
     components:
     - rot: 3.141592653589793 rad
-      pos: -9.5,-0.5
+      pos: -2.5,-9.5
       parent: 1
       type: Transform
   - uid: 1393
     components:
     - rot: 3.141592653589793 rad
-      pos: -13.5,-0.5
+      pos: 3.5,-9.5
       parent: 1
       type: Transform
   - uid: 1394
     components:
     - rot: 3.141592653589793 rad
-      pos: -13.5,-1.5
+      pos: -3.5,-3.5
       parent: 1
       type: Transform
   - uid: 1395
     components:
     - rot: 3.141592653589793 rad
-      pos: -13.5,-2.5
+      pos: -5.5,-5.5
       parent: 1
       type: Transform
   - uid: 1396
     components:
     - rot: 3.141592653589793 rad
-      pos: -13.5,-3.5
+      pos: -6.5,-6.5
       parent: 1
       type: Transform
   - uid: 1397
     components:
     - rot: 3.141592653589793 rad
-      pos: -13.5,-4.5
+      pos: -7.5,-7.5
       parent: 1
       type: Transform
   - uid: 1398
     components:
     - rot: 3.141592653589793 rad
-      pos: -13.5,-5.5
+      pos: 6.5,6.5
       parent: 1
       type: Transform
   - uid: 1399
     components:
     - rot: 3.141592653589793 rad
-      pos: -13.5,-6.5
+      pos: 7.5,6.5
       parent: 1
       type: Transform
   - uid: 1400
     components:
     - rot: 3.141592653589793 rad
-      pos: -13.5,-7.5
+      pos: 7.5,10.5
       parent: 1
       type: Transform
   - uid: 1401
     components:
-    - rot: 3.141592653589793 rad
-      pos: -13.5,-8.5
+    - pos: 5.5,6.5
       parent: 1
       type: Transform
   - uid: 1402
     components:
-    - rot: 3.141592653589793 rad
-      pos: -13.5,-9.5
+    - pos: 5.5,10.5
       parent: 1
       type: Transform
   - uid: 1403
     components:
-    - rot: 3.141592653589793 rad
-      pos: -13.5,-10.5
+    - rot: 1.5707963267948966 rad
+      pos: -0.5,-6.5
       parent: 1
       type: Transform
   - uid: 1404
     components:
-    - rot: 3.141592653589793 rad
-      pos: -13.5,-11.5
+    - rot: -1.5707963267948966 rad
+      pos: -9.5,-10.5
       parent: 1
       type: Transform
   - uid: 1405
     components:
     - rot: 3.141592653589793 rad
-      pos: -13.5,-12.5
+      pos: -7.5,-9.5
       parent: 1
       type: Transform
   - uid: 1406
     components:
-    - rot: 1.5707963267948966 rad
-      pos: 14.5,-12.5
+    - rot: 3.141592653589793 rad
+      pos: -9.5,-7.5
       parent: 1
       type: Transform
   - uid: 1407
     components:
-    - rot: 1.5707963267948966 rad
-      pos: -14.5,-16.5
+    - rot: 3.141592653589793 rad
+      pos: -9.5,-6.5
       parent: 1
       type: Transform
   - uid: 1408
     components:
-    - rot: 1.5707963267948966 rad
-      pos: -14.5,-12.5
+    - rot: 3.141592653589793 rad
+      pos: -9.5,-5.5
       parent: 1
       type: Transform
   - uid: 1409
     components:
     - rot: 3.141592653589793 rad
-      pos: -13.5,-16.5
+      pos: -9.5,-4.5
       parent: 1
       type: Transform
   - uid: 1410
     components:
-    - rot: 1.5707963267948966 rad
-      pos: 15.5,-12.5
+    - rot: 3.141592653589793 rad
+      pos: -9.5,-3.5
       parent: 1
       type: Transform
   - uid: 1411
     components:
     - rot: 3.141592653589793 rad
-      pos: -9.5,-12.5
+      pos: -9.5,-2.5
       parent: 1
       type: Transform
   - uid: 1412
     components:
     - rot: 3.141592653589793 rad
-      pos: -9.5,-16.5
+      pos: -9.5,-1.5
       parent: 1
       type: Transform
   - uid: 1413
     components:
-    - rot: 1.5707963267948966 rad
-      pos: 10.5,-0.5
+    - rot: 3.141592653589793 rad
+      pos: -9.5,-0.5
       parent: 1
       type: Transform
   - uid: 1414
     components:
-    - rot: 1.5707963267948966 rad
-      pos: 10.5,-1.5
+    - rot: 3.141592653589793 rad
+      pos: -13.5,-0.5
       parent: 1
       type: Transform
   - uid: 1415
     components:
-    - rot: 1.5707963267948966 rad
-      pos: 10.5,-2.5
+    - rot: 3.141592653589793 rad
+      pos: -13.5,-1.5
       parent: 1
       type: Transform
   - uid: 1416
     components:
-    - rot: 1.5707963267948966 rad
-      pos: 10.5,-3.5
+    - rot: 3.141592653589793 rad
+      pos: -13.5,-2.5
       parent: 1
       type: Transform
   - uid: 1417
     components:
-    - rot: 1.5707963267948966 rad
-      pos: 10.5,-4.5
+    - rot: 3.141592653589793 rad
+      pos: -13.5,-3.5
       parent: 1
       type: Transform
   - uid: 1418
     components:
-    - rot: 1.5707963267948966 rad
-      pos: 10.5,-5.5
+    - rot: 3.141592653589793 rad
+      pos: -13.5,-4.5
       parent: 1
       type: Transform
   - uid: 1419
     components:
-    - rot: 1.5707963267948966 rad
-      pos: 10.5,-6.5
+    - rot: 3.141592653589793 rad
+      pos: -13.5,-5.5
       parent: 1
       type: Transform
   - uid: 1420
     components:
-    - rot: 1.5707963267948966 rad
-      pos: 10.5,-7.5
+    - rot: 3.141592653589793 rad
+      pos: -13.5,-6.5
       parent: 1
       type: Transform
   - uid: 1421
     components:
     - rot: 3.141592653589793 rad
-      pos: 9.5,-10.5
+      pos: -13.5,-7.5
       parent: 1
       type: Transform
   - uid: 1422
     components:
-    - rot: -1.5707963267948966 rad
-      pos: -8.5,-10.5
+    - rot: 3.141592653589793 rad
+      pos: -13.5,-8.5
       parent: 1
       type: Transform
   - uid: 1423
     components:
-    - rot: 1.5707963267948966 rad
-      pos: 10.5,-11.5
+    - rot: 3.141592653589793 rad
+      pos: -13.5,-9.5
       parent: 1
       type: Transform
   - uid: 1424
     components:
-    - rot: 1.5707963267948966 rad
-      pos: 10.5,-12.5
+    - rot: 3.141592653589793 rad
+      pos: -13.5,-10.5
       parent: 1
       type: Transform
   - uid: 1425
     components:
-    - rot: 1.5707963267948966 rad
-      pos: 10.5,-16.5
+    - rot: 3.141592653589793 rad
+      pos: -13.5,-11.5
       parent: 1
       type: Transform
   - uid: 1426
     components:
-    - rot: 1.5707963267948966 rad
-      pos: -9.5,-11.5
+    - rot: 3.141592653589793 rad
+      pos: -13.5,-12.5
       parent: 1
       type: Transform
   - uid: 1427
     components:
     - rot: 1.5707963267948966 rad
-      pos: 15.5,-16.5
+      pos: 14.5,-12.5
       parent: 1
       type: Transform
   - uid: 1428
     components:
     - rot: 1.5707963267948966 rad
-      pos: 14.5,-16.5
+      pos: -14.5,-16.5
       parent: 1
       type: Transform
   - uid: 1429
     components:
     - rot: 1.5707963267948966 rad
-      pos: 14.5,-11.5
+      pos: -14.5,-12.5
       parent: 1
       type: Transform
   - uid: 1430
     components:
-    - rot: 1.5707963267948966 rad
-      pos: 14.5,-10.5
+    - rot: 3.141592653589793 rad
+      pos: -13.5,-16.5
       parent: 1
       type: Transform
   - uid: 1431
     components:
     - rot: 1.5707963267948966 rad
-      pos: 14.5,-9.5
+      pos: 15.5,-12.5
       parent: 1
       type: Transform
   - uid: 1432
     components:
-    - rot: 1.5707963267948966 rad
-      pos: 14.5,-8.5
+    - rot: 3.141592653589793 rad
+      pos: -9.5,-12.5
       parent: 1
       type: Transform
   - uid: 1433
     components:
-    - rot: 1.5707963267948966 rad
-      pos: 14.5,-7.5
+    - rot: 3.141592653589793 rad
+      pos: -9.5,-16.5
       parent: 1
       type: Transform
   - uid: 1434
     components:
     - rot: 1.5707963267948966 rad
-      pos: 14.5,-6.5
+      pos: 10.5,-0.5
       parent: 1
       type: Transform
   - uid: 1435
     components:
     - rot: 1.5707963267948966 rad
-      pos: 14.5,-5.5
+      pos: 10.5,-1.5
       parent: 1
       type: Transform
   - uid: 1436
     components:
     - rot: 1.5707963267948966 rad
-      pos: 14.5,-4.5
+      pos: 10.5,-2.5
       parent: 1
       type: Transform
   - uid: 1437
     components:
     - rot: 1.5707963267948966 rad
-      pos: 14.5,-3.5
+      pos: 10.5,-3.5
       parent: 1
       type: Transform
   - uid: 1438
     components:
     - rot: 1.5707963267948966 rad
-      pos: 14.5,-2.5
+      pos: 10.5,-4.5
       parent: 1
       type: Transform
   - uid: 1439
     components:
     - rot: 1.5707963267948966 rad
-      pos: 14.5,-1.5
+      pos: 10.5,-5.5
       parent: 1
       type: Transform
   - uid: 1440
     components:
     - rot: 1.5707963267948966 rad
-      pos: 14.5,-0.5
+      pos: 10.5,-6.5
       parent: 1
       type: Transform
   - uid: 1441
     components:
     - rot: 1.5707963267948966 rad
-      pos: -12.5,-12.5
+      pos: 10.5,-7.5
       parent: 1
       type: Transform
   - uid: 1442
     components:
-    - rot: 1.5707963267948966 rad
-      pos: -12.5,-16.5
+    - rot: 3.141592653589793 rad
+      pos: 9.5,-10.5
       parent: 1
       type: Transform
   - uid: 1443
     components:
-    - rot: 1.5707963267948966 rad
-      pos: 13.5,-12.5
+    - rot: -1.5707963267948966 rad
+      pos: -8.5,-10.5
       parent: 1
       type: Transform
   - uid: 1444
     components:
     - rot: 1.5707963267948966 rad
-      pos: 13.5,-16.5
+      pos: 10.5,-11.5
       parent: 1
       type: Transform
   - uid: 1445
     components:
     - rot: 1.5707963267948966 rad
-      pos: -11.5,1.5
+      pos: 10.5,-12.5
       parent: 1
       type: Transform
   - uid: 1446
     components:
     - rot: 1.5707963267948966 rad
-      pos: 12.5,1.5
+      pos: 10.5,-16.5
       parent: 1
       type: Transform
   - uid: 1447
     components:
-    - rot: 3.141592653589793 rad
-      pos: 10.5,-10.5
+    - rot: 1.5707963267948966 rad
+      pos: -9.5,-11.5
       parent: 1
       type: Transform
   - uid: 1448
     components:
     - rot: 1.5707963267948966 rad
-      pos: -10.5,-7.5
+      pos: 15.5,-16.5
       parent: 1
       type: Transform
   - uid: 1449
     components:
     - rot: 1.5707963267948966 rad
-      pos: -11.5,-7.5
+      pos: 14.5,-16.5
       parent: 1
       type: Transform
   - uid: 1450
     components:
     - rot: 1.5707963267948966 rad
-      pos: -12.5,-7.5
+      pos: 14.5,-11.5
       parent: 1
       type: Transform
   - uid: 1451
     components:
     - rot: 1.5707963267948966 rad
-      pos: 11.5,-7.5
+      pos: 14.5,-10.5
       parent: 1
       type: Transform
   - uid: 1452
     components:
     - rot: 1.5707963267948966 rad
-      pos: 12.5,-7.5
+      pos: 14.5,-9.5
       parent: 1
       type: Transform
   - uid: 1453
     components:
     - rot: 1.5707963267948966 rad
-      pos: 13.5,-7.5
+      pos: 14.5,-8.5
       parent: 1
       type: Transform
   - uid: 1454
     components:
-    - rot: 3.141592653589793 rad
-      pos: 11.5,-16.5
+    - rot: 1.5707963267948966 rad
+      pos: 14.5,-7.5
       parent: 1
       type: Transform
   - uid: 1455
     components:
-    - rot: 3.141592653589793 rad
-      pos: -10.5,-16.5
+    - rot: 1.5707963267948966 rad
+      pos: 14.5,-6.5
       parent: 1
       type: Transform
   - uid: 1456
     components:
-    - pos: 12.5,-12.5
+    - rot: 1.5707963267948966 rad
+      pos: 14.5,-5.5
       parent: 1
       type: Transform
   - uid: 1457
     components:
-    - pos: -1.5,-11.5
+    - rot: 1.5707963267948966 rad
+      pos: 14.5,-4.5
       parent: 1
       type: Transform
   - uid: 1458
     components:
-    - pos: 2.5,-11.5
+    - rot: 1.5707963267948966 rad
+      pos: 14.5,-3.5
       parent: 1
       type: Transform
   - uid: 1459
     components:
-    - pos: 0.5,-11.5
+    - rot: 1.5707963267948966 rad
+      pos: 14.5,-2.5
       parent: 1
       type: Transform
   - uid: 1460
     components:
-    - pos: 0.5,-9.5
+    - rot: 1.5707963267948966 rad
+      pos: 14.5,-1.5
       parent: 1
       type: Transform
   - uid: 1461
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 13.5,-14.5
+    - rot: 1.5707963267948966 rad
+      pos: 14.5,-0.5
       parent: 1
       type: Transform
   - uid: 1462
     components:
-    - rot: -1.5707963267948966 rad
-      pos: -12.5,-14.5
+    - rot: 1.5707963267948966 rad
+      pos: -12.5,-12.5
       parent: 1
       type: Transform
   - uid: 1463
     components:
     - rot: 1.5707963267948966 rad
-      pos: 15.5,-14.5
+      pos: -12.5,-16.5
       parent: 1
       type: Transform
   - uid: 1464
     components:
     - rot: 1.5707963267948966 rad
-      pos: -14.5,-14.5
+      pos: 13.5,-12.5
+      parent: 1
+      type: Transform
+  - uid: 1465
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 13.5,-16.5
       parent: 1
       type: Transform
   - uid: 1466
     components:
-    - pos: -11.5,-12.5
+    - rot: 1.5707963267948966 rad
+      pos: -11.5,1.5
       parent: 1
       type: Transform
   - uid: 1467
     components:
     - rot: 1.5707963267948966 rad
-      pos: -0.5,1.5
+      pos: 12.5,1.5
       parent: 1
       type: Transform
   - uid: 1468
     components:
-    - rot: 1.5707963267948966 rad
-      pos: 2.5,1.5
+    - rot: 3.141592653589793 rad
+      pos: 10.5,-10.5
       parent: 1
       type: Transform
   - uid: 1469
     components:
     - rot: 1.5707963267948966 rad
-      pos: 3.5,1.5
+      pos: -10.5,-7.5
       parent: 1
       type: Transform
   - uid: 1470
     components:
     - rot: 1.5707963267948966 rad
-      pos: 0.5,-6.5
+      pos: -11.5,-7.5
       parent: 1
       type: Transform
   - uid: 1471
     components:
-    - pos: 4.5,-6.5
+    - rot: 1.5707963267948966 rad
+      pos: -12.5,-7.5
       parent: 1
       type: Transform
   - uid: 1472
     components:
     - rot: 1.5707963267948966 rad
-      pos: 2.5,-1.5
+      pos: 11.5,-7.5
+      parent: 1
+      type: Transform
+  - uid: 1473
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 12.5,-7.5
       parent: 1
       type: Transform
   - uid: 1474
     components:
     - rot: 1.5707963267948966 rad
-      pos: -0.5,-1.5
+      pos: 13.5,-7.5
       parent: 1
       type: Transform
   - uid: 1475
     components:
-    - rot: 1.5707963267948966 rad
-      pos: 3.5,-1.5
+    - rot: 3.141592653589793 rad
+      pos: 11.5,-16.5
       parent: 1
       type: Transform
   - uid: 1476
     components:
-    - rot: 1.5707963267948966 rad
-      pos: 2.5,4.5
+    - rot: 3.141592653589793 rad
+      pos: -10.5,-16.5
       parent: 1
       type: Transform
   - uid: 1477
     components:
-    - rot: 1.5707963267948966 rad
-      pos: 3.5,4.5
+    - pos: 12.5,-12.5
       parent: 1
       type: Transform
   - uid: 1478
     components:
-    - pos: -2.5,-1.5
+    - pos: -1.5,-11.5
       parent: 1
       type: Transform
   - uid: 1479
     components:
-    - rot: 3.141592653589793 rad
-      pos: -8.5,-9.5
+    - pos: 2.5,-11.5
       parent: 1
       type: Transform
   - uid: 1480
     components:
-    - pos: 5.5,7.5
+    - pos: 0.5,-11.5
       parent: 1
       type: Transform
   - uid: 1481
     components:
-    - pos: 5.5,8.5
+    - pos: 0.5,-9.5
       parent: 1
       type: Transform
   - uid: 1482
     components:
-    - pos: -1.5,-1.5
+    - rot: -1.5707963267948966 rad
+      pos: 13.5,-14.5
       parent: 1
       type: Transform
   - uid: 1483
     components:
-    - rot: 3.141592653589793 rad
-      pos: 1.5,1.5
+    - rot: -1.5707963267948966 rad
+      pos: -12.5,-14.5
       parent: 1
       type: Transform
   - uid: 1484
     components:
-    - pos: -0.5,-0.5
+    - rot: 1.5707963267948966 rad
+      pos: 15.5,-14.5
       parent: 1
       type: Transform
   - uid: 1485
     components:
     - rot: 1.5707963267948966 rad
-      pos: 1.5,-1.5
+      pos: -14.5,-14.5
+      parent: 1
+      type: Transform
+  - uid: 1486
+    components:
+    - pos: -11.5,-12.5
       parent: 1
       type: Transform
   - uid: 1487
     components:
     - rot: 1.5707963267948966 rad
-      pos: -2.5,1.5
+      pos: -0.5,1.5
       parent: 1
       type: Transform
   - uid: 1488
     components:
     - rot: 1.5707963267948966 rad
-      pos: -1.5,1.5
+      pos: 2.5,1.5
       parent: 1
       type: Transform
   - uid: 1489
     components:
-    - pos: 1.5,-2.5
+    - rot: 1.5707963267948966 rad
+      pos: 3.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 1490
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 0.5,-6.5
       parent: 1
       type: Transform
   - uid: 1491
+    components:
+    - pos: 4.5,-6.5
+      parent: 1
+      type: Transform
+  - uid: 1492
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 2.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 1493
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -0.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 1494
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 3.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 1495
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 2.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 1496
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 3.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 1497
+    components:
+    - pos: -2.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 1498
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -8.5,-9.5
+      parent: 1
+      type: Transform
+  - uid: 1499
+    components:
+    - pos: 5.5,7.5
+      parent: 1
+      type: Transform
+  - uid: 1500
+    components:
+    - pos: 5.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 1501
+    components:
+    - pos: -1.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 1502
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 1.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 1503
+    components:
+    - pos: -0.5,-0.5
+      parent: 1
+      type: Transform
+  - uid: 1504
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 1.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 1505
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -2.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 1506
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -1.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 1507
+    components:
+    - pos: 1.5,-2.5
+      parent: 1
+      type: Transform
+  - uid: 1508
     components:
     - rot: 3.141592653589793 rad
       pos: -7.5,-6.5
       parent: 1
       type: Transform
-  - uid: 1492
+  - uid: 1509
     components:
     - rot: 3.141592653589793 rad
       pos: -8.5,-6.5
@@ -10262,19 +10407,19 @@ entities:
       type: Transform
 - proto: WallWeaponCapacitorRecharger
   entities:
-  - uid: 1493
+  - uid: 1510
     components:
     - pos: 4.5,-6.5
       parent: 1
       type: Transform
-  - uid: 1495
+  - uid: 1511
     components:
     - pos: -3.5,-6.5
       parent: 1
       type: Transform
 - proto: WarningAir
   entities:
-  - uid: 1496
+  - uid: 1512
     components:
     - rot: -1.5707963267948966 rad
       pos: -4.5,7.5
@@ -10282,7 +10427,7 @@ entities:
       type: Transform
 - proto: WarningN2
   entities:
-  - uid: 1497
+  - uid: 1513
     components:
     - rot: 1.5707963267948966 rad
       pos: -7.5,9.5
@@ -10290,7 +10435,7 @@ entities:
       type: Transform
 - proto: WarningO2
   entities:
-  - uid: 1498
+  - uid: 1514
     components:
     - rot: 1.5707963267948966 rad
       pos: -7.5,8.5
@@ -10298,7 +10443,7 @@ entities:
       type: Transform
 - proto: WarningWaste
   entities:
-  - uid: 1499
+  - uid: 1515
     components:
     - rot: 3.141592653589793 rad
       pos: -6.5,6.5
@@ -10306,7 +10451,7 @@ entities:
       type: Transform
 - proto: WarpPoint
   entities:
-  - uid: 1500
+  - uid: 1516
     components:
     - pos: 0.5,15.5
       parent: 1
@@ -10315,53 +10460,111 @@ entities:
       type: WarpPoint
 - proto: WeaponAntiqueLaser
   entities:
-  - uid: 10
+  - uid: 532
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 5
+    - parent: 522
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: WeaponEmpEmitter
   entities:
-  - uid: 890
+  - uid: 1517
     components:
     - pos: 6.52071,7.334463
       parent: 1
       type: Transform
-  - uid: 1238
+  - uid: 1518
     components:
     - pos: 6.536335,7.521963
       parent: 1
       type: Transform
 - proto: WeaponGrapplingGun
   entities:
-  - uid: 519
+  - uid: 1519
     components:
     - pos: -3.4768648,14.348688
       parent: 1
       type: Transform
-  - uid: 1503
+  - uid: 1520
     components:
     - pos: -3.4456148,14.598688
       parent: 1
       type: Transform
 - proto: WeaponLauncherRocketEmp
   entities:
-  - uid: 867
+  - uid: 511
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 861
+    - parent: 505
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: WeaponShotgunEnforcer
+  entities:
+  - uid: 895
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 893
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 899
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 893
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 901
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 893
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: WeaponSubMachineGunWt550
+  entities:
+  - uid: 886
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 883
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 887
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 883
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 892
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 883
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: WindoorSecureArmoryLocked
   entities:
-  - uid: 889
+  - uid: 1521
     components:
     - rot: -1.5707963267948966 rad
       pos: -0.5,4.5
@@ -10369,81 +10572,81 @@ entities:
       type: Transform
 - proto: WindoorSecureSecurityLocked
   entities:
-  - uid: 1223
+  - uid: 1522
     components:
     - rot: 1.5707963267948966 rad
       pos: -0.5,4.5
       parent: 1
       type: Transform
-  - uid: 1265
+  - uid: 1523
     components:
     - rot: 3.141592653589793 rad
       pos: -1.5,12.5
       parent: 1
       type: Transform
-  - uid: 1501
+  - uid: 1524
     components:
     - rot: 1.5707963267948966 rad
       pos: 1.5,3.5
       parent: 1
       type: Transform
     - links:
-      - 110
+      - 91
       type: DeviceLinkSink
-  - uid: 1502
+  - uid: 1525
     components:
     - rot: 1.5707963267948966 rad
       pos: 1.5,-0.5
       parent: 1
       type: Transform
     - links:
-      - 111
+      - 92
       type: DeviceLinkSink
 - proto: WindowReinforcedDirectional
   entities:
-  - uid: 915
+  - uid: 1526
     components:
     - rot: 3.141592653589793 rad
       pos: -2.5,8.5
       parent: 1
       type: Transform
-  - uid: 916
+  - uid: 1527
     components:
     - rot: 3.141592653589793 rad
       pos: -3.5,8.5
       parent: 1
       type: Transform
-  - uid: 1505
+  - uid: 1528
     components:
     - rot: 1.5707963267948966 rad
       pos: 1.5,2.5
       parent: 1
       type: Transform
-  - uid: 1506
+  - uid: 1529
     components:
     - rot: 1.5707963267948966 rad
       pos: 1.5,0.5
       parent: 1
       type: Transform
-  - uid: 1507
+  - uid: 1530
     components:
     - rot: -1.5707963267948966 rad
       pos: -1.5,-5.5
       parent: 1
       type: Transform
-  - uid: 1508
+  - uid: 1531
     components:
     - rot: 3.141592653589793 rad
       pos: -1.5,-5.5
       parent: 1
       type: Transform
-  - uid: 1509
+  - uid: 1532
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,-5.5
       parent: 1
       type: Transform
-  - uid: 1510
+  - uid: 1533
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,-5.5
@@ -10451,13 +10654,13 @@ entities:
       type: Transform
 - proto: WindowTintedDirectional
   entities:
-  - uid: 1075
+  - uid: 1534
     components:
     - rot: 3.141592653589793 rad
       pos: -2.5,12.5
       parent: 1
       type: Transform
-  - uid: 1233
+  - uid: 1535
     components:
     - rot: 3.141592653589793 rad
       pos: -3.5,12.5

--- a/Resources/Maps/Shuttles/prowler.yml
+++ b/Resources/Maps/Shuttles/prowler.yml
@@ -1,0 +1,4556 @@
+meta:
+  format: 5
+  postmapinit: false
+tilemap:
+  0: Space
+  23: FloorDark
+  46: FloorGym
+  59: FloorReinforced
+  60: FloorRockVault
+  79: FloorTechMaint
+  95: Plating
+entities:
+- proto: ""
+  entities:
+  - uid: 1
+    components:
+    - type: MetaData
+    - pos: -2.8437347,0.453125
+      parent: invalid
+      type: Transform
+    - chunks:
+        0,0:
+          ind: 0,0
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABfAAAAXwAAAF8AAAA8AAAAPAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATwAAAE8AAABfAAAAXwAAAF8AAABfAAAAPAAAAAAAAAAAAAAAAAAAADwAAAA8AAAAAAAAAAAAAAAAAAAAAAAAAE8AAABPAAAAXwAAABcAAAMXAAACXwAAAF8AAAA8AAAAAAAAAF8AAABfAAAAXwAAAF8AAAAAAAAAAAAAAAAAAABPAAAATwAAAF8AAAAXAAABFwAAAxcAAABfAAAAXwAAAF8AAAA7AAAAOwAAADsAAABfAAAAAAAAAAAAAAAAAAAATwAAAE8AAABfAAAAFwAAAhcAAAMXAAAAXwAAABcAAAJfAAAAOwAAADsAAAA7AAAAXwAAAAAAAAAAAAAAAAAAAE8AAABPAAAAXwAAABcAAAMXAAAAFwAAAV8AAAAXAAACXwAAADsAAAA7AAAAOwAAAF8AAAAAAAAAAAAAAAAAAABfAAAAXwAAAF8AAABfAAAAFwAAAV8AAABfAAAAFwAAA18AAAA7AAAAXwAAAF8AAABfAAAAAAAAAAAAAAAAAAAALgAAAi4AAAAuAAAAXwAAABcAAAAXAAABFwAAARcAAAMXAAABFwAAA18AAAA8AAAAAAAAAAAAAAAAAAAAAAAAAA==
+        0,1:
+          ind: 0,1
+          tiles: LgAAAi4AAAIuAAAAFwAAARcAAAMXAAAAFwAAAhcAAAIXAAABFwAAAV8AAAA8AAAAAAAAAAAAAAAAAAAAAAAAAC4AAAEuAAAALgAAAF8AAAAXAAAAFwAAABcAAAIXAAACFwAAAV8AAABfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXAAABXwAAAF8AAABfAAAAXwAAAF8AAAAXAAADXwAAAF8AAABfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFwAAAhcAAAJfAAAAFwAAAhcAAAAXAAACFwAAAxcAAAJfAAAAPAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABcAAAIXAAABXwAAABcAAAMXAAACFwAAARcAAABfAAAAXwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXAAAAFwAAAl8AAAAXAAABFwAAAxcAAAMXAAABXwAAADwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXwAAAF8AAABfAAAAXwAAAF8AAABfAAAAXwAAAF8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXwAAADsAAAA7AAAAOwAAAF8AAAA8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF8AAAA7AAAAOwAAADsAAABfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABfAAAAXwAAADsAAABfAAAAXwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADwAAAA8AAAAPAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AAAAPAAAADwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+        -1,1:
+          ind: -1,1
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAA8AAAAXwAAABcAAAMXAAADFwAAARcAAAAuAAADLgAAAi4AAAEuAAADLgAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF8AAABfAAAAFwAAABcAAANfAAAALgAAAS4AAAEuAAACLgAAAC4AAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXwAAAF8AAABfAAAAXwAAABcAAAJfAAAAXwAAAF8AAABfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADwAAABfAAAAFwAAAxcAAAIXAAADFwAAAhcAAABfAAAAFwAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXwAAAF8AAAAXAAADFwAAAhcAAAAXAAAAXwAAABcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADwAAABfAAAAFwAAARcAAANfAAAAFwAAA18AAAAXAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXwAAAF8AAABfAAAAXwAAAF8AAABfAAAAXwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADwAAABfAAAAOwAAADsAAAA7AAAAXwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXwAAADsAAAA7AAAAOwAAAF8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF8AAABfAAAAOwAAAF8AAABfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPAAAADwAAAA8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADwAAAA8AAAAPAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+        -1,0:
+          ind: -1,0
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AAAAPAAAAF8AAABfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AAAAPAAAAAAAAAAAAAAAAAAAADwAAABfAAAAXwAAAF8AAABfAAAATwAAAAAAAAAAAAAAAAAAAAAAAABfAAAAXwAAAF8AAABfAAAAAAAAADwAAABfAAAAXwAAAE8AAABPAAAATwAAAE8AAAAAAAAAAAAAAAAAAAAAAAAAOwAAADsAAAA7AAAAXwAAAF8AAABfAAAAXwAAAE8AAABPAAAATwAAAE8AAABPAAAAAAAAAAAAAAAAAAAAAAAAADsAAAA7AAAAOwAAADsAAAA7AAAAOwAAAF8AAABPAAAATwAAAE8AAABPAAAATwAAAAAAAAAAAAAAAAAAAAAAAAA7AAAAOwAAADsAAAA7AAAAOwAAADsAAABfAAAATwAAAE8AAABPAAAATwAAAE8AAAAAAAAAAAAAAAAAAAAAAAAAXwAAAF8AAABfAAAAXwAAAF8AAAA7AAAAXwAAAF8AAABPAAAAXwAAAF8AAABfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AAAAXwAAABcAAAIXAAACFwAAAF8AAAAuAAACLgAAAC4AAAEuAAADLgAAAA==
+      type: MapGrid
+    - type: Broadphase
+    - angularDamping: 0.05
+      linearDamping: 0.05
+      fixedRotation: False
+      bodyType: Dynamic
+      type: Physics
+    - fixtures: {}
+      type: Fixtures
+    - type: OccluderTree
+    - type: SpreaderGrid
+    - type: Shuttle
+    - type: GridPathfinding
+    - gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+      type: Gravity
+    - chunkCollection:
+        version: 2
+        nodes:
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileDarkCornerNe
+          decals:
+            0: 2,17
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileDarkCornerNw
+          decals:
+            1: -5,17
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileDarkCornerSe
+          decals:
+            3: 2,15
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileDarkCornerSw
+          decals:
+            2: -5,15
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileDarkLineE
+          decals:
+            4: 2,16
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileDarkLineN
+          decals:
+            11: -4,17
+            12: -3,17
+            13: -2,17
+            14: -1,17
+            15: 1,17
+            16: 0,17
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileDarkLineS
+          decals:
+            5: 1,15
+            6: 0,15
+            7: -1,15
+            8: -2,15
+            9: -3,15
+            10: -4,15
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileDarkLineW
+          decals:
+            17: -5,16
+      type: DecalGrid
+    - version: 2
+      data:
+        tiles:
+          0,0:
+            0: 4369
+          0,1:
+            0: 4369
+          0,2:
+            0: 1
+            1: 65534
+          0,3:
+            1: 65535
+          1,2:
+            1: 65393
+          1,3:
+            1: 65535
+          2,2:
+            1: 65216
+          2,3:
+            1: 65535
+          3,2:
+            1: 4352
+          3,3:
+            1: 273
+          0,4:
+            1: 65535
+          0,5:
+            1: 53247
+          0,6:
+            1: 35020
+          1,4:
+            1: 65535
+          1,5:
+            1: 65535
+          1,6:
+            1: 13175
+          2,4:
+            1: 13183
+          2,5:
+            1: 17
+          -3,4:
+            1: 35022
+          -2,4:
+            1: 65535
+          -2,5:
+            1: 61183
+          -2,6:
+            1: 35020
+          -1,4:
+            1: 65535
+          -1,5:
+            1: 32767
+          -1,6:
+            1: 13175
+          -3,2:
+            1: 65376
+          -3,3:
+            1: 61439
+          -2,2:
+            1: 65216
+          -2,3:
+            1: 65535
+          -1,2:
+            1: 65535
+          -1,3:
+            1: 65535
+        uniqueMixes:
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 21.824879
+          - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        chunkSize: 4
+      type: GridAtmosphere
+    - type: GasTileOverlay
+    - type: RadiationGridResistance
+    - id: Prowler
+      type: BecomesStation
+- proto: AirlockCaptainLocked
+  entities:
+  - uid: 2
+    components:
+    - pos: 4.5,14.5
+      parent: 1
+      type: Transform
+- proto: AirlockEngineering
+  entities:
+  - uid: 3
+    components:
+    - pos: -3.5,14.5
+      parent: 1
+      type: Transform
+- proto: AirlockExternalGlass
+  entities:
+  - uid: 4
+    components:
+    - pos: -8.5,13.5
+      parent: 1
+      type: Transform
+    - links:
+      - 503
+      type: DeviceLinkSink
+  - uid: 5
+    components:
+    - pos: -8.5,12.5
+      parent: 1
+      type: Transform
+    - links:
+      - 503
+      type: DeviceLinkSink
+  - uid: 6
+    components:
+    - pos: -3.5,25.5
+      parent: 1
+      type: Transform
+    - links:
+      - 503
+      type: DeviceLinkSink
+  - uid: 7
+    components:
+    - pos: 4.5,25.5
+      parent: 1
+      type: Transform
+    - links:
+      - 503
+      type: DeviceLinkSink
+- proto: AirlockGlassShuttle
+  entities:
+  - uid: 8
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -11.5,13.5
+      parent: 1
+      type: Transform
+  - uid: 9
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -11.5,11.5
+      parent: 1
+      type: Transform
+- proto: AirlockSecurityGlassLocked
+  entities:
+  - uid: 10
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 9.5,14.5
+      parent: 1
+      type: Transform
+- proto: AirlockSecurityLocked
+  entities:
+  - uid: 11
+    components:
+    - pos: 0.5,18.5
+      parent: 1
+      type: Transform
+  - uid: 12
+    components:
+    - pos: -5.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 13
+    components:
+    - pos: 6.5,18.5
+      parent: 1
+      type: Transform
+  - uid: 14
+    components:
+    - pos: -6.5,14.5
+      parent: 1
+      type: Transform
+  - uid: 15
+    components:
+    - pos: 7.5,14.5
+      parent: 1
+      type: Transform
+  - uid: 16
+    components:
+    - pos: -4.5,18.5
+      parent: 1
+      type: Transform
+  - uid: 17
+    components:
+    - pos: -4.5,22.5
+      parent: 1
+      type: Transform
+  - uid: 18
+    components:
+    - pos: 5.5,22.5
+      parent: 1
+      type: Transform
+  - uid: 19
+    components:
+    - pos: 3.5,16.5
+      parent: 1
+      type: Transform
+- proto: AmeController
+  entities:
+  - uid: 20
+    components:
+    - pos: -1.5,11.5
+      parent: 1
+      type: Transform
+    - injectionAmount: 4
+      injecting: True
+      type: AmeController
+    - containers:
+        AmeFuel: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: 21
+      type: ContainerContainer
+- proto: AmeJar
+  entities:
+  - uid: 21
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 20
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 22
+    components:
+    - pos: -0.45470285,13.564786
+      parent: 1
+      type: Transform
+- proto: AmeShielding
+  entities:
+  - uid: 23
+    components:
+    - pos: -0.5,11.5
+      parent: 1
+      type: Transform
+  - uid: 24
+    components:
+    - pos: -0.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 25
+    components:
+    - pos: -0.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 26
+    components:
+    - pos: 0.5,11.5
+      parent: 1
+      type: Transform
+    - radius: 2
+      enabled: True
+      type: PointLight
+  - uid: 27
+    components:
+    - pos: 0.5,10.5
+      parent: 1
+      type: Transform
+    - radius: 2
+      enabled: True
+      type: PointLight
+  - uid: 28
+    components:
+    - pos: 0.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 29
+    components:
+    - pos: 1.5,11.5
+      parent: 1
+      type: Transform
+  - uid: 30
+    components:
+    - pos: 1.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 31
+    components:
+    - pos: 1.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 32
+    components:
+    - pos: -0.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 33
+    components:
+    - pos: 0.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 34
+    components:
+    - pos: 1.5,12.5
+      parent: 1
+      type: Transform
+- proto: APCBasicEmpImmune
+  entities:
+  - uid: 35
+    components:
+    - pos: 1.5,18.5
+      parent: 1
+      type: Transform
+  - uid: 36
+    components:
+    - pos: -1.5,14.5
+      parent: 1
+      type: Transform
+- proto: AtmosDeviceFanTiny
+  entities:
+  - uid: 37
+    components:
+    - pos: -11.5,13.5
+      parent: 1
+      type: Transform
+  - uid: 38
+    components:
+    - pos: -11.5,11.5
+      parent: 1
+      type: Transform
+  - uid: 39
+    components:
+    - pos: -3.5,25.5
+      parent: 1
+      type: Transform
+  - uid: 40
+    components:
+    - pos: 4.5,25.5
+      parent: 1
+      type: Transform
+- proto: Bed
+  entities:
+  - uid: 41
+    components:
+    - pos: -8.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 42
+    components:
+    - pos: -8.5,15.5
+      parent: 1
+      type: Transform
+  - uid: 43
+    components:
+    - pos: 4.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 44
+    components:
+    - pos: 11.5,11.5
+      parent: 1
+      type: Transform
+- proto: BedsheetOrange
+  entities:
+  - uid: 45
+    components:
+    - pos: 11.5,11.5
+      parent: 1
+      type: Transform
+- proto: BenchSteelLeft
+  entities:
+  - uid: 46
+    components:
+    - pos: -2.5,17.5
+      parent: 1
+      type: Transform
+    - bodyType: Static
+      type: Physics
+- proto: BenchSteelRight
+  entities:
+  - uid: 47
+    components:
+    - pos: -1.5,17.5
+      parent: 1
+      type: Transform
+    - bodyType: Static
+      type: Physics
+- proto: BoxMRE
+  entities:
+  - uid: 48
+    components:
+    - pos: -6.504612,17.603258
+      parent: 1
+      type: Transform
+  - uid: 49
+    components:
+    - pos: -7.395237,17.626696
+      parent: 1
+      type: Transform
+- proto: BrigTimer
+  entities:
+  - uid: 50
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 8.5,14.5
+      parent: 1
+      type: Transform
+- proto: CableApcExtension
+  entities:
+  - uid: 51
+    components:
+    - pos: 1.5,18.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 52
+    components:
+    - pos: 0.5,18.5
+      parent: 1
+      type: Transform
+  - uid: 53
+    components:
+    - pos: -0.5,18.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 54
+    components:
+    - pos: -1.5,18.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 55
+    components:
+    - pos: -2.5,18.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 56
+    components:
+    - pos: -3.5,18.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 57
+    components:
+    - pos: -4.5,18.5
+      parent: 1
+      type: Transform
+  - uid: 58
+    components:
+    - pos: -4.5,19.5
+      parent: 1
+      type: Transform
+  - uid: 59
+    components:
+    - pos: -4.5,20.5
+      parent: 1
+      type: Transform
+  - uid: 60
+    components:
+    - pos: -4.5,21.5
+      parent: 1
+      type: Transform
+  - uid: 61
+    components:
+    - pos: -4.5,22.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 62
+    components:
+    - pos: -4.5,23.5
+      parent: 1
+      type: Transform
+  - uid: 63
+    components:
+    - pos: -4.5,24.5
+      parent: 1
+      type: Transform
+  - uid: 64
+    components:
+    - pos: -4.5,25.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 65
+    components:
+    - pos: 2.5,18.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 66
+    components:
+    - pos: 3.5,18.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 67
+    components:
+    - pos: 4.5,18.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 68
+    components:
+    - pos: 5.5,18.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 69
+    components:
+    - pos: 6.5,18.5
+      parent: 1
+      type: Transform
+  - uid: 70
+    components:
+    - pos: 5.5,19.5
+      parent: 1
+      type: Transform
+  - uid: 71
+    components:
+    - pos: 5.5,20.5
+      parent: 1
+      type: Transform
+  - uid: 72
+    components:
+    - pos: 5.5,21.5
+      parent: 1
+      type: Transform
+  - uid: 73
+    components:
+    - pos: 5.5,22.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 74
+    components:
+    - pos: 5.5,23.5
+      parent: 1
+      type: Transform
+  - uid: 75
+    components:
+    - pos: 5.5,24.5
+      parent: 1
+      type: Transform
+  - uid: 76
+    components:
+    - pos: 5.5,25.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 77
+    components:
+    - pos: -2.5,13.5
+      parent: 1
+      type: Transform
+  - uid: 78
+    components:
+    - pos: -2.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 79
+    components:
+    - pos: -2.5,11.5
+      parent: 1
+      type: Transform
+  - uid: 80
+    components:
+    - pos: -2.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 81
+    components:
+    - pos: -3.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 82
+    components:
+    - pos: -4.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 83
+    components:
+    - pos: -5.5,12.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 84
+    components:
+    - pos: -6.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 85
+    components:
+    - pos: -7.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 86
+    components:
+    - pos: -8.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 87
+    components:
+    - pos: -9.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 88
+    components:
+    - pos: -10.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 89
+    components:
+    - pos: -1.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 90
+    components:
+    - pos: -0.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 91
+    components:
+    - pos: 0.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 92
+    components:
+    - pos: 1.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 93
+    components:
+    - pos: 2.5,12.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 94
+    components:
+    - pos: 3.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 95
+    components:
+    - pos: 4.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 96
+    components:
+    - pos: 5.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 97
+    components:
+    - pos: 6.5,12.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 98
+    components:
+    - pos: 7.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 99
+    components:
+    - pos: 8.5,12.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 100
+    components:
+    - pos: 9.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 101
+    components:
+    - pos: 10.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 102
+    components:
+    - pos: 11.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 103
+    components:
+    - pos: 8.5,13.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 104
+    components:
+    - pos: 8.5,15.5
+      parent: 1
+      type: Transform
+  - uid: 105
+    components:
+    - pos: 8.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 106
+    components:
+    - pos: 8.5,13.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 107
+    components:
+    - pos: 8.5,14.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 108
+    components:
+    - pos: 7.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 109
+    components:
+    - pos: 6.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 110
+    components:
+    - pos: 5.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 111
+    components:
+    - pos: 4.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 112
+    components:
+    - pos: 3.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 113
+    components:
+    - pos: 2.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 114
+    components:
+    - pos: 1.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 115
+    components:
+    - pos: 0.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 116
+    components:
+    - pos: -0.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 117
+    components:
+    - pos: -1.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 118
+    components:
+    - pos: -2.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 119
+    components:
+    - pos: -3.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 120
+    components:
+    - pos: -4.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 121
+    components:
+    - pos: -5.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 122
+    components:
+    - pos: -6.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 123
+    components:
+    - pos: -7.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 124
+    components:
+    - pos: -7.5,15.5
+      parent: 1
+      type: Transform
+  - uid: 125
+    components:
+    - pos: -7.5,14.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 126
+    components:
+    - pos: -7.5,13.5
+      parent: 1
+      type: Transform
+  - uid: 127
+    components:
+    - pos: 1.5,19.5
+      parent: 1
+      type: Transform
+  - uid: 128
+    components:
+    - pos: 1.5,20.5
+      parent: 1
+      type: Transform
+  - uid: 129
+    components:
+    - pos: 1.5,21.5
+      parent: 1
+      type: Transform
+  - uid: 130
+    components:
+    - pos: 1.5,22.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 131
+    components:
+    - pos: 0.5,22.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 132
+    components:
+    - pos: -0.5,22.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 133
+    components:
+    - pos: -1.5,22.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 134
+    components:
+    - pos: -1.5,23.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 135
+    components:
+    - pos: -1.5,24.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 136
+    components:
+    - pos: 2.5,22.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 137
+    components:
+    - pos: 2.5,23.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 138
+    components:
+    - pos: 2.5,24.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 139
+    components:
+    - pos: -2.5,14.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 140
+    components:
+    - pos: -2.5,15.5
+      parent: 1
+      type: Transform
+  - uid: 141
+    components:
+    - pos: -1.5,14.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 142
+    components:
+    - pos: -10.5,13.5
+      parent: 1
+      type: Transform
+  - uid: 143
+    components:
+    - pos: -10.5,14.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 144
+    components:
+    - pos: -10.5,15.5
+      parent: 1
+      type: Transform
+  - uid: 145
+    components:
+    - pos: -10.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 146
+    components:
+    - pos: -10.5,11.5
+      parent: 1
+      type: Transform
+  - uid: 147
+    components:
+    - pos: -10.5,10.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 148
+    components:
+    - pos: -10.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 149
+    components:
+    - pos: -9.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 150
+    components:
+    - pos: -6.5,11.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 151
+    components:
+    - pos: -6.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 152
+    components:
+    - pos: -5.5,10.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 153
+    components:
+    - pos: -5.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 154
+    components:
+    - pos: -2.5,9.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 155
+    components:
+    - pos: -2.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 156
+    components:
+    - pos: -3.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 157
+    components:
+    - pos: 3.5,11.5
+      parent: 1
+      type: Transform
+  - uid: 158
+    components:
+    - pos: 3.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 159
+    components:
+    - pos: 3.5,9.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 160
+    components:
+    - pos: 3.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 161
+    components:
+    - pos: 4.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 162
+    components:
+    - pos: 5.5,11.5
+      parent: 1
+      type: Transform
+  - uid: 163
+    components:
+    - pos: 5.5,10.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 164
+    components:
+    - pos: 5.5,9.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 165
+    components:
+    - pos: 6.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 166
+    components:
+    - pos: 6.5,10.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 167
+    components:
+    - pos: 7.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 168
+    components:
+    - pos: 10.5,11.5
+      parent: 1
+      type: Transform
+  - uid: 169
+    components:
+    - pos: 10.5,10.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 170
+    components:
+    - pos: 10.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 171
+    components:
+    - pos: 11.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 172
+    components:
+    - pos: 10.5,13.5
+      parent: 1
+      type: Transform
+  - uid: 173
+    components:
+    - pos: 10.5,14.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 174
+    components:
+    - pos: 10.5,15.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 175
+    components:
+    - pos: 10.5,16.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 176
+    components:
+    - pos: 11.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 177
+    components:
+    - pos: 11.5,15.5
+      parent: 1
+      type: Transform
+  - uid: 178
+    components:
+    - pos: 8.5,17.5
+      parent: 1
+      type: Transform
+  - uid: 179
+    components:
+    - pos: 9.5,17.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 180
+    components:
+    - pos: 9.5,18.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 181
+    components:
+    - pos: 9.5,19.5
+      parent: 1
+      type: Transform
+  - uid: 182
+    components:
+    - pos: 8.5,19.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 183
+    components:
+    - pos: 8.5,20.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 184
+    components:
+    - pos: 8.5,21.5
+      parent: 1
+      type: Transform
+  - uid: 185
+    components:
+    - pos: 7.5,21.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 186
+    components:
+    - pos: 7.5,22.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 187
+    components:
+    - pos: 7.5,23.5
+      parent: 1
+      type: Transform
+  - uid: 188
+    components:
+    - pos: -7.5,17.5
+      parent: 1
+      type: Transform
+  - uid: 189
+    components:
+    - pos: -7.5,18.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 190
+    components:
+    - pos: -7.5,19.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 191
+    components:
+    - pos: -7.5,20.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 192
+    components:
+    - pos: -7.5,21.5
+      parent: 1
+      type: Transform
+  - uid: 193
+    components:
+    - pos: -8.5,19.5
+      parent: 1
+      type: Transform
+  - uid: 194
+    components:
+    - pos: -6.5,22.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 195
+    components:
+    - pos: -6.5,21.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 196
+    components:
+    - pos: -6.5,23.5
+      parent: 1
+      type: Transform
+- proto: CableHV
+  entities:
+  - uid: 197
+    components:
+    - pos: -3.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 198
+    components:
+    - pos: -2.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 199
+    components:
+    - pos: -1.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 200
+    components:
+    - pos: -1.5,11.5
+      parent: 1
+      type: Transform
+  - uid: 201
+    components:
+    - pos: -3.5,13.5
+      parent: 1
+      type: Transform
+  - uid: 202
+    components:
+    - pos: -4.5,13.5
+      parent: 1
+      type: Transform
+  - uid: 203
+    components:
+    - pos: -4.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 204
+    components:
+    - pos: -4.5,13.5
+      parent: 1
+      type: Transform
+  - uid: 205
+    components:
+    - pos: -4.5,11.5
+      parent: 1
+      type: Transform
+  - uid: 206
+    components:
+    - pos: -3.5,11.5
+      parent: 1
+      type: Transform
+- proto: CableMV
+  entities:
+  - uid: 207
+    components:
+    - pos: -1.5,14.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 208
+    components:
+    - pos: -1.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 209
+    components:
+    - pos: -2.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 210
+    components:
+    - pos: -2.5,13.5
+      parent: 1
+      type: Transform
+  - uid: 211
+    components:
+    - pos: -2.5,14.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 212
+    components:
+    - pos: -2.5,15.5
+      parent: 1
+      type: Transform
+  - uid: 213
+    components:
+    - pos: -2.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 214
+    components:
+    - pos: -1.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 215
+    components:
+    - pos: -0.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 216
+    components:
+    - pos: 0.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 217
+    components:
+    - pos: 1.5,17.5
+      parent: 1
+      type: Transform
+  - uid: 218
+    components:
+    - pos: 1.5,18.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 219
+    components:
+    - pos: 1.5,16.5
+      parent: 1
+      type: Transform
+- proto: CableTerminal
+  entities:
+  - uid: 220
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -3.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 221
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -3.5,13.5
+      parent: 1
+      type: Transform
+- proto: Chair
+  entities:
+  - uid: 222
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 5.5,17.5
+      parent: 1
+      type: Transform
+  - uid: 223
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 6.5,15.5
+      parent: 1
+      type: Transform
+  - uid: 224
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 8.5,15.5
+      parent: 1
+      type: Transform
+- proto: ChairPilotSeat
+  entities:
+  - uid: 225
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 1.5,20.5
+      parent: 1
+      type: Transform
+  - uid: 226
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -0.5,20.5
+      parent: 1
+      type: Transform
+- proto: ClothingShoesColorOrange
+  entities:
+  - uid: 228
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 227
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 229
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 227
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 230
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 227
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 231
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 227
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: ClothingUniformJumpskirtPrisoner
+  entities:
+  - uid: 232
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 227
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 233
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 227
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: ClothingUniformJumpsuitPrisoner
+  entities:
+  - uid: 234
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 227
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 235
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 227
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: ComfyChair
+  entities:
+  - uid: 236
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 4.5,12.5
+      parent: 1
+      type: Transform
+- proto: ComputerCriminalRecords
+  entities:
+  - uid: 237
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 3.5,13.5
+      parent: 1
+      type: Transform
+- proto: ComputerIFFSyndicate
+  entities:
+  - uid: 238
+    components:
+    - pos: 0.5,21.5
+      parent: 1
+      type: Transform
+- proto: ComputerRadar
+  entities:
+  - uid: 239
+    components:
+    - pos: -0.5,21.5
+      parent: 1
+      type: Transform
+- proto: ComputerShuttle
+  entities:
+  - uid: 240
+    components:
+    - pos: 1.5,21.5
+      parent: 1
+      type: Transform
+- proto: ComputerStationRecords
+  entities:
+  - uid: 241
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 5.5,11.5
+      parent: 1
+      type: Transform
+- proto: ConveyorBelt
+  entities:
+  - uid: 242
+    components:
+    - pos: -0.5,15.5
+      parent: 1
+      type: Transform
+    - links:
+      - 555
+      type: DeviceLinkSink
+  - uid: 243
+    components:
+    - pos: 1.5,15.5
+      parent: 1
+      type: Transform
+    - links:
+      - 555
+      type: DeviceLinkSink
+- proto: DefibrillatorCabinetFilled
+  entities:
+  - uid: 244
+    components:
+    - pos: 5.5,18.5
+      parent: 1
+      type: Transform
+- proto: FaxMachineBase
+  entities:
+  - uid: 245
+    components:
+    - pos: 1.5,19.5
+      parent: 1
+      type: Transform
+- proto: FloorDrain
+  entities:
+  - uid: 246
+    components:
+    - pos: -2.5,19.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 247
+    components:
+    - pos: 9.5,13.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+- proto: GasMixer
+  entities:
+  - uid: 248
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -3.5,11.5
+      parent: 1
+      type: Transform
+- proto: GasPassiveVent
+  entities:
+  - uid: 249
+    components:
+    - pos: -3.5,27.5
+      parent: 1
+      type: Transform
+  - uid: 250
+    components:
+    - pos: 4.5,27.5
+      parent: 1
+      type: Transform
+- proto: GasPipeBend
+  entities:
+  - uid: 251
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 8.5,12.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 252
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -2.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 253
+    components:
+    - pos: -2.5,11.5
+      parent: 1
+      type: Transform
+  - uid: 254
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -9.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 255
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -8.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 256
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -8.5,13.5
+      parent: 1
+      type: Transform
+  - uid: 257
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -6.5,13.5
+      parent: 1
+      type: Transform
+  - uid: 258
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 7.5,13.5
+      parent: 1
+      type: Transform
+  - uid: 259
+    components:
+    - pos: 6.5,20.5
+      parent: 1
+      type: Transform
+  - uid: 260
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 5.5,20.5
+      parent: 1
+      type: Transform
+  - uid: 261
+    components:
+    - pos: -3.5,21.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 262
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 4.5,23.5
+      parent: 1
+      type: Transform
+  - uid: 263
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -3.5,23.5
+      parent: 1
+      type: Transform
+  - uid: 264
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -4.5,12.5
+      parent: 1
+      type: Transform
+- proto: GasPipeFourway
+  entities:
+  - uid: 265
+    components:
+    - pos: -4.5,15.5
+      parent: 1
+      type: Transform
+  - uid: 266
+    components:
+    - pos: 6.5,19.5
+      parent: 1
+      type: Transform
+  - uid: 267
+    components:
+    - pos: -3.5,16.5
+      parent: 1
+      type: Transform
+- proto: GasPipeStraight
+  entities:
+  - uid: 268
+    components:
+    - pos: 8.5,13.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 269
+    components:
+    - pos: 8.5,14.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 270
+    components:
+    - pos: 8.5,15.5
+      parent: 1
+      type: Transform
+  - uid: 271
+    components:
+    - pos: 3.5,15.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 272
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 5.5,17.5
+      parent: 1
+      type: Transform
+  - uid: 273
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -6.5,14.5
+      parent: 1
+      type: Transform
+  - uid: 274
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -5.5,15.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 275
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -3.5,15.5
+      parent: 1
+      type: Transform
+  - uid: 276
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -2.5,15.5
+      parent: 1
+      type: Transform
+  - uid: 277
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -1.5,15.5
+      parent: 1
+      type: Transform
+  - uid: 278
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -0.5,15.5
+      parent: 1
+      type: Transform
+  - uid: 279
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 1.5,15.5
+      parent: 1
+      type: Transform
+  - uid: 280
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 2.5,15.5
+      parent: 1
+      type: Transform
+  - uid: 281
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 3.5,15.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 282
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 5.5,15.5
+      parent: 1
+      type: Transform
+  - uid: 283
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 8.5,15.5
+      parent: 1
+      type: Transform
+  - uid: 284
+    components:
+    - pos: 4.5,14.5
+      parent: 1
+      type: Transform
+  - uid: 285
+    components:
+    - pos: 4.5,13.5
+      parent: 1
+      type: Transform
+  - uid: 286
+    components:
+    - pos: 4.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 287
+    components:
+    - pos: 4.5,11.5
+      parent: 1
+      type: Transform
+  - uid: 288
+    components:
+    - pos: 7.5,14.5
+      parent: 1
+      type: Transform
+  - uid: 289
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 8.5,13.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 290
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 9.5,13.5
+      parent: 1
+      type: Transform
+  - uid: 291
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 10.5,13.5
+      parent: 1
+      type: Transform
+  - uid: 292
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 293
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,17.5
+      parent: 1
+      type: Transform
+  - uid: 294
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,18.5
+      parent: 1
+      type: Transform
+  - uid: 295
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,19.5
+      parent: 1
+      type: Transform
+  - uid: 296
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -4.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 297
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -4.5,17.5
+      parent: 1
+      type: Transform
+  - uid: 298
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -4.5,18.5
+      parent: 1
+      type: Transform
+  - uid: 299
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -4.5,21.5
+      parent: 1
+      type: Transform
+  - uid: 300
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -4.5,22.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 301
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 6.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 302
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 6.5,17.5
+      parent: 1
+      type: Transform
+  - uid: 303
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 6.5,18.5
+      parent: 1
+      type: Transform
+  - uid: 304
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 5.5,19.5
+      parent: 1
+      type: Transform
+  - uid: 305
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 4.5,19.5
+      parent: 1
+      type: Transform
+  - uid: 306
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 5.5,21.5
+      parent: 1
+      type: Transform
+  - uid: 307
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 5.5,22.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 308
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 10.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 309
+    components:
+    - pos: -4.5,14.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 310
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -3.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 311
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -3.5,14.5
+      parent: 1
+      type: Transform
+  - uid: 312
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -3.5,15.5
+      parent: 1
+      type: Transform
+  - uid: 313
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -4.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 314
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -5.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 315
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -6.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 316
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -2.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 317
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -1.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 318
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -0.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 319
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 0.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 320
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 1.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 321
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 2.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 322
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 4.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 323
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 6.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 324
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 7.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 325
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 5.5,18.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 326
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -3.5,17.5
+      parent: 1
+      type: Transform
+  - uid: 327
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -3.5,18.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 328
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -3.5,19.5
+      parent: 1
+      type: Transform
+  - uid: 329
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -3.5,20.5
+      parent: 1
+      type: Transform
+  - uid: 330
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -4.5,21.5
+      parent: 1
+      type: Transform
+  - uid: 331
+    components:
+    - pos: 3.5,14.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 332
+    components:
+    - pos: 3.5,13.5
+      parent: 1
+      type: Transform
+  - uid: 333
+    components:
+    - pos: 3.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 334
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -3.5,24.5
+      parent: 1
+      type: Transform
+  - uid: 335
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -3.5,25.5
+      parent: 1
+      type: Transform
+  - uid: 336
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -3.5,26.5
+      parent: 1
+      type: Transform
+  - uid: 337
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 4.5,24.5
+      parent: 1
+      type: Transform
+  - uid: 338
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 4.5,25.5
+      parent: 1
+      type: Transform
+  - uid: 339
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 4.5,26.5
+      parent: 1
+      type: Transform
+  - uid: 340
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -3.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 341
+    components:
+    - pos: -4.5,13.5
+      parent: 1
+      type: Transform
+  - uid: 342
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 9.5,12.5
+      parent: 1
+      type: Transform
+- proto: GasPipeTJunction
+  entities:
+  - uid: 343
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -4.5,19.5
+      parent: 1
+      type: Transform
+  - uid: 344
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -4.5,20.5
+      parent: 1
+      type: Transform
+  - uid: 345
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -4.5,23.5
+      parent: 1
+      type: Transform
+  - uid: 346
+    components:
+    - pos: -7.5,13.5
+      parent: 1
+      type: Transform
+  - uid: 347
+    components:
+    - pos: -6.5,15.5
+      parent: 1
+      type: Transform
+  - uid: 348
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,15.5
+      parent: 1
+      type: Transform
+  - uid: 349
+    components:
+    - pos: 4.5,15.5
+      parent: 1
+      type: Transform
+  - uid: 350
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 6.5,15.5
+      parent: 1
+      type: Transform
+  - uid: 351
+    components:
+    - pos: 7.5,15.5
+      parent: 1
+      type: Transform
+  - uid: 352
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 5.5,23.5
+      parent: 1
+      type: Transform
+  - uid: 353
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -3.5,13.5
+      parent: 1
+      type: Transform
+  - uid: 354
+    components:
+    - pos: 3.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 355
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 5.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 356
+    components:
+    - pos: 8.5,16.5
+      parent: 1
+      type: Transform
+- proto: GasPort
+  entities:
+  - uid: 357
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -3.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 358
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -1.5,10.5
+      parent: 1
+      type: Transform
+- proto: GasVentPump
+  entities:
+  - uid: 359
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -7.5,16.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+  - uid: 360
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 9.5,16.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+  - uid: 361
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 3.5,11.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+  - uid: 362
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -5.5,21.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+  - uid: 363
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 11.5,12.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+  - uid: 364
+    components:
+    - pos: 5.5,19.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+  - uid: 365
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -2.5,13.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+- proto: GasVentScrubber
+  entities:
+  - uid: 366
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -7.5,12.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+  - uid: 367
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -9.5,11.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+  - uid: 368
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -6.5,19.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+  - uid: 369
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 7.5,19.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+  - uid: 370
+    components:
+    - pos: 5.5,24.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+  - uid: 371
+    components:
+    - pos: -4.5,24.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+  - uid: 372
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -7.5,15.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+  - uid: 373
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 11.5,13.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+  - uid: 374
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 9.5,15.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+  - uid: 375
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 4.5,10.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+  - uid: 376
+    components:
+    - pos: 0.5,20.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+  - uid: 377
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -5.5,19.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+  - uid: 378
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 3.5,19.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+  - uid: 379
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -2.5,12.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+  - uid: 380
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -3.5,20.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+- proto: GravityGeneratorMini
+  entities:
+  - uid: 381
+    components:
+    - pos: -4.5,11.5
+      parent: 1
+      type: Transform
+- proto: Grille
+  entities:
+  - uid: 382
+    components:
+    - pos: 2.5,24.5
+      parent: 1
+      type: Transform
+  - uid: 383
+    components:
+    - pos: 8.5,13.5
+      parent: 1
+      type: Transform
+  - uid: 384
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -0.5,22.5
+      parent: 1
+      type: Transform
+  - uid: 385
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,22.5
+      parent: 1
+      type: Transform
+  - uid: 386
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 1.5,22.5
+      parent: 1
+      type: Transform
+  - uid: 387
+    components:
+    - pos: -1.5,24.5
+      parent: 1
+      type: Transform
+  - uid: 388
+    components:
+    - pos: 8.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 389
+    components:
+    - pos: 6.5,13.5
+      parent: 1
+      type: Transform
+  - uid: 390
+    components:
+    - pos: 6.5,12.5
+      parent: 1
+      type: Transform
+- proto: GunSafe
+  entities:
+  - uid: 391
+    components:
+    - pos: 3.5,12.5
+      parent: 1
+      type: Transform
+    - containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 392
+          - 393
+          - 394
+          - 395
+          - 396
+          - 398
+          - 399
+          - 397
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+      type: ContainerContainer
+  - uid: 400
+    components:
+    - pos: 3.5,11.5
+      parent: 1
+      type: Transform
+    - containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 401
+          - 402
+          - 403
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+      type: ContainerContainer
+- proto: Gyroscope
+  entities:
+  - uid: 404
+    components:
+    - pos: 1.5,13.5
+      parent: 1
+      type: Transform
+  - uid: 405
+    components:
+    - pos: 0.5,13.5
+      parent: 1
+      type: Transform
+- proto: HospitalCurtainsOpen
+  entities:
+  - uid: 406
+    components:
+    - pos: 4.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 407
+    components:
+    - pos: -8.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 408
+    components:
+    - pos: -8.5,15.5
+      parent: 1
+      type: Transform
+  - uid: 409
+    components:
+    - pos: -2.5,21.5
+      parent: 1
+      type: Transform
+- proto: KitchenMicrowave
+  entities:
+  - uid: 410
+    components:
+    - pos: 7.5,17.5
+      parent: 1
+      type: Transform
+- proto: LockerDetectiveFilled
+  entities:
+  - uid: 411
+    components:
+    - pos: 6.5,20.5
+      parent: 1
+      type: Transform
+- proto: LockerEvidence
+  entities:
+  - uid: 227
+    components:
+    - pos: 7.5,12.5
+      parent: 1
+      type: Transform
+    - containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 228
+          - 229
+          - 230
+          - 231
+          - 232
+          - 234
+          - 233
+          - 235
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+      type: ContainerContainer
+  - uid: 412
+    components:
+    - pos: 4.5,20.5
+      parent: 1
+      type: Transform
+  - uid: 413
+    components:
+    - pos: 4.5,21.5
+      parent: 1
+      type: Transform
+  - uid: 414
+    components:
+    - pos: 3.5,20.5
+      parent: 1
+      type: Transform
+  - uid: 415
+    components:
+    - pos: 3.5,21.5
+      parent: 1
+      type: Transform
+- proto: LockerSecurityFilled
+  entities:
+  - uid: 416
+    components:
+    - pos: -5.5,21.5
+      parent: 1
+      type: Transform
+  - uid: 417
+    components:
+    - pos: 6.5,21.5
+      parent: 1
+      type: Transform
+- proto: LockerWardenFilledHardsuit
+  entities:
+  - uid: 418
+    components:
+    - pos: 3.5,10.5
+      parent: 1
+      type: Transform
+- proto: MagazinePistolSubMachineGunTopMounted
+  entities:
+  - uid: 392
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 391
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 393
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 391
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 394
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 391
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 395
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 391
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 396
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 391
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 397
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 391
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: Mirror
+  entities:
+  - uid: 419
+    components:
+    - pos: -1.5,19.5
+      parent: 1
+      type: Transform
+- proto: NitrogenCanister
+  entities:
+  - uid: 420
+    components:
+    - pos: -1.5,10.5
+      parent: 1
+      type: Transform
+- proto: OxygenCanister
+  entities:
+  - uid: 421
+    components:
+    - pos: -3.5,10.5
+      parent: 1
+      type: Transform
+- proto: PaperBin10
+  entities:
+  - uid: 422
+    components:
+    - pos: 5.5,13.5
+      parent: 1
+      type: Transform
+  - uid: 423
+    components:
+    - pos: -0.5,19.5
+      parent: 1
+      type: Transform
+- proto: PortableFlasher
+  entities:
+  - uid: 424
+    components:
+    - pos: -6.5,12.5
+      parent: 1
+      type: Transform
+- proto: PosterContrabandEnergySwords
+  entities:
+  - uid: 425
+    components:
+    - pos: -4.5,14.5
+      parent: 1
+      type: Transform
+- proto: PosterContrabandFunPolice
+  entities:
+  - uid: 426
+    components:
+    - pos: -0.5,18.5
+      parent: 1
+      type: Transform
+- proto: PosterContrabandUnreadableAnnouncement
+  entities:
+  - uid: 427
+    components:
+    - pos: 2.5,14.5
+      parent: 1
+      type: Transform
+- proto: PosterLegitBotanyFood
+  entities:
+  - uid: 428
+    components:
+    - pos: 8.5,18.5
+      parent: 1
+      type: Transform
+- proto: PosterLegitEatMeat
+  entities:
+  - uid: 429
+    components:
+    - pos: -2.5,18.5
+      parent: 1
+      type: Transform
+- proto: PosterLegitEnlist
+  entities:
+  - uid: 430
+    components:
+    - pos: -1.5,18.5
+      parent: 1
+      type: Transform
+- proto: PosterLegitGetYourLEGS
+  entities:
+  - uid: 431
+    components:
+    - pos: 3.5,15.5
+      parent: 1
+      type: Transform
+- proto: PosterLegitHelpOthers
+  entities:
+  - uid: 432
+    components:
+    - pos: 3.5,17.5
+      parent: 1
+      type: Transform
+- proto: PosterLegitIonRifle
+  entities:
+  - uid: 433
+    components:
+    - pos: 2.5,18.5
+      parent: 1
+      type: Transform
+- proto: PosterLegitObey
+  entities:
+  - uid: 434
+    components:
+    - pos: -3.5,18.5
+      parent: 1
+      type: Transform
+- proto: PosterLegitSecWatch
+  entities:
+  - uid: 435
+    components:
+    - pos: -11.5,12.5
+      parent: 1
+      type: Transform
+- proto: PowerCellRecharger
+  entities:
+  - uid: 436
+    components:
+    - pos: 4.5,17.5
+      parent: 1
+      type: Transform
+- proto: Poweredlight
+  entities:
+  - uid: 437
+    components:
+    - pos: -3.5,17.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+  - uid: 438
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 2.5,15.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+  - uid: 439
+    components:
+    - pos: 5.5,17.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+  - uid: 440
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 7.5,12.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+  - uid: 441
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 9.5,16.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+  - uid: 442
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 5.5,19.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+  - uid: 443
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -0.5,19.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+  - uid: 444
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 1.5,19.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+  - uid: 445
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -2.5,19.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+  - uid: 446
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -5.5,21.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+  - uid: 447
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -6.5,13.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+  - uid: 448
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -6.5,15.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+  - uid: 449
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -9.5,11.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+  - uid: 450
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -2.5,10.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+  - uid: 451
+    components:
+    - pos: 1.5,13.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+  - uid: 452
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 3.5,12.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+  - uid: 453
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -3.5,23.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+  - uid: 454
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 4.5,23.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+- proto: PoweredLightPostSmallRed
+  entities:
+  - uid: 455
+    components:
+    - pos: -2.5,27.5
+      parent: 1
+      type: Transform
+  - uid: 456
+    components:
+    - pos: 3.5,27.5
+      parent: 1
+      type: Transform
+- proto: Rack
+  entities:
+  - uid: 457
+    components:
+    - pos: -0.5,13.5
+      parent: 1
+      type: Transform
+  - uid: 458
+    components:
+    - pos: -2.5,15.5
+      parent: 1
+      type: Transform
+- proto: Railing
+  entities:
+  - uid: 459
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -4.5,26.5
+      parent: 1
+      type: Transform
+  - uid: 460
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -2.5,26.5
+      parent: 1
+      type: Transform
+  - uid: 461
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 5.5,26.5
+      parent: 1
+      type: Transform
+  - uid: 462
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 3.5,26.5
+      parent: 1
+      type: Transform
+  - uid: 463
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -3.5,27.5
+      parent: 1
+      type: Transform
+  - uid: 464
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 4.5,27.5
+      parent: 1
+      type: Transform
+  - uid: 465
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -7.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 466
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -7.5,15.5
+      parent: 1
+      type: Transform
+  - uid: 467
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -1.5,15.5
+      parent: 1
+      type: Transform
+  - uid: 468
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 0.5,15.5
+      parent: 1
+      type: Transform
+  - uid: 469
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 0.5,15.5
+      parent: 1
+      type: Transform
+  - uid: 470
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 2.5,15.5
+      parent: 1
+      type: Transform
+- proto: RailingCorner
+  entities:
+  - uid: 471
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -2.5,27.5
+      parent: 1
+      type: Transform
+  - uid: 472
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 3.5,27.5
+      parent: 1
+      type: Transform
+  - uid: 473
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 5.5,27.5
+      parent: 1
+      type: Transform
+  - uid: 474
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -4.5,27.5
+      parent: 1
+      type: Transform
+- proto: RandomPosterLegit
+  entities:
+  - uid: 475
+    components:
+    - pos: -10.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 476
+    components:
+    - pos: -9.5,14.5
+      parent: 1
+      type: Transform
+  - uid: 477
+    components:
+    - pos: -6.5,11.5
+      parent: 1
+      type: Transform
+  - uid: 478
+    components:
+    - pos: -6.5,18.5
+      parent: 1
+      type: Transform
+  - uid: 479
+    components:
+    - pos: -3.5,21.5
+      parent: 1
+      type: Transform
+  - uid: 480
+    components:
+    - pos: 6.5,14.5
+      parent: 1
+      type: Transform
+  - uid: 481
+    components:
+    - pos: 7.5,18.5
+      parent: 1
+      type: Transform
+  - uid: 482
+    components:
+    - pos: 4.5,18.5
+      parent: 1
+      type: Transform
+  - uid: 483
+    components:
+    - pos: 10.5,15.5
+      parent: 1
+      type: Transform
+  - uid: 484
+    components:
+    - pos: 9.5,17.5
+      parent: 1
+      type: Transform
+- proto: ReinforcedPlasmaWindow
+  entities:
+  - uid: 485
+    components:
+    - pos: 2.5,24.5
+      parent: 1
+      type: Transform
+  - uid: 486
+    components:
+    - pos: -1.5,24.5
+      parent: 1
+      type: Transform
+  - uid: 487
+    components:
+    - pos: -0.5,22.5
+      parent: 1
+      type: Transform
+  - uid: 488
+    components:
+    - pos: 0.5,22.5
+      parent: 1
+      type: Transform
+  - uid: 489
+    components:
+    - pos: 1.5,22.5
+      parent: 1
+      type: Transform
+- proto: ReinforcedWindow
+  entities:
+  - uid: 490
+    components:
+    - pos: 6.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 491
+    components:
+    - pos: 6.5,13.5
+      parent: 1
+      type: Transform
+  - uid: 492
+    components:
+    - pos: 8.5,13.5
+      parent: 1
+      type: Transform
+  - uid: 493
+    components:
+    - pos: 8.5,12.5
+      parent: 1
+      type: Transform
+- proto: ShuttersNormal
+  entities:
+  - uid: 494
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 6.5,12.5
+      parent: 1
+      type: Transform
+    - links:
+      - 501
+      type: DeviceLinkSink
+  - uid: 495
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 6.5,13.5
+      parent: 1
+      type: Transform
+    - links:
+      - 501
+      type: DeviceLinkSink
+  - uid: 496
+    components:
+    - pos: -0.5,22.5
+      parent: 1
+      type: Transform
+    - links:
+      - 502
+      type: DeviceLinkSink
+  - uid: 497
+    components:
+    - pos: 0.5,22.5
+      parent: 1
+      type: Transform
+    - links:
+      - 502
+      type: DeviceLinkSink
+  - uid: 498
+    components:
+    - pos: 1.5,22.5
+      parent: 1
+      type: Transform
+    - links:
+      - 502
+      type: DeviceLinkSink
+  - uid: 499
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -1.5,24.5
+      parent: 1
+      type: Transform
+    - links:
+      - 502
+      type: DeviceLinkSink
+  - uid: 500
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 2.5,24.5
+      parent: 1
+      type: Transform
+    - links:
+      - 502
+      type: DeviceLinkSink
+- proto: SignalButton
+  entities:
+  - uid: 501
+    components:
+    - pos: 5.5,10.5
+      parent: 1
+      type: Transform
+    - linkedPorts:
+        494:
+        - Pressed: Toggle
+        495:
+        - Pressed: Toggle
+      type: DeviceLinkSource
+  - uid: 502
+    components:
+    - pos: 2.5,20.5
+      parent: 1
+      type: Transform
+    - linkedPorts:
+        496:
+        - Pressed: Toggle
+        497:
+        - Pressed: Toggle
+        498:
+        - Pressed: Toggle
+        499:
+        - Pressed: Toggle
+        500:
+        - Pressed: Toggle
+      type: DeviceLinkSource
+  - uid: 503
+    components:
+    - pos: -1.5,20.5
+      parent: 1
+      type: Transform
+    - linkedPorts:
+        4:
+        - Pressed: DoorBolt
+        5:
+        - Pressed: DoorBolt
+        6:
+        - Pressed: DoorBolt
+        7:
+        - Pressed: DoorBolt
+      type: DeviceLinkSource
+- proto: SinkStemlessWater
+  entities:
+  - uid: 504
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -2.5,19.5
+      parent: 1
+      type: Transform
+- proto: SinkWide
+  entities:
+  - uid: 505
+    components:
+    - pos: 11.5,13.5
+      parent: 1
+      type: Transform
+- proto: SMESBasic
+  entities:
+  - uid: 506
+    components:
+    - pos: -4.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 507
+    components:
+    - pos: -4.5,13.5
+      parent: 1
+      type: Transform
+- proto: soda_dispenser
+  entities:
+  - uid: 508
+    components:
+    - pos: 8.5,17.5
+      parent: 1
+      type: Transform
+- proto: SpawnPointDetective
+  entities:
+  - uid: 509
+    components:
+    - pos: 6.5,19.5
+      parent: 1
+      type: Transform
+- proto: SpawnPointLatejoin
+  entities:
+  - uid: 510
+    components:
+    - pos: -8.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 511
+    components:
+    - pos: -8.5,15.5
+      parent: 1
+      type: Transform
+- proto: SpawnPointSecurityCadet
+  entities:
+  - uid: 512
+    components:
+    - pos: -6.5,16.5
+      parent: 1
+      type: Transform
+- proto: SpawnPointSecurityOfficer
+  entities:
+  - uid: 513
+    components:
+    - pos: -7.5,16.5
+      parent: 1
+      type: Transform
+- proto: SubstationBasic
+  entities:
+  - uid: 514
+    components:
+    - pos: -1.5,12.5
+      parent: 1
+      type: Transform
+- proto: SuitStorageSec
+  entities:
+  - uid: 515
+    components:
+    - pos: 7.5,19.5
+      parent: 1
+      type: Transform
+  - uid: 516
+    components:
+    - pos: -6.5,19.5
+      parent: 1
+      type: Transform
+- proto: TableReinforced
+  entities:
+  - uid: 517
+    components:
+    - pos: 1.5,19.5
+      parent: 1
+      type: Transform
+  - uid: 518
+    components:
+    - pos: -0.5,19.5
+      parent: 1
+      type: Transform
+  - uid: 519
+    components:
+    - pos: 5.5,13.5
+      parent: 1
+      type: Transform
+  - uid: 520
+    components:
+    - pos: 5.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 521
+    components:
+    - pos: 8.5,17.5
+      parent: 1
+      type: Transform
+  - uid: 522
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 7.5,17.5
+      parent: 1
+      type: Transform
+  - uid: 523
+    components:
+    - pos: -7.5,17.5
+      parent: 1
+      type: Transform
+  - uid: 524
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 4.5,17.5
+      parent: 1
+      type: Transform
+  - uid: 525
+    components:
+    - pos: -6.5,17.5
+      parent: 1
+      type: Transform
+  - uid: 526
+    components:
+    - pos: 5.5,15.5
+      parent: 1
+      type: Transform
+- proto: TargetClown
+  entities:
+  - uid: 527
+    components:
+    - pos: -3.5,17.5
+      parent: 1
+      type: Transform
+- proto: TargetSyndicate
+  entities:
+  - uid: 528
+    components:
+    - pos: -0.5,17.5
+      parent: 1
+      type: Transform
+- proto: Thruster
+  entities:
+  - uid: 529
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -10.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 530
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -9.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 531
+    components:
+    - pos: 8.5,21.5
+      parent: 1
+      type: Transform
+  - uid: 532
+    components:
+    - pos: 7.5,23.5
+      parent: 1
+      type: Transform
+  - uid: 533
+    components:
+    - pos: -6.5,23.5
+      parent: 1
+      type: Transform
+  - uid: 534
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -6.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 535
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 6.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 536
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 3.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 537
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -3.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 538
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 4.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 539
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -2.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 540
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 10.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 541
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 11.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 542
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -5.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 543
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 7.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 544
+    components:
+    - pos: -8.5,19.5
+      parent: 1
+      type: Transform
+  - uid: 545
+    components:
+    - pos: -7.5,21.5
+      parent: 1
+      type: Transform
+  - uid: 546
+    components:
+    - pos: 9.5,19.5
+      parent: 1
+      type: Transform
+  - uid: 547
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 11.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 548
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 11.5,15.5
+      parent: 1
+      type: Transform
+  - uid: 549
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -10.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 550
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -10.5,15.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: Thruster
+- proto: ToiletDirtyWater
+  entities:
+  - uid: 551
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 10.5,11.5
+      parent: 1
+      type: Transform
+- proto: ToiletEmpty
+  entities:
+  - uid: 552
+    components:
+    - pos: -2.5,21.5
+      parent: 1
+      type: Transform
+- proto: ToolboxElectricalFilled
+  entities:
+  - uid: 553
+    components:
+    - pos: -2.6615949,15.424311
+      parent: 1
+      type: Transform
+- proto: ToolboxMechanicalFilled
+  entities:
+  - uid: 554
+    components:
+    - pos: -2.3959699,15.674311
+      parent: 1
+      type: Transform
+- proto: TwoWayLever
+  entities:
+  - uid: 555
+    components:
+    - pos: 0.5,15.5
+      parent: 1
+      type: Transform
+    - linkedPorts:
+        242:
+        - Right: Forward
+        - Left: Reverse
+        - Middle: Off
+        243:
+        - Right: Forward
+        - Left: Reverse
+        - Middle: Off
+      type: DeviceLinkSource
+- proto: VendingMachineSecDrobe
+  entities:
+  - uid: 556
+    components:
+    - flags: SessionSpecific
+      type: MetaData
+    - pos: -5.5,20.5
+      parent: 1
+      type: Transform
+- proto: WallmountTelevision
+  entities:
+  - uid: 557
+    components:
+    - pos: 0.5,14.5
+      parent: 1
+      type: Transform
+- proto: WallPlastitanium
+  entities:
+  - uid: 558
+    components:
+    - pos: -3.5,19.5
+      parent: 1
+      type: Transform
+  - uid: 559
+    components:
+    - pos: 3.5,18.5
+      parent: 1
+      type: Transform
+  - uid: 560
+    components:
+    - pos: -11.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 561
+    components:
+    - pos: -11.5,14.5
+      parent: 1
+      type: Transform
+  - uid: 562
+    components:
+    - pos: 12.5,14.5
+      parent: 1
+      type: Transform
+  - uid: 563
+    components:
+    - pos: 12.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 564
+    components:
+    - pos: -9.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 565
+    components:
+    - pos: -10.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 566
+    components:
+    - pos: -8.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 567
+    components:
+    - pos: 9.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 568
+    components:
+    - pos: 8.5,11.5
+      parent: 1
+      type: Transform
+  - uid: 569
+    components:
+    - pos: 7.5,11.5
+      parent: 1
+      type: Transform
+  - uid: 570
+    components:
+    - pos: 6.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 571
+    components:
+    - pos: 4.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 572
+    components:
+    - pos: 5.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 573
+    components:
+    - pos: 3.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 574
+    components:
+    - pos: 2.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 575
+    components:
+    - pos: 1.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 576
+    components:
+    - pos: 0.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 577
+    components:
+    - pos: -0.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 578
+    components:
+    - pos: -1.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 579
+    components:
+    - pos: -2.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 580
+    components:
+    - pos: -4.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 581
+    components:
+    - pos: -3.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 582
+    components:
+    - pos: -5.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 583
+    components:
+    - pos: -6.5,11.5
+      parent: 1
+      type: Transform
+  - uid: 584
+    components:
+    - pos: -7.5,11.5
+      parent: 1
+      type: Transform
+  - uid: 585
+    components:
+    - pos: 10.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 586
+    components:
+    - pos: -8.5,18.5
+      parent: 1
+      type: Transform
+  - uid: 587
+    components:
+    - pos: 5.5,14.5
+      parent: 1
+      type: Transform
+  - uid: 588
+    components:
+    - pos: -6.5,22.5
+      parent: 1
+      type: Transform
+  - uid: 589
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 10.5,17.5
+      parent: 1
+      type: Transform
+  - uid: 590
+    components:
+    - pos: -5.5,25.5
+      parent: 1
+      type: Transform
+  - uid: 591
+    components:
+    - pos: -4.5,25.5
+      parent: 1
+      type: Transform
+  - uid: 592
+    components:
+    - pos: -0.5,14.5
+      parent: 1
+      type: Transform
+  - uid: 593
+    components:
+    - pos: 1.5,14.5
+      parent: 1
+      type: Transform
+  - uid: 594
+    components:
+    - pos: 2.5,13.5
+      parent: 1
+      type: Transform
+  - uid: 595
+    components:
+    - pos: 2.5,14.5
+      parent: 1
+      type: Transform
+  - uid: 596
+    components:
+    - pos: 2.5,18.5
+      parent: 1
+      type: Transform
+  - uid: 597
+    components:
+    - pos: -4.5,14.5
+      parent: 1
+      type: Transform
+  - uid: 598
+    components:
+    - pos: -1.5,14.5
+      parent: 1
+      type: Transform
+  - uid: 599
+    components:
+    - pos: -1.5,25.5
+      parent: 1
+      type: Transform
+  - uid: 600
+    components:
+    - pos: -1.5,23.5
+      parent: 1
+      type: Transform
+  - uid: 601
+    components:
+    - pos: -1.5,22.5
+      parent: 1
+      type: Transform
+  - uid: 602
+    components:
+    - pos: -2.5,14.5
+      parent: 1
+      type: Transform
+  - uid: 603
+    components:
+    - pos: -5.5,13.5
+      parent: 1
+      type: Transform
+  - uid: 604
+    components:
+    - pos: -7.5,14.5
+      parent: 1
+      type: Transform
+  - uid: 605
+    components:
+    - pos: -3.5,18.5
+      parent: 1
+      type: Transform
+  - uid: 606
+    components:
+    - pos: 2.5,22.5
+      parent: 1
+      type: Transform
+  - uid: 607
+    components:
+    - pos: 2.5,23.5
+      parent: 1
+      type: Transform
+  - uid: 608
+    components:
+    - pos: 2.5,25.5
+      parent: 1
+      type: Transform
+  - uid: 609
+    components:
+    - pos: 10.5,15.5
+      parent: 1
+      type: Transform
+  - uid: 610
+    components:
+    - pos: 3.5,25.5
+      parent: 1
+      type: Transform
+  - uid: 611
+    components:
+    - pos: -2.5,25.5
+      parent: 1
+      type: Transform
+  - uid: 612
+    components:
+    - pos: 5.5,25.5
+      parent: 1
+      type: Transform
+  - uid: 613
+    components:
+    - pos: 6.5,25.5
+      parent: 1
+      type: Transform
+  - uid: 614
+    components:
+    - pos: 6.5,23.5
+      parent: 1
+      type: Transform
+  - uid: 615
+    components:
+    - pos: 7.5,22.5
+      parent: 1
+      type: Transform
+  - uid: 616
+    components:
+    - pos: 7.5,21.5
+      parent: 1
+      type: Transform
+  - uid: 617
+    components:
+    - pos: 8.5,19.5
+      parent: 1
+      type: Transform
+  - uid: 618
+    components:
+    - pos: 9.5,18.5
+      parent: 1
+      type: Transform
+  - uid: 619
+    components:
+    - pos: 9.5,17.5
+      parent: 1
+      type: Transform
+  - uid: 620
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -9.5,17.5
+      parent: 1
+      type: Transform
+  - uid: 621
+    components:
+    - pos: 10.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 622
+    components:
+    - pos: -9.5,15.5
+      parent: 1
+      type: Transform
+  - uid: 623
+    components:
+    - pos: 11.5,14.5
+      parent: 1
+      type: Transform
+  - uid: 624
+    components:
+    - pos: -10.5,14.5
+      parent: 1
+      type: Transform
+  - uid: 625
+    components:
+    - pos: -9.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 626
+    components:
+    - pos: -8.5,17.5
+      parent: 1
+      type: Transform
+  - uid: 627
+    components:
+    - pos: -7.5,20.5
+      parent: 1
+      type: Transform
+  - uid: 628
+    components:
+    - pos: -6.5,21.5
+      parent: 1
+      type: Transform
+  - uid: 629
+    components:
+    - pos: -5.5,23.5
+      parent: 1
+      type: Transform
+  - uid: 630
+    components:
+    - pos: -4.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 631
+    components:
+    - pos: -5.5,11.5
+      parent: 1
+      type: Transform
+  - uid: 632
+    components:
+    - pos: -8.5,11.5
+      parent: 1
+      type: Transform
+  - uid: 633
+    components:
+    - pos: -1.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 634
+    components:
+    - pos: 2.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 635
+    components:
+    - pos: 5.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 636
+    components:
+    - pos: 6.5,11.5
+      parent: 1
+      type: Transform
+  - uid: 637
+    components:
+    - pos: 9.5,11.5
+      parent: 1
+      type: Transform
+  - uid: 638
+    components:
+    - pos: -1.5,20.5
+      parent: 1
+      type: Transform
+  - uid: 639
+    components:
+    - pos: -1.5,21.5
+      parent: 1
+      type: Transform
+  - uid: 640
+    components:
+    - pos: -6.5,20.5
+      parent: 1
+      type: Transform
+  - uid: 641
+    components:
+    - pos: 2.5,20.5
+      parent: 1
+      type: Transform
+  - uid: 642
+    components:
+    - pos: 2.5,21.5
+      parent: 1
+      type: Transform
+  - uid: 643
+    components:
+    - pos: 7.5,20.5
+      parent: 1
+      type: Transform
+  - uid: 644
+    components:
+    - pos: 0.5,14.5
+      parent: 1
+      type: Transform
+  - uid: 645
+    components:
+    - pos: 11.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 646
+    components:
+    - pos: -1.5,18.5
+      parent: 1
+      type: Transform
+  - uid: 647
+    components:
+    - pos: 8.5,20.5
+      parent: 1
+      type: Transform
+  - uid: 648
+    components:
+    - pos: -7.5,19.5
+      parent: 1
+      type: Transform
+  - uid: 649
+    components:
+    - pos: -1.5,19.5
+      parent: 1
+      type: Transform
+  - uid: 650
+    components:
+    - pos: 2.5,19.5
+      parent: 1
+      type: Transform
+  - uid: 651
+    components:
+    - pos: 1.5,18.5
+      parent: 1
+      type: Transform
+  - uid: 652
+    components:
+    - pos: 8.5,18.5
+      parent: 1
+      type: Transform
+  - uid: 653
+    components:
+    - pos: 4.5,18.5
+      parent: 1
+      type: Transform
+  - uid: 654
+    components:
+    - pos: -9.5,14.5
+      parent: 1
+      type: Transform
+  - uid: 655
+    components:
+    - pos: -8.5,14.5
+      parent: 1
+      type: Transform
+  - uid: 656
+    components:
+    - pos: 10.5,14.5
+      parent: 1
+      type: Transform
+  - uid: 657
+    components:
+    - pos: -5.5,14.5
+      parent: 1
+      type: Transform
+  - uid: 658
+    components:
+    - pos: 8.5,14.5
+      parent: 1
+      type: Transform
+  - uid: 659
+    components:
+    - pos: -5.5,24.5
+      parent: 1
+      type: Transform
+  - uid: 660
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 2.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 661
+    components:
+    - pos: 12.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 662
+    components:
+    - pos: 12.5,13.5
+      parent: 1
+      type: Transform
+  - uid: 663
+    components:
+    - pos: -0.5,18.5
+      parent: 1
+      type: Transform
+  - uid: 664
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -5.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 665
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 2.5,11.5
+      parent: 1
+      type: Transform
+  - uid: 666
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 2.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 667
+    components:
+    - pos: -2.5,18.5
+      parent: 1
+      type: Transform
+  - uid: 668
+    components:
+    - pos: -3.5,21.5
+      parent: 1
+      type: Transform
+  - uid: 669
+    components:
+    - pos: 6.5,14.5
+      parent: 1
+      type: Transform
+  - uid: 670
+    components:
+    - pos: 12.5,11.5
+      parent: 1
+      type: Transform
+  - uid: 671
+    components:
+    - pos: -5.5,22.5
+      parent: 1
+      type: Transform
+  - uid: 672
+    components:
+    - pos: -3.5,22.5
+      parent: 1
+      type: Transform
+  - uid: 673
+    components:
+    - pos: -2.5,22.5
+      parent: 1
+      type: Transform
+  - uid: 674
+    components:
+    - pos: 3.5,22.5
+      parent: 1
+      type: Transform
+  - uid: 675
+    components:
+    - pos: 6.5,22.5
+      parent: 1
+      type: Transform
+  - uid: 676
+    components:
+    - pos: 6.5,24.5
+      parent: 1
+      type: Transform
+  - uid: 677
+    components:
+    - pos: 3.5,17.5
+      parent: 1
+      type: Transform
+  - uid: 678
+    components:
+    - pos: 4.5,22.5
+      parent: 1
+      type: Transform
+  - uid: 679
+    components:
+    - pos: -11.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 680
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -7.5,18.5
+      parent: 1
+      type: Transform
+  - uid: 681
+    components:
+    - pos: -6.5,18.5
+      parent: 1
+      type: Transform
+  - uid: 682
+    components:
+    - pos: -5.5,18.5
+      parent: 1
+      type: Transform
+  - uid: 683
+    components:
+    - pos: -5.5,17.5
+      parent: 1
+      type: Transform
+  - uid: 684
+    components:
+    - pos: 7.5,18.5
+      parent: 1
+      type: Transform
+  - uid: 685
+    components:
+    - pos: 3.5,14.5
+      parent: 1
+      type: Transform
+  - uid: 686
+    components:
+    - pos: -5.5,15.5
+      parent: 1
+      type: Transform
+  - uid: 687
+    components:
+    - pos: 3.5,15.5
+      parent: 1
+      type: Transform
+  - uid: 688
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 5.5,18.5
+      parent: 1
+      type: Transform
+- proto: WallWeaponCapacitorRecharger
+  entities:
+  - uid: 689
+    components:
+    - pos: 2.5,19.5
+      parent: 1
+      type: Transform
+- proto: WarpPoint
+  entities:
+  - uid: 690
+    components:
+    - pos: 0.5,17.5
+      parent: 1
+      type: Transform
+    - location: Prowler
+      type: WarpPoint
+- proto: WaterCooler
+  entities:
+  - uid: 691
+    components:
+    - pos: 2.5,17.5
+      parent: 1
+      type: Transform
+- proto: WeaponAntiqueLaser
+  entities:
+  - uid: 401
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 400
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: WeaponCapacitorRecharger
+  entities:
+  - uid: 692
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 5.5,15.5
+      parent: 1
+      type: Transform
+- proto: WeaponEmpEmitter
+  entities:
+  - uid: 402
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 400
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 403
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 400
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: WeaponSubMachineGunWt550
+  entities:
+  - uid: 398
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 391
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 399
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 391
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: WindoorSecureSecurityLocked
+  entities:
+  - uid: 693
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -3.5,20.5
+      parent: 1
+      type: Transform
+  - uid: 694
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 4.5,19.5
+      parent: 1
+      type: Transform
+- proto: WindowReinforcedDirectional
+  entities:
+  - uid: 695
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 4.5,20.5
+      parent: 1
+      type: Transform
+  - uid: 696
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 4.5,21.5
+      parent: 1
+      type: Transform
+...

--- a/Resources/Prototypes/_NF/Shipyard/default_shipyard_catalog.yml
+++ b/Resources/Prototypes/_NF/Shipyard/default_shipyard_catalog.yml
@@ -341,34 +341,34 @@
             # PrisonGuard: [ 0, 0 ]
             # SecurityOfficer: [ 1, 1 ]
 
-- type: vessel
-  id: Trident
-  name: NSF Trident
-  description: A medium sized security vessel equipped with deadly force
-  price: 49300
-  category: Medium
-  group: Security
-  shuttlePath: /Maps/Shuttles/trident.yml
+#- type: vessel
+#  id: Trident
+#  name: NSF Trident
+#  description: A medium sized security vessel equipped with deadly force
+#  price: 49300
+#  category: Medium
+#  group: Security
+#  shuttlePath: /Maps/Shuttles/trident.yml
 
-- type: gameMap
-  id: Trident
-  mapName: 'NSF Trident'
-  mapPath: /Maps/Shuttles/trident.yml
-  minPlayers: 0
-  stations:
-    Trident:
-      stationProto: StandardFrontierVessel
-      components:
-        - type: StationNameSetup
-          mapNameTemplate: '{0} Trident {1}'
-          nameGenerator:
-            !type:NanotrasenNameGenerator
-            prefixCreator: '14'
-        - type: StationJobs
-          overflowJobs: []
-          availableJobs:
-            PrisonGuard: [ 0, 0 ]
-            SecurityOfficer: [ 0, 0 ]
+#- type: gameMap
+#  id: Trident
+#  mapName: 'NSF Trident'
+#  mapPath: /Maps/Shuttles/trident.yml
+#  minPlayers: 0
+#  stations:
+#    Trident:
+#      stationProto: StandardFrontierVessel
+#      components:
+#        - type: StationNameSetup
+#          mapNameTemplate: '{0} Trident {1}'
+#          nameGenerator:
+#            !type:NanotrasenNameGenerator
+#            prefixCreator: '14'
+#        - type: StationJobs
+#          overflowJobs: []
+#          availableJobs:
+#            PrisonGuard: [ 0, 0 ]
+#            SecurityOfficer: [ 0, 0 ]
 
 - type: vessel
   id: Pulse

--- a/Resources/Prototypes/_NF/Shipyard/marauder.yml
+++ b/Resources/Prototypes/_NF/Shipyard/marauder.yml
@@ -1,7 +1,7 @@
 - type: vessel
   id: Marauder
   name: NT Marauder
-  description: A heavy corvette, the marauder class is a dedicated deep space patrol vessel outfitted with stealth armor and heavily fortified against pirate assault.
+  description: A heavy corvette, the marauder class is a dedicated deep space patrol vessel outfitted with a reduced radar cross-section and heavily fortified against hostile assault.
   price: 100200
   category: Large
   group: Security

--- a/Resources/Prototypes/_NF/Shipyard/prowler.yml
+++ b/Resources/Prototypes/_NF/Shipyard/prowler.yml
@@ -1,7 +1,7 @@
 - type: vessel
   id: Prowler
   name: NT Prowler
-  description: A medium-sized patrol craft, the prowler class is a dedicated deep space reconnaisance and enforcement vessel outfitted with ECM technology to avoid detection.
+  description: A medium-sized patrol craft, the prowler class is a dedicated deep space reconnaissance and enforcement vessel outfitted with ECM technology to avoid detection.
   price: 49200
   category: Medium
   group: Security

--- a/Resources/Prototypes/_NF/Shipyard/prowler.yml
+++ b/Resources/Prototypes/_NF/Shipyard/prowler.yml
@@ -1,0 +1,29 @@
+- type: vessel
+  id: Prowler
+  name: NT Prowler
+  description: A medium-sized patrol craft, the prowler class is a dedicated deep space reconnaisance and enforcement vessel outfitted with ECM technology to avoid detection.
+  price: 49200
+  category: Medium
+  group: Security
+  shuttlePath: /Maps/Shuttles/prowler.yml
+
+- type: gameMap
+  id: Prowler
+  mapName: 'NT Prowler'
+  mapPath: /Maps/Shuttles/prowler.yml
+  minPlayers: 0
+  stations:
+    Prowler:
+      stationProto: StandardFrontierVessel
+      components:
+        - type: StationNameSetup
+          mapNameTemplate: '{0} Prowler {1}'
+          nameGenerator:
+            !type:NanotrasenNameGenerator
+            prefixCreator: '14'
+        - type: StationJobs
+          overflowJobs: []
+          availableJobs:
+            Detective: [ 0, 0 ]
+            SecurityOfficer: [ 0, 0 ]
+            SecurityCadet: [ 0, 0 ]


### PR DESCRIPTION
## About the PR
Introduces the Prowler. A medium-sized patrol craft, the prowler class is a dedicated deep space reconnaissance and enforcement vessel outfitted with ECM technology to avoid detection.

The Marauder's stealth coating, upon further investigation by the Office of the Admiralty, was initially highly effective but has unfortunately lost its capabilities after long term exposure to the high UV rays found in the Frontier sector. As a result, only the shape of the vessel assists with providing stealth through a reduced radar cross section, and so IFF returns are able to be mitigated for longer-range stealth to be much the same as it was before.


**Media**
![image](https://github.com/new-frontiers-14/frontier-station-14/assets/96151729/ed2d538e-4ee0-44bb-a69e-1adff820451f)


**Changelog**
:cl: Kesiath
- add: Added the Prowler! A new Stealth capable Medium ship for Security.
- remove: Removed the Stealth IFF Console from the Marauder.
- remove: Removed the Trident from the Security catalog.
- fix: Fixed the gun cabinets on the Marauder to manually have the correct items.