### PR TITLE
Vending max output 3 items for free

### DIFF
--- a/Content.Server/VendingMachines/VendingMachineSystem.cs
+++ b/Content.Server/VendingMachines/VendingMachineSystem.cs
@@ -415,17 +415,21 @@ namespace Content.Server.VendingMachines
 
             var item = _random.Pick(availableItems);
 
-            if (forceEject)
+            if (vendComponent.EjectRandomMax > vendComponent.EjectRandomCounter)
             {
-                vendComponent.NextItemToEject = item.ID;
-                vendComponent.ThrowNextItem = throwItem;
-                var entry = GetEntry(uid, item.ID, item.Type, vendComponent);
-                if (entry != null)
-                    entry.Amount--;
-                //EjectItem(uid, vendComponent, forceEject); // Stop vending machine from giving free items
+                if (forceEject)
+                {
+                    vendComponent.NextItemToEject = item.ID;
+                    vendComponent.ThrowNextItem = throwItem;
+                    var entry = GetEntry(uid, item.ID, item.Type, vendComponent);
+                    if (entry != null)
+                        entry.Amount--;
+                    EjectItem(uid, vendComponent, forceEject);
+                }
+                else
+                TryEjectVendorItem(uid, item.Type, item.ID, throwItem, 0, vendComponent);
+                vendComponent.EjectRandomCounter += 1;
             }
-            //else
-            //TryEjectVendorItem(uid, item.Type, item.ID, throwItem, 0, vendComponent); // Stop vending machine from giving free items
         }
 
         private void EjectItem(EntityUid uid, VendingMachineComponent? vendComponent = null, bool forceEject = false)

--- a/Content.Shared/VendingMachines/VendingMachineComponent.cs
+++ b/Content.Shared/VendingMachines/VendingMachineComponent.cs
@@ -32,6 +32,18 @@ namespace Content.Shared.VendingMachines
         [DataField("ejectDelay")]
         public float EjectDelay = 1.2f;
 
+        /// <summary>
+        /// Used by the server to determine how many items the machine allowed to eject from random triggers.
+        /// </summary>
+        [DataField("ejectRandomMax")]
+        public float EjectRandomMax = 3f;
+
+        /// <summary>
+        /// Used by the server to determine how many items the machine ejected from random triggers.
+        /// </summary>
+        [DataField("ejectRandomCounter")]
+        public float EjectRandomCounter = 0f;
+
         [ViewVariables]
         public Dictionary<string, VendingMachineInventoryEntry> Inventory = new();
 


### PR DESCRIPTION
## About the PR
Max amount of items you can get for free from vending machines is now 3.
EMP / Hiting it / Multitool, all add up to max 3 in total (Either by a mix of them or one of them, wont pass the 3 in total)
You can get less then 3 items if you spam the vend wire with a multi tool instead of waiting because of the way the eject code is (It will not eject before the animation didn't end but it will still count the random eject event and add +1)

Please consider merging the EMP update before to make it harder for sec to EMP all the vend machines on frontier at the same time.