### PR TITLE
Updated Praeda with: Cameras, Crew Monitors, Medical hardsuit, 'medic…

### DIFF
--- a/Resources/Maps/Shuttles/praeda.yml
+++ b/Resources/Maps/Shuttles/praeda.yml
@@ -35,7 +35,7 @@ entities:
           tiles: XAAAAVwAAANcAAABXAAAA1wAAAJfAAAAWwAAAVsAAAFfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFwAAAJcAAADXAAAAl8AAABcAAACXwAAAFsAAABfAAAAXwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABcAAACXAAAAVwAAANcAAADXAAAAVsAAAFbAAAAWwAAA18AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXAAAA1wAAAJcAAADXwAAAFwAAAFfAAAAWwAAA1sAAAFfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF8AAABfAAAAXwAAAF8AAABfAAAAXwAAAFsAAAJfAAAAXgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABFAAABRQAAAkUAAAFFAAAARQAAA18AAABfAAAAXwAAAF4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQAAAkUAAANFAAAARQAAAEUAAANfAAAARQAAAV8AAABeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEUAAANFAAABRQAAA0UAAABFAAAAXwAAAEUAAABfAAAAXgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABFAAABRQAAAEUAAAFFAAADRQAAAl8AAABfAAAAXwAAAF4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQAAA0UAAANFAAAARQAAAkUAAABFAAACRQAAAl8AAABeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEUAAAJFAAACRQAAAEUAAAJFAAACXwAAAEUAAABfAAAAXgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABFAAADRQAAA0UAAABFAAAARQAAAF8AAABFAAADXwAAAF4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQAAAEUAAABFAAABRQAAAkUAAAJfAAAARQAAAl8AAABeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEUAAABFAAAARQAAAEUAAABFAAABXwAAAEUAAAJfAAAAXgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABfAAAAXwAAAF8AAABfAAAARQAAAV8AAABfAAAAXwAAAF4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXAAAAVwAAAFcAAABXwAAAEUAAAFfAAAAXwAAAF8AAABfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
         0,-2:
           ind: 0,-2
-          tiles: DwAAAA8AAAAPAAAADwAAAEUAAAFFAAADRQAAAUUAAANfAAAAXwAAAF8AAABfAAAAXwAAAF4AAAAAAAAAAAAAAEUAAABfAAAARQAAAkUAAANFAAAAXwAAAEUAAABFAAACXwAAAF8AAABfAAAAXwAAAF8AAABeAAAAAAAAAAAAAABfAAAAXwAAAF8AAABfAAAAXwAAAF8AAABFAAAARQAAAV8AAABFAAAARQAAAF8AAABfAAAAXgAAAAAAAAAAAAAAXwAAAF8AAABfAAAAXwAAAF8AAABfAAAARQAAAEUAAAFfAAAAXwAAAF8AAABfAAAAXwAAAF4AAAAAAAAAAAAAADsAAABfAAAAXwAAAF8AAABfAAAAXwAAAEUAAABFAAABXwAAAEUAAANfAAAAXwAAAF4AAAAAAAAAAAAAAAAAAABfAAAAXwAAAF8AAABfAAAAXwAAAF8AAABfAAAAXwAAAF8AAABFAAABXwAAAF4AAAAAAAAAAAAAAAAAAAAAAAAAXwAAAF8AAABfAAAAXwAAAF8AAABfAAAARQAAAkUAAAFfAAAAXwAAAF4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF8AAABfAAAAXwAAAF8AAABFAAABXwAAAEUAAAFFAAADXwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABfAAAAXwAAAF8AAABfAAAAXwAAAF8AAABFAAADXwAAAF4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXwAAAF8AAABfAAAAXwAAAF8AAABfAAAAXwAAAF8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AAAAPAAAAXwAAAF8AAABeAAAAXwAAAF8AAABfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABfAAAAXwAAAF8AAABeAAAAXgAAAF8AAABFAAABXwAAAF4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXgAAAF4AAABeAAAAXgAAAF8AAABFAAADRQAAAV8AAABfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF8AAABfAAAAXwAAAF8AAABFAAADRQAAAUUAAANfAAAAXwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABcAAABXAAAA1wAAAFcAAADXwAAAF8AAABfAAAAXwAAAF8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXAAAAFwAAAA6AAAAXAAAAVwAAABfAAAAWwAAA1sAAAJfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          tiles: RQAAAF8AAABFAAAARQAAAEUAAAFFAAADRQAAAUUAAANfAAAAXwAAAF8AAABfAAAAXwAAAF4AAAAAAAAAAAAAAEUAAABfAAAARQAAAkUAAANFAAAAXwAAAEUAAABFAAACXwAAAF8AAABfAAAAXwAAAF8AAABeAAAAAAAAAAAAAABfAAAAXwAAAF8AAABfAAAAXwAAAF8AAABFAAAARQAAAV8AAABFAAAARQAAAF8AAABfAAAAXgAAAAAAAAAAAAAAXwAAAF8AAABfAAAAXwAAAF8AAABfAAAARQAAAEUAAAFfAAAAXwAAAF8AAABfAAAAXwAAAF4AAAAAAAAAAAAAADsAAABfAAAAXwAAAF8AAABfAAAAXwAAAEUAAABFAAABXwAAAEUAAANfAAAAXwAAAF4AAAAAAAAAAAAAAAAAAABfAAAAXwAAAF8AAABfAAAAXwAAAF8AAABfAAAAXwAAAF8AAABFAAABXwAAAF4AAAAAAAAAAAAAAAAAAAAAAAAAXwAAAF8AAABfAAAAXwAAAF8AAABfAAAARQAAAkUAAAFfAAAAXwAAAF4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF8AAABfAAAAXwAAAF8AAABFAAABXwAAAEUAAAFFAAADXwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABfAAAAXwAAAF8AAABfAAAAXwAAAF8AAABFAAADXwAAAF4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXwAAAF8AAABfAAAAXwAAAF8AAABfAAAAXwAAAF8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AAAAPAAAAXwAAAF8AAABeAAAAXwAAAF8AAABfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABfAAAAXwAAAF8AAABeAAAAXgAAAF8AAABFAAABXwAAAF4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXgAAAF4AAABeAAAAXgAAAF8AAABFAAADRQAAAV8AAABfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF8AAABfAAAAXwAAAF8AAABFAAADRQAAAUUAAANfAAAAXwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABcAAABXAAAA1wAAAFcAAADXwAAAF8AAABfAAAAXwAAAF8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXAAAAFwAAAA6AAAAXAAAAVwAAABfAAAAWwAAA1sAAAJfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
         0,-3:
           ind: 0,-3
           tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABeAAAAXgAAAF4AAABeAAAAXgAAAF4AAABeAAAAXgAAAF4AAABeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXwAAAF8AAABfAAAAXwAAAF8AAABfAAAAXwAAAF8AAABfAAAAXwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF8AAABfAAAARQAAAUUAAANFAAABRQAAAEUAAAJFAAAARQAAAV8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABFAAACXwAAAEUAAANFAAADRQAAA0UAAAFFAAADRQAAA18AAABfAAAAXwAAAF4AAAAAAAAAAAAAAAAAAAAAAAAAXwAAAF8AAABFAAAASgAAAEoAAAJKAAABRQAAAkUAAAJfAAAAXwAAAF8AAABfAAAAXgAAAF4AAAAAAAAAAAAAAA==
@@ -44,10 +44,10 @@ entities:
           tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABfAAAAVgAAAVYAAABfAAAAXAAAAVwAAAJcAAADXAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXwAAAF8AAABWAAAAXwAAAFwAAAJfAAAAXAAAA1wAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF8AAABSAAABUgAAAFsAAAJcAAABXAAAAVwAAAJcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABfAAAAUgAAAlIAAABfAAAAXAAAAFwAAABcAAABXAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXgAAAF8AAABSAAABXwAAAF8AAABfAAAAXwAAAF8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF4AAABfAAAAXwAAAF8AAABFAAABRQAAAUUAAAFFAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABeAAAAXwAAAF8AAABfAAAARQAAA0UAAANFAAABRQAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXgAAAF8AAABfAAAAXwAAAEUAAANFAAADRQAAA0UAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF4AAABfAAAAXwAAAF8AAABFAAAARQAAAkUAAABFAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABeAAAAXwAAAEUAAABFAAADRQAAAEUAAANFAAAARQAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXgAAAF8AAABFAAAAXwAAAEUAAANFAAADRQAAA0UAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF4AAABfAAAARQAAA18AAABFAAACRQAAA0UAAABFAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABeAAAAXwAAAEUAAANfAAAARQAAAUUAAAJFAAACRQAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXgAAAF8AAABFAAADXwAAAEUAAAJFAAAARQAAAUUAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF4AAABfAAAAXwAAAF8AAABFAAAAXwAAAF8AAABfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABfAAAARQAAAF8AAABfAAAARQAAAV8AAABcAAACXAAAAQ==
         -1,-2:
           ind: -1,-2
-          tiles: AAAAAAAAAAAAAAAAXgAAAF8AAABfAAAAXAAAAlwAAAEPAAAAXAAAAFwAAAAPAAAADwAAAA8AAAAPAAAADwAAAAAAAAAAAAAAAAAAAF4AAABfAAAAXwAAAF8AAABfAAAAXwAAAFwAAAFcAAAAXwAAAFwAAABfAAAARQAAAkUAAAMAAAAAAAAAAAAAAABeAAAAXwAAAF8AAABFAAAARQAAAF8AAABcAAADXAAAAV8AAABfAAAAXwAAAA8AAABfAAAAAAAAAAAAAAAAAAAAXgAAAF8AAABfAAAAXwAAAF8AAABfAAAAXAAAAlwAAABfAAAAXAAAA18AAABfAAAAXwAAAAAAAAAAAAAAAAAAAAAAAABeAAAAXwAAAF8AAABFAAAAXwAAAFwAAAFcAAADXwAAAFwAAAJfAAAAXwAAAF8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF4AAABfAAAARQAAAF8AAABfAAAAXwAAAF8AAABfAAAAXwAAAF8AAABfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXgAAAF8AAABfAAAARQAAA0UAAAJfAAAADwAAAFwAAAJcAAACXAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXwAAAEUAAAFFAAACXwAAAA8AAABcAAACXAAAAlwAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF4AAABfAAAARQAAAF8AAABfAAAAXwAAAF8AAABfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXwAAAF8AAABfAAAAXwAAAF8AAABfAAAAXwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF8AAABfAAAAXwAAAF4AAABfAAAAXwAAAA8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF4AAABfAAAARQAAAl8AAABeAAAAXgAAAF8AAABfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABeAAAAXwAAAEUAAABFAAADXwAAAF4AAABeAAAAXgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXwAAAF8AAABFAAACRQAAAkUAAAJfAAAAXwAAAF8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF8AAABfAAAAXwAAAF8AAABfAAAAXAAAAlwAAANcAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABfAAAAVgAAA1YAAAJfAAAAXAAAA1wAAAM6AAAAXAAAAA==
+          tiles: AAAAAAAAAAAAAAAAXgAAAF8AAABfAAAAXAAAAlwAAAFfAAAAXAAAAFwAAABfAAAAXAAAAF8AAABFAAAARQAAAAAAAAAAAAAAAAAAAF4AAABfAAAAXwAAAF8AAABfAAAAXwAAAFwAAAFcAAAAXwAAAFwAAABfAAAARQAAAkUAAAMAAAAAAAAAAAAAAABeAAAAXwAAAF8AAABFAAAARQAAAF8AAABcAAADXAAAAV8AAABfAAAAXwAAAA8AAABfAAAAAAAAAAAAAAAAAAAAXgAAAF8AAABfAAAAXwAAAF8AAABfAAAAXAAAAlwAAABfAAAAXAAAA18AAABfAAAAXwAAAAAAAAAAAAAAAAAAAAAAAABeAAAAXwAAAF8AAABFAAAAXwAAAFwAAAFcAAADXwAAAFwAAAJfAAAAXwAAAF8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF4AAABfAAAARQAAAF8AAABfAAAAXwAAAF8AAABfAAAAXwAAAF8AAABfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXgAAAF8AAABfAAAARQAAA0UAAAJfAAAADwAAAFwAAAJcAAACXAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXwAAAEUAAAFFAAACXwAAAA8AAABcAAACXAAAAlwAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF4AAABfAAAARQAAAF8AAABfAAAAXwAAAF8AAABfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXwAAAF8AAABfAAAAXwAAAF8AAABfAAAAXwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF8AAABfAAAAXwAAAF4AAABfAAAAXwAAAA8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF4AAABfAAAARQAAAl8AAABeAAAAXgAAAF8AAABfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABeAAAAXwAAAEUAAABFAAADXwAAAF4AAABeAAAAXgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXwAAAF8AAABFAAACRQAAAkUAAAJfAAAAXwAAAF8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF8AAABfAAAAXwAAAF8AAABfAAAAXAAAAlwAAANcAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABfAAAAVgAAA1YAAAJfAAAAXAAAA1wAAAM6AAAAXAAAAA==
         -1,-3:
           ind: -1,-3
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXgAAAF4AAABeAAAAXgAAAF4AAABeAAAAXgAAAF4AAABeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF8AAABfAAAAXwAAAF8AAABfAAAAXwAAAF8AAABfAAAAXwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABfAAAADwAAAEUAAANFAAAARQAAAkUAAAJFAAABRQAAAF8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF4AAABfAAAAXwAAAA8AAABFAAADRQAAAkUAAAJFAAADRQAAAUUAAAJfAAAAAAAAAAAAAAAAAAAAXgAAAF4AAAAPAAAADwAAAA8AAABfAAAAXwAAAF8AAABfAAAAXwAAAF8AAABfAAAAXwAAAA==
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXgAAAF4AAABeAAAAXgAAAF4AAABeAAAAXgAAAF4AAABeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF8AAABfAAAAXwAAAF8AAABfAAAAXwAAAF8AAABfAAAAXwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABfAAAADwAAAEUAAANFAAAARQAAAkUAAAJFAAABRQAAAF8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF4AAABfAAAAXwAAAA8AAABFAAADRQAAAkUAAAJFAAADRQAAAUUAAAJfAAAAAAAAAAAAAAAAAAAAXgAAAF4AAABfAAAAXAAAAF8AAABfAAAAXwAAAF8AAABfAAAAXwAAAF8AAABfAAAAXwAAAA==
       type: MapGrid
     - type: Broadphase
     - angularDamping: 0.05
@@ -657,12 +657,12 @@ entities:
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 1644
-      - 1660
+      - 1645
+      - 1661
       type: DeviceNetwork
     - devices:
-      - 1660
-      - 1644
+      - 1661
+      - 1645
       type: DeviceList
   - uid: 4
     components:
@@ -671,16 +671,16 @@ entities:
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 1343
-      - 1649
-      - 1663
-      - 1331
+      - 1344
+      - 1650
+      - 1664
+      - 1332
       type: DeviceNetwork
     - devices:
-      - 1343
-      - 1649
-      - 1663
-      - 1331
+      - 1344
+      - 1650
+      - 1664
+      - 1332
       type: DeviceList
   - uid: 5
     components:
@@ -689,22 +689,22 @@ entities:
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 1315
-      - 1326
-      - 1337
-      - 1324
-      - 1645
-      - 1665
-      - 1672
+      - 1316
+      - 1327
+      - 1338
+      - 1325
+      - 1646
+      - 1666
+      - 1673
       type: DeviceNetwork
     - devices:
-      - 1324
-      - 1337
-      - 1315
-      - 1326
-      - 1645
-      - 1665
-      - 1672
+      - 1325
+      - 1338
+      - 1316
+      - 1327
+      - 1646
+      - 1666
+      - 1673
       type: DeviceList
   - uid: 6
     components:
@@ -712,16 +712,16 @@ entities:
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 1651
-      - 1666
-      - 1316
-      - 1321
+      - 1652
+      - 1667
+      - 1317
+      - 1322
       type: DeviceNetwork
     - devices:
-      - 1321
-      - 1316
-      - 1666
-      - 1651
+      - 1322
+      - 1317
+      - 1667
+      - 1652
       type: DeviceList
   - uid: 7
     components:
@@ -730,26 +730,26 @@ entities:
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 1322
       - 1323
-      - 1316
-      - 1336
-      - 1650
-      - 1667
+      - 1324
       - 1317
-      - 1327
-      - 1335
+      - 1337
+      - 1651
+      - 1668
+      - 1318
+      - 1328
+      - 1336
       type: DeviceNetwork
     - devices:
-      - 1667
-      - 1650
-      - 1316
-      - 1323
-      - 1322
+      - 1668
+      - 1651
       - 1317
-      - 1335
+      - 1324
+      - 1323
+      - 1318
       - 1336
-      - 1327
+      - 1337
+      - 1328
       type: DeviceList
   - uid: 8
     components:
@@ -758,16 +758,16 @@ entities:
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 1330
-      - 1675
-      - 1648
-      - 1340
+      - 1331
+      - 1676
+      - 1649
+      - 1341
       type: DeviceNetwork
     - devices:
-      - 1675
-      - 1648
-      - 1330
-      - 1340
+      - 1676
+      - 1649
+      - 1331
+      - 1341
       type: DeviceList
   - uid: 9
     components:
@@ -776,18 +776,18 @@ entities:
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 1361
-      - 1329
-      - 1342
-      - 1670
-      - 1654
+      - 1362
+      - 1330
+      - 1343
+      - 1671
+      - 1655
       type: DeviceNetwork
     - devices:
-      - 1670
-      - 1342
-      - 1329
-      - 1361
-      - 1654
+      - 1671
+      - 1343
+      - 1330
+      - 1362
+      - 1655
       type: DeviceList
   - uid: 10
     components:
@@ -796,18 +796,18 @@ entities:
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 1671
-      - 1655
-      - 1339
-      - 1359
+      - 1672
+      - 1656
+      - 1340
       - 1360
+      - 1361
       type: DeviceNetwork
     - devices:
-      - 1671
-      - 1655
+      - 1672
+      - 1656
+      - 1361
       - 1360
-      - 1359
-      - 1339
+      - 1340
       type: DeviceList
   - uid: 11
     components:
@@ -815,36 +815,36 @@ entities:
       parent: 1
       type: Transform
     - ShutdownSubscribers:
+      - 1341
+      - 1344
       - 1340
-      - 1343
-      - 1339
-      - 1359
       - 1360
-      - 1320
-      - 1318
-      - 1342
-      - 1329
       - 1361
-      - 1653
-      - 1668
-      - 1657
+      - 1321
+      - 1319
+      - 1343
+      - 1330
+      - 1362
+      - 1654
       - 1669
+      - 1658
+      - 1670
       type: DeviceNetwork
     - devices:
-      - 1342
-      - 1329
-      - 1361
-      - 1668
-      - 1669
-      - 1653
-      - 1657
-      - 1339
-      - 1359
-      - 1360
-      - 1318
-      - 1320
-      - 1340
       - 1343
+      - 1330
+      - 1362
+      - 1669
+      - 1670
+      - 1654
+      - 1658
+      - 1340
+      - 1360
+      - 1361
+      - 1319
+      - 1321
+      - 1341
+      - 1344
       type: DeviceList
   - uid: 12
     components:
@@ -853,14 +853,14 @@ entities:
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 1658
       - 1659
-      - 1363
+      - 1660
+      - 1364
       type: DeviceNetwork
     - devices:
-      - 1658
       - 1659
-      - 1363
+      - 1660
+      - 1364
       type: DeviceList
   - uid: 13
     components:
@@ -869,44 +869,44 @@ entities:
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 1349
+      - 1350
+      - 1356
+      - 1348
       - 1355
       - 1347
-      - 1354
       - 1346
       - 1345
-      - 1344
+      - 1354
       - 1353
       - 1352
       - 1351
-      - 1350
-      - 1357
       - 1358
-      - 1348
-      - 1646
-      - 1661
-      - 1356
-      - 1363
+      - 1359
+      - 1349
+      - 1647
+      - 1662
+      - 1357
+      - 1364
       type: DeviceNetwork
     - devices:
-      - 1348
+      - 1349
+      - 1359
       - 1358
-      - 1357
-      - 1350
       - 1351
       - 1352
       - 1353
-      - 1344
+      - 1354
       - 1345
       - 1346
-      - 1354
       - 1347
-      - 1356
       - 1355
-      - 1349
-      - 1363
-      - 1646
-      - 1661
+      - 1348
+      - 1357
+      - 1356
+      - 1350
+      - 1364
+      - 1647
+      - 1662
       type: DeviceList
   - uid: 14
     components:
@@ -914,34 +914,34 @@ entities:
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 1662
-      - 1314
-      - 1647
-      - 1319
-      - 1325
+      - 1663
+      - 1315
+      - 1648
       - 1320
-      - 1318
+      - 1326
+      - 1321
+      - 1319
+      - 1350
+      - 1356
       - 1349
-      - 1355
-      - 1348
-      - 1358
-      - 1334
-      - 1328
+      - 1359
+      - 1335
+      - 1329
       type: DeviceNetwork
     - devices:
-      - 1318
-      - 1320
-      - 1325
       - 1319
-      - 1314
-      - 1334
-      - 1328
-      - 1358
-      - 1348
+      - 1321
+      - 1326
+      - 1320
+      - 1315
+      - 1335
+      - 1329
+      - 1359
       - 1349
-      - 1355
-      - 1647
-      - 1662
+      - 1350
+      - 1356
+      - 1648
+      - 1663
       type: DeviceList
   - uid: 15
     components:
@@ -950,16 +950,16 @@ entities:
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 1664
-      - 1341
-      - 1652
-      - 1338
+      - 1665
+      - 1342
+      - 1653
+      - 1339
       type: DeviceNetwork
     - devices:
-      - 1664
-      - 1341
-      - 1652
-      - 1338
+      - 1665
+      - 1342
+      - 1653
+      - 1339
       type: DeviceList
   - uid: 16
     components:
@@ -968,18 +968,18 @@ entities:
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 1677
-      - 1656
-      - 1338
-      - 1333
-      - 1324
+      - 1678
+      - 1657
+      - 1339
+      - 1334
+      - 1325
       type: DeviceNetwork
     - devices:
-      - 1677
-      - 1656
-      - 1324
-      - 1333
-      - 1338
+      - 1678
+      - 1657
+      - 1325
+      - 1334
+      - 1339
       type: DeviceList
 - proto: Airlock
   entities:
@@ -1784,7 +1784,7 @@ entities:
       type: Transform
 - proto: BaseBallBat
   entities:
-  - uid: 1796
+  - uid: 163
     components:
     - desc: A robust baseb-Medical Stick!
       name: medical stick
@@ -1794,90 +1794,90 @@ entities:
       type: Transform
 - proto: Bed
   entities:
-  - uid: 163
+  - uid: 164
     components:
     - pos: -0.5,-27.5
       parent: 1
       type: Transform
-  - uid: 164
+  - uid: 165
     components:
     - pos: 2.5,1.5
       parent: 1
       type: Transform
-  - uid: 165
+  - uid: 166
     components:
     - pos: 4.5,-25.5
       parent: 1
       type: Transform
-  - uid: 166
+  - uid: 167
     components:
     - pos: -9.5,-31.5
       parent: 1
       type: Transform
-  - uid: 167
+  - uid: 168
     components:
     - pos: -3.5,-31.5
       parent: 1
       type: Transform
-  - uid: 168
+  - uid: 169
     components:
     - pos: -3.5,-28.5
       parent: 1
       type: Transform
 - proto: BedsheetCaptain
   entities:
-  - uid: 169
+  - uid: 170
     components:
     - pos: 4.5,-25.5
       parent: 1
       type: Transform
 - proto: BedsheetCE
   entities:
-  - uid: 170
+  - uid: 171
     components:
     - pos: -0.5,-27.5
       parent: 1
       type: Transform
 - proto: BedsheetClown
   entities:
-  - uid: 171
+  - uid: 172
     components:
     - pos: -9.5,-31.5
       parent: 1
       type: Transform
-  - uid: 172
+  - uid: 173
     components:
     - pos: -3.5,-28.5
       parent: 1
       type: Transform
-  - uid: 173
+  - uid: 174
     components:
     - pos: -3.5,-31.5
       parent: 1
       type: Transform
 - proto: BedsheetMedical
   entities:
-  - uid: 174
+  - uid: 175
     components:
     - rot: 1.5707963267948966 rad
       pos: 7.5,-15.5
       parent: 1
       type: Transform
-  - uid: 175
+  - uid: 176
     components:
     - pos: -5.5,-16.5
       parent: 1
       type: Transform
 - proto: BedsheetQM
   entities:
-  - uid: 176
+  - uid: 177
     components:
     - pos: 2.5,1.5
       parent: 1
       type: Transform
 - proto: BlastDoor
   entities:
-  - uid: 177
+  - uid: 178
     components:
     - pos: 8.5,-35.5
       parent: 1
@@ -1885,7 +1885,7 @@ entities:
     - links:
       - 1952
       type: DeviceLinkSink
-  - uid: 178
+  - uid: 179
     components:
     - pos: 7.5,-35.5
       parent: 1
@@ -1893,7 +1893,7 @@ entities:
     - links:
       - 1952
       type: DeviceLinkSink
-  - uid: 179
+  - uid: 180
     components:
     - pos: 2.5,-35.5
       parent: 1
@@ -1901,7 +1901,7 @@ entities:
     - links:
       - 1953
       type: DeviceLinkSink
-  - uid: 180
+  - uid: 181
     components:
     - pos: 3.5,-35.5
       parent: 1
@@ -1909,7 +1909,7 @@ entities:
     - links:
       - 1953
       type: DeviceLinkSink
-  - uid: 181
+  - uid: 182
     components:
     - pos: 4.5,-35.5
       parent: 1
@@ -1917,7 +1917,7 @@ entities:
     - links:
       - 1953
       type: DeviceLinkSink
-  - uid: 182
+  - uid: 183
     components:
     - pos: -1.5,-35.5
       parent: 1
@@ -1925,7 +1925,7 @@ entities:
     - links:
       - 1956
       type: DeviceLinkSink
-  - uid: 183
+  - uid: 184
     components:
     - pos: -2.5,-35.5
       parent: 1
@@ -1933,7 +1933,7 @@ entities:
     - links:
       - 1956
       type: DeviceLinkSink
-  - uid: 184
+  - uid: 185
     components:
     - pos: -3.5,-35.5
       parent: 1
@@ -1941,7 +1941,7 @@ entities:
     - links:
       - 1956
       type: DeviceLinkSink
-  - uid: 185
+  - uid: 186
     components:
     - pos: -6.5,-35.5
       parent: 1
@@ -1949,7 +1949,7 @@ entities:
     - links:
       - 1955
       type: DeviceLinkSink
-  - uid: 186
+  - uid: 187
     components:
     - pos: -7.5,-35.5
       parent: 1
@@ -1957,7 +1957,7 @@ entities:
     - links:
       - 1955
       type: DeviceLinkSink
-  - uid: 187
+  - uid: 188
     components:
     - pos: -6.5,-2.5
       parent: 1
@@ -1966,7 +1966,7 @@ entities:
       - 1960
       - 1980
       type: DeviceLinkSink
-  - uid: 188
+  - uid: 189
     components:
     - pos: -6.5,-3.5
       parent: 1
@@ -1975,7 +1975,7 @@ entities:
       - 1960
       - 1980
       type: DeviceLinkSink
-  - uid: 189
+  - uid: 190
     components:
     - pos: -6.5,-4.5
       parent: 1
@@ -1984,7 +1984,7 @@ entities:
       - 1960
       - 1980
       type: DeviceLinkSink
-  - uid: 190
+  - uid: 191
     components:
     - pos: -6.5,-5.5
       parent: 1
@@ -1993,7 +1993,7 @@ entities:
       - 1960
       - 1980
       type: DeviceLinkSink
-  - uid: 191
+  - uid: 192
     components:
     - pos: -6.5,-6.5
       parent: 1
@@ -2003,7 +2003,7 @@ entities:
       - 1960
       - 1980
       type: DeviceLinkSink
-  - uid: 192
+  - uid: 193
     components:
     - pos: 7.5,-6.5
       parent: 1
@@ -2013,7 +2013,7 @@ entities:
       - 1961
       - 1979
       type: DeviceLinkSink
-  - uid: 193
+  - uid: 194
     components:
     - pos: 7.5,-5.5
       parent: 1
@@ -2023,7 +2023,7 @@ entities:
       - 1961
       - 1979
       type: DeviceLinkSink
-  - uid: 194
+  - uid: 195
     components:
     - pos: 7.5,-4.5
       parent: 1
@@ -2033,7 +2033,7 @@ entities:
       - 1961
       - 1979
       type: DeviceLinkSink
-  - uid: 195
+  - uid: 196
     components:
     - pos: 7.5,-3.5
       parent: 1
@@ -2043,7 +2043,7 @@ entities:
       - 1961
       - 1979
       type: DeviceLinkSink
-  - uid: 196
+  - uid: 197
     components:
     - pos: 7.5,-2.5
       parent: 1
@@ -2053,7 +2053,7 @@ entities:
       - 1961
       - 1979
       type: DeviceLinkSink
-  - uid: 197
+  - uid: 198
     components:
     - pos: 6.5,-0.5
       parent: 1
@@ -2061,7 +2061,7 @@ entities:
     - links:
       - 1975
       type: DeviceLinkSink
-  - uid: 198
+  - uid: 199
     components:
     - pos: 8.5,0.5
       parent: 1
@@ -2070,7 +2070,7 @@ entities:
       - 1977
       - 1978
       type: DeviceLinkSink
-  - uid: 199
+  - uid: 200
     components:
     - pos: 8.5,-0.5
       parent: 1
@@ -2081,7 +2081,7 @@ entities:
       type: DeviceLinkSink
 - proto: BlastDoorOpen
   entities:
-  - uid: 200
+  - uid: 201
     components:
     - pos: 5.5,1.5
       parent: 1
@@ -2090,7 +2090,7 @@ entities:
       - 1948
       - 1981
       type: DeviceLinkSink
-  - uid: 201
+  - uid: 202
     components:
     - pos: 4.5,1.5
       parent: 1
@@ -2099,7 +2099,7 @@ entities:
       - 1981
       - 1948
       type: DeviceLinkSink
-  - uid: 202
+  - uid: 203
     components:
     - pos: -3.5,1.5
       parent: 1
@@ -2108,7 +2108,7 @@ entities:
       - 1981
       - 1948
       type: DeviceLinkSink
-  - uid: 203
+  - uid: 204
     components:
     - pos: -4.5,1.5
       parent: 1
@@ -2117,7 +2117,7 @@ entities:
       - 1948
       - 1981
       type: DeviceLinkSink
-  - uid: 204
+  - uid: 205
     components:
     - pos: 5.5,-23.5
       parent: 1
@@ -2126,7 +2126,7 @@ entities:
       - 1949
       - 1963
       type: DeviceLinkSink
-  - uid: 205
+  - uid: 206
     components:
     - pos: -4.5,-23.5
       parent: 1
@@ -2135,7 +2135,7 @@ entities:
       - 1949
       - 1963
       type: DeviceLinkSink
-  - uid: 206
+  - uid: 207
     components:
     - pos: 1.5,-31.5
       parent: 1
@@ -2145,14 +2145,14 @@ entities:
       type: DeviceLinkSink
 - proto: BookBartendersManual
   entities:
-  - uid: 207
+  - uid: 208
     components:
     - pos: 0.9112099,-14.4889145
       parent: 1
       type: Transform
 - proto: BoozeDispenser
   entities:
-  - uid: 208
+  - uid: 209
     components:
     - pos: -0.5,-12.5
       parent: 1
@@ -2170,11 +2170,11 @@ entities:
     - type: InsideEntityStorage
 - proto: BoxEncryptionKeyEngineering
   entities:
-  - uid: 210
+  - uid: 211
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 209
+    - parent: 210
       type: Transform
     - canCollide: False
       type: Physics
@@ -2192,2304 +2192,2301 @@ entities:
     - type: InsideEntityStorage
 - proto: BoxShotgunIncendiary
   entities:
-  - uid: 217
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 216
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
   - uid: 218
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 216
+    - parent: 217
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 219
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 217
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: Bucket
   entities:
-  - uid: 247
+  - uid: 248
     components:
     - pos: -5.7941527,-8.632696
       parent: 1
       type: Transform
 - proto: CableApcExtension
   entities:
-  - uid: 248
+  - uid: 249
     components:
     - pos: 3.5,1.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 249
+  - uid: 250
     components:
     - pos: 2.5,1.5
       parent: 1
       type: Transform
-  - uid: 250
+  - uid: 251
     components:
     - pos: 12.5,-30.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 251
+  - uid: 252
     components:
     - pos: 12.5,-31.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 252
+  - uid: 253
     components:
     - pos: 12.5,-29.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 253
+  - uid: 254
     components:
     - pos: 9.5,-28.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 254
+  - uid: 255
     components:
     - pos: 11.5,-29.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 255
+  - uid: 256
     components:
     - pos: 6.5,-4.5
       parent: 1
       type: Transform
-  - uid: 256
+  - uid: 257
     components:
     - pos: 11.5,-27.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 257
+  - uid: 258
     components:
     - pos: 8.5,-30.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 258
+  - uid: 259
     components:
     - pos: 7.5,-30.5
       parent: 1
       type: Transform
-  - uid: 259
+  - uid: 260
     components:
     - pos: 7.5,-31.5
       parent: 1
       type: Transform
-  - uid: 260
+  - uid: 261
     components:
     - pos: 7.5,-32.5
       parent: 1
       type: Transform
-  - uid: 261
+  - uid: 262
     components:
     - pos: 7.5,-33.5
       parent: 1
       type: Transform
-  - uid: 262
+  - uid: 263
     components:
     - pos: 7.5,-34.5
       parent: 1
       type: Transform
-  - uid: 263
+  - uid: 264
     components:
     - pos: 8.5,-34.5
       parent: 1
       type: Transform
-  - uid: 264
+  - uid: 265
     components:
     - pos: 6.5,-34.5
       parent: 1
       type: Transform
-  - uid: 265
+  - uid: 266
     components:
     - pos: 5.5,-34.5
       parent: 1
       type: Transform
-  - uid: 266
+  - uid: 267
     components:
     - pos: 4.5,-34.5
       parent: 1
       type: Transform
-  - uid: 267
+  - uid: 268
     components:
     - pos: 3.5,-34.5
       parent: 1
       type: Transform
-  - uid: 268
+  - uid: 269
     components:
     - pos: 2.5,-34.5
       parent: 1
       type: Transform
-  - uid: 269
+  - uid: 270
     components:
     - pos: 2.5,-33.5
       parent: 1
       type: Transform
-  - uid: 270
+  - uid: 271
     components:
     - pos: 2.5,-32.5
       parent: 1
       type: Transform
-  - uid: 271
+  - uid: 272
     components:
     - pos: 2.5,-31.5
       parent: 1
       type: Transform
-  - uid: 272
+  - uid: 273
     components:
     - pos: 1.5,-31.5
       parent: 1
       type: Transform
-  - uid: 273
+    - enabled: True
+      type: AmbientSound
+  - uid: 274
     components:
     - pos: 0.5,-31.5
       parent: 1
       type: Transform
-  - uid: 274
+  - uid: 275
     components:
     - pos: -0.5,-31.5
       parent: 1
       type: Transform
-  - uid: 275
+  - uid: 276
     components:
     - pos: -0.5,-30.5
       parent: 1
       type: Transform
-  - uid: 276
-    components:
-    - pos: -0.5,-29.5
-      parent: 1
-      type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 277
     components:
-    - pos: -0.5,-28.5
+    - pos: -0.5,-29.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
   - uid: 278
     components:
-    - pos: 1.5,-33.5
+    - pos: -0.5,-28.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
   - uid: 279
     components:
+    - pos: 1.5,-33.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 280
+    components:
     - pos: 0.5,-33.5
       parent: 1
       type: Transform
-  - uid: 280
+  - uid: 281
     components:
     - pos: -0.5,-33.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 281
+  - uid: 282
     components:
     - pos: -2.5,-24.5
       parent: 1
       type: Transform
-  - uid: 282
+  - uid: 283
     components:
     - pos: -1.5,-34.5
       parent: 1
       type: Transform
-  - uid: 283
+  - uid: 284
     components:
     - pos: -2.5,-34.5
       parent: 1
       type: Transform
-  - uid: 284
+  - uid: 285
     components:
     - pos: -3.5,-34.5
       parent: 1
       type: Transform
-  - uid: 285
+  - uid: 286
     components:
     - pos: -3.5,-33.5
       parent: 1
       type: Transform
-  - uid: 286
+  - uid: 287
     components:
     - pos: -4.5,-33.5
       parent: 1
       type: Transform
-  - uid: 287
+  - uid: 288
     components:
     - pos: -5.5,-33.5
       parent: 1
       type: Transform
-  - uid: 288
+  - uid: 289
     components:
     - pos: -5.5,-34.5
       parent: 1
       type: Transform
-  - uid: 289
+  - uid: 290
     components:
     - pos: -6.5,-34.5
       parent: 1
       type: Transform
-  - uid: 290
+  - uid: 291
     components:
     - pos: -7.5,-34.5
       parent: 1
       type: Transform
-  - uid: 291
+  - uid: 292
     components:
     - pos: -5.5,-32.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 292
+  - uid: 293
     components:
     - pos: -5.5,-31.5
       parent: 1
       type: Transform
-  - uid: 293
+  - uid: 294
     components:
     - pos: -5.5,-30.5
       parent: 1
       type: Transform
-  - uid: 294
+  - uid: 295
     components:
     - pos: -4.5,-30.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 295
+  - uid: 296
     components:
     - pos: -5.5,-29.5
       parent: 1
       type: Transform
-  - uid: 296
+  - uid: 297
     components:
     - pos: -6.5,-29.5
       parent: 1
       type: Transform
-  - uid: 297
+  - uid: 298
     components:
     - pos: -7.5,-29.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 298
+  - uid: 299
     components:
     - pos: -8.5,-29.5
       parent: 1
       type: Transform
-  - uid: 299
+  - uid: 300
     components:
     - pos: -9.5,-29.5
       parent: 1
       type: Transform
-  - uid: 300
+  - uid: 301
     components:
     - pos: -10.5,-29.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 301
+  - uid: 302
     components:
     - pos: -11.5,-29.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 302
+  - uid: 303
     components:
     - pos: -11.5,-30.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 303
+  - uid: 304
     components:
     - pos: -11.5,-31.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 304
+  - uid: 305
     components:
     - pos: -3.5,-24.5
       parent: 1
       type: Transform
-  - uid: 305
+  - uid: 306
     components:
     - pos: 6.5,-30.5
       parent: 1
       type: Transform
-  - uid: 306
+  - uid: 307
     components:
     - pos: 6.5,-29.5
       parent: 1
       type: Transform
-  - uid: 307
+  - uid: 308
     components:
     - pos: 6.5,-28.5
       parent: 1
       type: Transform
-  - uid: 308
+  - uid: 309
     components:
     - pos: 6.5,-27.5
       parent: 1
       type: Transform
-  - uid: 309
+  - uid: 310
     components:
     - pos: 7.5,-27.5
       parent: 1
       type: Transform
-  - uid: 310
+  - uid: 311
     components:
     - pos: 8.5,-27.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 311
+  - uid: 312
     components:
     - pos: 9.5,-27.5
       parent: 1
       type: Transform
-  - uid: 312
+  - uid: 313
     components:
     - pos: 10.5,-27.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 313
+  - uid: 314
     components:
     - pos: 6.5,-26.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 314
+  - uid: 315
     components:
     - pos: 6.5,-25.5
       parent: 1
       type: Transform
-  - uid: 315
+  - uid: 316
     components:
     - pos: 6.5,-24.5
       parent: 1
       type: Transform
-  - uid: 316
+  - uid: 317
     components:
     - pos: 6.5,-23.5
       parent: 1
       type: Transform
-  - uid: 317
-    components:
-    - pos: 5.5,-23.5
-      parent: 1
-      type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 318
     components:
-    - pos: 4.5,-23.5
+    - pos: 5.5,-23.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
   - uid: 319
     components:
+    - pos: 4.5,-23.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 320
+    components:
     - pos: 4.5,-24.5
       parent: 1
       type: Transform
-  - uid: 320
+  - uid: 321
     components:
     - pos: 3.5,-24.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 321
+  - uid: 322
     components:
     - pos: 2.5,-24.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 322
+  - uid: 323
     components:
     - pos: 1.5,-24.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 323
+  - uid: 324
     components:
     - pos: 0.5,-24.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 324
+  - uid: 325
     components:
     - pos: -0.5,-24.5
       parent: 1
       type: Transform
-  - uid: 325
+  - uid: 326
     components:
     - pos: -1.5,-24.5
       parent: 1
       type: Transform
-  - uid: 326
+  - uid: 327
     components:
     - pos: -3.5,-23.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 327
+  - uid: 328
     components:
     - pos: -4.5,-23.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 328
+  - uid: 329
     components:
     - pos: -1.5,-23.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 329
+  - uid: 330
     components:
     - pos: -1.5,-22.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 330
+  - uid: 331
     components:
     - pos: -1.5,-21.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 331
+  - uid: 332
     components:
     - pos: 4.5,-15.5
       parent: 1
       type: Transform
-  - uid: 332
+  - uid: 333
     components:
     - pos: -3.5,-3.5
       parent: 1
       type: Transform
-  - uid: 333
+  - uid: 334
     components:
     - pos: -2.5,-21.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 334
-    components:
-    - pos: -0.5,-22.5
-      parent: 1
-      type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 335
     components:
-    - pos: 0.5,-22.5
+    - pos: -0.5,-22.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
   - uid: 336
     components:
-    - pos: 1.5,-22.5
+    - pos: 0.5,-22.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
   - uid: 337
     components:
-    - pos: 2.5,-22.5
+    - pos: 1.5,-22.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
   - uid: 338
     components:
-    - pos: 2.5,-23.5
+    - pos: 2.5,-22.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
   - uid: 339
     components:
-    - pos: -5.5,-23.5
+    - pos: 2.5,-23.5
       parent: 1
       type: Transform
+    - enabled: True
+      type: AmbientSound
   - uid: 340
     components:
-    - pos: -5.5,-24.5
+    - pos: -5.5,-23.5
       parent: 1
       type: Transform
   - uid: 341
     components:
-    - pos: -5.5,-25.5
+    - pos: -5.5,-24.5
       parent: 1
       type: Transform
   - uid: 342
+    components:
+    - pos: -5.5,-25.5
+      parent: 1
+      type: Transform
+  - uid: 343
     components:
     - pos: -5.5,-26.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 343
+  - uid: 344
     components:
     - pos: -5.5,-27.5
       parent: 1
       type: Transform
-  - uid: 344
+  - uid: 345
     components:
     - pos: -5.5,-28.5
       parent: 1
       type: Transform
-  - uid: 345
-    components:
-    - pos: -5.5,-22.5
-      parent: 1
-      type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 346
     components:
-    - pos: -5.5,-21.5
+    - pos: -5.5,-22.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
   - uid: 347
     components:
-    - pos: -5.5,-20.5
+    - pos: -5.5,-21.5
       parent: 1
       type: Transform
+    - enabled: True
+      type: AmbientSound
   - uid: 348
     components:
-    - pos: -5.5,-19.5
+    - pos: -5.5,-20.5
       parent: 1
       type: Transform
   - uid: 349
     components:
-    - pos: -5.5,-18.5
+    - pos: -5.5,-19.5
       parent: 1
       type: Transform
   - uid: 350
     components:
-    - pos: -4.5,-18.5
+    - pos: -5.5,-18.5
       parent: 1
       type: Transform
   - uid: 351
     components:
-    - pos: -3.5,-18.5
+    - pos: -4.5,-18.5
       parent: 1
       type: Transform
   - uid: 352
+    components:
+    - pos: -3.5,-18.5
+      parent: 1
+      type: Transform
+  - uid: 353
     components:
     - pos: -3.5,-17.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 353
+  - uid: 354
     components:
     - pos: -3.5,-16.5
       parent: 1
       type: Transform
-  - uid: 354
-    components:
-    - pos: 6.5,-22.5
-      parent: 1
-      type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 355
     components:
-    - pos: 6.5,-21.5
+    - pos: 6.5,-22.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
   - uid: 356
     components:
-    - pos: 6.5,-20.5
+    - pos: 6.5,-21.5
       parent: 1
       type: Transform
+    - enabled: True
+      type: AmbientSound
   - uid: 357
     components:
-    - pos: 6.5,-19.5
+    - pos: 6.5,-20.5
       parent: 1
       type: Transform
   - uid: 358
     components:
-    - pos: 6.5,-18.5
+    - pos: 6.5,-19.5
       parent: 1
       type: Transform
   - uid: 359
     components:
-    - pos: 5.5,-18.5
+    - pos: 6.5,-18.5
       parent: 1
       type: Transform
   - uid: 360
     components:
-    - pos: 4.5,-18.5
+    - pos: 5.5,-18.5
       parent: 1
       type: Transform
   - uid: 361
+    components:
+    - pos: 4.5,-18.5
+      parent: 1
+      type: Transform
+  - uid: 362
     components:
     - pos: 4.5,-17.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 362
+  - uid: 363
     components:
     - pos: 4.5,-16.5
       parent: 1
       type: Transform
-  - uid: 363
+  - uid: 364
     components:
     - pos: 3.5,-15.5
       parent: 1
       type: Transform
-  - uid: 364
+  - uid: 365
     components:
     - pos: 2.5,-15.5
       parent: 1
       type: Transform
-  - uid: 365
+  - uid: 366
     components:
     - pos: 1.5,-15.5
       parent: 1
       type: Transform
-  - uid: 366
+  - uid: 367
     components:
     - pos: 0.5,-15.5
       parent: 1
       type: Transform
-  - uid: 367
+  - uid: 368
     components:
     - pos: -0.5,-15.5
       parent: 1
       type: Transform
-  - uid: 368
+  - uid: 369
     components:
     - pos: -1.5,-15.5
       parent: 1
       type: Transform
-  - uid: 369
+  - uid: 370
     components:
     - pos: -2.5,-15.5
       parent: 1
       type: Transform
-  - uid: 370
+  - uid: 371
     components:
     - pos: -3.5,-15.5
       parent: 1
       type: Transform
-  - uid: 371
+  - uid: 372
     components:
     - pos: 0.5,-16.5
       parent: 1
       type: Transform
-  - uid: 372
+  - uid: 373
     components:
     - pos: 0.5,-14.5
       parent: 1
       type: Transform
-  - uid: 373
+  - uid: 374
     components:
     - pos: 0.5,-13.5
       parent: 1
       type: Transform
-  - uid: 374
+  - uid: 375
     components:
     - pos: 0.5,-12.5
       parent: 1
       type: Transform
-  - uid: 375
+  - uid: 376
     components:
     - pos: 0.5,-11.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 376
+  - uid: 377
     components:
     - pos: -5.5,-10.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 377
+  - uid: 378
     components:
     - pos: -5.5,-11.5
       parent: 1
       type: Transform
-  - uid: 378
+  - uid: 379
     components:
     - pos: -5.5,-12.5
       parent: 1
       type: Transform
-  - uid: 379
+  - uid: 380
     components:
     - pos: -5.5,-13.5
       parent: 1
       type: Transform
-  - uid: 380
+  - uid: 381
     components:
     - pos: -5.5,-14.5
       parent: 1
       type: Transform
-  - uid: 381
+  - uid: 382
     components:
     - pos: -5.5,-15.5
       parent: 1
       type: Transform
-  - uid: 382
+  - uid: 383
     components:
     - pos: 6.5,-10.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 383
+  - uid: 384
     components:
     - pos: 6.5,-11.5
       parent: 1
       type: Transform
-  - uid: 384
+  - uid: 385
     components:
     - pos: 6.5,-12.5
       parent: 1
       type: Transform
-  - uid: 385
+  - uid: 386
     components:
     - pos: 6.5,-13.5
       parent: 1
       type: Transform
-  - uid: 386
+  - uid: 387
     components:
     - pos: 6.5,-14.5
       parent: 1
       type: Transform
-  - uid: 387
+  - uid: 388
     components:
     - pos: 6.5,-15.5
       parent: 1
       type: Transform
-  - uid: 388
+  - uid: 389
     components:
     - pos: -5.5,-1.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 389
+  - uid: 390
     components:
     - pos: -5.5,-2.5
       parent: 1
       type: Transform
-  - uid: 390
+  - uid: 391
     components:
     - pos: -5.5,-3.5
       parent: 1
       type: Transform
-  - uid: 391
+  - uid: 392
     components:
     - pos: -4.5,-3.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 392
+  - uid: 393
     components:
     - pos: -3.5,-4.5
       parent: 1
       type: Transform
-  - uid: 393
+  - uid: 394
     components:
     - pos: -5.5,-4.5
       parent: 1
       type: Transform
-  - uid: 394
+  - uid: 395
     components:
     - pos: -5.5,-5.5
       parent: 1
       type: Transform
-  - uid: 395
+  - uid: 396
     components:
     - pos: -5.5,-6.5
       parent: 1
       type: Transform
-  - uid: 396
+  - uid: 397
     components:
     - pos: -3.5,-5.5
       parent: 1
       type: Transform
-  - uid: 397
+  - uid: 398
     components:
     - pos: -3.5,-6.5
       parent: 1
       type: Transform
-  - uid: 398
+  - uid: 399
     components:
     - pos: -3.5,-7.5
       parent: 1
       type: Transform
-  - uid: 399
+  - uid: 400
     components:
     - pos: -3.5,-8.5
       parent: 1
       type: Transform
-  - uid: 400
+  - uid: 401
     components:
     - pos: -3.5,-9.5
       parent: 1
       type: Transform
-  - uid: 401
+  - uid: 402
     components:
     - pos: -3.5,-10.5
       parent: 1
       type: Transform
-  - uid: 402
+  - uid: 403
     components:
     - pos: -3.5,-11.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 403
+  - uid: 404
     components:
     - pos: -3.5,0.5
       parent: 1
       type: Transform
-  - uid: 404
+  - uid: 405
     components:
     - pos: 4.5,0.5
       parent: 1
       type: Transform
-  - uid: 405
+  - uid: 406
     components:
     - pos: -2.5,-9.5
       parent: 1
       type: Transform
-  - uid: 406
+  - uid: 407
     components:
     - pos: -1.5,-9.5
       parent: 1
       type: Transform
-  - uid: 407
+  - uid: 408
     components:
     - pos: -0.5,-9.5
       parent: 1
       type: Transform
-  - uid: 408
+  - uid: 409
     components:
     - pos: 0.5,-9.5
       parent: 1
       type: Transform
-  - uid: 409
+  - uid: 410
     components:
     - pos: 1.5,-9.5
       parent: 1
       type: Transform
-  - uid: 410
+  - uid: 411
     components:
     - pos: 2.5,-9.5
       parent: 1
       type: Transform
-  - uid: 411
+  - uid: 412
     components:
     - pos: 3.5,-9.5
       parent: 1
       type: Transform
-  - uid: 412
+  - uid: 413
     components:
     - pos: 4.5,-9.5
       parent: 1
       type: Transform
-  - uid: 413
+  - uid: 414
     components:
     - pos: 4.5,-10.5
       parent: 1
       type: Transform
-  - uid: 414
+  - uid: 415
     components:
     - pos: 4.5,-11.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 415
+  - uid: 416
     components:
     - pos: 0.5,-8.5
       parent: 1
       type: Transform
-  - uid: 416
+  - uid: 417
     components:
     - pos: 0.5,-7.5
       parent: 1
       type: Transform
-  - uid: 417
+  - uid: 418
     components:
     - pos: 0.5,-6.5
       parent: 1
       type: Transform
-  - uid: 418
+  - uid: 419
     components:
     - pos: 0.5,-5.5
       parent: 1
       type: Transform
-  - uid: 419
+  - uid: 420
     components:
     - pos: 0.5,-4.5
       parent: 1
       type: Transform
-  - uid: 420
+  - uid: 421
     components:
     - pos: 0.5,-3.5
       parent: 1
       type: Transform
-  - uid: 421
+  - uid: 422
     components:
     - pos: 4.5,-8.5
       parent: 1
       type: Transform
-  - uid: 422
+  - uid: 423
     components:
     - pos: 4.5,-7.5
       parent: 1
       type: Transform
-  - uid: 423
+  - uid: 424
     components:
     - pos: 4.5,-6.5
       parent: 1
       type: Transform
-  - uid: 424
+  - uid: 425
     components:
     - pos: 4.5,-5.5
       parent: 1
       type: Transform
-  - uid: 425
+  - uid: 426
     components:
     - pos: 4.5,-4.5
       parent: 1
       type: Transform
-  - uid: 426
+  - uid: 427
     components:
     - pos: 4.5,-3.5
       parent: 1
       type: Transform
-  - uid: 427
+  - uid: 428
     components:
     - pos: 0.5,-0.5
       parent: 1
       type: Transform
-  - uid: 428
+  - uid: 429
     components:
     - pos: 0.5,0.5
       parent: 1
       type: Transform
-  - uid: 429
+  - uid: 430
     components:
     - pos: 0.5,1.5
       parent: 1
       type: Transform
-  - uid: 430
+  - uid: 431
     components:
     - pos: -3.5,-2.5
       parent: 1
       type: Transform
-  - uid: 431
+  - uid: 432
     components:
     - pos: -3.5,-1.5
       parent: 1
       type: Transform
-  - uid: 432
+  - uid: 433
     components:
     - pos: -3.5,-0.5
       parent: 1
       type: Transform
-  - uid: 433
+  - uid: 434
     components:
     - pos: -3.5,1.5
       parent: 1
       type: Transform
-  - uid: 434
+  - uid: 435
     components:
     - pos: -3.5,2.5
       parent: 1
       type: Transform
-  - uid: 435
+  - uid: 436
     components:
     - pos: -1.5,1.5
       parent: 1
       type: Transform
-  - uid: 436
+  - uid: 437
     components:
     - pos: -0.5,1.5
       parent: 1
       type: Transform
-  - uid: 437
+  - uid: 438
     components:
     - pos: -3.5,3.5
       parent: 1
       type: Transform
-  - uid: 438
+  - uid: 439
     components:
     - pos: -2.5,3.5
       parent: 1
       type: Transform
-  - uid: 439
+  - uid: 440
     components:
     - pos: -0.5,4.5
       parent: 1
       type: Transform
-  - uid: 440
+  - uid: 441
     components:
     - pos: -0.5,5.5
       parent: 1
       type: Transform
-  - uid: 441
+  - uid: 442
     components:
     - pos: -0.5,6.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 442
+  - uid: 443
     components:
     - pos: -0.5,7.5
       parent: 1
       type: Transform
-  - uid: 443
-    components:
-    - pos: -1.5,7.5
-      parent: 1
-      type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 444
     components:
-    - pos: -2.5,7.5
+    - pos: -1.5,7.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
   - uid: 445
     components:
+    - pos: -2.5,7.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 446
+    components:
     - pos: -3.5,7.5
       parent: 1
       type: Transform
-  - uid: 446
+  - uid: 447
     components:
     - pos: -3.5,8.5
       parent: 1
       type: Transform
-  - uid: 447
+  - uid: 448
     components:
     - pos: -3.5,9.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 448
+  - uid: 449
     components:
     - pos: -4.5,7.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 449
+  - uid: 450
     components:
     - pos: -5.5,7.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 450
+  - uid: 451
     components:
     - pos: -5.5,8.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 451
+  - uid: 452
     components:
     - pos: -5.5,6.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 452
+  - uid: 453
     components:
     - pos: -1.5,8.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 453
+  - uid: 454
     components:
     - pos: -1.5,9.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 454
+  - uid: 455
     components:
     - pos: 4.5,-2.5
       parent: 1
       type: Transform
-  - uid: 455
+  - uid: 456
     components:
     - pos: 4.5,-1.5
       parent: 1
       type: Transform
-  - uid: 456
+  - uid: 457
     components:
     - pos: 4.5,-0.5
       parent: 1
       type: Transform
-  - uid: 457
+  - uid: 458
     components:
     - pos: 4.5,1.5
       parent: 1
       type: Transform
-  - uid: 458
+  - uid: 459
     components:
     - pos: 4.5,2.5
       parent: 1
       type: Transform
-  - uid: 459
+  - uid: 460
     components:
     - pos: 4.5,3.5
       parent: 1
       type: Transform
-  - uid: 460
+  - uid: 461
     components:
     - pos: 3.5,3.5
       parent: 1
       type: Transform
-  - uid: 461
+  - uid: 462
     components:
     - pos: 2.5,4.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 462
+  - uid: 463
     components:
     - pos: 1.5,4.5
       parent: 1
       type: Transform
-  - uid: 463
+  - uid: 464
     components:
     - pos: 1.5,5.5
       parent: 1
       type: Transform
-  - uid: 464
+  - uid: 465
     components:
     - pos: 1.5,6.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 465
+  - uid: 466
     components:
     - pos: 1.5,7.5
       parent: 1
       type: Transform
-  - uid: 466
-    components:
-    - pos: 2.5,7.5
-      parent: 1
-      type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 467
     components:
-    - pos: 2.5,8.5
+    - pos: 2.5,7.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
   - uid: 468
     components:
-    - pos: 2.5,9.5
+    - pos: 2.5,8.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
   - uid: 469
     components:
-    - pos: 3.5,7.5
+    - pos: 2.5,9.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
   - uid: 470
     components:
+    - pos: 3.5,7.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 471
+    components:
     - pos: 4.5,7.5
       parent: 1
       type: Transform
-  - uid: 471
+  - uid: 472
     components:
     - pos: 4.5,8.5
       parent: 1
       type: Transform
-  - uid: 472
+  - uid: 473
     components:
     - pos: 4.5,9.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 473
+  - uid: 474
     components:
     - pos: 5.5,7.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 474
+  - uid: 475
     components:
     - pos: 6.5,7.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 475
+  - uid: 476
     components:
     - pos: 6.5,8.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 476
+  - uid: 477
     components:
     - pos: 6.5,6.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 477
+  - uid: 478
     components:
     - pos: -4.5,-27.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 478
+  - uid: 479
     components:
     - pos: -2.5,4.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 479
+  - uid: 480
     components:
     - pos: -1.5,4.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 480
+  - uid: 481
     components:
     - pos: 3.5,4.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 481
+  - uid: 482
     components:
     - pos: 9.5,-29.5
       parent: 1
       type: Transform
-  - uid: 482
+  - uid: 483
     components:
     - pos: 10.5,-29.5
       parent: 1
       type: Transform
-  - uid: 483
+  - uid: 484
     components:
     - pos: 6.5,-3.5
       parent: 1
       type: Transform
-  - uid: 484
+  - uid: 485
     components:
     - pos: 5.5,-3.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 485
+  - uid: 486
     components:
     - pos: 6.5,-5.5
       parent: 1
       type: Transform
-  - uid: 486
+  - uid: 487
     components:
     - pos: 6.5,-6.5
       parent: 1
       type: Transform
-  - uid: 487
+  - uid: 488
     components:
     - pos: 5.5,0.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 488
+  - uid: 489
     components:
     - pos: 7.5,0.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 489
+  - uid: 490
     components:
     - pos: -4.5,0.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 490
+  - uid: 491
     components:
     - pos: -5.5,0.5
       parent: 1
       type: Transform
-  - uid: 491
+  - uid: 492
     components:
     - pos: -6.5,0.5
       parent: 1
       type: Transform
-  - uid: 492
+  - uid: 493
     components:
     - pos: 6.5,0.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 493
+  - uid: 494
     components:
     - pos: 1.5,0.5
       parent: 1
       type: Transform
-  - uid: 494
+  - uid: 495
     components:
     - pos: 2.5,0.5
       parent: 1
       type: Transform
-  - uid: 495
+  - uid: 496
     components:
     - pos: -6.5,-27.5
       parent: 1
       type: Transform
-  - uid: 496
+  - uid: 497
     components:
     - pos: -7.5,-27.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 497
+  - uid: 498
     components:
     - pos: -8.5,-27.5
       parent: 1
       type: Transform
-  - uid: 498
+  - uid: 499
     components:
     - pos: -9.5,-27.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 499
+  - uid: 500
     components:
     - pos: -10.5,-27.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 500
+  - uid: 501
     components:
     - pos: -4.5,3.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 501
+  - uid: 502
     components:
     - pos: -5.5,3.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 502
+  - uid: 503
     components:
     - pos: -6.5,3.5
       parent: 1
       type: Transform
-  - uid: 503
+  - uid: 504
     components:
     - pos: 5.5,3.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 504
+  - uid: 505
     components:
     - pos: 6.5,3.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 505
+  - uid: 506
     components:
     - pos: 7.5,3.5
       parent: 1
       type: Transform
-  - uid: 506
+  - uid: 507
     components:
     - pos: 7.5,4.5
       parent: 1
       type: Transform
-  - uid: 507
+  - uid: 508
     components:
     - pos: 7.5,2.5
       parent: 1
       type: Transform
-  - uid: 508
+  - uid: 509
     components:
     - pos: -6.5,4.5
       parent: 1
       type: Transform
-  - uid: 509
+  - uid: 510
     components:
     - pos: -6.5,2.5
       parent: 1
       type: Transform
 - proto: Cablecuffs
   entities:
-  - uid: 510
+  - uid: 511
     components:
     - pos: 7.5698066,-0.081031054
       parent: 1
       type: Transform
 - proto: CableHV
   entities:
-  - uid: 511
+  - uid: 512
     components:
     - pos: -5.5,-18.5
       parent: 1
       type: Transform
-  - uid: 512
+  - uid: 513
     components:
     - pos: 6.5,-30.5
       parent: 1
       type: Transform
-  - uid: 513
+  - uid: 514
     components:
     - pos: 5.5,-30.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 514
+  - uid: 515
     components:
     - pos: 4.5,-30.5
       parent: 1
       type: Transform
-  - uid: 515
+  - uid: 516
     components:
     - pos: 3.5,-30.5
       parent: 1
       type: Transform
-  - uid: 516
+  - uid: 517
     components:
     - pos: 6.5,-31.5
       parent: 1
       type: Transform
-  - uid: 517
+  - uid: 518
     components:
     - pos: 6.5,-32.5
       parent: 1
       type: Transform
-  - uid: 518
+  - uid: 519
     components:
     - pos: 6.5,-33.5
       parent: 1
       type: Transform
-  - uid: 519
+  - uid: 520
     components:
     - pos: 7.5,-33.5
       parent: 1
       type: Transform
-  - uid: 520
+  - uid: 521
     components:
     - pos: 7.5,-32.5
       parent: 1
       type: Transform
-  - uid: 521
+  - uid: 522
     components:
     - pos: 8.5,-33.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 522
+  - uid: 523
     components:
     - pos: 8.5,-32.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 523
+  - uid: 524
     components:
     - pos: 8.5,-31.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 524
+  - uid: 525
     components:
     - pos: 6.5,-29.5
       parent: 1
       type: Transform
-  - uid: 525
+  - uid: 526
     components:
     - pos: 6.5,-28.5
       parent: 1
       type: Transform
-  - uid: 526
+  - uid: 527
     components:
     - pos: 6.5,-27.5
       parent: 1
       type: Transform
-  - uid: 527
+  - uid: 528
     components:
     - pos: 6.5,-26.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 528
+  - uid: 529
     components:
     - pos: 6.5,-25.5
       parent: 1
       type: Transform
-  - uid: 529
+  - uid: 530
     components:
     - pos: 6.5,-24.5
       parent: 1
       type: Transform
-  - uid: 530
+  - uid: 531
     components:
     - pos: 6.5,-23.5
       parent: 1
       type: Transform
-  - uid: 531
+  - uid: 532
     components:
     - pos: 6.5,-22.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 532
+  - uid: 533
     components:
     - pos: 6.5,-21.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 533
+  - uid: 534
     components:
     - pos: 6.5,-20.5
       parent: 1
       type: Transform
-  - uid: 534
+  - uid: 535
     components:
     - pos: 6.5,-19.5
       parent: 1
       type: Transform
-  - uid: 535
+  - uid: 536
     components:
     - pos: 6.5,-18.5
       parent: 1
       type: Transform
-  - uid: 536
+  - uid: 537
     components:
     - pos: 5.5,-18.5
       parent: 1
       type: Transform
-  - uid: 537
+  - uid: 538
     components:
     - pos: 4.5,-18.5
       parent: 1
       type: Transform
-  - uid: 538
+  - uid: 539
     components:
     - pos: 4.5,-17.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 539
+  - uid: 540
     components:
     - pos: 4.5,-16.5
       parent: 1
       type: Transform
-  - uid: 540
+  - uid: 541
     components:
     - pos: 4.5,-15.5
       parent: 1
       type: Transform
-  - uid: 541
+  - uid: 542
     components:
     - pos: 4.5,-14.5
       parent: 1
       type: Transform
-  - uid: 542
+  - uid: 543
     components:
     - pos: 4.5,-13.5
       parent: 1
       type: Transform
-  - uid: 543
+  - uid: 544
     components:
     - pos: 4.5,-12.5
       parent: 1
       type: Transform
-  - uid: 544
+  - uid: 545
     components:
     - pos: 4.5,-11.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 545
+  - uid: 546
     components:
     - pos: 4.5,-10.5
       parent: 1
       type: Transform
-  - uid: 546
+  - uid: 547
     components:
     - pos: 4.5,-9.5
       parent: 1
       type: Transform
-  - uid: 547
+  - uid: 548
     components:
     - pos: 4.5,-8.5
       parent: 1
       type: Transform
-  - uid: 548
+  - uid: 549
     components:
     - pos: 4.5,-7.5
       parent: 1
       type: Transform
-  - uid: 549
+  - uid: 550
     components:
     - pos: 4.5,-6.5
       parent: 1
       type: Transform
-  - uid: 550
+  - uid: 551
     components:
     - pos: 4.5,-5.5
       parent: 1
       type: Transform
-  - uid: 551
+  - uid: 552
     components:
     - pos: 4.5,-4.5
       parent: 1
       type: Transform
-  - uid: 552
+  - uid: 553
     components:
     - pos: 4.5,-3.5
       parent: 1
       type: Transform
-  - uid: 553
+  - uid: 554
     components:
     - pos: 4.5,-2.5
       parent: 1
       type: Transform
-  - uid: 554
+  - uid: 555
     components:
     - pos: 4.5,-1.5
       parent: 1
       type: Transform
-  - uid: 555
+  - uid: 556
     components:
     - pos: 4.5,-0.5
       parent: 1
       type: Transform
-  - uid: 556
+  - uid: 557
     components:
     - pos: 4.5,0.5
       parent: 1
       type: Transform
-  - uid: 557
+  - uid: 558
     components:
     - pos: 4.5,1.5
       parent: 1
       type: Transform
-  - uid: 558
+  - uid: 559
     components:
     - pos: 4.5,2.5
       parent: 1
       type: Transform
-  - uid: 559
+  - uid: 560
     components:
     - pos: 4.5,3.5
       parent: 1
       type: Transform
-  - uid: 560
+  - uid: 561
     components:
     - pos: 3.5,3.5
       parent: 1
       type: Transform
-  - uid: 561
+  - uid: 562
     components:
     - pos: 2.5,-32.5
       parent: 1
       type: Transform
-  - uid: 562
+  - uid: 563
     components:
     - pos: -1.5,-33.5
       parent: 1
       type: Transform
-  - uid: 563
+  - uid: 564
     components:
     - pos: 3.5,7.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 564
+  - uid: 565
     components:
     - pos: 4.5,7.5
       parent: 1
       type: Transform
-  - uid: 565
+  - uid: 566
     components:
     - pos: 4.5,6.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 566
+  - uid: 567
     components:
     - pos: -3.5,6.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 567
+  - uid: 568
     components:
     - pos: -3.5,7.5
       parent: 1
       type: Transform
-  - uid: 568
+  - uid: 569
     components:
     - pos: -2.5,7.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 569
+  - uid: 570
     components:
     - pos: 2.5,3.5
       parent: 1
       type: Transform
-  - uid: 570
+  - uid: 571
     components:
     - pos: 1.5,4.5
       parent: 1
       type: Transform
-  - uid: 571
+  - uid: 572
     components:
     - pos: -1.5,3.5
       parent: 1
       type: Transform
-  - uid: 572
+  - uid: 573
     components:
     - pos: -2.5,3.5
       parent: 1
       type: Transform
-  - uid: 573
+  - uid: 574
     components:
     - pos: -3.5,3.5
       parent: 1
       type: Transform
-  - uid: 574
+  - uid: 575
     components:
     - pos: -3.5,2.5
       parent: 1
       type: Transform
-  - uid: 575
+  - uid: 576
     components:
     - pos: -3.5,1.5
       parent: 1
       type: Transform
-  - uid: 576
+  - uid: 577
     components:
     - pos: -3.5,0.5
       parent: 1
       type: Transform
-  - uid: 577
+  - uid: 578
     components:
     - pos: -3.5,-0.5
       parent: 1
       type: Transform
-  - uid: 578
+  - uid: 579
     components:
     - pos: -3.5,-1.5
       parent: 1
       type: Transform
-  - uid: 579
+  - uid: 580
     components:
     - pos: -3.5,-2.5
       parent: 1
       type: Transform
-  - uid: 580
+  - uid: 581
     components:
     - pos: -3.5,-3.5
       parent: 1
       type: Transform
-  - uid: 581
+  - uid: 582
     components:
     - pos: -3.5,-4.5
       parent: 1
       type: Transform
-  - uid: 582
+  - uid: 583
     components:
     - pos: -3.5,-5.5
       parent: 1
       type: Transform
-  - uid: 583
+  - uid: 584
     components:
     - pos: -3.5,-6.5
       parent: 1
       type: Transform
-  - uid: 584
+  - uid: 585
     components:
     - pos: -3.5,-7.5
       parent: 1
       type: Transform
-  - uid: 585
+  - uid: 586
     components:
     - pos: -3.5,-8.5
       parent: 1
       type: Transform
-  - uid: 586
+  - uid: 587
     components:
     - pos: -3.5,-9.5
       parent: 1
       type: Transform
-  - uid: 587
+  - uid: 588
     components:
     - pos: -3.5,-10.5
       parent: 1
       type: Transform
-  - uid: 588
+  - uid: 589
     components:
     - pos: -3.5,-11.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 589
+  - uid: 590
     components:
     - pos: -3.5,-12.5
       parent: 1
       type: Transform
-  - uid: 590
+  - uid: 591
     components:
     - pos: -3.5,-13.5
       parent: 1
       type: Transform
-  - uid: 591
+  - uid: 592
     components:
     - pos: -3.5,-14.5
       parent: 1
       type: Transform
-  - uid: 592
+  - uid: 593
     components:
     - pos: -3.5,-15.5
       parent: 1
       type: Transform
-  - uid: 593
+  - uid: 594
     components:
     - pos: -3.5,-16.5
       parent: 1
       type: Transform
-  - uid: 594
+  - uid: 595
     components:
     - pos: -3.5,-17.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 595
+  - uid: 596
     components:
     - pos: -3.5,-18.5
       parent: 1
       type: Transform
-  - uid: 596
+  - uid: 597
     components:
     - pos: -4.5,-18.5
       parent: 1
       type: Transform
-  - uid: 597
+  - uid: 598
     components:
     - pos: -5.5,-18.5
       parent: 1
       type: Transform
-  - uid: 598
+  - uid: 599
     components:
     - pos: -5.5,-19.5
       parent: 1
       type: Transform
-  - uid: 599
+  - uid: 600
     components:
     - pos: -5.5,-20.5
       parent: 1
       type: Transform
-  - uid: 600
+  - uid: 601
     components:
     - pos: -5.5,-21.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 601
+  - uid: 602
     components:
     - pos: -5.5,-22.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 602
+  - uid: 603
     components:
     - pos: -5.5,-23.5
       parent: 1
       type: Transform
-  - uid: 603
+  - uid: 604
     components:
     - pos: -5.5,-24.5
       parent: 1
       type: Transform
-  - uid: 604
+  - uid: 605
     components:
     - pos: -5.5,-25.5
       parent: 1
       type: Transform
-  - uid: 605
+  - uid: 606
     components:
     - pos: -5.5,-26.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 606
+  - uid: 607
     components:
     - pos: -5.5,-27.5
       parent: 1
       type: Transform
-  - uid: 607
+  - uid: 608
     components:
     - pos: -5.5,-28.5
       parent: 1
       type: Transform
-  - uid: 608
+  - uid: 609
     components:
     - pos: -5.5,-29.5
       parent: 1
       type: Transform
-  - uid: 609
+  - uid: 610
     components:
     - pos: -5.5,-30.5
       parent: 1
       type: Transform
-  - uid: 610
+  - uid: 611
     components:
     - pos: -5.5,-31.5
       parent: 1
       type: Transform
-  - uid: 611
+  - uid: 612
     components:
     - pos: -5.5,-32.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 612
+  - uid: 613
     components:
     - pos: -5.5,-33.5
       parent: 1
       type: Transform
-  - uid: 613
+  - uid: 614
     components:
     - pos: -4.5,-33.5
       parent: 1
       type: Transform
-  - uid: 614
+  - uid: 615
     components:
     - pos: -3.5,-33.5
       parent: 1
       type: Transform
-  - uid: 615
+  - uid: 616
     components:
     - pos: -2.5,-33.5
       parent: 1
       type: Transform
-  - uid: 616
+  - uid: 617
     components:
     - pos: 1.5,-33.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 617
+  - uid: 618
     components:
     - pos: 0.5,-33.5
       parent: 1
       type: Transform
-  - uid: 618
+  - uid: 619
     components:
     - pos: 2.5,-33.5
       parent: 1
       type: Transform
-  - uid: 619
+  - uid: 620
     components:
     - pos: 2.5,-30.5
       parent: 1
       type: Transform
-  - uid: 620
+  - uid: 621
     components:
     - pos: 2.5,-31.5
       parent: 1
       type: Transform
-  - uid: 621
+  - uid: 622
     components:
     - pos: -0.5,-33.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 622
+  - uid: 623
     components:
     - pos: 1.5,3.5
       parent: 1
       type: Transform
-  - uid: 623
+  - uid: 624
     components:
     - pos: 1.5,5.5
       parent: 1
       type: Transform
-  - uid: 624
+  - uid: 625
     components:
     - pos: 1.5,6.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 625
+  - uid: 626
     components:
     - pos: 1.5,7.5
       parent: 1
       type: Transform
-  - uid: 626
+  - uid: 627
     components:
     - pos: 2.5,7.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 627
+  - uid: 628
     components:
     - pos: -0.5,3.5
       parent: 1
       type: Transform
-  - uid: 628
+  - uid: 629
     components:
     - pos: -0.5,4.5
       parent: 1
       type: Transform
-  - uid: 629
+  - uid: 630
     components:
     - pos: -0.5,5.5
       parent: 1
       type: Transform
-  - uid: 630
+  - uid: 631
     components:
     - pos: -0.5,6.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 631
+  - uid: 632
     components:
     - pos: -0.5,7.5
       parent: 1
       type: Transform
-  - uid: 632
+  - uid: 633
     components:
     - pos: -1.5,7.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 633
-    components:
-    - pos: -6.5,-18.5
-      parent: 1
-      type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 634
     components:
-    - pos: 5.5,-23.5
+    - pos: -6.5,-18.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
   - uid: 635
     components:
-    - pos: 4.5,-23.5
+    - pos: 5.5,-23.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
   - uid: 636
     components:
-    - pos: 3.5,-23.5
+    - pos: 4.5,-23.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
   - uid: 637
     components:
-    - pos: 2.5,-23.5
+    - pos: 3.5,-23.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
   - uid: 638
     components:
-    - pos: 1.5,-23.5
+    - pos: 2.5,-23.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
   - uid: 639
     components:
-    - pos: 0.5,-23.5
+    - pos: 1.5,-23.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
   - uid: 640
     components:
-    - pos: -0.5,-23.5
+    - pos: 0.5,-23.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
   - uid: 641
     components:
-    - pos: -0.5,-22.5
+    - pos: -0.5,-23.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
   - uid: 642
     components:
-    - pos: -0.5,-21.5
+    - pos: -0.5,-22.5
       parent: 1
       type: Transform
+    - enabled: True
+      type: AmbientSound
   - uid: 643
     components:
-    - pos: 1.5,-31.5
+    - pos: -0.5,-21.5
       parent: 1
       type: Transform
   - uid: 644
     components:
+    - pos: 1.5,-31.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 645
+    components:
     - pos: 0.5,-31.5
       parent: 1
       type: Transform
-  - uid: 645
+  - uid: 646
     components:
     - pos: 0.5,-30.5
       parent: 1
       type: Transform
-  - uid: 646
+  - uid: 647
     components:
     - pos: 0.5,-29.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 647
+  - uid: 648
     components:
     - pos: -0.5,-29.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 648
+  - uid: 649
     components:
     - pos: -1.5,-29.5
       parent: 1
       type: Transform
-  - uid: 649
-    components:
-    - pos: -6.5,-17.5
-      parent: 1
-      type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 650
     components:
-    - pos: -6.5,-18.5
+    - pos: -6.5,-17.5
       parent: 1
       type: Transform
     - enabled: True
@@ -4503,12 +4500,19 @@ entities:
       type: AmbientSound
   - uid: 652
     components:
-    - pos: 7.5,-18.5
+    - pos: -6.5,-18.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
   - uid: 653
+    components:
+    - pos: 7.5,-18.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 654
     components:
     - pos: 7.5,-17.5
       parent: 1
@@ -4517,25 +4521,20 @@ entities:
       type: AmbientSound
 - proto: CableMV
   entities:
-  - uid: 654
+  - uid: 655
     components:
     - pos: -6.5,-17.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 655
+  - uid: 656
     components:
     - pos: -5.5,-17.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 656
-    components:
-    - pos: -5.5,-18.5
-      parent: 1
-      type: Transform
   - uid: 657
     components:
     - pos: -5.5,-18.5
@@ -4558,1191 +4557,1200 @@ entities:
       type: Transform
   - uid: 661
     components:
-    - pos: 10.5,-29.5
+    - pos: -5.5,-18.5
       parent: 1
       type: Transform
   - uid: 662
+    components:
+    - pos: 10.5,-29.5
+      parent: 1
+      type: Transform
+  - uid: 663
     components:
     - pos: 9.5,-28.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 663
+  - uid: 664
     components:
     - pos: 9.5,-29.5
       parent: 1
       type: Transform
-  - uid: 664
+  - uid: 665
     components:
     - pos: 10.5,-28.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 665
+  - uid: 666
     components:
     - pos: -0.5,4.5
       parent: 1
       type: Transform
-  - uid: 666
+  - uid: 667
     components:
     - pos: -1.5,7.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 667
+  - uid: 668
     components:
     - pos: -0.5,6.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 668
+  - uid: 669
     components:
     - pos: 1.5,5.5
       parent: 1
       type: Transform
-  - uid: 669
+  - uid: 670
     components:
     - pos: 1.5,6.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 670
+  - uid: 671
     components:
     - pos: 0.5,-4.5
       parent: 1
       type: Transform
-  - uid: 671
+  - uid: 672
     components:
     - pos: 7.5,-30.5
       parent: 1
       type: Transform
-  - uid: 672
+  - uid: 673
     components:
     - pos: 6.5,-29.5
       parent: 1
       type: Transform
-  - uid: 673
+  - uid: 674
     components:
     - pos: -3.5,-23.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 674
+  - uid: 675
     components:
     - pos: 7.5,-31.5
       parent: 1
       type: Transform
-  - uid: 675
+  - uid: 676
     components:
     - pos: 8.5,-30.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 676
+  - uid: 677
     components:
     - pos: 6.5,-30.5
       parent: 1
       type: Transform
-  - uid: 677
+  - uid: 678
     components:
     - pos: 4.5,-14.5
       parent: 1
       type: Transform
-  - uid: 678
+  - uid: 679
     components:
     - pos: 8.5,-31.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 679
+  - uid: 680
     components:
     - pos: 6.5,-28.5
       parent: 1
       type: Transform
-  - uid: 680
+  - uid: 681
     components:
     - pos: 6.5,-27.5
       parent: 1
       type: Transform
-  - uid: 681
+  - uid: 682
     components:
     - pos: 6.5,-26.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 682
+  - uid: 683
     components:
     - pos: 6.5,-25.5
       parent: 1
       type: Transform
-  - uid: 683
+  - uid: 684
     components:
     - pos: 6.5,-24.5
       parent: 1
       type: Transform
-  - uid: 684
+  - uid: 685
     components:
     - pos: 6.5,-23.5
       parent: 1
       type: Transform
-  - uid: 685
+  - uid: 686
     components:
     - pos: 6.5,-22.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 686
+  - uid: 687
     components:
     - pos: 6.5,-21.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 687
+  - uid: 688
     components:
     - pos: 6.5,-20.5
       parent: 1
       type: Transform
-  - uid: 688
+  - uid: 689
     components:
     - pos: 7.5,-27.5
       parent: 1
       type: Transform
-  - uid: 689
+  - uid: 690
     components:
     - pos: 8.5,-27.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 690
+  - uid: 691
     components:
     - pos: 9.5,-27.5
       parent: 1
       type: Transform
-  - uid: 691
+  - uid: 692
     components:
     - pos: 6.5,-19.5
       parent: 1
       type: Transform
-  - uid: 692
+  - uid: 693
     components:
     - pos: 6.5,-18.5
       parent: 1
       type: Transform
-  - uid: 693
+  - uid: 694
     components:
     - pos: 5.5,-18.5
       parent: 1
       type: Transform
-  - uid: 694
+  - uid: 695
     components:
     - pos: 4.5,-18.5
       parent: 1
       type: Transform
-  - uid: 695
+  - uid: 696
     components:
     - pos: 4.5,-17.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 696
+  - uid: 697
     components:
     - pos: 4.5,-16.5
       parent: 1
       type: Transform
-  - uid: 697
+  - uid: 698
     components:
     - pos: 4.5,-15.5
       parent: 1
       type: Transform
-  - uid: 698
+  - uid: 699
     components:
     - pos: 4.5,-13.5
       parent: 1
       type: Transform
-  - uid: 699
+  - uid: 700
     components:
     - pos: 4.5,-12.5
       parent: 1
       type: Transform
-  - uid: 700
+  - uid: 701
     components:
     - pos: 5.5,-12.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 701
+  - uid: 702
     components:
     - pos: 6.5,-12.5
       parent: 1
       type: Transform
-  - uid: 702
+  - uid: 703
     components:
     - pos: 6.5,-11.5
       parent: 1
       type: Transform
-  - uid: 703
+  - uid: 704
     components:
     - pos: 6.5,-10.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 704
+  - uid: 705
     components:
     - pos: 3.5,-13.5
       parent: 1
       type: Transform
-  - uid: 705
+  - uid: 706
     components:
     - pos: 2.5,-13.5
       parent: 1
       type: Transform
-  - uid: 706
+  - uid: 707
     components:
     - pos: 1.5,-13.5
       parent: 1
       type: Transform
-  - uid: 707
+  - uid: 708
     components:
     - pos: 0.5,-13.5
       parent: 1
       type: Transform
-  - uid: 708
+  - uid: 709
     components:
     - pos: 0.5,-12.5
       parent: 1
       type: Transform
-  - uid: 709
+  - uid: 710
     components:
     - pos: 0.5,-11.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 710
+  - uid: 711
     components:
     - pos: -0.5,-13.5
       parent: 1
       type: Transform
-  - uid: 711
+  - uid: 712
     components:
     - pos: -1.5,-13.5
       parent: 1
       type: Transform
-  - uid: 712
+  - uid: 713
     components:
     - pos: -2.5,-13.5
       parent: 1
       type: Transform
-  - uid: 713
+  - uid: 714
     components:
     - pos: -3.5,-13.5
       parent: 1
       type: Transform
-  - uid: 714
+  - uid: 715
     components:
     - pos: -3.5,-12.5
       parent: 1
       type: Transform
-  - uid: 715
+  - uid: 716
     components:
     - pos: -4.5,-12.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 716
+  - uid: 717
     components:
     - pos: -5.5,-12.5
       parent: 1
       type: Transform
-  - uid: 717
+  - uid: 718
     components:
     - pos: -5.5,-11.5
       parent: 1
       type: Transform
-  - uid: 718
+  - uid: 719
     components:
     - pos: -5.5,-10.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 719
+  - uid: 720
     components:
     - pos: -4.5,-23.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 720
+  - uid: 721
     components:
     - pos: -3.5,-11.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 721
+  - uid: 722
     components:
     - pos: -3.5,-10.5
       parent: 1
       type: Transform
-  - uid: 722
+  - uid: 723
     components:
     - pos: -3.5,-9.5
       parent: 1
       type: Transform
-  - uid: 723
+  - uid: 724
     components:
     - pos: -3.5,-8.5
       parent: 1
       type: Transform
-  - uid: 724
+  - uid: 725
     components:
     - pos: -3.5,-7.5
       parent: 1
       type: Transform
-  - uid: 725
+  - uid: 726
     components:
     - pos: -3.5,-6.5
       parent: 1
       type: Transform
-  - uid: 726
+  - uid: 727
     components:
     - pos: -3.5,-5.5
       parent: 1
       type: Transform
-  - uid: 727
+  - uid: 728
     components:
     - pos: -3.5,-4.5
       parent: 1
       type: Transform
-  - uid: 728
+  - uid: 729
     components:
     - pos: -3.5,-3.5
       parent: 1
       type: Transform
-  - uid: 729
+  - uid: 730
     components:
     - pos: -4.5,-3.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 730
+  - uid: 731
     components:
     - pos: -5.5,-3.5
       parent: 1
       type: Transform
-  - uid: 731
+  - uid: 732
     components:
     - pos: -5.5,-2.5
       parent: 1
       type: Transform
-  - uid: 732
+  - uid: 733
     components:
     - pos: -5.5,-1.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 733
+  - uid: 734
     components:
     - pos: 4.5,-11.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 734
+  - uid: 735
     components:
     - pos: 4.5,-10.5
       parent: 1
       type: Transform
-  - uid: 735
+  - uid: 736
     components:
     - pos: 4.5,-9.5
       parent: 1
       type: Transform
-  - uid: 736
+  - uid: 737
     components:
     - pos: 4.5,-8.5
       parent: 1
       type: Transform
-  - uid: 737
+  - uid: 738
     components:
     - pos: 4.5,-7.5
       parent: 1
       type: Transform
-  - uid: 738
+  - uid: 739
     components:
     - pos: 4.5,-6.5
       parent: 1
       type: Transform
-  - uid: 739
+  - uid: 740
     components:
     - pos: 4.5,-5.5
       parent: 1
       type: Transform
-  - uid: 740
+  - uid: 741
     components:
     - pos: 4.5,-4.5
       parent: 1
       type: Transform
-  - uid: 741
+  - uid: 742
     components:
     - pos: 4.5,-3.5
       parent: 1
       type: Transform
-  - uid: 742
+  - uid: 743
     components:
     - pos: 5.5,-3.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 743
+  - uid: 744
     components:
     - pos: 6.5,-3.5
       parent: 1
       type: Transform
-  - uid: 744
+  - uid: 745
     components:
     - pos: 6.5,-2.5
       parent: 1
       type: Transform
-  - uid: 745
+  - uid: 746
     components:
     - pos: 6.5,-1.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 746
+  - uid: 747
     components:
     - pos: 4.5,-2.5
       parent: 1
       type: Transform
-  - uid: 747
+  - uid: 748
     components:
     - pos: 4.5,-1.5
       parent: 1
       type: Transform
-  - uid: 748
+  - uid: 749
     components:
     - pos: -3.5,0.5
       parent: 1
       type: Transform
-  - uid: 749
+  - uid: 750
     components:
     - pos: 4.5,-0.5
       parent: 1
       type: Transform
-  - uid: 750
+  - uid: 751
     components:
     - pos: 4.5,0.5
       parent: 1
       type: Transform
-  - uid: 751
+  - uid: 752
     components:
     - pos: 4.5,1.5
       parent: 1
       type: Transform
-  - uid: 752
+  - uid: 753
     components:
     - pos: 4.5,2.5
       parent: 1
       type: Transform
-  - uid: 753
+  - uid: 754
     components:
     - pos: 4.5,3.5
       parent: 1
       type: Transform
-  - uid: 754
+  - uid: 755
     components:
     - pos: 3.5,3.5
       parent: 1
       type: Transform
-  - uid: 755
+  - uid: 756
     components:
     - pos: -0.5,5.5
       parent: 1
       type: Transform
-  - uid: 756
+  - uid: 757
     components:
     - pos: -0.5,7.5
       parent: 1
       type: Transform
-  - uid: 757
+  - uid: 758
     components:
     - pos: 3.5,4.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 758
+  - uid: 759
     components:
     - pos: 1.5,4.5
       parent: 1
       type: Transform
-  - uid: 759
+  - uid: 760
     components:
     - pos: 3.5,7.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 760
+  - uid: 761
     components:
     - pos: 4.5,7.5
       parent: 1
       type: Transform
-  - uid: 761
+  - uid: 762
     components:
     - pos: 4.5,6.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 762
+  - uid: 763
     components:
     - pos: 4.5,8.5
       parent: 1
       type: Transform
-  - uid: 763
+  - uid: 764
     components:
     - pos: 4.5,9.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 764
+  - uid: 765
     components:
     - pos: 1.5,7.5
       parent: 1
       type: Transform
-  - uid: 765
+  - uid: 766
     components:
     - pos: -2.5,7.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 766
+  - uid: 767
     components:
     - pos: -3.5,7.5
       parent: 1
       type: Transform
-  - uid: 767
+  - uid: 768
     components:
     - pos: -3.5,6.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 768
+  - uid: 769
     components:
     - pos: -3.5,8.5
       parent: 1
       type: Transform
-  - uid: 769
+  - uid: 770
     components:
     - pos: -3.5,9.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 770
+  - uid: 771
     components:
     - pos: 2.5,7.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 771
+  - uid: 772
     components:
     - pos: -2.5,4.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 772
+  - uid: 773
     components:
     - pos: -2.5,3.5
       parent: 1
       type: Transform
-  - uid: 773
+  - uid: 774
     components:
     - pos: -3.5,3.5
       parent: 1
       type: Transform
-  - uid: 774
+  - uid: 775
     components:
     - pos: -3.5,2.5
       parent: 1
       type: Transform
-  - uid: 775
+  - uid: 776
     components:
     - pos: -3.5,1.5
       parent: 1
       type: Transform
-  - uid: 776
+  - uid: 777
     components:
     - pos: -3.5,-0.5
       parent: 1
       type: Transform
-  - uid: 777
+  - uid: 778
     components:
     - pos: -3.5,-1.5
       parent: 1
       type: Transform
-  - uid: 778
+  - uid: 779
     components:
     - pos: -3.5,-2.5
       parent: 1
       type: Transform
-  - uid: 779
+  - uid: 780
     components:
     - pos: -2.5,-3.5
       parent: 1
       type: Transform
-  - uid: 780
+  - uid: 781
     components:
     - pos: -1.5,-3.5
       parent: 1
       type: Transform
-  - uid: 781
+  - uid: 782
     components:
     - pos: -0.5,-3.5
       parent: 1
       type: Transform
-  - uid: 782
+  - uid: 783
     components:
     - pos: 0.5,-3.5
       parent: 1
       type: Transform
-  - uid: 783
+  - uid: 784
     components:
     - pos: 3.5,-3.5
       parent: 1
       type: Transform
-  - uid: 784
+  - uid: 785
     components:
     - pos: 2.5,-3.5
       parent: 1
       type: Transform
-  - uid: 785
+  - uid: 786
     components:
     - pos: 1.5,-3.5
       parent: 1
       type: Transform
-  - uid: 786
+  - uid: 787
     components:
     - pos: 0.5,-2.5
       parent: 1
       type: Transform
-  - uid: 787
+  - uid: 788
     components:
     - pos: 0.5,-1.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 788
+  - uid: 789
     components:
     - pos: 0.5,-0.5
       parent: 1
       type: Transform
-  - uid: 789
+  - uid: 790
     components:
     - pos: 0.5,0.5
       parent: 1
       type: Transform
-  - uid: 790
+  - uid: 791
     components:
     - pos: 1.5,0.5
       parent: 1
       type: Transform
-  - uid: 791
+  - uid: 792
     components:
     - pos: 2.5,0.5
       parent: 1
       type: Transform
-  - uid: 792
+  - uid: 793
     components:
     - pos: 0.5,-5.5
       parent: 1
       type: Transform
-  - uid: 793
+  - uid: 794
     components:
     - pos: 0.5,-6.5
       parent: 1
       type: Transform
-  - uid: 794
+  - uid: 795
     components:
     - pos: 0.5,-7.5
       parent: 1
       type: Transform
-  - uid: 795
+  - uid: 796
     components:
     - pos: 0.5,-8.5
       parent: 1
       type: Transform
-  - uid: 796
+  - uid: 797
     components:
     - pos: 0.5,-9.5
       parent: 1
       type: Transform
-  - uid: 797
+  - uid: 798
     components:
     - pos: 0.5,-10.5
       parent: 1
       type: Transform
-  - uid: 798
+  - uid: 799
     components:
     - pos: -3.5,-14.5
       parent: 1
       type: Transform
-  - uid: 799
+  - uid: 800
     components:
     - pos: -3.5,-15.5
       parent: 1
       type: Transform
-  - uid: 800
+  - uid: 801
     components:
     - pos: -3.5,-16.5
       parent: 1
       type: Transform
-  - uid: 801
+  - uid: 802
     components:
     - pos: -3.5,-17.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 802
+  - uid: 803
     components:
     - pos: -3.5,-18.5
       parent: 1
       type: Transform
-  - uid: 803
+  - uid: 804
     components:
     - pos: -4.5,-18.5
       parent: 1
       type: Transform
-  - uid: 804
+  - uid: 805
     components:
     - pos: -5.5,-18.5
       parent: 1
       type: Transform
-  - uid: 805
+  - uid: 806
     components:
     - pos: -5.5,-19.5
       parent: 1
       type: Transform
-  - uid: 806
+  - uid: 807
     components:
     - pos: -5.5,-20.5
       parent: 1
       type: Transform
-  - uid: 807
+  - uid: 808
     components:
     - pos: -5.5,-21.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 808
+  - uid: 809
     components:
     - pos: -5.5,-22.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 809
+  - uid: 810
     components:
     - pos: -5.5,-23.5
       parent: 1
       type: Transform
-  - uid: 810
+  - uid: 811
     components:
     - pos: -2.5,-21.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 811
+  - uid: 812
     components:
     - pos: -2.5,-23.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 812
+  - uid: 813
     components:
     - pos: -1.5,-23.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 813
+  - uid: 814
     components:
     - pos: -1.5,-22.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 814
+  - uid: 815
     components:
     - pos: -1.5,-21.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 815
+  - uid: 816
     components:
     - pos: -0.5,-23.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 816
+  - uid: 817
     components:
     - pos: 0.5,-23.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 817
+  - uid: 818
     components:
     - pos: 1.5,-23.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 818
+  - uid: 819
     components:
     - pos: 2.5,-23.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 819
+  - uid: 820
     components:
     - pos: 3.5,-23.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 820
+  - uid: 821
     components:
     - pos: 4.5,-23.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 821
+  - uid: 822
     components:
     - pos: 5.5,-23.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 822
+  - uid: 823
     components:
     - pos: -5.5,-24.5
       parent: 1
       type: Transform
-  - uid: 823
+  - uid: 824
     components:
     - pos: -5.5,-25.5
       parent: 1
       type: Transform
-  - uid: 824
+  - uid: 825
     components:
     - pos: -5.5,-26.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 825
+  - uid: 826
     components:
     - pos: -5.5,-27.5
       parent: 1
       type: Transform
-  - uid: 826
+  - uid: 827
     components:
     - pos: -5.5,-28.5
       parent: 1
       type: Transform
-  - uid: 827
+  - uid: 828
     components:
     - pos: -5.5,-29.5
       parent: 1
       type: Transform
-  - uid: 828
+  - uid: 829
     components:
     - pos: -6.5,-29.5
       parent: 1
       type: Transform
-  - uid: 829
+  - uid: 830
     components:
     - pos: -7.5,-29.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 830
+  - uid: 831
     components:
     - pos: -8.5,-29.5
       parent: 1
       type: Transform
-  - uid: 831
+  - uid: 832
     components:
     - pos: -9.5,-29.5
       parent: 1
       type: Transform
-  - uid: 832
+  - uid: 833
     components:
     - pos: -9.5,-28.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 833
+  - uid: 834
     components:
     - pos: -5.5,-30.5
       parent: 1
       type: Transform
-  - uid: 834
+  - uid: 835
     components:
     - pos: -5.5,-31.5
       parent: 1
       type: Transform
-  - uid: 835
+  - uid: 836
     components:
     - pos: -5.5,-32.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 836
+  - uid: 837
     components:
     - pos: -5.5,-33.5
       parent: 1
       type: Transform
-  - uid: 837
+  - uid: 838
     components:
     - pos: -4.5,-33.5
       parent: 1
       type: Transform
-  - uid: 838
+  - uid: 839
     components:
     - pos: -3.5,-33.5
       parent: 1
       type: Transform
-  - uid: 839
+  - uid: 840
     components:
     - pos: -2.5,-33.5
       parent: 1
       type: Transform
-  - uid: 840
+  - uid: 841
     components:
     - pos: -0.5,-33.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 841
+  - uid: 842
     components:
     - pos: 0.5,-33.5
       parent: 1
       type: Transform
-  - uid: 842
+  - uid: 843
     components:
     - pos: 1.5,-33.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 843
+  - uid: 844
     components:
     - pos: 2.5,-33.5
       parent: 1
       type: Transform
-  - uid: 844
+  - uid: 845
     components:
     - pos: 2.5,-34.5
       parent: 1
       type: Transform
-  - uid: 845
+  - uid: 846
     components:
     - pos: 3.5,-34.5
       parent: 1
       type: Transform
-  - uid: 846
+  - uid: 847
     components:
     - pos: 4.5,-34.5
       parent: 1
       type: Transform
-  - uid: 847
+  - uid: 848
     components:
     - pos: 5.5,-34.5
       parent: 1
       type: Transform
-  - uid: 848
+  - uid: 849
     components:
     - pos: 6.5,-34.5
       parent: 1
       type: Transform
-  - uid: 849
+  - uid: 850
     components:
     - pos: 7.5,-34.5
       parent: 1
       type: Transform
-  - uid: 850
+  - uid: 851
     components:
     - pos: 7.5,-33.5
       parent: 1
       type: Transform
-  - uid: 851
+  - uid: 852
     components:
     - pos: 7.5,-32.5
       parent: 1
       type: Transform
-  - uid: 852
+  - uid: 853
     components:
     - pos: 2.5,-32.5
       parent: 1
       type: Transform
-  - uid: 853
+  - uid: 854
     components:
     - pos: 2.5,-31.5
       parent: 1
       type: Transform
-  - uid: 854
+  - uid: 855
     components:
     - pos: 1.5,-31.5
       parent: 1
       type: Transform
-  - uid: 855
+    - enabled: True
+      type: AmbientSound
+  - uid: 856
     components:
     - pos: 0.5,-31.5
       parent: 1
       type: Transform
-  - uid: 856
+  - uid: 857
     components:
     - pos: -0.5,-31.5
       parent: 1
       type: Transform
-  - uid: 857
+  - uid: 858
     components:
     - pos: -1.5,-31.5
       parent: 1
       type: Transform
-  - uid: 858
+  - uid: 859
     components:
     - pos: -1.5,-33.5
       parent: 1
       type: Transform
-  - uid: 859
+  - uid: 860
     components:
     - pos: 0.5,-34.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 860
-    components:
-    - pos: -2.5,-31.5
-      parent: 1
-      type: Transform
   - uid: 861
     components:
-    - pos: 0.5,-35.5
+    - pos: -2.5,-31.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
   - uid: 862
     components:
-    - pos: -1.5,4.5
+    - pos: 0.5,-35.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
   - uid: 863
     components:
-    - pos: 2.5,4.5
+    - pos: -1.5,4.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
   - uid: 864
     components:
-    - pos: 3.5,1.5
+    - pos: 2.5,4.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
   - uid: 865
     components:
+    - pos: 3.5,1.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 866
+    components:
     - pos: 2.5,1.5
       parent: 1
       type: Transform
-  - uid: 866
+  - uid: 867
     components:
     - pos: 7.5,-17.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 867
+  - uid: 868
     components:
     - pos: 6.5,-17.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 868
+  - uid: 869
     components:
     - pos: -3.5,3.5
       parent: 1
       type: Transform
 - proto: CableTerminal
   entities:
-  - uid: 869
+  - uid: 870
     components:
     - rot: 1.5707963267948966 rad
       pos: 6.5,-18.5
       parent: 1
       type: Transform
-  - uid: 870
+  - uid: 871
     components:
     - rot: 1.5707963267948966 rad
       pos: 7.5,-32.5
       parent: 1
       type: Transform
-  - uid: 871
+  - uid: 872
     components:
     - rot: 1.5707963267948966 rad
       pos: 7.5,-33.5
       parent: 1
       type: Transform
-  - uid: 872
+  - uid: 873
     components:
     - rot: -1.5707963267948966 rad
       pos: -5.5,-18.5
@@ -5750,35 +5758,35 @@ entities:
       type: Transform
 - proto: CargoPallet
   entities:
-  - uid: 873
+  - uid: 874
     components:
     - pos: 1.5,-4.5
       parent: 1
       type: Transform
-  - uid: 874
-    components:
-    - pos: -0.5,-4.5
-      parent: 1
-      type: Transform
   - uid: 875
     components:
-    - rot: 1.5707963267948966 rad
-      pos: -1.5,-4.5
+    - pos: -0.5,-4.5
       parent: 1
       type: Transform
   - uid: 876
     components:
     - rot: 1.5707963267948966 rad
-      pos: -2.5,-4.5
+      pos: -1.5,-4.5
       parent: 1
       type: Transform
   - uid: 877
     components:
     - rot: 1.5707963267948966 rad
-      pos: 2.5,-4.5
+      pos: -2.5,-4.5
       parent: 1
       type: Transform
   - uid: 878
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 2.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 879
     components:
     - rot: 1.5707963267948966 rad
       pos: 3.5,-4.5
@@ -5786,136 +5794,136 @@ entities:
       type: Transform
 - proto: Carpet
   entities:
-  - uid: 879
+  - uid: 880
     components:
     - pos: -3.5,-28.5
       parent: 1
       type: Transform
-  - uid: 880
+  - uid: 881
     components:
     - pos: -3.5,-31.5
       parent: 1
       type: Transform
-  - uid: 881
+  - uid: 882
     components:
     - pos: -9.5,-31.5
       parent: 1
       type: Transform
-  - uid: 882
-    components:
-    - pos: -9.5,-32.5
-      parent: 1
-      type: Transform
   - uid: 883
     components:
-    - rot: 1.5707963267948966 rad
-      pos: -1.5,-0.5
+    - pos: -9.5,-32.5
       parent: 1
       type: Transform
   - uid: 884
     components:
     - rot: 1.5707963267948966 rad
-      pos: -1.5,0.5
+      pos: -1.5,-0.5
       parent: 1
       type: Transform
   - uid: 885
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -1.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 886
     components:
     - pos: -1.5,1.5
       parent: 1
       type: Transform
 - proto: CarpetBlue
   entities:
-  - uid: 886
+  - uid: 887
     components:
     - rot: -1.5707963267948966 rad
       pos: 4.5,-23.5
       parent: 1
       type: Transform
-  - uid: 887
+  - uid: 888
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,-23.5
       parent: 1
       type: Transform
-  - uid: 888
+  - uid: 889
     components:
     - rot: -1.5707963267948966 rad
       pos: 2.5,-23.5
       parent: 1
       type: Transform
-  - uid: 889
+  - uid: 890
     components:
     - rot: -1.5707963267948966 rad
       pos: 1.5,-23.5
       parent: 1
       type: Transform
-  - uid: 890
+  - uid: 891
     components:
     - rot: -1.5707963267948966 rad
       pos: 0.5,-23.5
       parent: 1
       type: Transform
-  - uid: 891
+  - uid: 892
     components:
     - rot: -1.5707963267948966 rad
       pos: 1.5,-22.5
       parent: 1
       type: Transform
-  - uid: 892
+  - uid: 893
     components:
     - rot: -1.5707963267948966 rad
       pos: 0.5,-22.5
       parent: 1
       type: Transform
-  - uid: 893
+  - uid: 894
     components:
     - rot: -1.5707963267948966 rad
       pos: -0.5,-22.5
       parent: 1
       type: Transform
-  - uid: 894
+  - uid: 895
     components:
     - rot: -1.5707963267948966 rad
       pos: -0.5,-23.5
       parent: 1
       type: Transform
-  - uid: 895
+  - uid: 896
     components:
     - rot: -1.5707963267948966 rad
       pos: -1.5,-23.5
       parent: 1
       type: Transform
-  - uid: 896
+  - uid: 897
     components:
     - rot: -1.5707963267948966 rad
       pos: -2.5,-23.5
       parent: 1
       type: Transform
-  - uid: 897
+  - uid: 898
     components:
     - rot: -1.5707963267948966 rad
       pos: -3.5,-23.5
       parent: 1
       type: Transform
-  - uid: 898
+  - uid: 899
     components:
     - rot: -1.5707963267948966 rad
       pos: -1.5,-22.5
       parent: 1
       type: Transform
-  - uid: 899
+  - uid: 900
     components:
     - rot: -1.5707963267948966 rad
       pos: -1.5,-21.5
       parent: 1
       type: Transform
-  - uid: 900
+  - uid: 901
     components:
     - rot: -1.5707963267948966 rad
       pos: 2.5,-21.5
       parent: 1
       type: Transform
-  - uid: 901
+  - uid: 902
     components:
     - rot: -1.5707963267948966 rad
       pos: 2.5,-22.5
@@ -5923,18 +5931,18 @@ entities:
       type: Transform
 - proto: CarpetGreen
   entities:
-  - uid: 902
+  - uid: 903
     components:
     - pos: 0.5,-31.5
       parent: 1
       type: Transform
-  - uid: 903
+  - uid: 904
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,-31.5
       parent: 1
       type: Transform
-  - uid: 904
+  - uid: 905
     components:
     - rot: 3.141592653589793 rad
       pos: -1.5,-31.5
@@ -5942,594 +5950,594 @@ entities:
       type: Transform
 - proto: CarpetOrange
   entities:
-  - uid: 905
+  - uid: 906
     components:
     - pos: -1.5,-27.5
       parent: 1
       type: Transform
-  - uid: 906
+  - uid: 907
     components:
     - pos: -0.5,-27.5
       parent: 1
       type: Transform
-  - uid: 907
+  - uid: 908
     components:
     - pos: 0.5,-28.5
       parent: 1
       type: Transform
-  - uid: 908
+  - uid: 909
     components:
     - pos: -0.5,-28.5
       parent: 1
       type: Transform
-  - uid: 909
+  - uid: 910
     components:
     - pos: -1.5,-28.5
       parent: 1
       type: Transform
-  - uid: 910
+  - uid: 911
     components:
     - pos: -0.5,-29.5
       parent: 1
       type: Transform
-  - uid: 911
+  - uid: 912
     components:
     - pos: 0.5,-29.5
       parent: 1
       type: Transform
-  - uid: 912
+  - uid: 913
     components:
     - rot: 1.5707963267948966 rad
       pos: 2.5,1.5
       parent: 1
       type: Transform
-  - uid: 913
+  - uid: 914
     components:
     - pos: 2.5,0.5
       parent: 1
       type: Transform
-  - uid: 914
-    components:
-    - pos: 2.5,1.5
-      parent: 1
-      type: Transform
   - uid: 915
     components:
-    - rot: 1.5707963267948966 rad
-      pos: 1.5,-0.5
+    - pos: 2.5,1.5
       parent: 1
       type: Transform
   - uid: 916
     components:
     - rot: 1.5707963267948966 rad
-      pos: 1.5,0.5
+      pos: 1.5,-0.5
       parent: 1
       type: Transform
   - uid: 917
     components:
-    - pos: 0.5,1.5
+    - rot: 1.5707963267948966 rad
+      pos: 1.5,0.5
       parent: 1
       type: Transform
   - uid: 918
     components:
-    - pos: 1.5,1.5
+    - pos: 0.5,1.5
       parent: 1
       type: Transform
   - uid: 919
     components:
-    - rot: 1.5707963267948966 rad
-      pos: 0.5,0.5
+    - pos: 1.5,1.5
       parent: 1
       type: Transform
   - uid: 920
     components:
     - rot: 1.5707963267948966 rad
-      pos: 0.5,-0.5
+      pos: 0.5,0.5
       parent: 1
       type: Transform
   - uid: 921
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 0.5,-0.5
+      parent: 1
+      type: Transform
+  - uid: 922
     components:
     - pos: 2.5,-0.5
       parent: 1
       type: Transform
 - proto: CarpetSBlue
   entities:
-  - uid: 922
+  - uid: 923
     components:
     - rot: -1.5707963267948966 rad
       pos: 4.5,-25.5
       parent: 1
       type: Transform
-  - uid: 923
+  - uid: 924
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,-25.5
       parent: 1
       type: Transform
-  - uid: 924
+  - uid: 925
     components:
     - rot: -1.5707963267948966 rad
       pos: 2.5,-25.5
       parent: 1
       type: Transform
-  - uid: 925
+  - uid: 926
     components:
     - rot: -1.5707963267948966 rad
       pos: 2.5,-24.5
       parent: 1
       type: Transform
-  - uid: 926
+  - uid: 927
     components:
     - rot: -1.5707963267948966 rad
       pos: 1.5,-24.5
       parent: 1
       type: Transform
-  - uid: 927
+  - uid: 928
     components:
     - pos: 0.5,-24.5
       parent: 1
       type: Transform
-  - uid: 928
+  - uid: 929
     components:
     - pos: 1.5,-25.5
       parent: 1
       type: Transform
 - proto: Catwalk
   entities:
-  - uid: 929
+  - uid: 930
     components:
     - pos: 9.5,-28.5
       parent: 1
       type: Transform
-  - uid: 930
+  - uid: 931
     components:
     - pos: 8.5,-27.5
       parent: 1
       type: Transform
-  - uid: 931
+  - uid: 932
     components:
     - pos: 10.5,-27.5
       parent: 1
       type: Transform
-  - uid: 932
+  - uid: 933
     components:
     - pos: 11.5,-29.5
       parent: 1
       type: Transform
-  - uid: 933
+  - uid: 934
     components:
     - pos: 6.5,-26.5
       parent: 1
       type: Transform
-  - uid: 934
+  - uid: 935
     components:
     - pos: -5.5,-26.5
       parent: 1
       type: Transform
-  - uid: 935
+  - uid: 936
     components:
     - pos: -4.5,-27.5
       parent: 1
       type: Transform
-  - uid: 936
+  - uid: 937
     components:
     - pos: -4.5,-30.5
       parent: 1
       type: Transform
-  - uid: 937
+  - uid: 938
     components:
     - pos: -5.5,-32.5
       parent: 1
       type: Transform
-  - uid: 938
+  - uid: 939
     components:
     - pos: -0.5,-33.5
       parent: 1
       type: Transform
-  - uid: 939
+  - uid: 940
     components:
     - pos: 1.5,-33.5
       parent: 1
       type: Transform
-  - uid: 940
+  - uid: 941
     components:
     - pos: 1.5,-31.5
       parent: 1
       type: Transform
-  - uid: 941
+  - uid: 942
     components:
     - pos: -5.5,-21.5
       parent: 1
       type: Transform
-  - uid: 942
+  - uid: 943
     components:
     - pos: -3.5,-17.5
       parent: 1
       type: Transform
-  - uid: 943
+  - uid: 944
     components:
     - pos: 6.5,-21.5
       parent: 1
       type: Transform
-  - uid: 944
+  - uid: 945
     components:
     - pos: 6.5,-22.5
       parent: 1
       type: Transform
-  - uid: 945
+  - uid: 946
     components:
     - pos: 4.5,-17.5
       parent: 1
       type: Transform
-  - uid: 946
+  - uid: 947
     components:
     - pos: -4.5,-12.5
       parent: 1
       type: Transform
-  - uid: 947
+  - uid: 948
     components:
     - pos: 5.5,-12.5
       parent: 1
       type: Transform
-  - uid: 948
+  - uid: 949
     components:
     - pos: 4.5,-11.5
       parent: 1
       type: Transform
-  - uid: 949
+  - uid: 950
     components:
     - pos: -3.5,-11.5
       parent: 1
       type: Transform
-  - uid: 950
+  - uid: 951
     components:
     - pos: -4.5,-8.5
       parent: 1
       type: Transform
-  - uid: 951
+  - uid: 952
     components:
     - pos: 5.5,-8.5
       parent: 1
       type: Transform
-  - uid: 952
+  - uid: 953
     components:
     - pos: -5.5,-0.5
       parent: 1
       type: Transform
-  - uid: 953
+  - uid: 954
     components:
     - pos: -5.5,2.5
       parent: 1
       type: Transform
-  - uid: 954
+  - uid: 955
     components:
     - pos: -5.5,3.5
       parent: 1
       type: Transform
-  - uid: 955
+  - uid: 956
     components:
     - pos: -5.5,4.5
       parent: 1
       type: Transform
-  - uid: 956
+  - uid: 957
     components:
     - pos: -7.5,4.5
       parent: 1
       type: Transform
-  - uid: 957
+  - uid: 958
     components:
     - pos: -7.5,3.5
       parent: 1
       type: Transform
-  - uid: 958
+  - uid: 959
     components:
     - pos: -7.5,2.5
       parent: 1
       type: Transform
-  - uid: 959
+  - uid: 960
     components:
     - pos: -0.5,6.5
       parent: 1
       type: Transform
-  - uid: 960
+  - uid: 961
     components:
     - pos: 0.5,6.5
       parent: 1
       type: Transform
-  - uid: 961
+  - uid: 962
     components:
     - pos: 1.5,6.5
       parent: 1
       type: Transform
-  - uid: 962
+  - uid: 963
     components:
     - pos: 6.5,4.5
       parent: 1
       type: Transform
-  - uid: 963
+  - uid: 964
     components:
     - pos: 6.5,3.5
       parent: 1
       type: Transform
-  - uid: 964
+  - uid: 965
     components:
     - pos: 6.5,2.5
       parent: 1
       type: Transform
-  - uid: 965
+  - uid: 966
     components:
     - pos: -0.5,10.5
       parent: 1
       type: Transform
-  - uid: 966
+  - uid: 967
     components:
     - pos: 0.5,10.5
       parent: 1
       type: Transform
-  - uid: 967
+  - uid: 968
     components:
     - pos: 1.5,10.5
       parent: 1
       type: Transform
-  - uid: 968
+  - uid: 969
     components:
     - pos: 8.5,4.5
       parent: 1
       type: Transform
-  - uid: 969
+  - uid: 970
     components:
     - pos: 8.5,3.5
       parent: 1
       type: Transform
-  - uid: 970
+  - uid: 971
     components:
     - pos: 8.5,2.5
       parent: 1
       type: Transform
-  - uid: 971
+  - uid: 972
     components:
     - pos: 0.5,-1.5
       parent: 1
       type: Transform
-  - uid: 972
+  - uid: 973
     components:
     - pos: -5.5,-22.5
       parent: 1
       type: Transform
-  - uid: 973
+  - uid: 974
     components:
     - pos: -4.5,-23.5
       parent: 1
       type: Transform
-  - uid: 974
+  - uid: 975
     components:
     - pos: 5.5,-23.5
       parent: 1
       type: Transform
-  - uid: 975
+  - uid: 976
     components:
     - pos: -7.5,-31.5
       parent: 1
       type: Transform
-  - uid: 976
+  - uid: 977
     components:
     - pos: -7.5,-29.5
       parent: 1
       type: Transform
-  - uid: 977
+  - uid: 978
     components:
     - pos: -10.5,-29.5
       parent: 1
       type: Transform
-  - uid: 978
+  - uid: 979
     components:
     - pos: -7.5,-27.5
       parent: 1
       type: Transform
-  - uid: 979
+  - uid: 980
     components:
     - pos: -9.5,-27.5
       parent: 1
       type: Transform
-  - uid: 980
+  - uid: 981
     components:
     - pos: -4.5,-5.5
       parent: 1
       type: Transform
-  - uid: 981
+  - uid: 982
     components:
     - pos: -4.5,-4.5
       parent: 1
       type: Transform
-  - uid: 982
+  - uid: 983
     components:
     - pos: -4.5,-3.5
       parent: 1
       type: Transform
-  - uid: 983
+  - uid: 984
     components:
     - pos: -4.5,-2.5
       parent: 1
       type: Transform
-  - uid: 984
+  - uid: 985
     components:
     - pos: -4.5,-1.5
       parent: 1
       type: Transform
-  - uid: 985
+  - uid: 986
     components:
     - pos: -4.5,-0.5
       parent: 1
       type: Transform
-  - uid: 986
+  - uid: 987
     components:
     - pos: -4.5,0.5
       parent: 1
       type: Transform
-  - uid: 987
+  - uid: 988
     components:
     - pos: -4.5,1.5
       parent: 1
       type: Transform
-  - uid: 988
+  - uid: 989
     components:
     - pos: -4.5,2.5
       parent: 1
       type: Transform
-  - uid: 989
+  - uid: 990
     components:
     - pos: -4.5,3.5
       parent: 1
       type: Transform
-  - uid: 990
+  - uid: 991
     components:
     - pos: -4.5,4.5
       parent: 1
       type: Transform
-  - uid: 991
+  - uid: 992
     components:
     - pos: -3.5,4.5
       parent: 1
       type: Transform
-  - uid: 992
+  - uid: 993
     components:
     - pos: -2.5,4.5
       parent: 1
       type: Transform
-  - uid: 993
+  - uid: 994
     components:
     - pos: -1.5,4.5
       parent: 1
       type: Transform
-  - uid: 994
+  - uid: 995
     components:
     - pos: -1.5,5.5
       parent: 1
       type: Transform
-  - uid: 995
+  - uid: 996
     components:
     - pos: -1.5,6.5
       parent: 1
       type: Transform
-  - uid: 996
+  - uid: 997
     components:
     - pos: -1.5,7.5
       parent: 1
       type: Transform
-  - uid: 997
+  - uid: 998
     components:
     - pos: -1.5,8.5
       parent: 1
       type: Transform
-  - uid: 998
+  - uid: 999
     components:
     - pos: -1.5,9.5
       parent: 1
       type: Transform
-  - uid: 999
+  - uid: 1000
     components:
     - pos: 2.5,9.5
       parent: 1
       type: Transform
-  - uid: 1000
+  - uid: 1001
     components:
     - pos: 2.5,8.5
       parent: 1
       type: Transform
-  - uid: 1001
+  - uid: 1002
     components:
     - pos: 2.5,7.5
       parent: 1
       type: Transform
-  - uid: 1002
+  - uid: 1003
     components:
     - pos: 2.5,6.5
       parent: 1
       type: Transform
-  - uid: 1003
+  - uid: 1004
     components:
     - pos: 2.5,5.5
       parent: 1
       type: Transform
-  - uid: 1004
+  - uid: 1005
     components:
     - pos: 2.5,4.5
       parent: 1
       type: Transform
-  - uid: 1005
+  - uid: 1006
     components:
     - pos: 3.5,4.5
       parent: 1
       type: Transform
-  - uid: 1006
+  - uid: 1007
     components:
     - pos: 4.5,4.5
       parent: 1
       type: Transform
-  - uid: 1007
+  - uid: 1008
     components:
     - pos: 5.5,4.5
       parent: 1
       type: Transform
-  - uid: 1008
+  - uid: 1009
     components:
     - pos: 5.5,3.5
       parent: 1
       type: Transform
-  - uid: 1009
+  - uid: 1010
     components:
     - pos: 5.5,2.5
       parent: 1
       type: Transform
-  - uid: 1010
+  - uid: 1011
     components:
     - pos: 5.5,1.5
       parent: 1
       type: Transform
-  - uid: 1011
+  - uid: 1012
     components:
     - pos: 5.5,0.5
       parent: 1
       type: Transform
-  - uid: 1012
+  - uid: 1013
     components:
     - pos: 5.5,-0.5
       parent: 1
       type: Transform
-  - uid: 1013
+  - uid: 1014
     components:
     - pos: 5.5,-1.5
       parent: 1
       type: Transform
-  - uid: 1014
+  - uid: 1015
     components:
     - pos: 5.5,-2.5
       parent: 1
       type: Transform
-  - uid: 1015
+  - uid: 1016
     components:
     - pos: 5.5,-3.5
       parent: 1
       type: Transform
-  - uid: 1016
+  - uid: 1017
     components:
     - pos: 5.5,-4.5
       parent: 1
       type: Transform
-  - uid: 1017
+  - uid: 1018
     components:
     - pos: 5.5,-5.5
       parent: 1
       type: Transform
 - proto: Chair
   entities:
-  - uid: 1018
+  - uid: 1019
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,-31.5
       parent: 1
       type: Transform
-  - uid: 1019
+  - uid: 1020
     components:
     - rot: 1.5707963267948966 rad
       pos: -6.5,0.5
@@ -6537,25 +6545,25 @@ entities:
       type: Transform
 - proto: ChairFolding
   entities:
-  - uid: 1020
+  - uid: 1021
     components:
     - rot: 1.5707963267948966 rad
       pos: -0.5,-7.5
       parent: 1
       type: Transform
-  - uid: 1021
+  - uid: 1022
     components:
     - rot: 1.5707963267948966 rad
       pos: -0.5,-8.5
       parent: 1
       type: Transform
-  - uid: 1022
+  - uid: 1023
     components:
     - rot: -1.5707963267948966 rad
       pos: 1.5,-7.5
       parent: 1
       type: Transform
-  - uid: 1023
+  - uid: 1024
     components:
     - rot: -1.5707963267948966 rad
       pos: 1.5,-8.5
@@ -6563,21 +6571,21 @@ entities:
       type: Transform
 - proto: ChairFoldingSpawnFolded
   entities:
-  - uid: 1024
+  - uid: 1025
     components:
     - pos: -5.3470545,-8.756538
       parent: 1
       type: Transform
 - proto: ChairOfficeDark
   entities:
-  - uid: 1025
+  - uid: 1026
     components:
     - pos: -0.5,-29.5
       parent: 1
       type: Transform
 - proto: ChairOfficeLight
   entities:
-  - uid: 1026
+  - uid: 1027
     components:
     - rot: 1.5707963267948966 rad
       pos: -1.5,0.5
@@ -6585,19 +6593,19 @@ entities:
       type: Transform
 - proto: ChairPilotSeat
   entities:
-  - uid: 1027
+  - uid: 1028
     components:
     - rot: 3.141592653589793 rad
       pos: 1.5,-22.5
       parent: 1
       type: Transform
-  - uid: 1028
+  - uid: 1029
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,-22.5
       parent: 1
       type: Transform
-  - uid: 1029
+  - uid: 1030
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,-22.5
@@ -6605,61 +6613,61 @@ entities:
       type: Transform
 - proto: CheapLighter
   entities:
-  - uid: 1030
+  - uid: 1031
     components:
     - pos: 7.777271,-16.329456
       parent: 1
       type: Transform
-  - uid: 1031
+  - uid: 1032
     components:
     - pos: -6.77578,-16.362549
       parent: 1
       type: Transform
 - proto: chem_master
   entities:
-  - uid: 1032
+  - uid: 1033
     components:
     - pos: 7.5,-12.5
       parent: 1
       type: Transform
 - proto: Cigar
   entities:
-  - uid: 1033
+  - uid: 1034
     components:
     - pos: -0.4920463,-17.327991
       parent: 1
       type: Transform
 - proto: Cigarette
   entities:
-  - uid: 1034
+  - uid: 1035
     components:
     - pos: -6.46328,-16.028984
       parent: 1
       type: Transform
-  - uid: 1035
+  - uid: 1036
     components:
     - pos: 7.607122,-16.079285
       parent: 1
       type: Transform
 - proto: CigarGold
   entities:
-  - uid: 1036
+  - uid: 1037
     components:
     - pos: -0.64304274,-30.25811
       parent: 1
       type: Transform
-  - uid: 1037
+  - uid: 1038
     components:
     - pos: -0.7390743,0.7418492
       parent: 1
       type: Transform
-  - uid: 1038
+  - uid: 1039
     components:
     - rot: -1.5707963267948966 rad
       pos: 1.4902998,-25.30999
       parent: 1
       type: Transform
-  - uid: 1039
+  - uid: 1040
     components:
     - rot: -1.5707963267948966 rad
       pos: 1.3340497,-25.372534
@@ -6667,84 +6675,84 @@ entities:
       type: Transform
 - proto: ClosetToolFilled
   entities:
-  - uid: 1040
+  - uid: 1041
     components:
     - pos: 7.5,-28.5
       parent: 1
       type: Transform
 - proto: ClosetWallEmergencyFilledRandom
   entities:
-  - uid: 1041
+  - uid: 1042
     components:
     - rot: 1.5707963267948966 rad
       pos: -4.5,-31.5
       parent: 1
       type: Transform
-  - uid: 1042
+  - uid: 1043
     components:
     - rot: 1.5707963267948966 rad
       pos: -4.5,-28.5
       parent: 1
       type: Transform
-  - uid: 1043
+  - uid: 1044
     components:
     - pos: -8.5,-30.5
       parent: 1
       type: Transform
-  - uid: 1044
+  - uid: 1045
     components:
     - pos: -2.5,-12.5
       parent: 1
       type: Transform
 - proto: ClosetWallFireFilledRandom
   entities:
-  - uid: 1045
+  - uid: 1046
     components:
     - pos: 3.5,-12.5
       parent: 1
       type: Transform
 - proto: ClosetWallMaintenanceFilledRandom
   entities:
-  - uid: 1046
+  - uid: 1047
     components:
     - pos: -3.5,-29.5
       parent: 1
       type: Transform
-  - uid: 1047
+  - uid: 1048
     components:
     - pos: -3.5,-26.5
       parent: 1
       type: Transform
-  - uid: 1048
+  - uid: 1049
     components:
     - pos: -9.5,-30.5
       parent: 1
       type: Transform
 - proto: ClothingBackpackCaptain
   entities:
-  - uid: 219
+  - uid: 220
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 216
+    - parent: 217
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: ClothingBackpackDuffelSurgeryFilled
   entities:
-  - uid: 1049
+  - uid: 1050
     components:
     - pos: -6.3591137,-16.300005
       parent: 1
       type: Transform
 - proto: ClothingBeltSheathFilled
   entities:
-  - uid: 220
+  - uid: 221
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 216
+    - parent: 217
       type: Transform
     - canCollide: False
       type: Physics
@@ -6760,31 +6768,11 @@ entities:
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 1051
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 1050
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
-  - uid: 1055
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 1054
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
-- proto: ClothingEyesGlassesMeson
-  entities:
   - uid: 1052
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 1050
+    - parent: 1051
       type: Transform
     - canCollide: False
       type: Physics
@@ -6793,65 +6781,85 @@ entities:
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 1054
+    - parent: 1055
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: ClothingEyesGlassesMeson
+  entities:
+  - uid: 1053
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 1051
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 1057
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 1055
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: ClothingEyesGlassesSecurity
   entities:
-  - uid: 221
+  - uid: 222
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 216
+    - parent: 217
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: ClothingEyesGlassesSunglasses
   entities:
-  - uid: 222
+  - uid: 223
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 216
+    - parent: 217
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: ClothingHandsGlovesCaptain
   entities:
-  - uid: 223
+  - uid: 224
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 216
+    - parent: 217
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: ClothingHeadHatBowlerHat
   entities:
-  - uid: 1058
+  - uid: 1059
     components:
     - pos: 1.3621204,-17.150785
       parent: 1
       type: Transform
 - proto: ClothingHeadHatCaptain
   entities:
-  - uid: 224
+  - uid: 225
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 216
+    - parent: 217
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: ClothingHeadHatCone
   entities:
-  - uid: 1059
+  - uid: 1060
     components:
     - pos: 4.469919,-30.10354
       parent: 1
@@ -6869,11 +6877,11 @@ entities:
     - type: InsideEntityStorage
 - proto: ClothingHeadHatPirate
   entities:
-  - uid: 1061
+  - uid: 1062
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 1060
+    - parent: 1061
       type: Transform
     - canCollide: False
       type: Physics
@@ -6891,7 +6899,7 @@ entities:
     - type: InsideEntityStorage
 - proto: ClothingHeadHelmetEVA
   entities:
-  - uid: 1065
+  - uid: 1066
     components:
     - pos: 10.221624,-32.356922
       parent: 1
@@ -6909,44 +6917,44 @@ entities:
     - type: InsideEntityStorage
 - proto: ClothingMaskItalianMoustache
   entities:
-  - uid: 225
+  - uid: 226
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 216
+    - parent: 217
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: ClothingNeckCloakCap
   entities:
-  - uid: 226
+  - uid: 227
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 216
+    - parent: 217
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: ClothingNeckCloakCapFormal
   entities:
-  - uid: 227
+  - uid: 228
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 216
+    - parent: 217
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: ClothingNeckCloakPirateCap
   entities:
-  - uid: 1062
+  - uid: 1063
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 1060
+    - parent: 1061
       type: Transform
     - canCollide: False
       type: Physics
@@ -6964,11 +6972,11 @@ entities:
     - type: InsideEntityStorage
 - proto: ClothingOuterArmorCaptainCarapace
   entities:
-  - uid: 228
+  - uid: 229
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 216
+    - parent: 217
       type: Transform
     - group:
       - hoverMessage: ""
@@ -7004,29 +7012,29 @@ entities:
     - type: InsideEntityStorage
 - proto: ClothingOuterHardsuitEVA
   entities:
-  - uid: 1066
+  - uid: 1067
     components:
     - pos: 10.643499,-32.59146
       parent: 1
       type: Transform
 - proto: ClothingOuterHardsuitMedical
   entities:
-  - uid: 1068
+  - uid: 1069
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 1067
+    - parent: 1068
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: ClothingOuterWinterCap
   entities:
-  - uid: 229
+  - uid: 230
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 216
+    - parent: 217
       type: Transform
     - canCollide: False
       type: Physics
@@ -7044,57 +7052,57 @@ entities:
     - type: InsideEntityStorage
 - proto: ClothingUniformJumpskirtCapFormalDress
   entities:
-  - uid: 230
+  - uid: 231
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 216
+    - parent: 217
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: ClothingUniformJumpskirtCaptain
   entities:
-  - uid: 231
+  - uid: 232
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 216
+    - parent: 217
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: ClothingUniformJumpsuitCapFormal
   entities:
-  - uid: 232
+  - uid: 233
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 216
+    - parent: 217
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: ClothingUniformJumpsuitCaptain
   entities:
-  - uid: 233
+  - uid: 234
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 216
+    - parent: 217
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: ComfyChair
   entities:
-  - uid: 1069
+  - uid: 1070
     components:
     - rot: 3.141592653589793 rad
       pos: -1.5,-17.5
       parent: 1
       type: Transform
-  - uid: 1070
+  - uid: 1071
     components:
     - rot: 3.141592653589793 rad
       pos: 2.5,-17.5
@@ -7102,12 +7110,12 @@ entities:
       type: Transform
 - proto: ComputerCrewMonitoring
   entities:
-  - uid: 1071
+  - uid: 1072
     components:
     - pos: -5.5,-11.5
       parent: 1
       type: Transform
-  - uid: 1072
+  - uid: 1073
     components:
     - rot: 1.5707963267948966 rad
       pos: -3.5,-24.5
@@ -7115,7 +7123,7 @@ entities:
       type: Transform
 - proto: ComputerPowerMonitoring
   entities:
-  - uid: 1073
+  - uid: 1074
     components:
     - rot: 1.5707963267948966 rad
       pos: -1.5,-29.5
@@ -7123,33 +7131,33 @@ entities:
       type: Transform
 - proto: ComputerRadar
   entities:
-  - uid: 1074
+  - uid: 1075
     components:
     - pos: 1.5,-21.5
       parent: 1
       type: Transform
-  - uid: 1075
+  - uid: 1076
     components:
     - pos: -1.5,1.5
       parent: 1
       type: Transform
 - proto: ComputerSalvageExpedition
   entities:
-  - uid: 1076
+  - uid: 1077
     components:
     - pos: -0.5,-21.5
       parent: 1
       type: Transform
 - proto: ComputerShuttle
   entities:
-  - uid: 1077
+  - uid: 1078
     components:
     - pos: 0.5,-21.5
       parent: 1
       type: Transform
 - proto: ComputerStationRecords
   entities:
-  - uid: 1078
+  - uid: 1079
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,-24.5
@@ -7157,7 +7165,7 @@ entities:
       type: Transform
 - proto: ComputerSurveillanceCameraMonitor
   entities:
-  - uid: 1079
+  - uid: 1080
     components:
     - rot: 1.5707963267948966 rad
       pos: -3.5,-25.5
@@ -7165,7 +7173,7 @@ entities:
       type: Transform
 - proto: ComputerWallmountWithdrawBankATM
   entities:
-  - uid: 1080
+  - uid: 1081
     components:
     - rot: 1.5707963267948966 rad
       pos: 2.5,-1.5
@@ -7173,7 +7181,7 @@ entities:
       type: Transform
 - proto: ConveyorBelt
   entities:
-  - uid: 1081
+  - uid: 1082
     components:
     - rot: 3.141592653589793 rad
       pos: -4.5,-5.5
@@ -7182,7 +7190,7 @@ entities:
     - links:
       - 2157
       type: DeviceLinkSink
-  - uid: 1082
+  - uid: 1083
     components:
     - rot: 3.141592653589793 rad
       pos: -4.5,-4.5
@@ -7191,7 +7199,7 @@ entities:
     - links:
       - 2157
       type: DeviceLinkSink
-  - uid: 1083
+  - uid: 1084
     components:
     - rot: 3.141592653589793 rad
       pos: -4.5,-3.5
@@ -7200,7 +7208,7 @@ entities:
     - links:
       - 2157
       type: DeviceLinkSink
-  - uid: 1084
+  - uid: 1085
     components:
     - rot: 3.141592653589793 rad
       pos: -4.5,-2.5
@@ -7209,7 +7217,7 @@ entities:
     - links:
       - 2157
       type: DeviceLinkSink
-  - uid: 1085
+  - uid: 1086
     components:
     - rot: 3.141592653589793 rad
       pos: -4.5,-1.5
@@ -7218,7 +7226,7 @@ entities:
     - links:
       - 2157
       type: DeviceLinkSink
-  - uid: 1086
+  - uid: 1087
     components:
     - rot: 3.141592653589793 rad
       pos: -4.5,-0.5
@@ -7227,7 +7235,7 @@ entities:
     - links:
       - 2157
       type: DeviceLinkSink
-  - uid: 1087
+  - uid: 1088
     components:
     - rot: 3.141592653589793 rad
       pos: -4.5,0.5
@@ -7236,7 +7244,7 @@ entities:
     - links:
       - 2157
       type: DeviceLinkSink
-  - uid: 1088
+  - uid: 1089
     components:
     - rot: 3.141592653589793 rad
       pos: -4.5,2.5
@@ -7245,7 +7253,7 @@ entities:
     - links:
       - 2157
       type: DeviceLinkSink
-  - uid: 1089
+  - uid: 1090
     components:
     - rot: 3.141592653589793 rad
       pos: -4.5,3.5
@@ -7254,7 +7262,7 @@ entities:
     - links:
       - 2157
       type: DeviceLinkSink
-  - uid: 1090
+  - uid: 1091
     components:
     - rot: 1.5707963267948966 rad
       pos: -4.5,4.5
@@ -7263,7 +7271,7 @@ entities:
     - links:
       - 2157
       type: DeviceLinkSink
-  - uid: 1091
+  - uid: 1092
     components:
     - rot: 1.5707963267948966 rad
       pos: -3.5,4.5
@@ -7272,7 +7280,7 @@ entities:
     - links:
       - 2157
       type: DeviceLinkSink
-  - uid: 1092
+  - uid: 1093
     components:
     - rot: 1.5707963267948966 rad
       pos: -2.5,4.5
@@ -7281,7 +7289,7 @@ entities:
     - links:
       - 2157
       type: DeviceLinkSink
-  - uid: 1093
+  - uid: 1094
     components:
     - rot: 3.141592653589793 rad
       pos: -1.5,4.5
@@ -7290,7 +7298,7 @@ entities:
     - links:
       - 2157
       type: DeviceLinkSink
-  - uid: 1094
+  - uid: 1095
     components:
     - rot: 3.141592653589793 rad
       pos: -1.5,5.5
@@ -7299,7 +7307,7 @@ entities:
     - links:
       - 2157
       type: DeviceLinkSink
-  - uid: 1095
+  - uid: 1096
     components:
     - rot: 3.141592653589793 rad
       pos: -1.5,6.5
@@ -7308,7 +7316,7 @@ entities:
     - links:
       - 2157
       type: DeviceLinkSink
-  - uid: 1096
+  - uid: 1097
     components:
     - rot: 3.141592653589793 rad
       pos: -1.5,7.5
@@ -7317,7 +7325,7 @@ entities:
     - links:
       - 2157
       type: DeviceLinkSink
-  - uid: 1097
+  - uid: 1098
     components:
     - rot: 3.141592653589793 rad
       pos: -1.5,8.5
@@ -7326,7 +7334,7 @@ entities:
     - links:
       - 2157
       type: DeviceLinkSink
-  - uid: 1098
+  - uid: 1099
     components:
     - rot: 3.141592653589793 rad
       pos: -1.5,9.5
@@ -7335,7 +7343,7 @@ entities:
     - links:
       - 2157
       type: DeviceLinkSink
-  - uid: 1099
+  - uid: 1100
     components:
     - rot: 3.141592653589793 rad
       pos: -1.5,10.5
@@ -7344,7 +7352,7 @@ entities:
     - links:
       - 2157
       type: DeviceLinkSink
-  - uid: 1100
+  - uid: 1101
     components:
     - pos: 2.5,10.5
       parent: 1
@@ -7352,7 +7360,7 @@ entities:
     - links:
       - 2158
       type: DeviceLinkSink
-  - uid: 1101
+  - uid: 1102
     components:
     - pos: 2.5,9.5
       parent: 1
@@ -7360,7 +7368,7 @@ entities:
     - links:
       - 2158
       type: DeviceLinkSink
-  - uid: 1102
+  - uid: 1103
     components:
     - pos: 2.5,8.5
       parent: 1
@@ -7368,7 +7376,7 @@ entities:
     - links:
       - 2158
       type: DeviceLinkSink
-  - uid: 1103
+  - uid: 1104
     components:
     - pos: 2.5,7.5
       parent: 1
@@ -7376,7 +7384,7 @@ entities:
     - links:
       - 2158
       type: DeviceLinkSink
-  - uid: 1104
+  - uid: 1105
     components:
     - pos: 2.5,6.5
       parent: 1
@@ -7384,18 +7392,9 @@ entities:
     - links:
       - 2158
       type: DeviceLinkSink
-  - uid: 1105
-    components:
-    - pos: 2.5,5.5
-      parent: 1
-      type: Transform
-    - links:
-      - 2158
-      type: DeviceLinkSink
   - uid: 1106
     components:
-    - rot: 1.5707963267948966 rad
-      pos: 2.5,4.5
+    - pos: 2.5,5.5
       parent: 1
       type: Transform
     - links:
@@ -7404,7 +7403,7 @@ entities:
   - uid: 1107
     components:
     - rot: 1.5707963267948966 rad
-      pos: 3.5,4.5
+      pos: 2.5,4.5
       parent: 1
       type: Transform
     - links:
@@ -7413,7 +7412,7 @@ entities:
   - uid: 1108
     components:
     - rot: 1.5707963267948966 rad
-      pos: 4.5,4.5
+      pos: 3.5,4.5
       parent: 1
       type: Transform
     - links:
@@ -7421,7 +7420,8 @@ entities:
       type: DeviceLinkSink
   - uid: 1109
     components:
-    - pos: 5.5,4.5
+    - rot: 1.5707963267948966 rad
+      pos: 4.5,4.5
       parent: 1
       type: Transform
     - links:
@@ -7429,7 +7429,7 @@ entities:
       type: DeviceLinkSink
   - uid: 1110
     components:
-    - pos: 5.5,3.5
+    - pos: 5.5,4.5
       parent: 1
       type: Transform
     - links:
@@ -7437,7 +7437,7 @@ entities:
       type: DeviceLinkSink
   - uid: 1111
     components:
-    - pos: 5.5,2.5
+    - pos: 5.5,3.5
       parent: 1
       type: Transform
     - links:
@@ -7445,7 +7445,7 @@ entities:
       type: DeviceLinkSink
   - uid: 1112
     components:
-    - pos: 5.5,0.5
+    - pos: 5.5,2.5
       parent: 1
       type: Transform
     - links:
@@ -7453,7 +7453,7 @@ entities:
       type: DeviceLinkSink
   - uid: 1113
     components:
-    - pos: 5.5,-0.5
+    - pos: 5.5,0.5
       parent: 1
       type: Transform
     - links:
@@ -7461,7 +7461,7 @@ entities:
       type: DeviceLinkSink
   - uid: 1114
     components:
-    - pos: 5.5,-1.5
+    - pos: 5.5,-0.5
       parent: 1
       type: Transform
     - links:
@@ -7469,7 +7469,7 @@ entities:
       type: DeviceLinkSink
   - uid: 1115
     components:
-    - pos: 5.5,-2.5
+    - pos: 5.5,-1.5
       parent: 1
       type: Transform
     - links:
@@ -7477,7 +7477,7 @@ entities:
       type: DeviceLinkSink
   - uid: 1116
     components:
-    - pos: 5.5,-3.5
+    - pos: 5.5,-2.5
       parent: 1
       type: Transform
     - links:
@@ -7485,13 +7485,21 @@ entities:
       type: DeviceLinkSink
   - uid: 1117
     components:
-    - pos: 5.5,-4.5
+    - pos: 5.5,-3.5
       parent: 1
       type: Transform
     - links:
       - 2158
       type: DeviceLinkSink
   - uid: 1118
+    components:
+    - pos: 5.5,-4.5
+      parent: 1
+      type: Transform
+    - links:
+      - 2158
+      type: DeviceLinkSink
+  - uid: 1119
     components:
     - pos: 5.5,-5.5
       parent: 1
@@ -7501,40 +7509,40 @@ entities:
       type: DeviceLinkSink
 - proto: ConveyorBeltAssembly
   entities:
-  - uid: 1119
+  - uid: 1120
     components:
     - pos: 2.4542723,-2.6279476
       parent: 1
       type: Transform
-  - uid: 1120
+  - uid: 1121
     components:
     - pos: 2.5261548,-2.3826964
       parent: 1
       type: Transform
 - proto: CrateEngineeringAMEJar
   entities:
-  - uid: 1121
+  - uid: 1122
     components:
     - pos: 3.5,-30.5
       parent: 1
       type: Transform
 - proto: CrateEngineeringCableBulk
   entities:
-  - uid: 1122
+  - uid: 1123
     components:
     - pos: 2.5,-30.5
       parent: 1
       type: Transform
 - proto: CrateEngineeringGenerator
   entities:
-  - uid: 1123
+  - uid: 1124
     components:
     - pos: 7.5,-30.5
       parent: 1
       type: Transform
 - proto: CratePirate
   entities:
-  - uid: 1060
+  - uid: 1061
     components:
     - pos: -0.5,-25.5
       parent: 1
@@ -7562,10 +7570,10 @@ entities:
           showEnts: False
           occludes: True
           ents:
+          - 1065
           - 1064
-          - 1063
-          - 1061
           - 1062
+          - 1063
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -7573,151 +7581,151 @@ entities:
       type: ContainerContainer
 - proto: CrowbarRed
   entities:
-  - uid: 1124
+  - uid: 1125
     components:
     - pos: 1.4561255,-25.424812
       parent: 1
       type: Transform
 - proto: DefibrillatorCabinetFilled
   entities:
-  - uid: 1125
+  - uid: 1126
     components:
     - pos: -6.5,-14.5
       parent: 1
       type: Transform
 - proto: DisposalBend
   entities:
-  - uid: 1126
+  - uid: 1127
     components:
     - rot: -1.5707963267948966 rad
       pos: 0.5,-4.5
       parent: 1
       type: Transform
-  - uid: 1127
+  - uid: 1128
     components:
     - rot: -1.5707963267948966 rad
       pos: -3.5,-18.5
       parent: 1
       type: Transform
-  - uid: 1128
+  - uid: 1129
     components:
     - rot: 1.5707963267948966 rad
       pos: -5.5,-18.5
       parent: 1
       type: Transform
-  - uid: 1129
+  - uid: 1130
     components:
     - rot: 3.141592653589793 rad
       pos: -5.5,-33.5
       parent: 1
       type: Transform
-  - uid: 1130
+  - uid: 1131
     components:
     - rot: -1.5707963267948966 rad
       pos: 6.5,-33.5
       parent: 1
       type: Transform
-  - uid: 1131
+  - uid: 1132
     components:
     - pos: 6.5,-18.5
       parent: 1
       type: Transform
-  - uid: 1132
+  - uid: 1133
     components:
     - rot: 3.141592653589793 rad
       pos: 4.5,-18.5
       parent: 1
       type: Transform
-  - uid: 1133
+  - uid: 1134
     components:
     - pos: 4.5,-10.5
       parent: 1
       type: Transform
-  - uid: 1134
+  - uid: 1135
     components:
     - rot: 3.141592653589793 rad
       pos: 3.5,-10.5
       parent: 1
       type: Transform
-  - uid: 1135
+  - uid: 1136
     components:
     - pos: 2.5,-31.5
       parent: 1
       type: Transform
-  - uid: 1136
+  - uid: 1137
     components:
     - rot: -1.5707963267948966 rad
       pos: 1.5,-0.5
       parent: 1
       type: Transform
-  - uid: 1137
+  - uid: 1138
     components:
     - rot: 1.5707963267948966 rad
       pos: 0.5,-0.5
       parent: 1
       type: Transform
-  - uid: 1138
+  - uid: 1139
     components:
     - rot: 1.5707963267948966 rad
       pos: -0.5,-4.5
       parent: 1
       type: Transform
-  - uid: 1139
+  - uid: 1140
     components:
     - pos: 3.5,-8.5
       parent: 1
       type: Transform
-  - uid: 1140
+  - uid: 1141
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,-9.5
       parent: 1
       type: Transform
-  - uid: 1141
+  - uid: 1142
     components:
     - pos: 10.5,-29.5
       parent: 1
       type: Transform
-  - uid: 1142
+  - uid: 1143
     components:
     - rot: 3.141592653589793 rad
       pos: 9.5,-29.5
       parent: 1
       type: Transform
-  - uid: 1143
+  - uid: 1144
     components:
     - pos: 9.5,-27.5
       parent: 1
       type: Transform
-  - uid: 1144
+  - uid: 1145
     components:
     - rot: 3.141592653589793 rad
       pos: 7.5,-27.5
       parent: 1
       type: Transform
-  - uid: 1145
+  - uid: 1146
     components:
     - pos: 7.5,-24.5
       parent: 1
       type: Transform
-  - uid: 1146
+  - uid: 1147
     components:
     - pos: 0.5,-9.5
       parent: 1
       type: Transform
-  - uid: 1147
+  - uid: 1148
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,-8.5
       parent: 1
       type: Transform
-  - uid: 1148
+  - uid: 1149
     components:
     - rot: -1.5707963267948966 rad
       pos: -1.5,-15.5
       parent: 1
       type: Transform
-  - uid: 1149
+  - uid: 1150
     components:
     - rot: 1.5707963267948966 rad
       pos: -3.5,-15.5
@@ -7725,18 +7733,18 @@ entities:
       type: Transform
 - proto: DisposalJunction
   entities:
-  - uid: 1150
+  - uid: 1151
     components:
     - rot: -1.5707963267948966 rad
       pos: 2.5,-33.5
       parent: 1
       type: Transform
-  - uid: 1151
+  - uid: 1152
     components:
     - pos: -5.5,-25.5
       parent: 1
       type: Transform
-  - uid: 1152
+  - uid: 1153
     components:
     - rot: 1.5707963267948966 rad
       pos: -1.5,-33.5
@@ -7744,7 +7752,7 @@ entities:
       type: Transform
 - proto: DisposalJunctionFlipped
   entities:
-  - uid: 1153
+  - uid: 1154
     components:
     - rot: 1.5707963267948966 rad
       pos: 0.5,-24.5
@@ -7752,235 +7760,229 @@ entities:
       type: Transform
 - proto: DisposalPipe
   entities:
-  - uid: 1154
+  - uid: 1155
     components:
     - rot: -1.5707963267948966 rad
       pos: 4.5,-24.5
       parent: 1
       type: Transform
-  - uid: 1155
+  - uid: 1156
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,-3.5
       parent: 1
       type: Transform
-  - uid: 1156
+  - uid: 1157
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,-5.5
       parent: 1
       type: Transform
-  - uid: 1157
+  - uid: 1158
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,-6.5
       parent: 1
       type: Transform
-  - uid: 1158
+  - uid: 1159
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,-7.5
       parent: 1
       type: Transform
-  - uid: 1159
+  - uid: 1160
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,-8.5
       parent: 1
       type: Transform
-  - uid: 1160
+  - uid: 1161
     components:
     - pos: -3.5,-16.5
       parent: 1
       type: Transform
-  - uid: 1161
+  - uid: 1162
     components:
     - pos: -3.5,-17.5
       parent: 1
       type: Transform
-  - uid: 1162
+  - uid: 1163
     components:
     - rot: -1.5707963267948966 rad
       pos: -4.5,-18.5
       parent: 1
       type: Transform
-  - uid: 1163
+  - uid: 1164
     components:
     - pos: -5.5,-19.5
       parent: 1
       type: Transform
-  - uid: 1164
+  - uid: 1165
     components:
     - pos: -5.5,-20.5
       parent: 1
       type: Transform
-  - uid: 1165
+  - uid: 1166
     components:
     - pos: -5.5,-23.5
       parent: 1
       type: Transform
-  - uid: 1166
+  - uid: 1167
     components:
     - pos: -5.5,-24.5
       parent: 1
       type: Transform
-  - uid: 1167
+  - uid: 1168
     components:
     - pos: -5.5,-22.5
       parent: 1
       type: Transform
-  - uid: 1168
+  - uid: 1169
     components:
     - pos: -5.5,-21.5
       parent: 1
       type: Transform
-  - uid: 1169
+  - uid: 1170
     components:
     - pos: -5.5,-26.5
       parent: 1
       type: Transform
-  - uid: 1170
+  - uid: 1171
     components:
     - pos: -5.5,-27.5
       parent: 1
       type: Transform
-  - uid: 1171
+  - uid: 1172
     components:
     - pos: -5.5,-28.5
       parent: 1
       type: Transform
-  - uid: 1172
+  - uid: 1173
     components:
     - pos: -5.5,-29.5
       parent: 1
       type: Transform
-  - uid: 1173
+  - uid: 1174
     components:
     - pos: -5.5,-30.5
       parent: 1
       type: Transform
-  - uid: 1174
+  - uid: 1175
     components:
     - pos: -5.5,-31.5
       parent: 1
       type: Transform
-  - uid: 1175
-    components:
-    - pos: -5.5,-32.5
-      parent: 1
-      type: Transform
   - uid: 1176
     components:
-    - rot: 1.5707963267948966 rad
-      pos: -4.5,-33.5
+    - pos: -5.5,-32.5
       parent: 1
       type: Transform
   - uid: 1177
     components:
     - rot: 1.5707963267948966 rad
-      pos: -3.5,-33.5
+      pos: -4.5,-33.5
       parent: 1
       type: Transform
   - uid: 1178
     components:
     - rot: 1.5707963267948966 rad
-      pos: -2.5,-33.5
+      pos: -3.5,-33.5
       parent: 1
       type: Transform
   - uid: 1179
     components:
-    - rot: -1.5707963267948966 rad
-      pos: -0.5,-33.5
+    - rot: 1.5707963267948966 rad
+      pos: -2.5,-33.5
       parent: 1
       type: Transform
   - uid: 1180
     components:
     - rot: -1.5707963267948966 rad
-      pos: 1.5,-33.5
+      pos: -0.5,-33.5
       parent: 1
       type: Transform
   - uid: 1181
     components:
     - rot: -1.5707963267948966 rad
-      pos: 3.5,-33.5
+      pos: 1.5,-33.5
       parent: 1
       type: Transform
   - uid: 1182
     components:
     - rot: -1.5707963267948966 rad
-      pos: 4.5,-33.5
+      pos: 3.5,-33.5
       parent: 1
       type: Transform
   - uid: 1183
     components:
     - rot: -1.5707963267948966 rad
-      pos: 5.5,-33.5
+      pos: 4.5,-33.5
       parent: 1
       type: Transform
   - uid: 1184
     components:
-    - rot: 3.141592653589793 rad
-      pos: 6.5,-32.5
+    - rot: -1.5707963267948966 rad
+      pos: 5.5,-33.5
       parent: 1
       type: Transform
   - uid: 1185
     components:
     - rot: 3.141592653589793 rad
-      pos: 6.5,-31.5
+      pos: 6.5,-32.5
       parent: 1
       type: Transform
   - uid: 1186
     components:
     - rot: 3.141592653589793 rad
-      pos: 6.5,-30.5
+      pos: 6.5,-31.5
       parent: 1
       type: Transform
   - uid: 1187
     components:
     - rot: 3.141592653589793 rad
-      pos: 6.5,-29.5
+      pos: 6.5,-30.5
       parent: 1
       type: Transform
   - uid: 1188
     components:
     - rot: 3.141592653589793 rad
-      pos: 6.5,-28.5
+      pos: 6.5,-29.5
       parent: 1
       type: Transform
   - uid: 1189
     components:
     - rot: 3.141592653589793 rad
-      pos: 6.5,-27.5
+      pos: 6.5,-28.5
       parent: 1
       type: Transform
   - uid: 1190
     components:
     - rot: 3.141592653589793 rad
-      pos: 6.5,-26.5
+      pos: 6.5,-27.5
       parent: 1
       type: Transform
   - uid: 1191
     components:
     - rot: 3.141592653589793 rad
-      pos: 6.5,-25.5
+      pos: 6.5,-26.5
       parent: 1
       type: Transform
   - uid: 1192
     components:
     - rot: 3.141592653589793 rad
-      pos: 6.5,-24.5
+      pos: 6.5,-25.5
       parent: 1
       type: Transform
   - uid: 1193
     components:
     - rot: 3.141592653589793 rad
-      pos: 6.5,-23.5
+      pos: 6.5,-24.5
       parent: 1
       type: Transform
   - uid: 1194
     components:
     - rot: 3.141592653589793 rad
-      pos: 6.5,-22.5
+      pos: 6.5,-23.5
       parent: 1
       type: Transform
   - uid: 1195
@@ -7992,347 +7994,353 @@ entities:
   - uid: 1196
     components:
     - rot: 3.141592653589793 rad
-      pos: 6.5,-21.5
+      pos: 6.5,-22.5
       parent: 1
       type: Transform
   - uid: 1197
     components:
     - rot: 3.141592653589793 rad
-      pos: 6.5,-20.5
+      pos: 6.5,-21.5
       parent: 1
       type: Transform
   - uid: 1198
     components:
     - rot: 3.141592653589793 rad
-      pos: 6.5,-19.5
+      pos: 6.5,-20.5
       parent: 1
       type: Transform
   - uid: 1199
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 6.5,-19.5
+      parent: 1
+      type: Transform
+  - uid: 1200
     components:
     - rot: 1.5707963267948966 rad
       pos: 5.5,-18.5
       parent: 1
       type: Transform
-  - uid: 1200
-    components:
-    - pos: 4.5,-17.5
-      parent: 1
-      type: Transform
   - uid: 1201
     components:
-    - pos: 4.5,-16.5
+    - pos: 4.5,-17.5
       parent: 1
       type: Transform
   - uid: 1202
     components:
-    - pos: 4.5,-17.5
+    - pos: 4.5,-16.5
       parent: 1
       type: Transform
   - uid: 1203
     components:
-    - pos: 4.5,-15.5
+    - pos: 4.5,-17.5
       parent: 1
       type: Transform
   - uid: 1204
     components:
-    - pos: 4.5,-14.5
+    - pos: 4.5,-15.5
       parent: 1
       type: Transform
   - uid: 1205
     components:
-    - pos: 4.5,-13.5
+    - pos: 4.5,-14.5
       parent: 1
       type: Transform
   - uid: 1206
     components:
-    - pos: 4.5,-12.5
+    - pos: 4.5,-13.5
       parent: 1
       type: Transform
   - uid: 1207
     components:
-    - pos: 4.5,-11.5
+    - pos: 4.5,-12.5
       parent: 1
       type: Transform
   - uid: 1208
     components:
-    - rot: 3.141592653589793 rad
-      pos: 3.5,-9.5
+    - pos: 4.5,-11.5
       parent: 1
       type: Transform
   - uid: 1209
     components:
     - rot: 3.141592653589793 rad
-      pos: 0.5,-34.5
+      pos: 3.5,-9.5
       parent: 1
       type: Transform
   - uid: 1210
     components:
     - rot: 3.141592653589793 rad
-      pos: 0.5,-35.5
+      pos: 0.5,-34.5
       parent: 1
       type: Transform
   - uid: 1211
     components:
     - rot: 3.141592653589793 rad
-      pos: 0.5,-36.5
+      pos: 0.5,-35.5
       parent: 1
       type: Transform
   - uid: 1212
     components:
-    - rot: 1.5707963267948966 rad
-      pos: -0.5,-31.5
+    - rot: 3.141592653589793 rad
+      pos: 0.5,-36.5
       parent: 1
       type: Transform
   - uid: 1213
     components:
     - rot: 1.5707963267948966 rad
-      pos: 0.5,-31.5
+      pos: -0.5,-31.5
       parent: 1
       type: Transform
   - uid: 1214
     components:
     - rot: 1.5707963267948966 rad
-      pos: 1.5,-31.5
+      pos: 0.5,-31.5
       parent: 1
       type: Transform
   - uid: 1215
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 1.5,-31.5
+      parent: 1
+      type: Transform
+  - uid: 1216
     components:
     - rot: 3.141592653589793 rad
       pos: 2.5,-32.5
       parent: 1
       type: Transform
-  - uid: 1216
+  - uid: 1217
     components:
     - pos: 1.5,0.5
       parent: 1
       type: Transform
-  - uid: 1217
+  - uid: 1218
     components:
     - pos: 0.5,-1.5
       parent: 1
       type: Transform
-  - uid: 1218
-    components:
-    - pos: 0.5,-2.5
-      parent: 1
-      type: Transform
   - uid: 1219
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 2.5,-8.5
+    - pos: 0.5,-2.5
       parent: 1
       type: Transform
   - uid: 1220
     components:
     - rot: -1.5707963267948966 rad
-      pos: 1.5,-8.5
+      pos: 2.5,-8.5
       parent: 1
       type: Transform
   - uid: 1221
     components:
-    - pos: 0.5,-7.5
+    - rot: -1.5707963267948966 rad
+      pos: 1.5,-8.5
       parent: 1
       type: Transform
   - uid: 1222
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 5.5,-24.5
+    - pos: 0.5,-7.5
       parent: 1
       type: Transform
   - uid: 1223
     components:
     - rot: -1.5707963267948966 rad
-      pos: 8.5,-27.5
+      pos: 5.5,-24.5
       parent: 1
       type: Transform
   - uid: 1224
     components:
-    - pos: 7.5,-26.5
+    - rot: -1.5707963267948966 rad
+      pos: 8.5,-27.5
       parent: 1
       type: Transform
   - uid: 1225
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 6.5,-24.5
+    - pos: 7.5,-26.5
       parent: 1
       type: Transform
   - uid: 1226
     components:
     - rot: -1.5707963267948966 rad
-      pos: 5.5,-24.5
+      pos: 6.5,-24.5
       parent: 1
       type: Transform
   - uid: 1227
     components:
     - rot: -1.5707963267948966 rad
-      pos: 3.5,-24.5
+      pos: 5.5,-24.5
       parent: 1
       type: Transform
   - uid: 1228
     components:
     - rot: -1.5707963267948966 rad
-      pos: 2.5,-24.5
+      pos: 3.5,-24.5
       parent: 1
       type: Transform
   - uid: 1229
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 2.5,-24.5
+      parent: 1
+      type: Transform
+  - uid: 1230
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,-23.5
       parent: 1
       type: Transform
-  - uid: 1230
+  - uid: 1231
     components:
     - rot: 1.5707963267948966 rad
       pos: 1.5,-24.5
       parent: 1
       type: Transform
-  - uid: 1231
+  - uid: 1232
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,-22.5
       parent: 1
       type: Transform
-  - uid: 1232
+  - uid: 1233
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,-21.5
       parent: 1
       type: Transform
-  - uid: 1233
+  - uid: 1234
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,-20.5
       parent: 1
       type: Transform
-  - uid: 1234
+  - uid: 1235
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,-19.5
       parent: 1
       type: Transform
-  - uid: 1235
+  - uid: 1236
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,-18.5
       parent: 1
       type: Transform
-  - uid: 1236
+  - uid: 1237
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,-17.5
       parent: 1
       type: Transform
-  - uid: 1237
+  - uid: 1238
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,-16.5
       parent: 1
       type: Transform
-  - uid: 1238
+  - uid: 1239
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,-15.5
       parent: 1
       type: Transform
-  - uid: 1239
+  - uid: 1240
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,-14.5
       parent: 1
       type: Transform
-  - uid: 1240
+  - uid: 1241
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,-13.5
       parent: 1
       type: Transform
-  - uid: 1241
+  - uid: 1242
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,-12.5
       parent: 1
       type: Transform
-  - uid: 1242
+  - uid: 1243
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,-11.5
       parent: 1
       type: Transform
-  - uid: 1243
+  - uid: 1244
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,-10.5
       parent: 1
       type: Transform
-  - uid: 1244
+  - uid: 1245
     components:
     - rot: -1.5707963267948966 rad
       pos: -2.5,-15.5
       parent: 1
       type: Transform
-  - uid: 1245
+  - uid: 1246
     components:
     - pos: 7.5,-25.5
       parent: 1
       type: Transform
-  - uid: 1246
+  - uid: 1247
     components:
     - pos: 7.5,-26.5
       parent: 1
       type: Transform
-  - uid: 1247
+  - uid: 1248
     components:
     - rot: 3.141592653589793 rad
       pos: 9.5,-28.5
       parent: 1
       type: Transform
-  - uid: 1248
+  - uid: 1249
     components:
     - pos: 10.5,-30.5
       parent: 1
       type: Transform
 - proto: DisposalTrunk
   entities:
-  - uid: 1249
+  - uid: 1250
     components:
     - rot: 3.141592653589793 rad
       pos: -1.5,-34.5
       parent: 1
       type: Transform
-  - uid: 1250
+  - uid: 1251
     components:
     - rot: 1.5707963267948966 rad
       pos: -1.5,-31.5
       parent: 1
       type: Transform
-  - uid: 1251
+  - uid: 1252
     components:
     - pos: 1.5,1.5
       parent: 1
       type: Transform
-  - uid: 1252
+  - uid: 1253
     components:
     - rot: 1.5707963267948966 rad
       pos: -0.5,-24.5
       parent: 1
       type: Transform
-  - uid: 1253
+  - uid: 1254
     components:
     - rot: 3.141592653589793 rad
       pos: 10.5,-31.5
       parent: 1
       type: Transform
-  - uid: 1254
+  - uid: 1255
     components:
     - pos: 0.5,-6.5
       parent: 1
       type: Transform
-  - uid: 1255
+  - uid: 1256
     components:
     - pos: -1.5,-14.5
       parent: 1
       type: Transform
-  - uid: 1256
+  - uid: 1257
     components:
     - rot: 1.5707963267948966 rad
       pos: -6.5,-25.5
@@ -8340,7 +8348,7 @@ entities:
       type: Transform
 - proto: DisposalUnit
   entities:
-  - uid: 1257
+  - uid: 1258
     components:
     - pos: 0.5,-6.5
       parent: 1
@@ -8348,64 +8356,64 @@ entities:
     - recentlyEjected:
       - invalid
       type: DisposalUnit
-  - uid: 1258
-    components:
-    - pos: -1.5,-31.5
-      parent: 1
-      type: Transform
   - uid: 1259
     components:
-    - name: '"disposal unit"'
-      type: MetaData
-    - pos: 1.5,1.5
+    - pos: -1.5,-31.5
       parent: 1
       type: Transform
   - uid: 1260
     components:
     - name: '"disposal unit"'
       type: MetaData
-    - pos: -0.5,-24.5
+    - pos: 1.5,1.5
       parent: 1
       type: Transform
   - uid: 1261
     components:
     - name: '"disposal unit"'
       type: MetaData
-    - pos: 10.5,-31.5
+    - pos: -0.5,-24.5
       parent: 1
       type: Transform
   - uid: 1262
     components:
-    - pos: -1.5,-14.5
+    - name: '"disposal unit"'
+      type: MetaData
+    - pos: 10.5,-31.5
       parent: 1
       type: Transform
   - uid: 1263
     components:
-    - pos: -6.5,-25.5
+    - pos: -1.5,-14.5
       parent: 1
       type: Transform
   - uid: 1264
+    components:
+    - pos: -6.5,-25.5
+      parent: 1
+      type: Transform
+  - uid: 1265
     components:
     - pos: -1.5,-34.5
       parent: 1
       type: Transform
 - proto: DisposalYJunction
   entities:
-  - uid: 1265
+  - uid: 1266
     components:
     - pos: 0.5,-33.5
       parent: 1
       type: Transform
 - proto: DrinkBeerBottleFull
   entities:
-  - uid: 1266
+  - uid: 1267
     components:
     - pos: -0.40871298,-14.107004
       parent: 1
       type: Transform
 - proto: DrinkCafeLatte
   entities:
-  - uid: 1267
+  - uid: 1268
     components:
     - name: Steve's latte
       type: MetaData
@@ -8414,179 +8422,179 @@ entities:
       type: Transform
 - proto: DrinkCognacBottleFull
   entities:
-  - uid: 1268
+  - uid: 1269
     components:
     - pos: 4.549162,-25.429996
       parent: 1
       type: Transform
 - proto: DrinkFlask
   entities:
-  - uid: 1269
+  - uid: 1270
     components:
     - pos: 4.4121666,-24.277555
       parent: 1
       type: Transform
 - proto: DrinkGlass
   entities:
-  - uid: 1270
+  - uid: 1271
     components:
     - pos: 0.23712039,-14.161533
       parent: 1
       type: Transform
-  - uid: 1271
+  - uid: 1272
     components:
     - pos: 0.08087039,-14.411707
       parent: 1
       type: Transform
-  - uid: 1272
+  - uid: 1273
     components:
     - pos: -0.15871298,-14.192805
       parent: 1
       type: Transform
 - proto: DrinkHotCoffee
   entities:
-  - uid: 1273
+  - uid: 1274
     components:
     - pos: -1.4439895,-21.777922
       parent: 1
       type: Transform
 - proto: DrinkMugDog
   entities:
-  - uid: 234
+  - uid: 235
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 216
+    - parent: 217
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: DrinkRumBottleFull
   entities:
-  - uid: 235
+  - uid: 236
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 216
+    - parent: 217
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: DrinkRumGlass
   entities:
-  - uid: 1274
+  - uid: 1275
     components:
     - pos: -5.582541,-16.646059
       parent: 1
       type: Transform
 - proto: DrinkScrewdriverCocktailGlass
   entities:
-  - uid: 1275
+  - uid: 1276
     components:
     - pos: -0.43513387,-27.543575
       parent: 1
       type: Transform
 - proto: DrinkShotGlass
   entities:
-  - uid: 1276
+  - uid: 1277
     components:
     - pos: -0.80478126,1.3002728
       parent: 1
       type: Transform
 - proto: DrinkWhiskeyBottleFull
   entities:
-  - uid: 1277
+  - uid: 1278
     components:
     - pos: 2.414081,1.4204162
       parent: 1
       type: Transform
 - proto: EmergencyLight
   entities:
-  - uid: 1278
+  - uid: 1279
     components:
     - pos: -3.5,-23.5
       parent: 1
       type: Transform
-  - uid: 1279
+  - uid: 1280
     components:
     - pos: 4.5,-23.5
       parent: 1
       type: Transform
-  - uid: 1280
+  - uid: 1281
     components:
     - rot: 1.5707963267948966 rad
       pos: 2.5,-34.5
       parent: 1
       type: Transform
-  - uid: 1281
+  - uid: 1282
     components:
     - rot: -1.5707963267948966 rad
       pos: 8.5,-34.5
       parent: 1
       type: Transform
-  - uid: 1282
+  - uid: 1283
     components:
     - rot: -1.5707963267948966 rad
       pos: 7.5,-29.5
       parent: 1
       type: Transform
-  - uid: 1283
+  - uid: 1284
     components:
     - rot: 1.5707963267948966 rad
       pos: -1.5,-28.5
       parent: 1
       type: Transform
-  - uid: 1284
+  - uid: 1285
     components:
     - pos: 5.5,-27.5
       parent: 1
       type: Transform
-  - uid: 1285
+  - uid: 1286
     components:
     - pos: -3.5,-33.5
       parent: 1
       type: Transform
-  - uid: 1286
+  - uid: 1287
     components:
     - rot: 1.5707963267948966 rad
       pos: -7.5,-33.5
       parent: 1
       type: Transform
-  - uid: 1287
+  - uid: 1288
     components:
     - rot: 3.141592653589793 rad
       pos: 5.5,-34.5
       parent: 1
       type: Transform
-  - uid: 1288
+  - uid: 1289
     components:
     - pos: -3.5,4.5
       parent: 1
       type: Transform
-  - uid: 1289
-    components:
-    - pos: 4.5,4.5
-      parent: 1
-      type: Transform
   - uid: 1290
     components:
-    - rot: 3.141592653589793 rad
-      pos: 2.5,3.5
+    - pos: 4.5,4.5
       parent: 1
       type: Transform
   - uid: 1291
     components:
     - rot: 3.141592653589793 rad
-      pos: -1.5,3.5
+      pos: 2.5,3.5
       parent: 1
       type: Transform
   - uid: 1292
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -1.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 1293
     components:
     - rot: -1.5707963267948966 rad
       pos: 4.5,-7.5
       parent: 1
       type: Transform
-  - uid: 1293
+  - uid: 1294
     components:
     - rot: 1.5707963267948966 rad
       pos: -3.5,-7.5
@@ -8594,443 +8602,443 @@ entities:
       type: Transform
 - proto: EncryptionKeyCargo
   entities:
-  - uid: 1294
+  - uid: 1295
     components:
     - pos: -0.2920506,0.97472227
       parent: 1
       type: Transform
 - proto: EncryptionKeyCommand
   entities:
-  - uid: 1295
+  - uid: 1296
     components:
     - pos: -1.2307451,-22.015284
       parent: 1
       type: Transform
 - proto: EncryptionKeyEngineering
   entities:
-  - uid: 1296
+  - uid: 1297
     components:
     - pos: -0.97588915,-30.425823
       parent: 1
       type: Transform
 - proto: EnergyCutlass
   entities:
-  - uid: 1063
+  - uid: 1064
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 1060
+    - parent: 1061
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: ExtendedEmergencyOxygenTankFilled
   entities:
-  - uid: 1053
+  - uid: 1054
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 1050
+    - parent: 1051
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 1057
+  - uid: 1058
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 1054
+    - parent: 1055
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: FaxMachineShip
   entities:
-  - uid: 1297
+  - uid: 1298
     components:
     - pos: -0.5,1.5
       parent: 1
       type: Transform
 - proto: FireAlarm
   entities:
-  - uid: 1298
+  - uid: 1299
     components:
     - pos: -4.5,5.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 1348
+      - 1349
+      - 1359
       - 1358
-      - 1357
-      - 1350
       - 1351
       - 1352
       - 1353
-      - 1344
+      - 1354
       - 1345
       - 1346
-      - 1354
       - 1347
-      - 1356
       - 1355
-      - 1349
-      - 1661
-      - 1646
-      - 1363
-      type: DeviceNetwork
-    - devices:
       - 1348
-      - 1358
       - 1357
-      - 1350
-      - 1351
-      - 1352
-      - 1353
-      - 1344
-      - 1345
-      - 1346
-      - 1354
-      - 1347
       - 1356
-      - 1355
-      - 1349
-      - 1363
-      - 1646
-      - 1661
-      type: DeviceList
-  - uid: 1299
-    components:
-    - rot: 3.141592653589793 rad
-      pos: -5.5,-7.5
-      parent: 1
-      type: Transform
-    - ShutdownSubscribers:
-      - 1358
-      - 1348
-      - 1349
-      - 1355
-      - 1314
-      - 1647
+      - 1350
       - 1662
-      - 1318
-      - 1320
-      - 1325
-      - 1319
-      - 1334
-      - 1328
+      - 1647
+      - 1364
       type: DeviceNetwork
     - devices:
-      - 1318
-      - 1320
-      - 1325
-      - 1319
-      - 1314
-      - 1334
-      - 1328
-      - 1358
-      - 1348
       - 1349
+      - 1359
+      - 1358
+      - 1351
+      - 1352
+      - 1353
+      - 1354
+      - 1345
+      - 1346
+      - 1347
       - 1355
+      - 1348
+      - 1357
+      - 1356
+      - 1350
+      - 1364
       - 1647
       - 1662
       type: DeviceList
   - uid: 1300
     components:
     - rot: 3.141592653589793 rad
+      pos: -5.5,-7.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 1359
+      - 1349
+      - 1350
+      - 1356
+      - 1315
+      - 1648
+      - 1663
+      - 1319
+      - 1321
+      - 1326
+      - 1320
+      - 1335
+      - 1329
+      type: DeviceNetwork
+    - devices:
+      - 1319
+      - 1321
+      - 1326
+      - 1320
+      - 1315
+      - 1335
+      - 1329
+      - 1359
+      - 1349
+      - 1350
+      - 1356
+      - 1648
+      - 1663
+      type: DeviceList
+  - uid: 1301
+    components:
+    - rot: 3.141592653589793 rad
       pos: 6.5,-7.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 1358
-      - 1348
+      - 1359
       - 1349
-      - 1355
-      - 1314
-      - 1647
-      - 1662
-      - 1318
-      - 1320
-      - 1325
+      - 1350
+      - 1356
+      - 1315
+      - 1648
+      - 1663
       - 1319
-      - 1334
-      - 1328
+      - 1321
+      - 1326
+      - 1320
+      - 1335
+      - 1329
       type: DeviceNetwork
     - devices:
-      - 1318
-      - 1320
-      - 1325
       - 1319
-      - 1314
-      - 1334
-      - 1328
-      - 1358
-      - 1348
+      - 1321
+      - 1326
+      - 1320
+      - 1315
+      - 1335
+      - 1329
+      - 1359
       - 1349
-      - 1355
-      - 1647
-      - 1662
+      - 1350
+      - 1356
+      - 1648
+      - 1663
       type: DeviceList
-  - uid: 1301
+  - uid: 1302
     components:
     - rot: 3.141592653589793 rad
       pos: 5.5,5.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 1349
-      - 1355
+      - 1350
       - 1356
-      - 1347
-      - 1354
-      - 1345
+      - 1357
+      - 1348
+      - 1355
       - 1346
-      - 1344
+      - 1347
+      - 1345
+      - 1354
       - 1353
       - 1352
       - 1351
-      - 1350
-      - 1357
       - 1358
-      - 1348
-      - 1661
-      - 1646
-      - 1363
+      - 1359
+      - 1349
+      - 1662
+      - 1647
+      - 1364
       type: DeviceNetwork
     - devices:
-      - 1348
+      - 1349
+      - 1359
       - 1358
-      - 1357
-      - 1350
       - 1351
       - 1352
       - 1353
-      - 1344
+      - 1354
       - 1345
       - 1346
-      - 1354
       - 1347
-      - 1356
       - 1355
-      - 1349
-      - 1363
-      - 1646
-      - 1661
+      - 1348
+      - 1357
+      - 1356
+      - 1350
+      - 1364
+      - 1647
+      - 1662
       type: DeviceList
-  - uid: 1302
+  - uid: 1303
     components:
     - rot: -1.5707963267948966 rad
       pos: 8.5,-28.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 1326
-      - 1645
-      - 1665
-      - 1315
-      - 1337
-      - 1324
-      - 1672
+      - 1327
+      - 1646
+      - 1666
+      - 1316
+      - 1338
+      - 1325
+      - 1673
       type: DeviceNetwork
     - devices:
-      - 1324
-      - 1337
-      - 1315
-      - 1326
-      - 1645
-      - 1665
-      - 1672
+      - 1325
+      - 1338
+      - 1316
+      - 1327
+      - 1646
+      - 1666
+      - 1673
       type: DeviceList
-  - uid: 1303
+  - uid: 1304
     components:
     - pos: -4.5,-32.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 1666
-      - 1651
-      - 1316
-      - 1321
+      - 1667
+      - 1652
+      - 1317
+      - 1322
       type: DeviceNetwork
     - devices:
-      - 1321
-      - 1316
-      - 1666
-      - 1651
+      - 1322
+      - 1317
+      - 1667
+      - 1652
       type: DeviceList
-  - uid: 1304
+  - uid: 1305
     components:
     - rot: 1.5707963267948966 rad
       pos: -7.5,-28.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 1667
-      - 1327
-      - 1322
-      - 1316
-      - 1317
+      - 1668
+      - 1328
       - 1323
+      - 1317
+      - 1318
+      - 1324
+      - 1337
       - 1336
-      - 1335
-      - 1650
+      - 1651
       type: DeviceNetwork
     - devices:
-      - 1667
-      - 1650
-      - 1316
-      - 1323
-      - 1322
+      - 1668
+      - 1651
       - 1317
-      - 1335
+      - 1324
+      - 1323
+      - 1318
       - 1336
-      - 1327
+      - 1337
+      - 1328
       type: DeviceList
-  - uid: 1305
+  - uid: 1306
     components:
     - rot: -1.5707963267948966 rad
       pos: 8.5,-25.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 1656
-      - 1677
-      - 1324
-      - 1333
-      - 1338
+      - 1657
+      - 1678
+      - 1325
+      - 1334
+      - 1339
       type: DeviceNetwork
     - devices:
-      - 1677
-      - 1656
-      - 1324
-      - 1333
-      - 1338
+      - 1678
+      - 1657
+      - 1325
+      - 1334
+      - 1339
       type: DeviceList
-  - uid: 1306
+  - uid: 1307
     components:
     - pos: -1.5,-11.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 1668
       - 1669
-      - 1653
-      - 1657
-      - 1340
+      - 1670
+      - 1654
+      - 1658
+      - 1341
+      - 1344
+      - 1330
       - 1343
-      - 1329
-      - 1342
-      - 1361
-      - 1339
-      - 1359
+      - 1362
+      - 1340
       - 1360
-      - 1318
-      - 1320
+      - 1361
+      - 1319
+      - 1321
       type: DeviceNetwork
     - devices:
-      - 1342
-      - 1329
-      - 1361
-      - 1668
-      - 1669
-      - 1653
-      - 1657
-      - 1339
-      - 1359
-      - 1360
-      - 1318
-      - 1320
-      - 1340
       - 1343
+      - 1330
+      - 1362
+      - 1669
+      - 1670
+      - 1654
+      - 1658
+      - 1340
+      - 1360
+      - 1361
+      - 1319
+      - 1321
+      - 1341
+      - 1344
       type: DeviceList
-  - uid: 1307
+  - uid: 1308
     components:
     - rot: 1.5707963267948966 rad
       pos: -6.5,-11.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 1670
-      - 1361
-      - 1329
-      - 1342
-      - 1654
+      - 1671
+      - 1362
+      - 1330
+      - 1343
+      - 1655
       type: DeviceNetwork
     - devices:
-      - 1670
-      - 1342
-      - 1329
-      - 1361
-      - 1654
+      - 1671
+      - 1343
+      - 1330
+      - 1362
+      - 1655
       type: DeviceList
-  - uid: 1308
+  - uid: 1309
     components:
     - rot: -1.5707963267948966 rad
       pos: 7.5,-11.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 1671
+      - 1672
+      - 1361
       - 1360
-      - 1359
-      - 1339
-      - 1655
+      - 1340
+      - 1656
       type: DeviceNetwork
     - devices:
-      - 1671
-      - 1655
+      - 1672
+      - 1656
+      - 1361
       - 1360
-      - 1359
-      - 1339
+      - 1340
       type: DeviceList
-  - uid: 1309
+  - uid: 1310
     components:
     - pos: -4.5,-17.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 1340
-      - 1648
-      - 1675
-      - 1330
+      - 1341
+      - 1649
+      - 1676
+      - 1331
       type: DeviceNetwork
     - devices:
-      - 1675
-      - 1648
-      - 1330
-      - 1340
+      - 1676
+      - 1649
+      - 1331
+      - 1341
       type: DeviceList
-  - uid: 1310
+  - uid: 1311
     components:
     - pos: 5.5,-17.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 1343
-      - 1331
-      - 1333
-      - 1663
-      - 1649
+      - 1344
+      - 1332
+      - 1334
+      - 1664
+      - 1650
       type: DeviceNetwork
     - devices:
-      - 1343
-      - 1331
-      - 1333
-      - 1663
-      - 1649
+      - 1344
+      - 1332
+      - 1334
+      - 1664
+      - 1650
       type: DeviceList
 - proto: FireAxeCabinetFilled
   entities:
-  - uid: 1311
+  - uid: 1312
     components:
     - pos: -0.5,-26.5
       parent: 1
       type: Transform
-  - uid: 1312
+  - uid: 1313
     components:
     - pos: 2.5,2.5
       parent: 1
       type: Transform
-  - uid: 1313
+  - uid: 1314
     components:
     - rot: -1.5707963267948966 rad
       pos: 5.5,-25.5
@@ -9038,158 +9046,158 @@ entities:
       type: Transform
 - proto: Firelock
   entities:
-  - uid: 1314
+  - uid: 1315
     components:
     - pos: 0.5,-1.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
       - 14
-      - 1299
       - 1300
+      - 1301
       type: DeviceNetwork
-  - uid: 1315
+  - uid: 1316
     components:
     - pos: 1.5,-33.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
       - 5
-      - 1302
+      - 1303
       type: DeviceNetwork
-  - uid: 1316
+  - uid: 1317
     components:
     - pos: -5.5,-32.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
       - 6
-      - 1303
-      - 7
       - 1304
+      - 7
+      - 1305
       type: DeviceNetwork
-  - uid: 1317
+  - uid: 1318
     components:
     - pos: -5.5,-26.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
       - 7
-      - 1304
+      - 1305
       type: DeviceNetwork
-  - uid: 1318
+  - uid: 1319
     components:
     - pos: 4.5,-11.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 1306
+      - 1307
       - 11
       - 14
-      - 1299
       - 1300
+      - 1301
       type: DeviceNetwork
-  - uid: 1319
+  - uid: 1320
     components:
     - pos: -4.5,-8.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
       - 14
-      - 1299
       - 1300
+      - 1301
       type: DeviceNetwork
-  - uid: 1320
+  - uid: 1321
     components:
     - pos: -3.5,-11.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 1306
+      - 1307
       - 11
       - 14
-      - 1299
       - 1300
+      - 1301
       type: DeviceNetwork
-  - uid: 1321
+  - uid: 1322
     components:
     - pos: -0.5,-33.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
       - 6
-      - 1303
+      - 1304
       type: DeviceNetwork
-  - uid: 1322
+  - uid: 1323
     components:
     - pos: -4.5,-27.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
       - 7
-      - 1304
+      - 1305
       type: DeviceNetwork
-  - uid: 1323
+  - uid: 1324
     components:
     - pos: -4.5,-30.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
       - 7
-      - 1304
+      - 1305
       type: DeviceNetwork
-  - uid: 1324
+  - uid: 1325
     components:
     - pos: 6.5,-26.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
       - 5
-      - 1302
+      - 1303
       - 16
-      - 1305
+      - 1306
       type: DeviceNetwork
-  - uid: 1325
+  - uid: 1326
     components:
     - pos: 5.5,-8.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
       - 14
-      - 1299
       - 1300
+      - 1301
       type: DeviceNetwork
-  - uid: 1326
+  - uid: 1327
     components:
     - pos: 1.5,-31.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
       - 5
-      - 1302
+      - 1303
       type: DeviceNetwork
-  - uid: 1327
+  - uid: 1328
     components:
     - pos: -7.5,-31.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
       - 7
-      - 1304
+      - 1305
       type: DeviceNetwork
 - proto: FirelockGlass
   entities:
-  - uid: 1328
+  - uid: 1329
     components:
     - pos: -5.5,0.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
       - 14
-      - 1299
       - 1300
+      - 1301
       type: DeviceNetwork
-  - uid: 1329
+  - uid: 1330
     components:
     - pos: -4.5,-13.5
       parent: 1
@@ -9197,80 +9205,80 @@ entities:
     - ShutdownSubscribers:
       - 9
       - 11
+      - 1308
       - 1307
-      - 1306
       type: DeviceNetwork
-  - uid: 1330
+  - uid: 1331
     components:
     - pos: -5.5,-21.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
       - 8
-      - 1309
+      - 1310
       type: DeviceNetwork
-  - uid: 1331
+  - uid: 1332
     components:
     - pos: 6.5,-21.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
       - 4
-      - 1310
+      - 1311
       type: DeviceNetwork
-  - uid: 1332
+  - uid: 1333
     components:
     - pos: -5.5,-22.5
       parent: 1
       type: Transform
-  - uid: 1333
+  - uid: 1334
     components:
     - pos: 6.5,-22.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
       - 16
-      - 1305
-      - 1310
+      - 1306
+      - 1311
       type: DeviceNetwork
-  - uid: 1334
+  - uid: 1335
     components:
     - pos: -5.5,-0.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
       - 14
-      - 1299
       - 1300
+      - 1301
       type: DeviceNetwork
-  - uid: 1335
+  - uid: 1336
     components:
     - pos: -7.5,-27.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
       - 7
-      - 1304
+      - 1305
       type: DeviceNetwork
-  - uid: 1336
+  - uid: 1337
     components:
     - pos: -7.5,-29.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
       - 7
-      - 1304
+      - 1305
       type: DeviceNetwork
-  - uid: 1337
+  - uid: 1338
     components:
     - pos: 8.5,-27.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
       - 5
-      - 1302
+      - 1303
       type: DeviceNetwork
-  - uid: 1338
+  - uid: 1339
     components:
     - pos: 5.5,-23.5
       parent: 1
@@ -9278,9 +9286,9 @@ entities:
     - ShutdownSubscribers:
       - 16
       - 15
-      - 1305
+      - 1306
       type: DeviceNetwork
-  - uid: 1339
+  - uid: 1340
     components:
     - pos: 5.5,-14.5
       parent: 1
@@ -9288,10 +9296,10 @@ entities:
     - ShutdownSubscribers:
       - 10
       - 11
-      - 1308
-      - 1306
+      - 1309
+      - 1307
       type: DeviceNetwork
-  - uid: 1340
+  - uid: 1341
     components:
     - pos: -3.5,-17.5
       parent: 1
@@ -9299,10 +9307,10 @@ entities:
     - ShutdownSubscribers:
       - 11
       - 8
-      - 1306
-      - 1309
+      - 1307
+      - 1310
       type: DeviceNetwork
-  - uid: 1341
+  - uid: 1342
     components:
     - pos: -4.5,-23.5
       parent: 1
@@ -9310,7 +9318,7 @@ entities:
     - ShutdownSubscribers:
       - 15
       type: DeviceNetwork
-  - uid: 1342
+  - uid: 1343
     components:
     - pos: -4.5,-12.5
       parent: 1
@@ -9318,10 +9326,10 @@ entities:
     - ShutdownSubscribers:
       - 9
       - 11
+      - 1308
       - 1307
-      - 1306
       type: DeviceNetwork
-  - uid: 1343
+  - uid: 1344
     components:
     - pos: 4.5,-17.5
       parent: 1
@@ -9329,10 +9337,10 @@ entities:
     - ShutdownSubscribers:
       - 11
       - 4
-      - 1306
-      - 1310
+      - 1307
+      - 1311
       type: DeviceNetwork
-  - uid: 1344
+  - uid: 1345
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,6.5
@@ -9340,10 +9348,10 @@ entities:
       type: Transform
     - ShutdownSubscribers:
       - 13
-      - 1298
-      - 1301
+      - 1299
+      - 1302
       type: DeviceNetwork
-  - uid: 1345
+  - uid: 1346
     components:
     - rot: 3.141592653589793 rad
       pos: 1.5,6.5
@@ -9351,10 +9359,10 @@ entities:
       type: Transform
     - ShutdownSubscribers:
       - 13
-      - 1298
-      - 1301
+      - 1299
+      - 1302
       type: DeviceNetwork
-  - uid: 1346
+  - uid: 1347
     components:
     - rot: 3.141592653589793 rad
       pos: 2.5,6.5
@@ -9362,10 +9370,10 @@ entities:
       type: Transform
     - ShutdownSubscribers:
       - 13
-      - 1298
-      - 1301
+      - 1299
+      - 1302
       type: DeviceNetwork
-  - uid: 1347
+  - uid: 1348
     components:
     - rot: 3.141592653589793 rad
       pos: 6.5,3.5
@@ -9373,10 +9381,10 @@ entities:
       type: Transform
     - ShutdownSubscribers:
       - 13
-      - 1298
-      - 1301
+      - 1299
+      - 1302
       type: DeviceNetwork
-  - uid: 1348
+  - uid: 1349
     components:
     - rot: 3.141592653589793 rad
       pos: -3.5,1.5
@@ -9384,13 +9392,13 @@ entities:
       type: Transform
     - ShutdownSubscribers:
       - 13
-      - 1298
       - 1299
       - 1300
       - 1301
+      - 1302
       - 14
       type: DeviceNetwork
-  - uid: 1349
+  - uid: 1350
     components:
     - rot: 3.141592653589793 rad
       pos: 4.5,1.5
@@ -9398,13 +9406,13 @@ entities:
       type: Transform
     - ShutdownSubscribers:
       - 13
-      - 1298
       - 1299
       - 1300
       - 1301
+      - 1302
       - 14
       type: DeviceNetwork
-  - uid: 1350
+  - uid: 1351
     components:
     - rot: 3.141592653589793 rad
       pos: -5.5,3.5
@@ -9412,10 +9420,10 @@ entities:
       type: Transform
     - ShutdownSubscribers:
       - 13
-      - 1298
-      - 1301
+      - 1299
+      - 1302
       type: DeviceNetwork
-  - uid: 1351
+  - uid: 1352
     components:
     - rot: 3.141592653589793 rad
       pos: -5.5,4.5
@@ -9423,10 +9431,10 @@ entities:
       type: Transform
     - ShutdownSubscribers:
       - 13
-      - 1298
-      - 1301
+      - 1299
+      - 1302
       type: DeviceNetwork
-  - uid: 1352
+  - uid: 1353
     components:
     - rot: 3.141592653589793 rad
       pos: -1.5,6.5
@@ -9434,10 +9442,10 @@ entities:
       type: Transform
     - ShutdownSubscribers:
       - 13
-      - 1298
-      - 1301
+      - 1299
+      - 1302
       type: DeviceNetwork
-  - uid: 1353
+  - uid: 1354
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,6.5
@@ -9445,10 +9453,10 @@ entities:
       type: Transform
     - ShutdownSubscribers:
       - 13
-      - 1298
-      - 1301
+      - 1299
+      - 1302
       type: DeviceNetwork
-  - uid: 1354
+  - uid: 1355
     components:
     - rot: 3.141592653589793 rad
       pos: 6.5,4.5
@@ -9456,10 +9464,10 @@ entities:
       type: Transform
     - ShutdownSubscribers:
       - 13
-      - 1298
-      - 1301
+      - 1299
+      - 1302
       type: DeviceNetwork
-  - uid: 1355
+  - uid: 1356
     components:
     - rot: 3.141592653589793 rad
       pos: 5.5,1.5
@@ -9467,13 +9475,13 @@ entities:
       type: Transform
     - ShutdownSubscribers:
       - 13
-      - 1298
       - 1299
       - 1300
       - 1301
+      - 1302
       - 14
       type: DeviceNetwork
-  - uid: 1356
+  - uid: 1357
     components:
     - rot: 3.141592653589793 rad
       pos: 6.5,2.5
@@ -9481,10 +9489,10 @@ entities:
       type: Transform
     - ShutdownSubscribers:
       - 13
-      - 1298
-      - 1301
+      - 1299
+      - 1302
       type: DeviceNetwork
-  - uid: 1357
+  - uid: 1358
     components:
     - rot: 3.141592653589793 rad
       pos: -5.5,2.5
@@ -9492,10 +9500,10 @@ entities:
       type: Transform
     - ShutdownSubscribers:
       - 13
-      - 1298
-      - 1301
+      - 1299
+      - 1302
       type: DeviceNetwork
-  - uid: 1358
+  - uid: 1359
     components:
     - rot: 3.141592653589793 rad
       pos: -4.5,1.5
@@ -9503,13 +9511,13 @@ entities:
       type: Transform
     - ShutdownSubscribers:
       - 13
-      - 1298
       - 1299
       - 1300
       - 1301
+      - 1302
       - 14
       type: DeviceNetwork
-  - uid: 1359
+  - uid: 1360
     components:
     - pos: 5.5,-13.5
       parent: 1
@@ -9517,10 +9525,10 @@ entities:
     - ShutdownSubscribers:
       - 10
       - 11
-      - 1308
-      - 1306
+      - 1309
+      - 1307
       type: DeviceNetwork
-  - uid: 1360
+  - uid: 1361
     components:
     - pos: 5.5,-12.5
       parent: 1
@@ -9528,10 +9536,10 @@ entities:
     - ShutdownSubscribers:
       - 10
       - 11
-      - 1308
-      - 1306
+      - 1309
+      - 1307
       type: DeviceNetwork
-  - uid: 1361
+  - uid: 1362
     components:
     - pos: -4.5,-14.5
       parent: 1
@@ -9539,15 +9547,15 @@ entities:
     - ShutdownSubscribers:
       - 9
       - 11
+      - 1308
       - 1307
-      - 1306
       type: DeviceNetwork
-  - uid: 1362
+  - uid: 1363
     components:
     - pos: 4.5,-30.5
       parent: 1
       type: Transform
-  - uid: 1363
+  - uid: 1364
     components:
     - rot: -1.5707963267948966 rad
       pos: 0.5,2.5
@@ -9556,8 +9564,8 @@ entities:
     - ShutdownSubscribers:
       - 12
       - 13
-      - 1298
-      - 1301
+      - 1299
+      - 1302
       type: DeviceNetwork
 - proto: Flash
   entities:
@@ -9572,7 +9580,7 @@ entities:
     - type: InsideEntityStorage
 - proto: FoodBoxDonkpocketHonk
   entities:
-  - uid: 1364
+  - uid: 1365
     components:
     - pos: 1.5919714,-14.375789
       parent: 1
@@ -9590,14 +9598,14 @@ entities:
     - type: InsideEntityStorage
 - proto: FoodBurgerBacon
   entities:
-  - uid: 1365
+  - uid: 1366
     components:
     - name: Steve's Burger Fort (1/2)
       type: MetaData
     - pos: 2.2029314,-21.799337
       parent: 1
       type: Transform
-  - uid: 1366
+  - uid: 1367
     components:
     - name: Steve's Burger Fort (2/2)
       type: MetaData
@@ -9606,7 +9614,7 @@ entities:
       type: Transform
 - proto: GasMixer
   entities:
-  - uid: 1367
+  - uid: 1368
     components:
     - rot: -1.5707963267948966 rad
       pos: 4.5,-33.5
@@ -9616,7 +9624,7 @@ entities:
       inletOneConcentration: 0.79
       targetPressure: 4500
       type: GasMixer
-  - uid: 1368
+  - uid: 1369
     components:
     - rot: -1.5707963267948966 rad
       pos: 2.5,-33.5
@@ -9630,7 +9638,7 @@ entities:
       type: AtmosPipeColor
 - proto: GasPassiveVent
   entities:
-  - uid: 1369
+  - uid: 1370
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,-36.5
@@ -9638,7 +9646,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1370
+  - uid: 1371
     components:
     - rot: -1.5707963267948966 rad
       pos: 7.5,0.5
@@ -9646,13 +9654,13 @@ entities:
       type: Transform
 - proto: GasPipeBend
   entities:
-  - uid: 1371
+  - uid: 1372
     components:
     - rot: -1.5707963267948966 rad
       pos: 5.5,-33.5
       parent: 1
       type: Transform
-  - uid: 1372
+  - uid: 1373
     components:
     - rot: 1.5707963267948966 rad
       pos: -2.5,-31.5
@@ -9660,7 +9668,9 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1373
+    - enabled: True
+      type: AmbientSound
+  - uid: 1374
     components:
     - rot: -1.5707963267948966 rad
       pos: -2.5,-33.5
@@ -9668,7 +9678,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1374
+  - uid: 1375
     components:
     - rot: -1.5707963267948966 rad
       pos: -1.5,-34.5
@@ -9676,14 +9686,16 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1375
+  - uid: 1376
     components:
     - pos: 1.5,-31.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1376
+    - enabled: True
+      type: AmbientSound
+  - uid: 1377
     components:
     - rot: 1.5707963267948966 rad
       pos: -1.5,-33.5
@@ -9691,7 +9703,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1377
+  - uid: 1378
     components:
     - rot: 3.141592653589793 rad
       pos: -6.5,-34.5
@@ -9699,7 +9711,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1378
+  - uid: 1379
     components:
     - rot: 1.5707963267948966 rad
       pos: -5.5,-25.5
@@ -9707,7 +9719,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1379
+  - uid: 1380
     components:
     - rot: -1.5707963267948966 rad
       pos: -5.5,-24.5
@@ -9715,7 +9727,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1380
+  - uid: 1381
     components:
     - rot: 1.5707963267948966 rad
       pos: -6.5,-24.5
@@ -9723,7 +9735,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1381
+  - uid: 1382
     components:
     - rot: 1.5707963267948966 rad
       pos: -5.5,-23.5
@@ -9731,7 +9743,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1382
+  - uid: 1383
     components:
     - rot: -1.5707963267948966 rad
       pos: -0.5,-25.5
@@ -9739,7 +9751,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1383
+  - uid: 1384
     components:
     - rot: -1.5707963267948966 rad
       pos: -1.5,-23.5
@@ -9749,14 +9761,14 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1384
+  - uid: 1385
     components:
     - pos: -0.5,-3.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1385
+  - uid: 1386
     components:
     - rot: 1.5707963267948966 rad
       pos: -1.5,1.5
@@ -9764,14 +9776,14 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1386
+  - uid: 1387
     components:
     - pos: 2.5,1.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1387
+  - uid: 1388
     components:
     - rot: 3.141592653589793 rad
       pos: -3.5,-3.5
@@ -9779,7 +9791,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1388
+  - uid: 1389
     components:
     - rot: -1.5707963267948966 rad
       pos: 4.5,-3.5
@@ -9787,7 +9799,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1389
+  - uid: 1390
     components:
     - rot: 1.5707963267948966 rad
       pos: 1.5,-3.5
@@ -9795,7 +9807,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1390
+  - uid: 1391
     components:
     - rot: 3.141592653589793 rad
       pos: 2.5,-23.5
@@ -9805,7 +9817,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1391
+  - uid: 1392
     components:
     - rot: 3.141592653589793 rad
       pos: 1.5,-25.5
@@ -9815,21 +9827,21 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1392
+  - uid: 1393
     components:
     - pos: 6.5,-23.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1393
+  - uid: 1394
     components:
     - pos: 7.5,-24.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1394
+  - uid: 1395
     components:
     - rot: 3.141592653589793 rad
       pos: 1.5,-33.5
@@ -9839,7 +9851,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1395
+  - uid: 1396
     components:
     - rot: 1.5707963267948966 rad
       pos: -5.5,-14.5
@@ -9847,7 +9859,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1396
+  - uid: 1397
     components:
     - rot: 1.5707963267948966 rad
       pos: -3.5,-15.5
@@ -9855,28 +9867,28 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1397
+  - uid: 1398
     components:
     - pos: 6.5,-14.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1398
+  - uid: 1399
     components:
     - pos: 4.5,-15.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1399
+  - uid: 1400
     components:
     - pos: 4.5,3.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1400
+  - uid: 1401
     components:
     - rot: 1.5707963267948966 rad
       pos: -3.5,3.5
@@ -9884,7 +9896,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1401
+  - uid: 1402
     components:
     - rot: -1.5707963267948966 rad
       pos: 0.5,-0.5
@@ -9894,14 +9906,14 @@ entities:
       type: AtmosPipeColor
 - proto: GasPipeFourway
   entities:
-  - uid: 1402
+  - uid: 1403
     components:
     - pos: 1.5,-13.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1403
+  - uid: 1404
     components:
     - pos: -0.5,1.5
       parent: 1
@@ -9910,14 +9922,14 @@ entities:
       type: AtmosPipeColor
 - proto: GasPipeStraight
   entities:
-  - uid: 1404
+  - uid: 1405
     components:
     - pos: -1.5,-2.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1405
+  - uid: 1406
     components:
     - rot: -1.5707963267948966 rad
       pos: 2.5,-13.5
@@ -9925,7 +9937,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1406
+  - uid: 1407
     components:
     - pos: 0.5,-35.5
       parent: 1
@@ -9934,7 +9946,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1407
+  - uid: 1408
     components:
     - pos: 0.5,-34.5
       parent: 1
@@ -9943,7 +9955,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1408
+  - uid: 1409
     components:
     - rot: -1.5707963267948966 rad
       pos: -5.5,-34.5
@@ -9951,7 +9963,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1409
+  - uid: 1410
     components:
     - rot: 3.141592653589793 rad
       pos: -5.5,-18.5
@@ -9959,7 +9971,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1410
+  - uid: 1411
     components:
     - rot: 3.141592653589793 rad
       pos: -5.5,-17.5
@@ -9969,7 +9981,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1411
+  - uid: 1412
     components:
     - rot: -1.5707963267948966 rad
       pos: -2.5,-34.5
@@ -9977,7 +9989,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1412
+  - uid: 1413
     components:
     - pos: -2.5,-32.5
       parent: 1
@@ -9986,7 +9998,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1413
+  - uid: 1414
     components:
     - rot: -1.5707963267948966 rad
       pos: 0.5,-31.5
@@ -9994,7 +10006,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1414
+  - uid: 1415
     components:
     - rot: 3.141592653589793 rad
       pos: 1.5,-32.5
@@ -10004,7 +10016,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1415
+  - uid: 1416
     components:
     - rot: -1.5707963267948966 rad
       pos: -4.5,-34.5
@@ -10012,7 +10024,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1416
+  - uid: 1417
     components:
     - rot: -1.5707963267948966 rad
       pos: -3.5,-34.5
@@ -10020,7 +10032,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1417
+  - uid: 1418
     components:
     - rot: -1.5707963267948966 rad
       pos: -4.5,-33.5
@@ -10028,7 +10040,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1418
+  - uid: 1419
     components:
     - rot: 3.141592653589793 rad
       pos: -5.5,-32.5
@@ -10038,7 +10050,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1419
+  - uid: 1420
     components:
     - rot: -1.5707963267948966 rad
       pos: -0.5,-33.5
@@ -10048,7 +10060,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1420
+  - uid: 1421
     components:
     - rot: 3.141592653589793 rad
       pos: -6.5,-32.5
@@ -10058,7 +10070,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1421
+  - uid: 1422
     components:
     - rot: 3.141592653589793 rad
       pos: -6.5,-29.5
@@ -10066,7 +10078,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1422
+  - uid: 1423
     components:
     - rot: 3.141592653589793 rad
       pos: -6.5,-26.5
@@ -10076,7 +10088,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1423
+  - uid: 1424
     components:
     - rot: 3.141592653589793 rad
       pos: -6.5,-25.5
@@ -10084,7 +10096,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1424
+  - uid: 1425
     components:
     - rot: 1.5707963267948966 rad
       pos: -3.5,-33.5
@@ -10092,47 +10104,37 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1425
+  - uid: 1426
     components:
     - pos: -5.5,-31.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1426
+  - uid: 1427
     components:
     - pos: -5.5,-30.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1427
+  - uid: 1428
     components:
     - pos: -5.5,-28.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1428
+  - uid: 1429
     components:
     - pos: -5.5,-27.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1429
-    components:
-    - pos: -5.5,-26.5
-      parent: 1
-      type: Transform
-    - color: '#0055CCFF'
-      type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 1430
     components:
-    - rot: 1.5707963267948966 rad
-      pos: -4.5,-25.5
+    - pos: -5.5,-26.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
@@ -10142,12 +10144,22 @@ entities:
   - uid: 1431
     components:
     - rot: 1.5707963267948966 rad
+      pos: -4.5,-25.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+    - enabled: True
+      type: AmbientSound
+  - uid: 1432
+    components:
+    - rot: 1.5707963267948966 rad
       pos: -3.5,-25.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1432
+  - uid: 1433
     components:
     - rot: -1.5707963267948966 rad
       pos: -2.5,-25.5
@@ -10155,7 +10167,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1433
+  - uid: 1434
     components:
     - rot: -1.5707963267948966 rad
       pos: -4.5,-23.5
@@ -10165,7 +10177,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1434
+  - uid: 1435
     components:
     - rot: -1.5707963267948966 rad
       pos: -3.5,-23.5
@@ -10175,7 +10187,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1435
+  - uid: 1436
     components:
     - rot: 3.141592653589793 rad
       pos: -1.5,-22.5
@@ -10185,7 +10197,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1436
+  - uid: 1437
     components:
     - rot: 3.141592653589793 rad
       pos: -1.5,-21.5
@@ -10195,7 +10207,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1437
+  - uid: 1438
     components:
     - rot: 3.141592653589793 rad
       pos: -1.5,-20.5
@@ -10205,7 +10217,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1438
+  - uid: 1439
     components:
     - rot: 3.141592653589793 rad
       pos: -1.5,-19.5
@@ -10215,7 +10227,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1439
+  - uid: 1440
     components:
     - rot: 3.141592653589793 rad
       pos: -1.5,-18.5
@@ -10225,7 +10237,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1440
+  - uid: 1441
     components:
     - rot: 3.141592653589793 rad
       pos: -1.5,-17.5
@@ -10233,7 +10245,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1441
+  - uid: 1442
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,-24.5
@@ -10241,7 +10253,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1442
+  - uid: 1443
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,-23.5
@@ -10251,7 +10263,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1443
+  - uid: 1444
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,-22.5
@@ -10261,7 +10273,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1444
+  - uid: 1445
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,-21.5
@@ -10269,7 +10281,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1445
+  - uid: 1446
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,-20.5
@@ -10279,7 +10291,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1446
+  - uid: 1447
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,-19.5
@@ -10289,7 +10301,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1447
+  - uid: 1448
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,-18.5
@@ -10299,7 +10311,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1448
+  - uid: 1449
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,-17.5
@@ -10307,7 +10319,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1449
+  - uid: 1450
     components:
     - rot: 3.141592653589793 rad
       pos: -1.5,-13.5
@@ -10315,7 +10327,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1450
+  - uid: 1451
     components:
     - rot: 3.141592653589793 rad
       pos: -1.5,-11.5
@@ -10325,7 +10337,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1451
+  - uid: 1452
     components:
     - rot: 3.141592653589793 rad
       pos: -1.5,-10.5
@@ -10333,7 +10345,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1452
+  - uid: 1453
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,-16.5
@@ -10341,7 +10353,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1453
+  - uid: 1454
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,-14.5
@@ -10349,7 +10361,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1454
+  - uid: 1455
     components:
     - rot: 1.5707963267948966 rad
       pos: -1.5,-15.5
@@ -10357,7 +10369,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1455
+  - uid: 1456
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,-12.5
@@ -10365,7 +10377,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1456
+  - uid: 1457
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,-11.5
@@ -10375,7 +10387,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1457
+  - uid: 1458
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,-10.5
@@ -10383,7 +10395,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1458
+  - uid: 1459
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,-9.5
@@ -10391,7 +10403,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1459
+  - uid: 1460
     components:
     - rot: 3.141592653589793 rad
       pos: -1.5,-9.5
@@ -10399,7 +10411,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1460
+  - uid: 1461
     components:
     - rot: 3.141592653589793 rad
       pos: -1.5,-8.5
@@ -10407,7 +10419,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1461
+  - uid: 1462
     components:
     - rot: 3.141592653589793 rad
       pos: 2.5,-7.5
@@ -10415,7 +10427,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1462
+  - uid: 1463
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,-8.5
@@ -10423,7 +10435,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1463
+  - uid: 1464
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,-7.5
@@ -10431,7 +10443,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1464
+  - uid: 1465
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,-6.5
@@ -10439,7 +10451,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1465
+  - uid: 1466
     components:
     - rot: 3.141592653589793 rad
       pos: -1.5,-6.5
@@ -10447,49 +10459,49 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1466
+  - uid: 1467
     components:
     - pos: -0.5,-4.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1467
+  - uid: 1468
     components:
     - pos: -1.5,-5.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1468
+  - uid: 1469
     components:
     - pos: -1.5,-4.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1469
+  - uid: 1470
     components:
     - pos: -1.5,-3.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1470
+  - uid: 1471
     components:
     - pos: -1.5,-0.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1471
+  - uid: 1472
     components:
     - pos: -1.5,0.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1472
+  - uid: 1473
     components:
     - rot: 1.5707963267948966 rad
       pos: 1.5,1.5
@@ -10497,21 +10509,21 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1473
+  - uid: 1474
     components:
     - pos: 2.5,0.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1474
+  - uid: 1475
     components:
     - pos: 2.5,-0.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1475
+  - uid: 1476
     components:
     - rot: -1.5707963267948966 rad
       pos: -1.5,-3.5
@@ -10519,7 +10531,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1476
+  - uid: 1477
     components:
     - rot: -1.5707963267948966 rad
       pos: -2.5,-3.5
@@ -10527,7 +10539,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1477
+  - uid: 1478
     components:
     - rot: 3.141592653589793 rad
       pos: -3.5,-2.5
@@ -10535,7 +10547,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1478
+  - uid: 1479
     components:
     - rot: 3.141592653589793 rad
       pos: -3.5,-1.5
@@ -10543,7 +10555,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1479
+  - uid: 1480
     components:
     - rot: 3.141592653589793 rad
       pos: -3.5,-0.5
@@ -10551,7 +10563,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1480
+  - uid: 1481
     components:
     - rot: 3.141592653589793 rad
       pos: -3.5,0.5
@@ -10559,7 +10571,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1481
+  - uid: 1482
     components:
     - rot: 3.141592653589793 rad
       pos: -3.5,1.5
@@ -10567,7 +10579,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1482
+  - uid: 1483
     components:
     - rot: 3.141592653589793 rad
       pos: -3.5,2.5
@@ -10575,7 +10587,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1483
+  - uid: 1484
     components:
     - rot: 1.5707963267948966 rad
       pos: -2.5,3.5
@@ -10583,7 +10595,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1484
+  - uid: 1485
     components:
     - rot: 1.5707963267948966 rad
       pos: -1.5,3.5
@@ -10591,7 +10603,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1485
+  - uid: 1486
     components:
     - rot: 1.5707963267948966 rad
       pos: 0.5,1.5
@@ -10599,7 +10611,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1486
+  - uid: 1487
     components:
     - pos: 0.5,2.5
       parent: 1
@@ -10608,7 +10620,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1487
+  - uid: 1488
     components:
     - rot: 1.5707963267948966 rad
       pos: 2.5,3.5
@@ -10616,7 +10628,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1488
+  - uid: 1489
     components:
     - rot: 1.5707963267948966 rad
       pos: 3.5,3.5
@@ -10624,52 +10636,44 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1489
+  - uid: 1490
     components:
     - pos: 4.5,2.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1490
+  - uid: 1491
     components:
     - pos: 4.5,1.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1491
+  - uid: 1492
     components:
     - pos: 4.5,0.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1492
+  - uid: 1493
     components:
     - pos: 4.5,-0.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1493
+  - uid: 1494
     components:
     - pos: 4.5,-1.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1494
-    components:
-    - pos: 4.5,-2.5
-      parent: 1
-      type: Transform
-    - color: '#0055CCFF'
-      type: AtmosPipeColor
   - uid: 1495
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 3.5,-3.5
+    - pos: 4.5,-2.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
@@ -10677,96 +10681,104 @@ entities:
   - uid: 1496
     components:
     - rot: -1.5707963267948966 rad
-      pos: 2.5,-3.5
+      pos: 3.5,-3.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 1497
     components:
-    - pos: 1.5,-4.5
+    - rot: -1.5707963267948966 rad
+      pos: 2.5,-3.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 1498
     components:
-    - pos: 1.5,-6.5
+    - pos: 1.5,-4.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 1499
     components:
-    - pos: 1.5,-7.5
+    - pos: 1.5,-6.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 1500
     components:
-    - pos: 1.5,-8.5
+    - pos: 1.5,-7.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 1501
     components:
-    - pos: 1.5,-9.5
+    - pos: 1.5,-8.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 1502
     components:
-    - pos: 1.5,-10.5
+    - pos: 1.5,-9.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 1503
     components:
-    - pos: 2.5,-3.5
+    - pos: 1.5,-10.5
       parent: 1
       type: Transform
-    - color: '#990000FF'
+    - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 1504
     components:
-    - pos: 2.5,-4.5
+    - pos: 2.5,-3.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 1505
     components:
-    - pos: 2.5,-6.5
+    - pos: 2.5,-4.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 1506
     components:
-    - pos: 2.5,-8.5
+    - pos: 2.5,-6.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 1507
     components:
-    - pos: 2.5,-9.5
+    - pos: 2.5,-8.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 1508
     components:
-    - pos: 2.5,-10.5
+    - pos: 2.5,-9.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 1509
+    components:
+    - pos: 2.5,-10.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 1510
     components:
     - pos: 1.5,-11.5
       parent: 1
@@ -10775,28 +10787,28 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1510
+  - uid: 1511
     components:
     - pos: 1.5,-12.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1511
+  - uid: 1512
     components:
     - pos: 1.5,-14.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1512
+  - uid: 1513
     components:
     - pos: 1.5,-16.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1513
+  - uid: 1514
     components:
     - pos: 1.5,-18.5
       parent: 1
@@ -10805,7 +10817,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1514
+  - uid: 1515
     components:
     - pos: 1.5,-19.5
       parent: 1
@@ -10814,7 +10826,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1515
+  - uid: 1516
     components:
     - pos: 1.5,-20.5
       parent: 1
@@ -10823,14 +10835,14 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1516
+  - uid: 1517
     components:
     - pos: 1.5,-21.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1517
+  - uid: 1518
     components:
     - pos: 1.5,-22.5
       parent: 1
@@ -10839,7 +10851,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1518
+  - uid: 1519
     components:
     - pos: 1.5,-23.5
       parent: 1
@@ -10848,7 +10860,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1519
+  - uid: 1520
     components:
     - pos: 1.5,-24.5
       parent: 1
@@ -10857,7 +10869,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1520
+  - uid: 1521
     components:
     - pos: 2.5,-11.5
       parent: 1
@@ -10866,7 +10878,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1521
+  - uid: 1522
     components:
     - rot: 3.141592653589793 rad
       pos: 6.5,-16.5
@@ -10874,14 +10886,14 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1522
+  - uid: 1523
     components:
     - pos: 2.5,-13.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1523
+  - uid: 1524
     components:
     - rot: 3.141592653589793 rad
       pos: 6.5,-17.5
@@ -10891,14 +10903,14 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1524
+  - uid: 1525
     components:
     - pos: 2.5,-15.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1525
+  - uid: 1526
     components:
     - rot: 3.141592653589793 rad
       pos: 6.5,-18.5
@@ -10906,14 +10918,14 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1526
+  - uid: 1527
     components:
     - pos: 2.5,-17.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1527
+  - uid: 1528
     components:
     - pos: 2.5,-18.5
       parent: 1
@@ -10922,7 +10934,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1528
+  - uid: 1529
     components:
     - pos: 2.5,-19.5
       parent: 1
@@ -10931,7 +10943,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1529
+  - uid: 1530
     components:
     - pos: 2.5,-20.5
       parent: 1
@@ -10940,7 +10952,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1530
+  - uid: 1531
     components:
     - pos: 2.5,-21.5
       parent: 1
@@ -10949,19 +10961,9 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1531
-    components:
-    - pos: 2.5,-22.5
-      parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 1532
     components:
-    - rot: 1.5707963267948966 rad
-      pos: 4.5,-23.5
+    - pos: 2.5,-22.5
       parent: 1
       type: Transform
     - color: '#990000FF'
@@ -10971,7 +10973,7 @@ entities:
   - uid: 1533
     components:
     - rot: 1.5707963267948966 rad
-      pos: 5.5,-23.5
+      pos: 4.5,-23.5
       parent: 1
       type: Transform
     - color: '#990000FF'
@@ -10979,6 +10981,16 @@ entities:
     - enabled: True
       type: AmbientSound
   - uid: 1534
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 5.5,-23.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+    - enabled: True
+      type: AmbientSound
+  - uid: 1535
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,-25.5
@@ -10988,7 +11000,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1535
+  - uid: 1536
     components:
     - rot: -1.5707963267948966 rad
       pos: 4.5,-25.5
@@ -10998,7 +11010,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1536
+  - uid: 1537
     components:
     - rot: -1.5707963267948966 rad
       pos: 5.5,-25.5
@@ -11008,14 +11020,14 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1537
+  - uid: 1538
     components:
     - pos: 7.5,-25.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1538
+  - uid: 1539
     components:
     - pos: 7.5,-26.5
       parent: 1
@@ -11024,14 +11036,14 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1539
+  - uid: 1540
     components:
     - pos: 7.5,-27.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1540
+  - uid: 1541
     components:
     - rot: 3.141592653589793 rad
       pos: 6.5,-26.5
@@ -11041,7 +11053,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1541
+  - uid: 1542
     components:
     - rot: 3.141592653589793 rad
       pos: 6.5,-27.5
@@ -11049,7 +11061,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1542
+  - uid: 1543
     components:
     - rot: 3.141592653589793 rad
       pos: 6.5,-28.5
@@ -11057,7 +11069,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1543
+  - uid: 1544
     components:
     - rot: 3.141592653589793 rad
       pos: 6.5,-29.5
@@ -11065,7 +11077,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1544
+  - uid: 1545
     components:
     - rot: 3.141592653589793 rad
       pos: 6.5,-30.5
@@ -11073,7 +11085,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1545
+  - uid: 1546
     components:
     - rot: 3.141592653589793 rad
       pos: 6.5,-31.5
@@ -11081,7 +11093,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1546
+  - uid: 1547
     components:
     - rot: 3.141592653589793 rad
       pos: 6.5,-32.5
@@ -11089,7 +11101,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1547
+  - uid: 1548
     components:
     - rot: 1.5707963267948966 rad
       pos: -1.5,-31.5
@@ -11097,7 +11109,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1548
+  - uid: 1549
     components:
     - rot: 3.141592653589793 rad
       pos: 7.5,-29.5
@@ -11105,7 +11117,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1549
+  - uid: 1550
     components:
     - rot: 3.141592653589793 rad
       pos: 7.5,-30.5
@@ -11113,7 +11125,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1550
+  - uid: 1551
     components:
     - rot: 3.141592653589793 rad
       pos: 7.5,-31.5
@@ -11121,7 +11133,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1551
+  - uid: 1552
     components:
     - rot: 3.141592653589793 rad
       pos: 7.5,-32.5
@@ -11129,7 +11141,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1552
+  - uid: 1553
     components:
     - rot: 3.141592653589793 rad
       pos: 7.5,-33.5
@@ -11137,7 +11149,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1553
+  - uid: 1554
     components:
     - rot: 3.141592653589793 rad
       pos: -5.5,-16.5
@@ -11145,7 +11157,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1554
+  - uid: 1555
     components:
     - rot: 3.141592653589793 rad
       pos: -5.5,-15.5
@@ -11153,7 +11165,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1555
+  - uid: 1556
     components:
     - rot: 1.5707963267948966 rad
       pos: -5.5,-12.5
@@ -11161,7 +11173,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1556
+  - uid: 1557
     components:
     - rot: 1.5707963267948966 rad
       pos: -4.5,-12.5
@@ -11171,7 +11183,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1557
+  - uid: 1558
     components:
     - rot: -1.5707963267948966 rad
       pos: -3.5,-12.5
@@ -11179,7 +11191,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1558
+  - uid: 1559
     components:
     - rot: -1.5707963267948966 rad
       pos: -2.5,-12.5
@@ -11187,7 +11199,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1559
+  - uid: 1560
     components:
     - rot: -1.5707963267948966 rad
       pos: -5.5,-13.5
@@ -11195,7 +11207,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1560
+  - uid: 1561
     components:
     - rot: -1.5707963267948966 rad
       pos: -4.5,-13.5
@@ -11203,7 +11215,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1561
+  - uid: 1562
     components:
     - rot: -1.5707963267948966 rad
       pos: -3.5,-13.5
@@ -11211,7 +11223,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1562
+  - uid: 1563
     components:
     - rot: -1.5707963267948966 rad
       pos: -2.5,-13.5
@@ -11219,7 +11231,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1563
+  - uid: 1564
     components:
     - rot: -1.5707963267948966 rad
       pos: -1.5,-13.5
@@ -11227,7 +11239,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1564
+  - uid: 1565
     components:
     - rot: 1.5707963267948966 rad
       pos: -4.5,-14.5
@@ -11237,7 +11249,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1565
+  - uid: 1566
     components:
     - rot: 1.5707963267948966 rad
       pos: -3.5,-14.5
@@ -11245,7 +11257,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1566
+  - uid: 1567
     components:
     - rot: 1.5707963267948966 rad
       pos: -2.5,-14.5
@@ -11255,7 +11267,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1567
+  - uid: 1568
     components:
     - pos: -3.5,-17.5
       parent: 1
@@ -11264,14 +11276,14 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1568
+  - uid: 1569
     components:
     - pos: -3.5,-16.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1569
+  - uid: 1570
     components:
     - rot: 1.5707963267948966 rad
       pos: -2.5,-15.5
@@ -11279,7 +11291,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1570
+  - uid: 1571
     components:
     - rot: 3.141592653589793 rad
       pos: -1.5,-15.5
@@ -11287,14 +11299,14 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1571
+  - uid: 1572
     components:
     - pos: 2.5,-5.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1572
+  - uid: 1573
     components:
     - pos: -1.5,-1.5
       parent: 1
@@ -11303,7 +11315,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1573
+  - uid: 1574
     components:
     - pos: 2.5,-1.5
       parent: 1
@@ -11312,14 +11324,14 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1574
+  - uid: 1575
     components:
     - pos: 2.5,-2.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1575
+  - uid: 1576
     components:
     - rot: 3.141592653589793 rad
       pos: 6.5,-15.5
@@ -11327,7 +11339,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1576
+  - uid: 1577
     components:
     - rot: 1.5707963267948966 rad
       pos: 6.5,-12.5
@@ -11335,7 +11347,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1577
+  - uid: 1578
     components:
     - rot: 1.5707963267948966 rad
       pos: 5.5,-12.5
@@ -11345,7 +11357,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1578
+  - uid: 1579
     components:
     - rot: 1.5707963267948966 rad
       pos: 4.5,-12.5
@@ -11353,7 +11365,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1579
+  - uid: 1580
     components:
     - rot: 1.5707963267948966 rad
       pos: 3.5,-12.5
@@ -11363,7 +11375,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1580
+  - uid: 1581
     components:
     - rot: -1.5707963267948966 rad
       pos: 5.5,-14.5
@@ -11373,7 +11385,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1581
+  - uid: 1582
     components:
     - rot: -1.5707963267948966 rad
       pos: 4.5,-14.5
@@ -11381,7 +11393,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1582
+  - uid: 1583
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,-14.5
@@ -11391,7 +11403,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1583
+  - uid: 1584
     components:
     - rot: 3.141592653589793 rad
       pos: 4.5,-17.5
@@ -11401,7 +11413,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1584
+  - uid: 1585
     components:
     - rot: 3.141592653589793 rad
       pos: 4.5,-16.5
@@ -11409,7 +11421,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1585
+  - uid: 1586
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,-15.5
@@ -11417,7 +11429,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1586
+  - uid: 1587
     components:
     - rot: -1.5707963267948966 rad
       pos: 2.5,-15.5
@@ -11425,7 +11437,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1587
+  - uid: 1588
     components:
     - rot: -1.5707963267948966 rad
       pos: -4.5,-30.5
@@ -11435,7 +11447,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1588
+  - uid: 1589
     components:
     - rot: -1.5707963267948966 rad
       pos: -5.5,-30.5
@@ -11443,7 +11455,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1589
+  - uid: 1590
     components:
     - rot: -1.5707963267948966 rad
       pos: -4.5,-27.5
@@ -11453,7 +11465,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1590
+  - uid: 1591
     components:
     - rot: -1.5707963267948966 rad
       pos: -5.5,-27.5
@@ -11461,7 +11473,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1591
+  - uid: 1592
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,-32.5
@@ -11471,7 +11483,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1592
+  - uid: 1593
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,-31.5
@@ -11479,7 +11491,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1593
+  - uid: 1594
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,-13.5
@@ -11487,7 +11499,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1594
+  - uid: 1595
     components:
     - rot: -1.5707963267948966 rad
       pos: 4.5,-13.5
@@ -11495,7 +11507,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1595
+  - uid: 1596
     components:
     - rot: -1.5707963267948966 rad
       pos: 5.5,-13.5
@@ -11503,7 +11515,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1596
+  - uid: 1597
     components:
     - rot: -1.5707963267948966 rad
       pos: 6.5,-13.5
@@ -11511,14 +11523,14 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1597
+  - uid: 1598
     components:
     - pos: -0.5,3.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1598
+  - uid: 1599
     components:
     - rot: -1.5707963267948966 rad
       pos: -0.5,-7.5
@@ -11526,7 +11538,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1599
+  - uid: 1600
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,2.5
@@ -11536,7 +11548,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1600
+  - uid: 1601
     components:
     - rot: 3.141592653589793 rad
       pos: 1.5,-5.5
@@ -11544,7 +11556,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1601
+  - uid: 1602
     components:
     - rot: -1.5707963267948966 rad
       pos: -7.5,-31.5
@@ -11552,7 +11564,9 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1602
+    - enabled: True
+      type: AmbientSound
+  - uid: 1603
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,-23.5
@@ -11562,7 +11576,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1603
+  - uid: 1604
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,2.5
@@ -11572,7 +11586,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1604
+  - uid: 1605
     components:
     - rot: -1.5707963267948966 rad
       pos: 2.5,-25.5
@@ -11582,7 +11596,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1605
+  - uid: 1606
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,0.5
@@ -11590,7 +11604,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1606
+  - uid: 1607
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,1.5
@@ -11598,7 +11612,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1607
+  - uid: 1608
     components:
     - rot: 1.5707963267948966 rad
       pos: -0.5,3.5
@@ -11606,7 +11620,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1608
+  - uid: 1609
     components:
     - rot: -1.5707963267948966 rad
       pos: 5.5,0.5
@@ -11614,7 +11628,7 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 1609
+  - uid: 1610
     components:
     - rot: -1.5707963267948966 rad
       pos: 6.5,0.5
@@ -11624,14 +11638,14 @@ entities:
       type: AmbientSound
 - proto: GasPipeTJunction
   entities:
-  - uid: 1610
+  - uid: 1611
     components:
     - pos: 0.5,3.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1611
+  - uid: 1612
     components:
     - rot: 1.5707963267948966 rad
       pos: 6.5,-24.5
@@ -11639,13 +11653,13 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1612
+  - uid: 1613
     components:
     - rot: 3.141592653589793 rad
       pos: 3.5,-33.5
       parent: 1
       type: Transform
-  - uid: 1613
+  - uid: 1614
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,-31.5
@@ -11653,7 +11667,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1614
+  - uid: 1615
     components:
     - rot: 1.5707963267948966 rad
       pos: -5.5,-33.5
@@ -11661,7 +11675,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1615
+  - uid: 1616
     components:
     - rot: -1.5707963267948966 rad
       pos: -6.5,-33.5
@@ -11669,7 +11683,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1616
+  - uid: 1617
     components:
     - rot: 1.5707963267948966 rad
       pos: -6.5,-30.5
@@ -11677,7 +11691,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1617
+  - uid: 1618
     components:
     - rot: -1.5707963267948966 rad
       pos: -6.5,-31.5
@@ -11685,7 +11699,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1618
+  - uid: 1619
     components:
     - rot: 1.5707963267948966 rad
       pos: -6.5,-27.5
@@ -11693,7 +11707,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1619
+  - uid: 1620
     components:
     - rot: -1.5707963267948966 rad
       pos: -5.5,-29.5
@@ -11701,7 +11715,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1620
+  - uid: 1621
     components:
     - rot: -1.5707963267948966 rad
       pos: -1.5,-12.5
@@ -11709,7 +11723,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1621
+  - uid: 1622
     components:
     - rot: -1.5707963267948966 rad
       pos: -0.5,-15.5
@@ -11717,7 +11731,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1622
+  - uid: 1623
     components:
     - rot: -1.5707963267948966 rad
       pos: -1.5,-14.5
@@ -11725,7 +11739,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1623
+  - uid: 1624
     components:
     - rot: -1.5707963267948966 rad
       pos: -1.5,-16.5
@@ -11733,7 +11747,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1624
+  - uid: 1625
     components:
     - rot: -1.5707963267948966 rad
       pos: -0.5,-13.5
@@ -11741,7 +11755,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1625
+  - uid: 1626
     components:
     - rot: 1.5707963267948966 rad
       pos: -1.5,-7.5
@@ -11749,7 +11763,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1626
+  - uid: 1627
     components:
     - rot: 3.141592653589793 rad
       pos: 1.5,3.5
@@ -11757,7 +11771,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1627
+  - uid: 1628
     components:
     - rot: 1.5707963267948966 rad
       pos: 1.5,-15.5
@@ -11765,7 +11779,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1628
+  - uid: 1629
     components:
     - rot: -1.5707963267948966 rad
       pos: 1.5,-17.5
@@ -11773,7 +11787,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1629
+  - uid: 1630
     components:
     - pos: -2.5,-23.5
       parent: 1
@@ -11782,7 +11796,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1630
+  - uid: 1631
     components:
     - rot: 3.141592653589793 rad
       pos: -1.5,-25.5
@@ -11790,14 +11804,14 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1631
+  - uid: 1632
     components:
     - pos: 6.5,-25.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1632
+  - uid: 1633
     components:
     - rot: -1.5707963267948966 rad
       pos: 7.5,-28.5
@@ -11805,7 +11819,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1633
+  - uid: 1634
     components:
     - rot: -1.5707963267948966 rad
       pos: 0.5,-33.5
@@ -11813,7 +11827,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1634
+  - uid: 1635
     components:
     - rot: 1.5707963267948966 rad
       pos: -6.5,-28.5
@@ -11821,7 +11835,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1635
+  - uid: 1636
     components:
     - rot: 1.5707963267948966 rad
       pos: 2.5,-12.5
@@ -11829,7 +11843,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1636
+  - uid: 1637
     components:
     - rot: 1.5707963267948966 rad
       pos: 2.5,-14.5
@@ -11837,7 +11851,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1637
+  - uid: 1638
     components:
     - rot: 1.5707963267948966 rad
       pos: 2.5,-16.5
@@ -11845,7 +11859,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1638
+  - uid: 1639
     components:
     - rot: 1.5707963267948966 rad
       pos: -0.5,-5.5
@@ -11855,22 +11869,22 @@ entities:
       type: AtmosPipeColor
 - proto: GasPort
   entities:
-  - uid: 1639
+  - uid: 1640
     components:
     - pos: 4.5,-32.5
       parent: 1
       type: Transform
-  - uid: 1640
+  - uid: 1641
     components:
     - pos: 5.5,-32.5
       parent: 1
       type: Transform
-  - uid: 1641
+  - uid: 1642
     components:
     - pos: 2.5,-32.5
       parent: 1
       type: Transform
-  - uid: 1642
+  - uid: 1643
     components:
     - rot: 1.5707963267948966 rad
       pos: 4.5,0.5
@@ -11878,14 +11892,14 @@ entities:
       type: Transform
 - proto: GasThermoMachineHeater
   entities:
-  - uid: 1643
+  - uid: 1644
     components:
     - pos: 3.5,-32.5
       parent: 1
       type: Transform
 - proto: GasVentPump
   entities:
-  - uid: 1644
+  - uid: 1645
     components:
     - pos: -0.5,-30.5
       parent: 1
@@ -11897,7 +11911,7 @@ entities:
       type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1645
+  - uid: 1646
     components:
     - rot: 3.141592653589793 rad
       pos: 6.5,-33.5
@@ -11905,21 +11919,7 @@ entities:
       type: Transform
     - ShutdownSubscribers:
       - 5
-      - 1302
-      type: DeviceNetwork
-    - enabled: False
-      type: AmbientSound
-    - color: '#0055CCFF'
-      type: AtmosPipeColor
-  - uid: 1646
-    components:
-    - pos: 1.5,4.5
-      parent: 1
-      type: Transform
-    - ShutdownSubscribers:
-      - 13
-      - 1298
-      - 1301
+      - 1303
       type: DeviceNetwork
     - enabled: False
       type: AmbientSound
@@ -11927,14 +11927,13 @@ entities:
       type: AtmosPipeColor
   - uid: 1647
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 0.5,-5.5
+    - pos: 1.5,4.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 14
+      - 13
       - 1299
-      - 1300
+      - 1302
       type: DeviceNetwork
     - enabled: False
       type: AmbientSound
@@ -11942,13 +11941,14 @@ entities:
       type: AtmosPipeColor
   - uid: 1648
     components:
-    - rot: 3.141592653589793 rad
-      pos: -3.5,-18.5
+    - rot: -1.5707963267948966 rad
+      pos: 0.5,-5.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 8
-      - 1309
+      - 14
+      - 1300
+      - 1301
       type: DeviceNetwork
     - enabled: False
       type: AmbientSound
@@ -11957,11 +11957,11 @@ entities:
   - uid: 1649
     components:
     - rot: 3.141592653589793 rad
-      pos: 4.5,-18.5
+      pos: -3.5,-18.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 4
+      - 8
       - 1310
       type: DeviceNetwork
     - enabled: False
@@ -11970,13 +11970,13 @@ entities:
       type: AtmosPipeColor
   - uid: 1650
     components:
-    - rot: 1.5707963267948966 rad
-      pos: -6.5,-29.5
+    - rot: 3.141592653589793 rad
+      pos: 4.5,-18.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 7
-      - 1304
+      - 4
+      - 1311
       type: DeviceNetwork
     - enabled: False
       type: AmbientSound
@@ -11984,19 +11984,33 @@ entities:
       type: AtmosPipeColor
   - uid: 1651
     components:
-    - rot: 3.141592653589793 rad
-      pos: -5.5,-34.5
+    - rot: 1.5707963267948966 rad
+      pos: -6.5,-29.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 6
-      - 1303
+      - 7
+      - 1305
       type: DeviceNetwork
     - enabled: False
       type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 1652
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -5.5,-34.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 6
+      - 1304
+      type: DeviceNetwork
+    - enabled: False
+      type: AmbientSound
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 1653
     components:
     - pos: -1.5,-24.5
       parent: 1
@@ -12008,7 +12022,7 @@ entities:
       type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1653
+  - uid: 1654
     components:
     - rot: 1.5707963267948966 rad
       pos: 0.5,-13.5
@@ -12016,20 +12030,6 @@ entities:
       type: Transform
     - ShutdownSubscribers:
       - 11
-      - 1306
-      type: DeviceNetwork
-    - enabled: False
-      type: AmbientSound
-    - color: '#0055CCFF'
-      type: AtmosPipeColor
-  - uid: 1654
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -6.5,-13.5
-      parent: 1
-      type: Transform
-    - ShutdownSubscribers:
-      - 9
       - 1307
       type: DeviceNetwork
     - enabled: False
@@ -12038,12 +12038,12 @@ entities:
       type: AtmosPipeColor
   - uid: 1655
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 7.5,-13.5
+    - rot: 1.5707963267948966 rad
+      pos: -6.5,-13.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 10
+      - 9
       - 1308
       type: DeviceNetwork
     - enabled: False
@@ -12053,12 +12053,12 @@ entities:
   - uid: 1656
     components:
     - rot: -1.5707963267948966 rad
-      pos: 7.5,-25.5
+      pos: 7.5,-13.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 16
-      - 1305
+      - 10
+      - 1309
       type: DeviceNetwork
     - enabled: False
       type: AmbientSound
@@ -12066,12 +12066,12 @@ entities:
       type: AtmosPipeColor
   - uid: 1657
     components:
-    - rot: 1.5707963267948966 rad
-      pos: 0.5,-17.5
+    - rot: -1.5707963267948966 rad
+      pos: 7.5,-25.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 11
+      - 16
       - 1306
       type: DeviceNetwork
     - enabled: False
@@ -12079,6 +12079,20 @@ entities:
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 1658
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 0.5,-17.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 11
+      - 1307
+      type: DeviceNetwork
+    - enabled: False
+      type: AmbientSound
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 1659
     components:
     - rot: 1.5707963267948966 rad
       pos: -0.5,-0.5
@@ -12093,7 +12107,7 @@ entities:
       type: AtmosPipeColor
 - proto: GasVentScrubber
   entities:
-  - uid: 1659
+  - uid: 1660
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,0.5
@@ -12106,7 +12120,7 @@ entities:
       type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1660
+  - uid: 1661
     components:
     - pos: 0.5,-30.5
       parent: 1
@@ -12118,30 +12132,15 @@ entities:
       type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1661
+  - uid: 1662
     components:
     - pos: -0.5,4.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
       - 13
-      - 1298
-      - 1301
-      type: DeviceNetwork
-    - enabled: False
-      type: AmbientSound
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 1662
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 0.5,-7.5
-      parent: 1
-      type: Transform
-    - ShutdownSubscribers:
-      - 14
       - 1299
-      - 1300
+      - 1302
       type: DeviceNetwork
     - enabled: False
       type: AmbientSound
@@ -12149,19 +12148,34 @@ entities:
       type: AtmosPipeColor
   - uid: 1663
     components:
-    - rot: 3.141592653589793 rad
-      pos: 6.5,-19.5
+    - rot: -1.5707963267948966 rad
+      pos: 0.5,-7.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 4
-      - 1310
+      - 14
+      - 1300
+      - 1301
       type: DeviceNetwork
     - enabled: False
       type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 1664
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 6.5,-19.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 4
+      - 1311
+      type: DeviceNetwork
+    - enabled: False
+      type: AmbientSound
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 1665
     components:
     - rot: 3.141592653589793 rad
       pos: -2.5,-24.5
@@ -12174,7 +12188,7 @@ entities:
       type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1665
+  - uid: 1666
     components:
     - rot: 3.141592653589793 rad
       pos: 7.5,-34.5
@@ -12182,20 +12196,6 @@ entities:
       type: Transform
     - ShutdownSubscribers:
       - 5
-      - 1302
-      type: DeviceNetwork
-    - enabled: False
-      type: AmbientSound
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 1666
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -7.5,-33.5
-      parent: 1
-      type: Transform
-    - ShutdownSubscribers:
-      - 6
       - 1303
       type: DeviceNetwork
     - enabled: False
@@ -12204,12 +12204,12 @@ entities:
       type: AtmosPipeColor
   - uid: 1667
     components:
-    - rot: -1.5707963267948966 rad
-      pos: -5.5,-28.5
+    - rot: 1.5707963267948966 rad
+      pos: -7.5,-33.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 7
+      - 6
       - 1304
       type: DeviceNetwork
     - enabled: False
@@ -12218,13 +12218,13 @@ entities:
       type: AtmosPipeColor
   - uid: 1668
     components:
-    - rot: 1.5707963267948966 rad
-      pos: -2.5,-16.5
+    - rot: -1.5707963267948966 rad
+      pos: -5.5,-28.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 11
-      - 1306
+      - 7
+      - 1305
       type: DeviceNetwork
     - enabled: False
       type: AmbientSound
@@ -12232,13 +12232,13 @@ entities:
       type: AtmosPipeColor
   - uid: 1669
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 3.5,-16.5
+    - rot: 1.5707963267948966 rad
+      pos: -2.5,-16.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
       - 11
-      - 1306
+      - 1307
       type: DeviceNetwork
     - enabled: False
       type: AmbientSound
@@ -12246,12 +12246,12 @@ entities:
       type: AtmosPipeColor
   - uid: 1670
     components:
-    - rot: 1.5707963267948966 rad
-      pos: -6.5,-12.5
+    - rot: -1.5707963267948966 rad
+      pos: 3.5,-16.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 9
+      - 11
       - 1307
       type: DeviceNetwork
     - enabled: False
@@ -12260,12 +12260,12 @@ entities:
       type: AtmosPipeColor
   - uid: 1671
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 7.5,-12.5
+    - rot: 1.5707963267948966 rad
+      pos: -6.5,-12.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 10
+      - 9
       - 1308
       type: DeviceNetwork
     - enabled: False
@@ -12274,19 +12274,33 @@ entities:
       type: AtmosPipeColor
   - uid: 1672
     components:
-    - rot: 1.5707963267948966 rad
-      pos: 6.5,-28.5
+    - rot: -1.5707963267948966 rad
+      pos: 7.5,-12.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 5
-      - 1302
+      - 10
+      - 1309
       type: DeviceNetwork
     - enabled: False
       type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 1673
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 6.5,-28.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 5
+      - 1303
+      type: DeviceNetwork
+    - enabled: False
+      type: AmbientSound
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 1674
     components:
     - rot: -1.5707963267948966 rad
       pos: -3.5,-30.5
@@ -12296,7 +12310,7 @@ entities:
       type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1674
+  - uid: 1675
     components:
     - rot: -1.5707963267948966 rad
       pos: -3.5,-27.5
@@ -12306,7 +12320,7 @@ entities:
       type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1675
+  - uid: 1676
     components:
     - rot: 3.141592653589793 rad
       pos: -5.5,-19.5
@@ -12314,13 +12328,13 @@ entities:
       type: Transform
     - ShutdownSubscribers:
       - 8
-      - 1309
+      - 1310
       type: DeviceNetwork
     - enabled: False
       type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1676
+  - uid: 1677
     components:
     - rot: 1.5707963267948966 rad
       pos: -8.5,-31.5
@@ -12330,7 +12344,7 @@ entities:
       type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1677
+  - uid: 1678
     components:
     - rot: 3.141592653589793 rad
       pos: 6.5,-25.5
@@ -12338,7 +12352,7 @@ entities:
       type: Transform
     - ShutdownSubscribers:
       - 16
-      - 1305
+      - 1306
       type: DeviceNetwork
     - enabled: False
       type: AmbientSound
@@ -12346,249 +12360,249 @@ entities:
       type: AtmosPipeColor
 - proto: GravityGeneratorMini
   entities:
-  - uid: 1678
+  - uid: 1679
     components:
     - pos: 0.5,-34.5
       parent: 1
       type: Transform
 - proto: Grille
   entities:
-  - uid: 1679
+  - uid: 1680
     components:
     - pos: 1.5,-29.5
       parent: 1
       type: Transform
-  - uid: 1680
+  - uid: 1681
     components:
     - pos: 0.5,-18.5
       parent: 1
       type: Transform
-  - uid: 1681
+  - uid: 1682
     components:
     - pos: 1.5,-18.5
       parent: 1
       type: Transform
-  - uid: 1682
+  - uid: 1683
     components:
     - pos: 2.5,-18.5
       parent: 1
       type: Transform
-  - uid: 1683
+  - uid: 1684
     components:
     - pos: -1.5,-20.5
       parent: 1
       type: Transform
-  - uid: 1684
+  - uid: 1685
     components:
     - pos: -0.5,-20.5
       parent: 1
       type: Transform
-  - uid: 1685
+  - uid: 1686
     components:
     - pos: 1.5,-20.5
       parent: 1
       type: Transform
-  - uid: 1686
+  - uid: 1687
     components:
     - pos: 2.5,-20.5
       parent: 1
       type: Transform
-  - uid: 1687
+  - uid: 1688
     components:
     - pos: -0.5,-18.5
       parent: 1
       type: Transform
-  - uid: 1688
+  - uid: 1689
     components:
     - pos: -1.5,-18.5
       parent: 1
       type: Transform
-  - uid: 1689
+  - uid: 1690
     components:
     - pos: 0.5,-20.5
       parent: 1
       type: Transform
-  - uid: 1690
+  - uid: 1691
     components:
     - pos: -2.5,-22.5
       parent: 1
       type: Transform
-  - uid: 1691
+  - uid: 1692
     components:
     - pos: -3.5,-22.5
       parent: 1
       type: Transform
-  - uid: 1692
+  - uid: 1693
     components:
     - pos: -4.5,-22.5
       parent: 1
       type: Transform
-  - uid: 1693
+  - uid: 1694
     components:
     - pos: -6.5,-22.5
       parent: 1
       type: Transform
-  - uid: 1694
+  - uid: 1695
     components:
     - pos: 3.5,-22.5
       parent: 1
       type: Transform
-  - uid: 1695
+  - uid: 1696
     components:
     - pos: 4.5,-22.5
       parent: 1
       type: Transform
-  - uid: 1696
+  - uid: 1697
     components:
     - pos: 5.5,-22.5
       parent: 1
       type: Transform
-  - uid: 1697
+  - uid: 1698
     components:
     - pos: 7.5,-22.5
       parent: 1
       type: Transform
-  - uid: 1698
+  - uid: 1699
     components:
     - pos: 3.5,-26.5
       parent: 1
       type: Transform
-  - uid: 1699
+  - uid: 1700
     components:
     - rot: -1.5707963267948966 rad
       pos: 8.5,-24.5
       parent: 1
       type: Transform
-  - uid: 1700
-    components:
-    - pos: -7.5,-24.5
-      parent: 1
-      type: Transform
   - uid: 1701
     components:
-    - rot: 3.141592653589793 rad
-      pos: 1.5,-27.5
+    - pos: -7.5,-24.5
       parent: 1
       type: Transform
   - uid: 1702
     components:
     - rot: 3.141592653589793 rad
-      pos: 1.5,-28.5
+      pos: 1.5,-27.5
       parent: 1
       type: Transform
   - uid: 1703
     components:
-    - rot: 1.5707963267948966 rad
-      pos: -7.5,-15.5
+    - rot: 3.141592653589793 rad
+      pos: 1.5,-28.5
       parent: 1
       type: Transform
   - uid: 1704
     components:
     - rot: 1.5707963267948966 rad
-      pos: -7.5,-16.5
+      pos: -7.5,-15.5
       parent: 1
       type: Transform
   - uid: 1705
     components:
-    - rot: 3.141592653589793 rad
-      pos: 8.5,-16.5
+    - rot: 1.5707963267948966 rad
+      pos: -7.5,-16.5
       parent: 1
       type: Transform
   - uid: 1706
     components:
     - rot: 3.141592653589793 rad
-      pos: 8.5,-15.5
+      pos: 8.5,-16.5
       parent: 1
       type: Transform
   - uid: 1707
     components:
-    - rot: -1.5707963267948966 rad
-      pos: -2.5,0.5
+    - rot: 3.141592653589793 rad
+      pos: 8.5,-15.5
       parent: 1
       type: Transform
   - uid: 1708
     components:
     - rot: -1.5707963267948966 rad
-      pos: -0.5,2.5
+      pos: -2.5,0.5
       parent: 1
       type: Transform
   - uid: 1709
     components:
     - rot: -1.5707963267948966 rad
-      pos: 1.5,2.5
+      pos: -0.5,2.5
       parent: 1
       type: Transform
   - uid: 1710
     components:
     - rot: -1.5707963267948966 rad
-      pos: 3.5,0.5
+      pos: 1.5,2.5
       parent: 1
       type: Transform
   - uid: 1711
     components:
-    - rot: 3.141592653589793 rad
-      pos: 1.5,-34.5
+    - rot: -1.5707963267948966 rad
+      pos: 3.5,0.5
       parent: 1
       type: Transform
   - uid: 1712
     components:
     - rot: 3.141592653589793 rad
-      pos: -0.5,-34.5
+      pos: 1.5,-34.5
       parent: 1
       type: Transform
   - uid: 1713
     components:
-    - pos: 4.5,-26.5
+    - rot: 3.141592653589793 rad
+      pos: -0.5,-34.5
       parent: 1
       type: Transform
   - uid: 1714
     components:
-    - pos: 2.5,-26.5
+    - pos: 4.5,-26.5
       parent: 1
       type: Transform
   - uid: 1715
     components:
-    - rot: 3.141592653589793 rad
-      pos: 0.5,-32.5
+    - pos: 2.5,-26.5
       parent: 1
       type: Transform
   - uid: 1716
     components:
     - rot: 3.141592653589793 rad
-      pos: -9.5,-33.5
+      pos: 0.5,-32.5
       parent: 1
       type: Transform
   - uid: 1717
     components:
-    - pos: -0.5,-1.5
+    - rot: 3.141592653589793 rad
+      pos: -9.5,-33.5
       parent: 1
       type: Transform
   - uid: 1718
+    components:
+    - pos: -0.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 1719
     components:
     - rot: 3.141592653589793 rad
       pos: 3.5,-24.5
       parent: 1
       type: Transform
-  - uid: 1719
+  - uid: 1720
     components:
     - pos: -6.5,-26.5
       parent: 1
       type: Transform
-  - uid: 1720
+  - uid: 1721
     components:
     - pos: 6.5,0.5
       parent: 1
       type: Transform
 - proto: GroundTobacco
   entities:
-  - uid: 1721
+  - uid: 1722
     components:
     - pos: 1.7202549,-17.40029
       parent: 1
       type: Transform
 - proto: GunSafe
   entities:
-  - uid: 1722
+  - uid: 1723
     components:
     - pos: 0.5,-27.5
       parent: 1
@@ -12618,10 +12632,10 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 1725
           - 1726
-          - 1723
+          - 1727
           - 1724
+          - 1725
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -12629,57 +12643,57 @@ entities:
       type: ContainerContainer
 - proto: Gyroscope
   entities:
-  - uid: 1727
+  - uid: 1728
     components:
     - pos: 9.5,-26.5
       parent: 1
       type: Transform
-  - uid: 1728
+  - uid: 1729
     components:
     - pos: -8.5,-26.5
       parent: 1
       type: Transform
 - proto: HospitalCurtains
   entities:
-  - uid: 1729
+  - uid: 1730
     components:
     - pos: -3.5,-28.5
       parent: 1
       type: Transform
-  - uid: 1730
+  - uid: 1731
     components:
     - pos: -3.5,-31.5
       parent: 1
       type: Transform
-  - uid: 1731
+  - uid: 1732
     components:
     - pos: -9.5,-31.5
       parent: 1
       type: Transform
 - proto: HospitalCurtainsOpen
   entities:
-  - uid: 1732
+  - uid: 1733
     components:
     - pos: -5.5,-16.5
       parent: 1
       type: Transform
-  - uid: 1733
+  - uid: 1734
     components:
     - pos: 2.5,1.5
       parent: 1
       type: Transform
-  - uid: 1734
+  - uid: 1735
     components:
     - pos: -0.5,-27.5
       parent: 1
       type: Transform
-  - uid: 1735
+  - uid: 1736
     components:
     - rot: 1.5707963267948966 rad
       pos: 4.5,-25.5
       parent: 1
       type: Transform
-  - uid: 1736
+  - uid: 1737
     components:
     - rot: 1.5707963267948966 rad
       pos: 7.5,-15.5
@@ -12687,7 +12701,7 @@ entities:
       type: Transform
 - proto: HydroponicsToolHatchet
   entities:
-  - uid: 1737
+  - uid: 1738
     components:
     - name: Steve's hatchet
       type: MetaData
@@ -12696,28 +12710,28 @@ entities:
       type: Transform
 - proto: KitchenMicrowave
   entities:
-  - uid: 1738
+  - uid: 1739
     components:
     - pos: 1.5,-12.5
       parent: 1
       type: Transform
 - proto: KitchenReagentGrinder
   entities:
-  - uid: 1739
+  - uid: 1740
     components:
     - pos: 7.5,-13.5
       parent: 1
       type: Transform
 - proto: Lamp
   entities:
-  - uid: 1740
+  - uid: 1741
     components:
     - pos: -9.682015,-32.198692
       parent: 1
       type: Transform
 - proto: LampGold
   entities:
-  - uid: 1741
+  - uid: 1742
     components:
     - rot: 3.141592653589793 rad
       pos: 4.7820306,-24.235859
@@ -12725,7 +12739,7 @@ entities:
       type: Transform
 - proto: LockerBoozeFilled
   entities:
-  - uid: 1742
+  - uid: 1743
     components:
     - pos: -1.5,-12.5
       parent: 1
@@ -12734,7 +12748,7 @@ entities:
       type: Lock
 - proto: LockerCaptain
   entities:
-  - uid: 216
+  - uid: 217
     components:
     - pos: -1.5,-24.5
       parent: 1
@@ -12762,36 +12776,36 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 242
           - 243
-          - 241
-          - 237
-          - 225
-          - 236
           - 244
-          - 234
-          - 235
-          - 228
-          - 223
-          - 245
-          - 230
-          - 232
-          - 227
-          - 219
-          - 246
-          - 221
-          - 226
-          - 231
-          - 220
-          - 224
-          - 240
-          - 222
-          - 217
-          - 229
+          - 242
           - 238
-          - 218
+          - 226
+          - 237
+          - 245
+          - 235
+          - 236
+          - 229
+          - 224
+          - 246
+          - 231
           - 233
+          - 228
+          - 220
+          - 247
+          - 222
+          - 227
+          - 232
+          - 221
+          - 225
+          - 241
+          - 223
+          - 218
+          - 230
           - 239
+          - 219
+          - 234
+          - 240
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -12799,7 +12813,7 @@ entities:
       type: ContainerContainer
 - proto: LockerChiefEngineerFilled
   entities:
-  - uid: 209
+  - uid: 210
     components:
     - pos: -1.5,-27.5
       parent: 1
@@ -12829,12 +12843,12 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 210
+          - 211
+          - 215
           - 214
           - 213
           - 212
-          - 211
-          - 215
+          - 216
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -12842,7 +12856,7 @@ entities:
       type: ContainerContainer
 - proto: LockerEngineerFilled
   entities:
-  - uid: 1050
+  - uid: 1051
     components:
     - pos: 3.5,-34.5
       parent: 1
@@ -12870,15 +12884,15 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 1052
-          - 1051
           - 1053
+          - 1052
+          - 1054
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
           ent: null
       type: ContainerContainer
-  - uid: 1054
+  - uid: 1055
     components:
     - pos: 2.5,-34.5
       parent: 1
@@ -12906,9 +12920,9 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 1056
-          - 1055
           - 1057
+          - 1056
+          - 1058
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -12916,7 +12930,7 @@ entities:
       type: ContainerContainer
 - proto: LockerParamedicFilled
   entities:
-  - uid: 1067
+  - uid: 1068
     components:
     - pos: -6.5,-12.5
       parent: 1
@@ -12946,7 +12960,7 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 1068
+          - 1069
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -13007,7 +13021,7 @@ entities:
       type: ContainerContainer
 - proto: LockerSalvageSpecialistFilled
   entities:
-  - uid: 1743
+  - uid: 1744
     components:
     - pos: -2.5,-10.5
       parent: 1
@@ -13037,13 +13051,13 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 1744
+          - 1745
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
           ent: null
       type: ContainerContainer
-  - uid: 1745
+  - uid: 1746
     components:
     - pos: 3.5,-10.5
       parent: 1
@@ -13073,7 +13087,7 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 1746
+          - 1747
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -13081,7 +13095,7 @@ entities:
       type: ContainerContainer
 - proto: LockerWallMedicalDoctorFilled
   entities:
-  - uid: 1747
+  - uid: 1748
     components:
     - rot: 3.141592653589793 rad
       pos: -5.5,-17.5
@@ -13091,12 +13105,12 @@ entities:
       type: Lock
 - proto: LockerWallMedicalFilled
   entities:
-  - uid: 1748
+  - uid: 1749
     components:
     - pos: -1.5,-26.5
       parent: 1
       type: Transform
-  - uid: 1749
+  - uid: 1750
     components:
     - rot: 1.5707963267948966 rad
       pos: -2.5,-0.5
@@ -13128,11 +13142,11 @@ entities:
           occludes: True
           ents:
           - 1751
-          - 1752
           - 1753
-          - 1750
+          - 1752
+          - 1754
       type: ContainerContainer
-  - uid: 1754
+  - uid: 1755
     components:
     - rot: 3.141592653589793 rad
       pos: 1.5,-26.5
@@ -13140,117 +13154,117 @@ entities:
       type: Transform
 - proto: LockerWeldingSuppliesFilled
   entities:
-  - uid: 1755
+  - uid: 1756
     components:
     - pos: 7.5,-29.5
       parent: 1
       type: Transform
 - proto: MagazineBoxMagnum
   entities:
-  - uid: 236
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 216
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
   - uid: 237
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 216
+    - parent: 217
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 238
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 217
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: Matchbox
   entities:
-  - uid: 1756
+  - uid: 1757
     components:
     - pos: -1.2443821,-30.366787
       parent: 1
       type: Transform
-  - uid: 1757
+  - uid: 1758
     components:
     - pos: -0.62868136,1.0963256
       parent: 1
       type: Transform
-  - uid: 1758
+  - uid: 1759
     components:
     - pos: 1.8340497,-25.57059
       parent: 1
       type: Transform
-  - uid: 1759
+  - uid: 1760
     components:
     - pos: -0.47121298,-17.48435
       parent: 1
       type: Transform
 - proto: MedicalBed
   entities:
-  - uid: 1760
+  - uid: 1761
     components:
     - pos: 7.5,-15.5
       parent: 1
       type: Transform
-  - uid: 1761
+  - uid: 1762
     components:
     - pos: -5.5,-16.5
       parent: 1
       type: Transform
 - proto: MedkitFilled
   entities:
-  - uid: 1762
+  - uid: 1763
     components:
     - pos: -6.6608167,-13.206823
       parent: 1
       type: Transform
 - proto: MopBucketFull
   entities:
-  - uid: 1763
+  - uid: 1764
     components:
     - pos: -5.4816527,-8.21574
       parent: 1
       type: Transform
 - proto: MopItem
   entities:
-  - uid: 1764
+  - uid: 1765
     components:
     - pos: -5.4608197,-8.6222725
       parent: 1
       type: Transform
 - proto: NitrogenCanister
   entities:
-  - uid: 1765
+  - uid: 1766
     components:
     - pos: 5.5,-32.5
       parent: 1
       type: Transform
 - proto: OperatingTable
   entities:
-  - uid: 1766
+  - uid: 1767
     components:
     - pos: -6.5,-15.5
       parent: 1
       type: Transform
 - proto: OreProcessor
   entities:
-  - uid: 1767
+  - uid: 1768
     components:
     - pos: -0.5,-2.5
       parent: 1
       type: Transform
 - proto: OxygenCanister
   entities:
-  - uid: 1768
+  - uid: 1769
     components:
     - pos: 4.5,-32.5
       parent: 1
       type: Transform
 - proto: PaintingSkeletonBoof
   entities:
-  - uid: 1769
+  - uid: 1770
     components:
     - rot: 1.5707963267948966 rad
       pos: -2.5,-27.5
@@ -13258,20 +13272,11 @@ entities:
       type: Transform
 - proto: Paper
   entities:
-  - uid: 211
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 209
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
   - uid: 212
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 209
+    - parent: 210
       type: Transform
     - canCollide: False
       type: Physics
@@ -13280,7 +13285,7 @@ entities:
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 209
+    - parent: 210
       type: Transform
     - canCollide: False
       type: Physics
@@ -13289,7 +13294,7 @@ entities:
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 209
+    - parent: 210
       type: Transform
     - canCollide: False
       type: Physics
@@ -13298,103 +13303,112 @@ entities:
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 209
+    - parent: 210
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 216
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 210
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: PaperBin10
   entities:
-  - uid: 1770
+  - uid: 1771
     components:
     - pos: -0.5,0.5
       parent: 1
       type: Transform
-  - uid: 1771
+  - uid: 1772
     components:
     - pos: -1.5,-22.5
       parent: 1
       type: Transform
 - proto: PenCap
   entities:
-  - uid: 1772
+  - uid: 1773
     components:
     - pos: -1.3206933,-22.118023
       parent: 1
       type: Transform
 - proto: PhoneInstrument
   entities:
-  - uid: 1773
+  - uid: 1774
     components:
     - pos: -1.5209062,-21.368505
       parent: 1
       type: Transform
 - proto: PillDexalin
   entities:
-  - uid: 1774
+  - uid: 1775
     components:
     - pos: -6.629308,-13.535651
       parent: 1
       type: Transform
-  - uid: 1775
+  - uid: 1776
     components:
     - pos: -6.3688912,-13.535651
       parent: 1
       type: Transform
-  - uid: 1776
+  - uid: 1777
     components:
     - pos: -6.285558,-13.420988
       parent: 1
       type: Transform
-  - uid: 1777
+  - uid: 1778
     components:
     - pos: -6.5147247,-13.3792925
       parent: 1
       type: Transform
-  - uid: 1778
+  - uid: 1779
     components:
     - pos: -6.492127,-13.44615
       parent: 1
       type: Transform
 - proto: PlasmaReinforcedWindowDirectional
   entities:
-  - uid: 1779
+  - uid: 1780
     components:
     - rot: 3.141592653589793 rad
       pos: 2.5,-31.5
       parent: 1
       type: Transform
-  - uid: 1780
+  - uid: 1781
     components:
     - rot: 3.141592653589793 rad
       pos: 5.5,-31.5
       parent: 1
       type: Transform
-  - uid: 1781
+  - uid: 1782
     components:
     - rot: 3.141592653589793 rad
       pos: 3.5,-31.5
       parent: 1
       type: Transform
-  - uid: 1782
+  - uid: 1783
     components:
     - rot: -1.5707963267948966 rad
       pos: 6.5,-30.5
       parent: 1
       type: Transform
-  - uid: 1783
+  - uid: 1784
     components:
     - rot: -1.5707963267948966 rad
       pos: 6.5,-29.5
       parent: 1
       type: Transform
-  - uid: 1784
+  - uid: 1785
     components:
     - rot: -1.5707963267948966 rad
       pos: 6.5,-28.5
       parent: 1
       type: Transform
-  - uid: 1785
+  - uid: 1786
     components:
     - rot: -1.5707963267948966 rad
       pos: 6.5,-27.5
@@ -13402,36 +13416,36 @@ entities:
       type: Transform
 - proto: PlasticFlapsAirtightClear
   entities:
-  - uid: 1786
+  - uid: 1787
     components:
     - pos: -1.5,6.5
       parent: 1
       type: Transform
-  - uid: 1787
+  - uid: 1788
     components:
     - pos: 2.5,6.5
       parent: 1
       type: Transform
-  - uid: 1788
+  - uid: 1789
     components:
     - pos: 2.5,10.5
       parent: 1
       type: Transform
-  - uid: 1789
+  - uid: 1790
     components:
     - pos: -1.5,10.5
       parent: 1
       type: Transform
 - proto: PlushieBee
   entities:
-  - uid: 1790
+  - uid: 1791
     components:
     - pos: 2.412711,1.4376178
       parent: 1
       type: Transform
 - proto: PlushieHampter
   entities:
-  - uid: 1791
+  - uid: 1792
     components:
     - name: Steve The Hampter
       type: MetaData
@@ -13440,14 +13454,14 @@ entities:
       type: Transform
 - proto: PlushieRouny
   entities:
-  - uid: 1792
+  - uid: 1793
     components:
     - pos: -5.4992075,-16.437582
       parent: 1
       type: Transform
 - proto: PlushieSpaceLizard
   entities:
-  - uid: 1793
+  - uid: 1794
     components:
     - pos: -0.5601339,-27.595695
       parent: 1
@@ -13461,7 +13475,7 @@ entities:
       type: Transform
 - proto: PosterLegitAnatomyPoster
   entities:
-  - uid: 1794
+  - uid: 1796
     components:
     - rot: 1.5707963267948966 rad
       pos: -7.5,-15.5
@@ -13565,20 +13579,20 @@ entities:
       type: Transform
 - proto: PowerCellHyper
   entities:
-  - uid: 238
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 216
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
   - uid: 239
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 216
+    - parent: 217
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 240
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 217
       type: Transform
     - canCollide: False
       type: Physics
@@ -14140,11 +14154,11 @@ entities:
       type: Transform
 - proto: RubberStampCaptain
   entities:
-  - uid: 240
+  - uid: 241
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 216
+    - parent: 217
       type: Transform
     - canCollide: False
       type: Physics
@@ -14671,13 +14685,13 @@ entities:
       parent: 1
       type: Transform
     - linkedPorts:
-        203:
-        - Pressed: Open
-        200:
-        - Pressed: Open
-        202:
+        204:
         - Pressed: Open
         201:
+        - Pressed: Open
+        203:
+        - Pressed: Open
+        202:
         - Pressed: Open
       type: DeviceLinkSource
   - uid: 1949
@@ -14720,9 +14734,9 @@ entities:
         - Pressed: Close
         1902:
         - Pressed: Close
-        205:
+        206:
         - Pressed: Close
-        204:
+        205:
         - Pressed: Close
       type: DeviceLinkSource
   - uid: 1950
@@ -14771,9 +14785,9 @@ entities:
       parent: 1
       type: Transform
     - linkedPorts:
-        178:
+        179:
         - Pressed: Toggle
-        177:
+        178:
         - Pressed: Toggle
       type: DeviceLinkSource
   - uid: 1953
@@ -14785,11 +14799,11 @@ entities:
       parent: 1
       type: Transform
     - linkedPorts:
+        182:
+        - Pressed: Toggle
         181:
         - Pressed: Toggle
         180:
-        - Pressed: Toggle
-        179:
         - Pressed: Toggle
       type: DeviceLinkSource
   - uid: 1954
@@ -14813,9 +14827,9 @@ entities:
       parent: 1
       type: Transform
     - linkedPorts:
-        185:
-        - Pressed: Toggle
         186:
+        - Pressed: Toggle
+        187:
         - Pressed: Toggle
       type: DeviceLinkSource
   - uid: 1956
@@ -14827,11 +14841,11 @@ entities:
       parent: 1
       type: Transform
     - linkedPorts:
+        185:
+        - Pressed: Toggle
         184:
         - Pressed: Toggle
         183:
-        - Pressed: Toggle
-        182:
         - Pressed: Toggle
       type: DeviceLinkSource
   - uid: 1957
@@ -14889,6 +14903,8 @@ entities:
     - state: True
       type: SignalSwitch
     - linkedPorts:
+        192:
+        - Pressed: Close
         191:
         - Pressed: Close
         190:
@@ -14896,8 +14912,6 @@ entities:
         189:
         - Pressed: Close
         188:
-        - Pressed: Close
-        187:
         - Pressed: Close
       type: DeviceLinkSource
     - type: ItemCooldown
@@ -14912,8 +14926,6 @@ entities:
     - state: True
       type: SignalSwitch
     - linkedPorts:
-        192:
-        - Pressed: Close
         193:
         - Pressed: Close
         194:
@@ -14921,6 +14933,8 @@ entities:
         195:
         - Pressed: Close
         196:
+        - Pressed: Close
+        197:
         - Pressed: Close
       type: DeviceLinkSource
     - type: ItemCooldown
@@ -14954,7 +14968,7 @@ entities:
         - Pressed: Open
         1893:
         - Pressed: Open
-        204:
+        205:
         - Pressed: Open
         1906:
         - Pressed: Open
@@ -14974,7 +14988,7 @@ entities:
         - Pressed: Open
         1900:
         - Pressed: Open
-        205:
+        206:
         - Pressed: Open
         1901:
         - Pressed: Open
@@ -15045,7 +15059,7 @@ entities:
       parent: 1
       type: Transform
     - linkedPorts:
-        206:
+        207:
         - Pressed: Toggle
       type: DeviceLinkSource
   - uid: 1969
@@ -15139,7 +15153,7 @@ entities:
       parent: 1
       type: Transform
     - linkedPorts:
-        197:
+        198:
         - Pressed: Toggle
       type: DeviceLinkSource
   - uid: 1976
@@ -15163,9 +15177,9 @@ entities:
       parent: 1
       type: Transform
     - linkedPorts:
-        199:
+        200:
         - Pressed: Close
-        198:
+        199:
         - Pressed: Close
       type: DeviceLinkSource
   - uid: 1978
@@ -15177,9 +15191,9 @@ entities:
       parent: 1
       type: Transform
     - linkedPorts:
-        199:
+        200:
         - Pressed: Open
-        198:
+        199:
         - Pressed: Open
       type: DeviceLinkSource
   - uid: 1979
@@ -15193,8 +15207,6 @@ entities:
     - state: True
       type: SignalSwitch
     - linkedPorts:
-        192:
-        - Pressed: Open
         193:
         - Pressed: Open
         194:
@@ -15202,6 +15214,8 @@ entities:
         195:
         - Pressed: Open
         196:
+        - Pressed: Open
+        197:
         - Pressed: Open
       type: DeviceLinkSource
     - type: ItemCooldown
@@ -15214,6 +15228,8 @@ entities:
       parent: 1
       type: Transform
     - linkedPorts:
+        192:
+        - Pressed: Open
         191:
         - Pressed: Open
         190:
@@ -15221,8 +15237,6 @@ entities:
         189:
         - Pressed: Open
         188:
-        - Pressed: Open
-        187:
         - Pressed: Open
       type: DeviceLinkSource
   - uid: 1981
@@ -15233,13 +15247,13 @@ entities:
       parent: 1
       type: Transform
     - linkedPorts:
+        204:
+        - Pressed: Close
         203:
         - Pressed: Close
         202:
         - Pressed: Close
         201:
-        - Pressed: Close
-        200:
         - Pressed: Close
       type: DeviceLinkSource
   - uid: 1982
@@ -15723,29 +15737,20 @@ entities:
       type: Transform
 - proto: SpeedLoaderMagnum
   entities:
-  - uid: 241
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 216
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
   - uid: 242
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 216
+    - parent: 217
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 1723
+  - uid: 243
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 1722
+    - parent: 217
       type: Transform
     - canCollide: False
       type: Physics
@@ -15754,7 +15759,16 @@ entities:
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 1722
+    - parent: 1723
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 1725
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 1723
       type: Transform
     - canCollide: False
       type: Physics
@@ -15763,16 +15777,16 @@ entities:
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 1749
+    - parent: 1750
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 1753
+  - uid: 1752
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 1749
+    - parent: 1750
       type: Transform
     - canCollide: False
       type: Physics
@@ -15784,31 +15798,31 @@ entities:
       type: Transform
 - proto: SpeedLoaderMagnumHighVelocity
   entities:
-  - uid: 243
+  - uid: 244
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 216
+    - parent: 217
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 1725
+  - uid: 1726
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 1722
+    - parent: 1723
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: SpeedLoaderMagnumRubber
   entities:
-  - uid: 1752
+  - uid: 1753
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 1749
+    - parent: 1750
       type: Transform
     - canCollide: False
       type: Physics
@@ -16433,11 +16447,11 @@ entities:
       type: Transform
 - proto: ToyFigurineCaptain
   entities:
-  - uid: 244
+  - uid: 245
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 216
+    - parent: 217
       type: Transform
     - canCollide: False
       type: Physics
@@ -16461,10 +16475,6 @@ entities:
       parent: 1
       type: Transform
     - linkedPorts:
-        1081:
-        - Middle: Off
-        - Right: Forward
-        - Left: Forward
         1082:
         - Middle: Off
         - Right: Forward
@@ -16489,7 +16499,7 @@ entities:
         - Middle: Off
         - Right: Forward
         - Left: Forward
-        1089:
+        1088:
         - Middle: Off
         - Right: Forward
         - Left: Forward
@@ -16505,7 +16515,7 @@ entities:
         - Middle: Off
         - Right: Forward
         - Left: Forward
-        1094:
+        1093:
         - Middle: Off
         - Right: Forward
         - Left: Forward
@@ -16529,11 +16539,15 @@ entities:
         - Middle: Off
         - Right: Forward
         - Left: Forward
-        1088:
+        1100:
         - Middle: Off
         - Right: Forward
         - Left: Forward
-        1093:
+        1089:
+        - Middle: Off
+        - Right: Forward
+        - Left: Forward
+        1094:
         - Middle: Off
         - Right: Forward
         - Left: Forward
@@ -16544,6 +16558,10 @@ entities:
       parent: 1
       type: Transform
     - linkedPorts:
+        1119:
+        - Middle: Off
+        - Right: Forward
+        - Left: Forward
         1118:
         - Middle: Off
         - Right: Forward
@@ -16613,10 +16631,6 @@ entities:
         - Right: Forward
         - Left: Forward
         1101:
-        - Middle: Off
-        - Right: Forward
-        - Left: Forward
-        1100:
         - Middle: Off
         - Right: Forward
         - Left: Forward
@@ -18160,11 +18174,11 @@ entities:
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 245
+  - uid: 246
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 216
+    - parent: 217
       type: Transform
     - canCollide: False
       type: Physics
@@ -18182,31 +18196,31 @@ entities:
     - type: InsideEntityStorage
 - proto: WeaponLaserGun
   entities:
-  - uid: 246
+  - uid: 247
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 216
+    - parent: 217
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: WeaponProtoKineticAccelerator
   entities:
-  - uid: 1744
+  - uid: 1745
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 1743
+    - parent: 1744
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 1746
+  - uid: 1747
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 1745
+    - parent: 1746
       type: Transform
     - canCollide: False
       type: Physics
@@ -18220,32 +18234,32 @@ entities:
       type: Transform
 - proto: WeaponRevolverPirate
   entities:
-  - uid: 1064
+  - uid: 1065
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 1060
+    - parent: 1061
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: WeaponRevolverPython
   entities:
-  - uid: 1726
+  - uid: 1727
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 1722
+    - parent: 1723
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 1750
+  - uid: 1754
     components:
     - flags: InContainer
       name: Medical Python
       type: MetaData
-    - parent: 1749
+    - parent: 1750
       type: Transform
     - canCollide: False
       type: Physics

--- a/Resources/Maps/Shuttles/praeda.yml
+++ b/Resources/Maps/Shuttles/praeda.yml
@@ -1786,7 +1786,7 @@ entities:
   entities:
   - uid: 163
     components:
-    - desc: A robust baseb-Medical Stick!
+    - desc: A robust baseb-Medicine Stick!
       name: medical stick
       type: MetaData
     - pos: -5.569474,-16.72594

--- a/Resources/Maps/Shuttles/praeda.yml
+++ b/Resources/Maps/Shuttles/praeda.yml
@@ -16252,7 +16252,7 @@ entities:
     - pos: -0.5,0.5
       parent: 1
       type: Transform
-- proto: TelecomServer
+- proto: TelecomServerFilled
   entities:
   - uid: 2125
     components:

--- a/Resources/Maps/Shuttles/praeda.yml
+++ b/Resources/Maps/Shuttles/praeda.yml
@@ -35,7 +35,7 @@ entities:
           tiles: XAAAAVwAAANcAAABXAAAA1wAAAJfAAAAWwAAAVsAAAFfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFwAAAJcAAADXAAAAl8AAABcAAACXwAAAFsAAABfAAAAXwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABcAAACXAAAAVwAAANcAAADXAAAAVsAAAFbAAAAWwAAA18AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXAAAA1wAAAJcAAADXwAAAFwAAAFfAAAAWwAAA1sAAAFfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF8AAABfAAAAXwAAAF8AAABfAAAAXwAAAFsAAAJfAAAAXgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABFAAABRQAAAkUAAAFFAAAARQAAA18AAABfAAAAXwAAAF4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQAAAkUAAANFAAAARQAAAEUAAANfAAAARQAAAV8AAABeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEUAAANFAAABRQAAA0UAAABFAAAAXwAAAEUAAABfAAAAXgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABFAAABRQAAAEUAAAFFAAADRQAAAl8AAABfAAAAXwAAAF4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQAAA0UAAANFAAAARQAAAkUAAABFAAACRQAAAl8AAABeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEUAAAJFAAACRQAAAEUAAAJFAAACXwAAAEUAAABfAAAAXgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABFAAADRQAAA0UAAABFAAAARQAAAF8AAABFAAADXwAAAF4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQAAAEUAAABFAAABRQAAAkUAAAJfAAAARQAAAl8AAABeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEUAAABFAAAARQAAAEUAAABFAAABXwAAAEUAAAJfAAAAXgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABfAAAAXwAAAF8AAABfAAAARQAAAV8AAABfAAAAXwAAAF4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXAAAAVwAAAFcAAABXwAAAEUAAAFfAAAAXwAAAF8AAABfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
         0,-2:
           ind: 0,-2
-          tiles: XwAAAF8AAABFAAACRQAAAEUAAAFFAAADRQAAAUUAAANfAAAAXwAAAF8AAABfAAAAXwAAAF4AAAAAAAAAAAAAAEUAAABfAAAARQAAAkUAAANFAAAAXwAAAEUAAABFAAACXwAAAF8AAABfAAAAXwAAAF8AAABeAAAAAAAAAAAAAABfAAAAXwAAAF8AAABfAAAAXwAAAF8AAABFAAAARQAAAV8AAABFAAAARQAAAF8AAABfAAAAXgAAAAAAAAAAAAAAXwAAAF8AAABfAAAAXwAAAF8AAABfAAAARQAAAEUAAAFfAAAAXwAAAF8AAABfAAAAXwAAAF4AAAAAAAAAAAAAADsAAABfAAAAXwAAAF8AAABfAAAAXwAAAEUAAABFAAABXwAAAEUAAANfAAAAXwAAAF4AAAAAAAAAAAAAAAAAAABfAAAAXwAAAF8AAABfAAAAXwAAAF8AAABfAAAAXwAAAF8AAABFAAABXwAAAF4AAAAAAAAAAAAAAAAAAAAAAAAAXwAAAF8AAABfAAAAXwAAAF8AAABfAAAARQAAAkUAAAFfAAAAXwAAAF4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF8AAABfAAAAXwAAAF8AAABFAAABXwAAAEUAAAFFAAADXwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABfAAAAXwAAAF8AAABfAAAAXwAAAF8AAABFAAADXwAAAF4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXwAAAF8AAABfAAAAXwAAAF8AAABfAAAAXwAAAF8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AAAAPAAAAXwAAAF8AAABeAAAAXwAAAF8AAABfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABfAAAAXwAAAF8AAABeAAAAXgAAAF8AAABFAAABXwAAAF4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXgAAAF4AAABeAAAAXgAAAF8AAABFAAADRQAAAV8AAABfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF8AAABfAAAAXwAAAF8AAABFAAADRQAAAUUAAANfAAAAXwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABcAAABXAAAA1wAAAFcAAADXwAAAF8AAABfAAAAXwAAAF8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXAAAAFwAAAA6AAAAXAAAAVwAAABfAAAAWwAAA1sAAAJfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          tiles: DwAAAA8AAAAPAAAADwAAAEUAAAFFAAADRQAAAUUAAANfAAAAXwAAAF8AAABfAAAAXwAAAF4AAAAAAAAAAAAAAEUAAABfAAAARQAAAkUAAANFAAAAXwAAAEUAAABFAAACXwAAAF8AAABfAAAAXwAAAF8AAABeAAAAAAAAAAAAAABfAAAAXwAAAF8AAABfAAAAXwAAAF8AAABFAAAARQAAAV8AAABFAAAARQAAAF8AAABfAAAAXgAAAAAAAAAAAAAAXwAAAF8AAABfAAAAXwAAAF8AAABfAAAARQAAAEUAAAFfAAAAXwAAAF8AAABfAAAAXwAAAF4AAAAAAAAAAAAAADsAAABfAAAAXwAAAF8AAABfAAAAXwAAAEUAAABFAAABXwAAAEUAAANfAAAAXwAAAF4AAAAAAAAAAAAAAAAAAABfAAAAXwAAAF8AAABfAAAAXwAAAF8AAABfAAAAXwAAAF8AAABFAAABXwAAAF4AAAAAAAAAAAAAAAAAAAAAAAAAXwAAAF8AAABfAAAAXwAAAF8AAABfAAAARQAAAkUAAAFfAAAAXwAAAF4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF8AAABfAAAAXwAAAF8AAABFAAABXwAAAEUAAAFFAAADXwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABfAAAAXwAAAF8AAABfAAAAXwAAAF8AAABFAAADXwAAAF4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXwAAAF8AAABfAAAAXwAAAF8AAABfAAAAXwAAAF8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AAAAPAAAAXwAAAF8AAABeAAAAXwAAAF8AAABfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABfAAAAXwAAAF8AAABeAAAAXgAAAF8AAABFAAABXwAAAF4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXgAAAF4AAABeAAAAXgAAAF8AAABFAAADRQAAAV8AAABfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF8AAABfAAAAXwAAAF8AAABFAAADRQAAAUUAAANfAAAAXwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABcAAABXAAAA1wAAAFcAAADXwAAAF8AAABfAAAAXwAAAF8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXAAAAFwAAAA6AAAAXAAAAVwAAABfAAAAWwAAA1sAAAJfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
         0,-3:
           ind: 0,-3
           tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABeAAAAXgAAAF4AAABeAAAAXgAAAF4AAABeAAAAXgAAAF4AAABeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXwAAAF8AAABfAAAAXwAAAF8AAABfAAAAXwAAAF8AAABfAAAAXwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF8AAABfAAAARQAAAUUAAANFAAABRQAAAEUAAAJFAAAARQAAAV8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABFAAACXwAAAEUAAANFAAADRQAAA0UAAAFFAAADRQAAA18AAABfAAAAXwAAAF4AAAAAAAAAAAAAAAAAAAAAAAAAXwAAAF8AAABFAAAASgAAAEoAAAJKAAABRQAAAkUAAAJfAAAAXwAAAF8AAABfAAAAXgAAAF4AAAAAAAAAAAAAAA==
@@ -44,10 +44,10 @@ entities:
           tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABfAAAAVgAAAVYAAABfAAAAXAAAAVwAAAJcAAADXAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXwAAAF8AAABWAAAAXwAAAFwAAAJfAAAAXAAAA1wAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF8AAABSAAABUgAAAFsAAAJcAAABXAAAAVwAAAJcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABfAAAAUgAAAlIAAABfAAAAXAAAAFwAAABcAAABXAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXgAAAF8AAABSAAABXwAAAF8AAABfAAAAXwAAAF8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF4AAABfAAAAXwAAAF8AAABFAAABRQAAAUUAAAFFAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABeAAAAXwAAAF8AAABfAAAARQAAA0UAAANFAAABRQAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXgAAAF8AAABfAAAAXwAAAEUAAANFAAADRQAAA0UAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF4AAABfAAAAXwAAAF8AAABFAAAARQAAAkUAAABFAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABeAAAAXwAAAEUAAABFAAADRQAAAEUAAANFAAAARQAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXgAAAF8AAABFAAAAXwAAAEUAAANFAAADRQAAA0UAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF4AAABfAAAARQAAA18AAABFAAACRQAAA0UAAABFAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABeAAAAXwAAAEUAAANfAAAARQAAAUUAAAJFAAACRQAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXgAAAF8AAABFAAADXwAAAEUAAAJFAAAARQAAAUUAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF4AAABfAAAAXwAAAF8AAABFAAAAXwAAAF8AAABfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABfAAAARQAAAF8AAABfAAAARQAAAV8AAABcAAACXAAAAQ==
         -1,-2:
           ind: -1,-2
-          tiles: AAAAAAAAAAAAAAAAXgAAAF8AAABfAAAAXAAAAlwAAAFfAAAAXAAAAVwAAABfAAAAXAAAAl8AAABfAAAAXwAAAAAAAAAAAAAAAAAAAF4AAABfAAAAXwAAAF8AAABfAAAAXwAAAFwAAAFcAAAAXwAAAFwAAABfAAAARQAAAkUAAAMAAAAAAAAAAAAAAABeAAAAXwAAAF8AAABFAAAARQAAAF8AAABcAAADXAAAAV8AAABfAAAAXwAAAA8AAABfAAAAAAAAAAAAAAAAAAAAXgAAAF8AAABfAAAAXwAAAF8AAABfAAAAXAAAAlwAAABfAAAAXAAAA18AAABfAAAAXwAAAAAAAAAAAAAAAAAAAAAAAABeAAAAXwAAAF8AAABFAAAAXwAAAFwAAAFcAAADXwAAAFwAAAJfAAAAXwAAAF8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF4AAABfAAAARQAAAF8AAABfAAAAXwAAAF8AAABfAAAAXwAAAF8AAABfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXgAAAF8AAABfAAAARQAAA0UAAAJfAAAAOwAAAFwAAAJcAAACXAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXwAAAEUAAAFFAAACXwAAADsAAABcAAACXAAAAlwAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF4AAABfAAAARQAAAF8AAABfAAAAXwAAAF8AAABfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXwAAAF8AAABfAAAAXwAAAF8AAABfAAAAXwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF8AAABfAAAAXwAAAF4AAABfAAAAXwAAAA8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF4AAABfAAAARQAAAl8AAABeAAAAXgAAAF8AAABfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABeAAAAXwAAAEUAAABFAAADXwAAAF4AAABeAAAAXgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXwAAAF8AAABFAAACRQAAAkUAAAJfAAAAXwAAAF8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF8AAABfAAAAXwAAAF8AAABfAAAAXAAAAlwAAANcAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABfAAAAVgAAA1YAAAJfAAAAXAAAA1wAAAM6AAAAXAAAAA==
+          tiles: AAAAAAAAAAAAAAAAXgAAAF8AAABfAAAAXAAAAlwAAAEPAAAAXAAAAFwAAAAPAAAADwAAAA8AAAAPAAAADwAAAAAAAAAAAAAAAAAAAF4AAABfAAAAXwAAAF8AAABfAAAAXwAAAFwAAAFcAAAAXwAAAFwAAABfAAAARQAAAkUAAAMAAAAAAAAAAAAAAABeAAAAXwAAAF8AAABFAAAARQAAAF8AAABcAAADXAAAAV8AAABfAAAAXwAAAA8AAABfAAAAAAAAAAAAAAAAAAAAXgAAAF8AAABfAAAAXwAAAF8AAABfAAAAXAAAAlwAAABfAAAAXAAAA18AAABfAAAAXwAAAAAAAAAAAAAAAAAAAAAAAABeAAAAXwAAAF8AAABFAAAAXwAAAFwAAAFcAAADXwAAAFwAAAJfAAAAXwAAAF8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF4AAABfAAAARQAAAF8AAABfAAAAXwAAAF8AAABfAAAAXwAAAF8AAABfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXgAAAF8AAABfAAAARQAAA0UAAAJfAAAADwAAAFwAAAJcAAACXAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXwAAAEUAAAFFAAACXwAAAA8AAABcAAACXAAAAlwAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF4AAABfAAAARQAAAF8AAABfAAAAXwAAAF8AAABfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXwAAAF8AAABfAAAAXwAAAF8AAABfAAAAXwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF8AAABfAAAAXwAAAF4AAABfAAAAXwAAAA8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF4AAABfAAAARQAAAl8AAABeAAAAXgAAAF8AAABfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABeAAAAXwAAAEUAAABFAAADXwAAAF4AAABeAAAAXgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXwAAAF8AAABFAAACRQAAAkUAAAJfAAAAXwAAAF8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF8AAABfAAAAXwAAAF8AAABfAAAAXAAAAlwAAANcAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABfAAAAVgAAA1YAAAJfAAAAXAAAA1wAAAM6AAAAXAAAAA==
         -1,-3:
           ind: -1,-3
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXgAAAF4AAABeAAAAXgAAAF4AAABeAAAAXgAAAF4AAABeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF8AAABfAAAAXwAAAF8AAABfAAAAXwAAAF8AAABfAAAAXwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABfAAAARQAAAkUAAANFAAAARQAAAkUAAAJFAAABRQAAAF8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF4AAABfAAAAXwAAAEUAAAFFAAADRQAAAkUAAAJFAAADRQAAAUUAAAJfAAAAAAAAAAAAAAAAAAAAXgAAAF4AAABfAAAAXwAAAF8AAABfAAAAXwAAAF8AAABfAAAAXwAAAF8AAABfAAAAXwAAAA==
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXgAAAF4AAABeAAAAXgAAAF4AAABeAAAAXgAAAF4AAABeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF8AAABfAAAAXwAAAF8AAABfAAAAXwAAAF8AAABfAAAAXwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABfAAAADwAAAEUAAANFAAAARQAAAkUAAAJFAAABRQAAAF8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF4AAABfAAAAXwAAAA8AAABFAAADRQAAAkUAAAJFAAADRQAAAUUAAAJfAAAAAAAAAAAAAAAAAAAAXgAAAF4AAAAPAAAADwAAAA8AAABfAAAAXwAAAF8AAABfAAAAXwAAAF8AAABfAAAAXwAAAA==
       type: MapGrid
     - type: Broadphase
     - angularDamping: 0.05
@@ -94,30 +94,30 @@ entities:
             20: 1,-5
             21: 2,-5
             22: 3,-7
-            157: -2,-5
-            158: -1,-5
-            159: 3,-5
-            160: 3,-6
-            167: -3,-8
-            168: -3,-9
-            169: -1,-9
+            153: -2,-5
+            154: -1,-5
+            155: 3,-5
+            156: 3,-6
+            163: -3,-8
+            164: -3,-9
+            165: -1,-9
         - node:
             color: '#FFFFFFFF'
             id: Box
           decals:
-            161: 4,-33
-            162: 5,-33
-            163: 2,-33
+            157: 4,-33
+            158: 5,-33
+            159: 2,-33
         - node:
             color: '#FF333EFF'
             id: BoxGreyscale
           decals:
-            165: 3,-33
+            161: 3,-33
         - node:
             color: '#FFFFFFFF'
             id: BoxGreyscale
           decals:
-            164: 3,-33
+            160: 3,-33
         - node:
             color: '#D381C996'
             id: BrickTileWhiteCornerNe
@@ -238,7 +238,6 @@ entities:
             130: -3,-35
             131: -4,-35
             132: -7,-35
-            133: -8,-35
         - node:
             color: '#52B4E996'
             id: HalfTileOverlayGreyscale
@@ -261,8 +260,8 @@ entities:
             color: '#EFB34196'
             id: HalfTileOverlayGreyscale
           decals:
-            146: 0,-34
-            147: -2,-34
+            145: 0,-34
+            146: -2,-34
         - node:
             color: '#52B4E996'
             id: HalfTileOverlayGreyscale180
@@ -296,19 +295,18 @@ entities:
             color: '#EFB34196'
             id: HalfTileOverlayGreyscale180
           decals:
-            135: 7,-35
-            136: 6,-35
-            137: 5,-35
-            138: 4,-35
-            139: 3,-35
-            140: 2,-35
-            148: -2,-35
-            149: -3,-35
-            150: -4,-35
-            151: -5,-35
-            152: -6,-35
-            153: -7,-35
-            154: -8,-35
+            134: 7,-35
+            135: 6,-35
+            136: 5,-35
+            137: 4,-35
+            138: 3,-35
+            139: 2,-35
+            147: -2,-35
+            148: -3,-35
+            149: -4,-35
+            150: -5,-35
+            151: -6,-35
+            152: -7,-35
         - node:
             color: '#52B4E996'
             id: HalfTileOverlayGreyscale270
@@ -332,13 +330,11 @@ entities:
             color: '#EFB34196'
             id: HalfTileOverlayGreyscale270
           decals:
-            141: 2,-33
-            142: 2,-32
-            143: 2,-31
-            144: 2,-34
-            145: 2,-35
-            155: -8,-35
-            156: -8,-34
+            140: 2,-33
+            141: 2,-32
+            142: 2,-31
+            143: 2,-34
+            144: 2,-35
         - node:
             color: '#A4610696'
             id: HalfTileOverlayGreyscale90
@@ -369,7 +365,7 @@ entities:
             121: 7,-32
             122: 7,-33
             123: 7,-34
-            134: 7,-35
+            133: 7,-35
         - node:
             color: '#A4610696'
             id: QuarterTileOverlayGreyscale
@@ -396,12 +392,12 @@ entities:
             color: '#FFFFFFFF'
             id: beepsky
           decals:
-            166: -6,-10
+            162: -6,-10
         - node:
             color: '#FFFFFFFF'
             id: dwarf
           decals:
-            170: 10,-33
+            166: 10,-33
       type: DecalGrid
     - version: 2
       data:
@@ -501,7 +497,8 @@ entities:
           2,-9:
             0: 65331
           -2,-4:
-            0: 65535
+            0: 57343
+            1: 8192
           -2,-3:
             0: 65535
           -2,-2:
@@ -516,7 +513,8 @@ entities:
           -1,-2:
             0: 65535
           -1,-1:
-            0: 65535
+            0: 49151
+            1: 16384
           -2,-8:
             0: 65535
           -2,-7:
@@ -528,9 +526,10 @@ entities:
           -1,-8:
             0: 65535
           -1,-7:
-            0: 42751
-            1: 20736
-            3: 2048
+            0: 42747
+            1: 16388
+            3: 4352
+            4: 2048
           -1,-6:
             0: 65535
           -1,-5:
@@ -608,6 +607,21 @@ entities:
           - 0
           - 0
         - volume: 2500
+          temperature: 293.14996
+          moles:
+          - 21.824879
+          - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
           temperature: 293.14993
           moles:
           - 20.078888
@@ -643,12 +657,12 @@ entities:
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 1583
-      - 1599
+      - 1644
+      - 1660
       type: DeviceNetwork
     - devices:
-      - 1599
-      - 1583
+      - 1660
+      - 1644
       type: DeviceList
   - uid: 4
     components:
@@ -657,16 +671,16 @@ entities:
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 1282
-      - 1588
-      - 1602
-      - 1270
+      - 1343
+      - 1649
+      - 1663
+      - 1331
       type: DeviceNetwork
     - devices:
-      - 1282
-      - 1588
-      - 1602
-      - 1270
+      - 1343
+      - 1649
+      - 1663
+      - 1331
       type: DeviceList
   - uid: 5
     components:
@@ -675,22 +689,22 @@ entities:
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 1254
-      - 1265
-      - 1276
-      - 1263
-      - 1584
-      - 1604
-      - 1611
+      - 1315
+      - 1326
+      - 1337
+      - 1324
+      - 1645
+      - 1665
+      - 1672
       type: DeviceNetwork
     - devices:
-      - 1263
-      - 1276
-      - 1254
-      - 1265
-      - 1584
-      - 1604
-      - 1611
+      - 1324
+      - 1337
+      - 1315
+      - 1326
+      - 1645
+      - 1665
+      - 1672
       type: DeviceList
   - uid: 6
     components:
@@ -698,16 +712,16 @@ entities:
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 1590
-      - 1605
-      - 1255
-      - 1260
+      - 1651
+      - 1666
+      - 1316
+      - 1321
       type: DeviceNetwork
     - devices:
-      - 1260
-      - 1255
-      - 1605
-      - 1590
+      - 1321
+      - 1316
+      - 1666
+      - 1651
       type: DeviceList
   - uid: 7
     components:
@@ -716,26 +730,26 @@ entities:
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 1261
-      - 1262
-      - 1255
-      - 1275
-      - 1589
-      - 1606
-      - 1256
-      - 1266
-      - 1274
+      - 1322
+      - 1323
+      - 1316
+      - 1336
+      - 1650
+      - 1667
+      - 1317
+      - 1327
+      - 1335
       type: DeviceNetwork
     - devices:
-      - 1606
-      - 1589
-      - 1255
-      - 1262
-      - 1261
-      - 1256
-      - 1274
-      - 1275
-      - 1266
+      - 1667
+      - 1650
+      - 1316
+      - 1323
+      - 1322
+      - 1317
+      - 1335
+      - 1336
+      - 1327
       type: DeviceList
   - uid: 8
     components:
@@ -744,16 +758,16 @@ entities:
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 1269
-      - 1614
-      - 1587
-      - 1279
+      - 1330
+      - 1675
+      - 1648
+      - 1340
       type: DeviceNetwork
     - devices:
-      - 1614
-      - 1587
-      - 1269
-      - 1279
+      - 1675
+      - 1648
+      - 1330
+      - 1340
       type: DeviceList
   - uid: 9
     components:
@@ -762,18 +776,18 @@ entities:
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 1300
-      - 1268
-      - 1281
-      - 1609
-      - 1593
+      - 1361
+      - 1329
+      - 1342
+      - 1670
+      - 1654
       type: DeviceNetwork
     - devices:
-      - 1609
-      - 1281
-      - 1268
-      - 1300
-      - 1593
+      - 1670
+      - 1342
+      - 1329
+      - 1361
+      - 1654
       type: DeviceList
   - uid: 10
     components:
@@ -782,18 +796,18 @@ entities:
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 1610
-      - 1594
-      - 1278
-      - 1298
-      - 1299
+      - 1671
+      - 1655
+      - 1339
+      - 1359
+      - 1360
       type: DeviceNetwork
     - devices:
-      - 1610
-      - 1594
-      - 1299
-      - 1298
-      - 1278
+      - 1671
+      - 1655
+      - 1360
+      - 1359
+      - 1339
       type: DeviceList
   - uid: 11
     components:
@@ -801,36 +815,36 @@ entities:
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 1279
-      - 1282
-      - 1278
-      - 1298
-      - 1299
-      - 1259
-      - 1257
-      - 1281
-      - 1268
-      - 1300
-      - 1592
-      - 1607
-      - 1596
-      - 1608
+      - 1340
+      - 1343
+      - 1339
+      - 1359
+      - 1360
+      - 1320
+      - 1318
+      - 1342
+      - 1329
+      - 1361
+      - 1653
+      - 1668
+      - 1657
+      - 1669
       type: DeviceNetwork
     - devices:
-      - 1281
-      - 1268
-      - 1300
-      - 1607
-      - 1608
-      - 1592
-      - 1596
-      - 1278
-      - 1298
-      - 1299
-      - 1257
-      - 1259
-      - 1279
-      - 1282
+      - 1342
+      - 1329
+      - 1361
+      - 1668
+      - 1669
+      - 1653
+      - 1657
+      - 1339
+      - 1359
+      - 1360
+      - 1318
+      - 1320
+      - 1340
+      - 1343
       type: DeviceList
   - uid: 12
     components:
@@ -839,14 +853,14 @@ entities:
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 1597
-      - 1598
-      - 1302
+      - 1658
+      - 1659
+      - 1363
       type: DeviceNetwork
     - devices:
-      - 1597
-      - 1598
-      - 1302
+      - 1658
+      - 1659
+      - 1363
       type: DeviceList
   - uid: 13
     components:
@@ -855,44 +869,44 @@ entities:
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 1288
-      - 1294
-      - 1286
-      - 1293
-      - 1285
-      - 1284
-      - 1283
-      - 1292
-      - 1291
-      - 1290
-      - 1289
-      - 1296
-      - 1297
-      - 1287
-      - 1585
-      - 1600
-      - 1295
-      - 1302
+      - 1349
+      - 1355
+      - 1347
+      - 1354
+      - 1346
+      - 1345
+      - 1344
+      - 1353
+      - 1352
+      - 1351
+      - 1350
+      - 1357
+      - 1358
+      - 1348
+      - 1646
+      - 1661
+      - 1356
+      - 1363
       type: DeviceNetwork
     - devices:
-      - 1287
-      - 1297
-      - 1296
-      - 1289
-      - 1290
-      - 1291
-      - 1292
-      - 1283
-      - 1284
-      - 1285
-      - 1293
-      - 1286
-      - 1295
-      - 1294
-      - 1288
-      - 1302
-      - 1585
-      - 1600
+      - 1348
+      - 1358
+      - 1357
+      - 1350
+      - 1351
+      - 1352
+      - 1353
+      - 1344
+      - 1345
+      - 1346
+      - 1354
+      - 1347
+      - 1356
+      - 1355
+      - 1349
+      - 1363
+      - 1646
+      - 1661
       type: DeviceList
   - uid: 14
     components:
@@ -900,34 +914,34 @@ entities:
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 1601
-      - 1253
-      - 1586
-      - 1258
-      - 1264
-      - 1259
-      - 1257
-      - 1288
-      - 1294
-      - 1287
-      - 1297
-      - 1273
-      - 1267
+      - 1662
+      - 1314
+      - 1647
+      - 1319
+      - 1325
+      - 1320
+      - 1318
+      - 1349
+      - 1355
+      - 1348
+      - 1358
+      - 1334
+      - 1328
       type: DeviceNetwork
     - devices:
-      - 1257
-      - 1259
-      - 1264
-      - 1258
-      - 1253
-      - 1273
-      - 1267
-      - 1297
-      - 1287
-      - 1288
-      - 1294
-      - 1586
-      - 1601
+      - 1318
+      - 1320
+      - 1325
+      - 1319
+      - 1314
+      - 1334
+      - 1328
+      - 1358
+      - 1348
+      - 1349
+      - 1355
+      - 1647
+      - 1662
       type: DeviceList
   - uid: 15
     components:
@@ -936,16 +950,16 @@ entities:
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 1603
-      - 1280
-      - 1591
-      - 1277
+      - 1664
+      - 1341
+      - 1652
+      - 1338
       type: DeviceNetwork
     - devices:
-      - 1603
-      - 1280
-      - 1591
-      - 1277
+      - 1664
+      - 1341
+      - 1652
+      - 1338
       type: DeviceList
   - uid: 16
     components:
@@ -954,18 +968,18 @@ entities:
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 1616
-      - 1595
-      - 1277
-      - 1272
-      - 1263
+      - 1677
+      - 1656
+      - 1338
+      - 1333
+      - 1324
       type: DeviceNetwork
     - devices:
-      - 1616
-      - 1595
-      - 1263
-      - 1272
-      - 1277
+      - 1677
+      - 1656
+      - 1324
+      - 1333
+      - 1338
       type: DeviceList
 - proto: Airlock
   entities:
@@ -1017,26 +1031,26 @@ entities:
   entities:
   - uid: 23
     components:
-    - pos: -3.5,-11.5
-      parent: 1
-      type: Transform
-  - uid: 24
-    components:
-    - pos: 4.5,-11.5
-      parent: 1
-      type: Transform
-  - uid: 25
-    components:
     - pos: -4.5,-8.5
       parent: 1
       type: Transform
-  - uid: 26
+  - uid: 24
     components:
     - pos: 5.5,-8.5
       parent: 1
       type: Transform
 - proto: AirlockCargoGlass
   entities:
+  - uid: 25
+    components:
+    - pos: 4.5,-11.5
+      parent: 1
+      type: Transform
+  - uid: 26
+    components:
+    - pos: -3.5,-11.5
+      parent: 1
+      type: Transform
   - uid: 27
     components:
     - pos: -5.5,4.5
@@ -1117,8 +1131,12 @@ entities:
     - pos: 1.5,-33.5
       parent: 1
       type: Transform
+- proto: AirlockEngineeringLocked
+  entities:
   - uid: 41
     components:
+    - name: Engineering
+      type: MetaData
     - pos: 6.5,-26.5
       parent: 1
       type: Transform
@@ -1483,254 +1501,264 @@ entities:
     - pos: -1.7131324,-21.819618
       parent: 1
       type: Transform
-  - uid: 101
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 100
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
-  - uid: 116
+  - uid: 100
     components:
     - pos: 3.298502,-2.4168472
       parent: 1
       type: Transform
+  - uid: 101
+    components:
+    - pos: 3.6367984,-2.4686034
+      parent: 1
+      type: Transform
+  - uid: 102
+    components:
+    - pos: 2.9961734,-2.2809727
+      parent: 1
+      type: Transform
+  - uid: 104
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 103
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
 - proto: AtmosDeviceFanTiny
   entities:
-  - uid: 117
+  - uid: 120
     components:
     - rot: 3.141592653589793 rad
       pos: -6.5,-6.5
       parent: 1
       type: Transform
-  - uid: 118
+  - uid: 121
     components:
     - rot: 3.141592653589793 rad
       pos: -6.5,-5.5
       parent: 1
       type: Transform
-  - uid: 119
+  - uid: 122
     components:
     - rot: 3.141592653589793 rad
       pos: -6.5,-4.5
       parent: 1
       type: Transform
-  - uid: 120
+  - uid: 123
     components:
     - rot: 3.141592653589793 rad
       pos: -6.5,-3.5
       parent: 1
       type: Transform
-  - uid: 121
+  - uid: 124
     components:
     - rot: 3.141592653589793 rad
       pos: -6.5,-2.5
       parent: 1
       type: Transform
-  - uid: 122
+  - uid: 125
     components:
     - rot: 3.141592653589793 rad
       pos: 7.5,-6.5
       parent: 1
       type: Transform
-  - uid: 123
+  - uid: 126
     components:
     - rot: 3.141592653589793 rad
       pos: 7.5,-5.5
       parent: 1
       type: Transform
-  - uid: 124
+  - uid: 127
     components:
     - rot: 3.141592653589793 rad
       pos: 7.5,-4.5
       parent: 1
       type: Transform
-  - uid: 125
+  - uid: 128
     components:
     - rot: 3.141592653589793 rad
       pos: 7.5,-3.5
       parent: 1
       type: Transform
-  - uid: 126
+  - uid: 129
     components:
     - rot: 3.141592653589793 rad
       pos: 7.5,-2.5
       parent: 1
       type: Transform
-  - uid: 127
+  - uid: 130
     components:
     - rot: 3.141592653589793 rad
       pos: -10.5,-29.5
       parent: 1
       type: Transform
-  - uid: 128
+  - uid: 131
     components:
     - rot: 3.141592653589793 rad
       pos: -9.5,-27.5
       parent: 1
       type: Transform
-  - uid: 129
+  - uid: 132
     components:
     - rot: 3.141592653589793 rad
       pos: 8.5,-35.5
       parent: 1
       type: Transform
-  - uid: 130
+  - uid: 133
     components:
     - rot: 3.141592653589793 rad
       pos: 7.5,-35.5
       parent: 1
       type: Transform
-  - uid: 131
+  - uid: 134
     components:
     - rot: 3.141592653589793 rad
       pos: 4.5,-35.5
       parent: 1
       type: Transform
-  - uid: 132
+  - uid: 135
     components:
     - rot: 3.141592653589793 rad
       pos: 3.5,-35.5
       parent: 1
       type: Transform
-  - uid: 133
+  - uid: 136
     components:
     - rot: 3.141592653589793 rad
       pos: 2.5,-35.5
       parent: 1
       type: Transform
-  - uid: 134
+  - uid: 137
     components:
     - rot: 3.141592653589793 rad
       pos: -1.5,-35.5
       parent: 1
       type: Transform
-  - uid: 135
+  - uid: 138
     components:
     - rot: 3.141592653589793 rad
       pos: -2.5,-35.5
       parent: 1
       type: Transform
-  - uid: 136
+  - uid: 139
     components:
     - rot: 3.141592653589793 rad
       pos: -3.5,-35.5
       parent: 1
       type: Transform
-  - uid: 137
+  - uid: 140
     components:
     - rot: 3.141592653589793 rad
       pos: -6.5,-35.5
       parent: 1
       type: Transform
-  - uid: 138
+  - uid: 141
     components:
     - rot: 3.141592653589793 rad
       pos: -7.5,-35.5
       parent: 1
       type: Transform
-  - uid: 139
+  - uid: 142
     components:
     - pos: -7.5,2.5
       parent: 1
       type: Transform
-  - uid: 140
+  - uid: 143
     components:
     - pos: -7.5,3.5
       parent: 1
       type: Transform
-  - uid: 141
-    components:
-    - pos: -7.5,4.5
-      parent: 1
-      type: Transform
-  - uid: 142
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 2.5,10.5
-      parent: 1
-      type: Transform
-  - uid: 143
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 1.5,10.5
-      parent: 1
-      type: Transform
   - uid: 144
     components:
-    - rot: 1.5707963267948966 rad
-      pos: 0.5,10.5
+    - pos: -7.5,4.5
       parent: 1
       type: Transform
   - uid: 145
     components:
     - rot: 1.5707963267948966 rad
-      pos: -0.5,10.5
+      pos: 2.5,10.5
       parent: 1
       type: Transform
   - uid: 146
     components:
     - rot: 1.5707963267948966 rad
-      pos: -1.5,10.5
+      pos: 1.5,10.5
       parent: 1
       type: Transform
   - uid: 147
     components:
-    - pos: -4.5,7.5
+    - rot: 1.5707963267948966 rad
+      pos: 0.5,10.5
       parent: 1
       type: Transform
   - uid: 148
     components:
-    - pos: 5.5,7.5
+    - rot: 1.5707963267948966 rad
+      pos: -0.5,10.5
       parent: 1
       type: Transform
   - uid: 149
     components:
-    - pos: 8.5,4.5
+    - rot: 1.5707963267948966 rad
+      pos: -1.5,10.5
       parent: 1
       type: Transform
   - uid: 150
     components:
-    - pos: 8.5,3.5
+    - pos: -4.5,7.5
       parent: 1
       type: Transform
   - uid: 151
     components:
-    - pos: 8.5,2.5
+    - pos: 5.5,7.5
       parent: 1
       type: Transform
   - uid: 152
     components:
-    - pos: 6.5,-0.5
+    - pos: 8.5,4.5
       parent: 1
       type: Transform
   - uid: 153
     components:
-    - pos: 10.5,-27.5
+    - pos: 8.5,3.5
       parent: 1
       type: Transform
   - uid: 154
+    components:
+    - pos: 8.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 155
+    components:
+    - pos: 6.5,-0.5
+      parent: 1
+      type: Transform
+  - uid: 156
+    components:
+    - pos: 10.5,-27.5
+      parent: 1
+      type: Transform
+  - uid: 157
     components:
     - pos: 11.5,-29.5
       parent: 1
       type: Transform
 - proto: AtmosFixBlockerMarker
   entities:
-  - uid: 155
+  - uid: 158
     components:
     - pos: 10.5,-31.5
       parent: 1
       type: Transform
-  - uid: 156
+  - uid: 159
     components:
     - pos: 10.5,-32.5
       parent: 1
       type: Transform
 - proto: BannerCargo
   entities:
-  - uid: 157
+  - uid: 160
     components:
     - desc: A banner displaying the colors of the cargo department. Hail Cargonia!
       name: Cargo banner
@@ -1738,7 +1766,7 @@ entities:
     - pos: 0.5,-4.5
       parent: 1
       type: Transform
-  - uid: 158
+  - uid: 161
     components:
     - desc: A banner displaying the colors of the cargo department. Hail Cargonia!
       name: Cargo banner
@@ -1746,7 +1774,7 @@ entities:
     - pos: -4.5,-19.5
       parent: 1
       type: Transform
-  - uid: 159
+  - uid: 162
     components:
     - desc: A banner displaying the colors of the cargo department. Hail Cargonia!
       name: Cargo banner
@@ -1754,2711 +1782,2733 @@ entities:
     - pos: 5.5,-19.5
       parent: 1
       type: Transform
+- proto: BaseBallBat
+  entities:
+  - uid: 1796
+    components:
+    - desc: A robust baseb-Medical Stick!
+      name: medical stick
+      type: MetaData
+    - pos: -5.569474,-16.72594
+      parent: 1
+      type: Transform
 - proto: Bed
   entities:
-  - uid: 160
+  - uid: 163
     components:
     - pos: -0.5,-27.5
       parent: 1
       type: Transform
-  - uid: 161
+  - uid: 164
     components:
     - pos: 2.5,1.5
       parent: 1
       type: Transform
-  - uid: 162
+  - uid: 165
     components:
     - pos: 4.5,-25.5
       parent: 1
       type: Transform
-  - uid: 163
+  - uid: 166
     components:
     - pos: -9.5,-31.5
       parent: 1
       type: Transform
-  - uid: 164
+  - uid: 167
     components:
     - pos: -3.5,-31.5
       parent: 1
       type: Transform
-  - uid: 165
+  - uid: 168
     components:
     - pos: -3.5,-28.5
       parent: 1
       type: Transform
 - proto: BedsheetCaptain
   entities:
-  - uid: 166
+  - uid: 169
     components:
     - pos: 4.5,-25.5
       parent: 1
       type: Transform
 - proto: BedsheetCE
   entities:
-  - uid: 167
+  - uid: 170
     components:
     - pos: -0.5,-27.5
       parent: 1
       type: Transform
 - proto: BedsheetClown
   entities:
-  - uid: 168
+  - uid: 171
     components:
     - pos: -9.5,-31.5
       parent: 1
       type: Transform
-  - uid: 169
+  - uid: 172
     components:
     - pos: -3.5,-28.5
       parent: 1
       type: Transform
-  - uid: 170
+  - uid: 173
     components:
     - pos: -3.5,-31.5
       parent: 1
       type: Transform
 - proto: BedsheetMedical
   entities:
-  - uid: 171
-    components:
-    - pos: -6.5,-15.5
-      parent: 1
-      type: Transform
-  - uid: 172
+  - uid: 174
     components:
     - rot: 1.5707963267948966 rad
       pos: 7.5,-15.5
       parent: 1
       type: Transform
+  - uid: 175
+    components:
+    - pos: -5.5,-16.5
+      parent: 1
+      type: Transform
 - proto: BedsheetQM
   entities:
-  - uid: 173
+  - uid: 176
     components:
     - pos: 2.5,1.5
       parent: 1
       type: Transform
 - proto: BlastDoor
   entities:
-  - uid: 174
+  - uid: 177
     components:
     - pos: 8.5,-35.5
       parent: 1
       type: Transform
     - links:
-      - 1887
+      - 1952
       type: DeviceLinkSink
-  - uid: 175
+  - uid: 178
     components:
     - pos: 7.5,-35.5
       parent: 1
       type: Transform
     - links:
-      - 1887
+      - 1952
       type: DeviceLinkSink
-  - uid: 176
+  - uid: 179
     components:
     - pos: 2.5,-35.5
       parent: 1
       type: Transform
     - links:
-      - 1888
+      - 1953
       type: DeviceLinkSink
-  - uid: 177
+  - uid: 180
     components:
     - pos: 3.5,-35.5
       parent: 1
       type: Transform
     - links:
-      - 1888
+      - 1953
       type: DeviceLinkSink
-  - uid: 178
+  - uid: 181
     components:
     - pos: 4.5,-35.5
       parent: 1
       type: Transform
     - links:
-      - 1888
+      - 1953
       type: DeviceLinkSink
-  - uid: 179
+  - uid: 182
     components:
     - pos: -1.5,-35.5
       parent: 1
       type: Transform
     - links:
-      - 1891
+      - 1956
       type: DeviceLinkSink
-  - uid: 180
+  - uid: 183
     components:
     - pos: -2.5,-35.5
       parent: 1
       type: Transform
     - links:
-      - 1891
+      - 1956
       type: DeviceLinkSink
-  - uid: 181
+  - uid: 184
     components:
     - pos: -3.5,-35.5
       parent: 1
       type: Transform
     - links:
-      - 1891
+      - 1956
       type: DeviceLinkSink
-  - uid: 182
+  - uid: 185
     components:
     - pos: -6.5,-35.5
       parent: 1
       type: Transform
     - links:
-      - 1890
+      - 1955
       type: DeviceLinkSink
-  - uid: 183
+  - uid: 186
     components:
     - pos: -7.5,-35.5
       parent: 1
       type: Transform
     - links:
-      - 1890
+      - 1955
       type: DeviceLinkSink
-  - uid: 184
+  - uid: 187
     components:
     - pos: -6.5,-2.5
       parent: 1
       type: Transform
     - links:
-      - 1895
-      - 1916
+      - 1960
+      - 1980
       type: DeviceLinkSink
-  - uid: 185
+  - uid: 188
     components:
     - pos: -6.5,-3.5
       parent: 1
       type: Transform
     - links:
-      - 1895
-      - 1916
+      - 1960
+      - 1980
       type: DeviceLinkSink
-  - uid: 186
+  - uid: 189
     components:
     - pos: -6.5,-4.5
       parent: 1
       type: Transform
     - links:
-      - 1895
-      - 1916
+      - 1960
+      - 1980
       type: DeviceLinkSink
-  - uid: 187
+  - uid: 190
     components:
     - pos: -6.5,-5.5
       parent: 1
       type: Transform
     - links:
-      - 1895
-      - 1916
+      - 1960
+      - 1980
       type: DeviceLinkSink
-  - uid: 188
+  - uid: 191
     components:
     - pos: -6.5,-6.5
       parent: 1
       type: Transform
     - invokeCounter: 1
       links:
-      - 1895
-      - 1916
+      - 1960
+      - 1980
       type: DeviceLinkSink
-  - uid: 189
+  - uid: 192
     components:
     - pos: 7.5,-6.5
       parent: 1
       type: Transform
     - invokeCounter: 2
       links:
-      - 1896
-      - 1915
+      - 1961
+      - 1979
       type: DeviceLinkSink
-  - uid: 190
+  - uid: 193
     components:
     - pos: 7.5,-5.5
       parent: 1
       type: Transform
     - invokeCounter: 2
       links:
-      - 1896
-      - 1915
+      - 1961
+      - 1979
       type: DeviceLinkSink
-  - uid: 191
+  - uid: 194
     components:
     - pos: 7.5,-4.5
       parent: 1
       type: Transform
     - invokeCounter: 2
       links:
-      - 1896
-      - 1915
+      - 1961
+      - 1979
       type: DeviceLinkSink
-  - uid: 192
+  - uid: 195
     components:
     - pos: 7.5,-3.5
       parent: 1
       type: Transform
     - invokeCounter: 2
       links:
-      - 1896
-      - 1915
+      - 1961
+      - 1979
       type: DeviceLinkSink
-  - uid: 193
+  - uid: 196
     components:
     - pos: 7.5,-2.5
       parent: 1
       type: Transform
     - invokeCounter: 2
       links:
-      - 1896
-      - 1915
+      - 1961
+      - 1979
       type: DeviceLinkSink
-  - uid: 194
+  - uid: 197
     components:
     - pos: 6.5,-0.5
       parent: 1
       type: Transform
     - links:
-      - 1911
+      - 1975
       type: DeviceLinkSink
-  - uid: 195
+  - uid: 198
     components:
     - pos: 8.5,0.5
       parent: 1
       type: Transform
     - links:
-      - 1913
-      - 1914
+      - 1977
+      - 1978
       type: DeviceLinkSink
-  - uid: 196
+  - uid: 199
     components:
     - pos: 8.5,-0.5
       parent: 1
       type: Transform
     - links:
-      - 1913
-      - 1914
+      - 1977
+      - 1978
       type: DeviceLinkSink
 - proto: BlastDoorOpen
   entities:
-  - uid: 197
+  - uid: 200
     components:
     - pos: 5.5,1.5
       parent: 1
       type: Transform
     - links:
-      - 1883
-      - 1917
+      - 1948
+      - 1981
       type: DeviceLinkSink
-  - uid: 198
+  - uid: 201
     components:
     - pos: 4.5,1.5
       parent: 1
       type: Transform
     - links:
-      - 1917
-      - 1883
+      - 1981
+      - 1948
       type: DeviceLinkSink
-  - uid: 199
+  - uid: 202
     components:
     - pos: -3.5,1.5
       parent: 1
       type: Transform
     - links:
-      - 1917
-      - 1883
+      - 1981
+      - 1948
       type: DeviceLinkSink
-  - uid: 200
+  - uid: 203
     components:
     - pos: -4.5,1.5
       parent: 1
       type: Transform
     - links:
-      - 1883
-      - 1917
+      - 1948
+      - 1981
       type: DeviceLinkSink
-  - uid: 201
+  - uid: 204
     components:
     - pos: 5.5,-23.5
       parent: 1
       type: Transform
     - links:
-      - 1884
-      - 1898
+      - 1949
+      - 1963
       type: DeviceLinkSink
-  - uid: 202
+  - uid: 205
     components:
     - pos: -4.5,-23.5
       parent: 1
       type: Transform
     - links:
-      - 1884
-      - 1898
+      - 1949
+      - 1963
       type: DeviceLinkSink
-  - uid: 203
+  - uid: 206
     components:
     - pos: 1.5,-31.5
       parent: 1
       type: Transform
     - links:
-      - 1903
+      - 1968
       type: DeviceLinkSink
 - proto: BookBartendersManual
   entities:
-  - uid: 204
+  - uid: 207
     components:
     - pos: 0.9112099,-14.4889145
       parent: 1
       type: Transform
 - proto: BoozeDispenser
   entities:
-  - uid: 205
+  - uid: 208
     components:
     - pos: -0.5,-12.5
       parent: 1
       type: Transform
-- proto: BoxFlare
+- proto: BoxEncryptionKeyCargo
   entities:
-  - uid: 102
+  - uid: 105
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 100
+    - parent: 103
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: BoxEncryptionKeyEngineering
+  entities:
+  - uid: 210
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 209
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: BoxFlare
+  entities:
+  - uid: 106
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 103
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: BoxShotgunIncendiary
   entities:
-  - uid: 228
+  - uid: 217
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 227
+    - parent: 216
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 229
+  - uid: 218
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 227
+    - parent: 216
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: Bucket
   entities:
-  - uid: 258
+  - uid: 247
     components:
     - pos: -5.7941527,-8.632696
       parent: 1
       type: Transform
 - proto: CableApcExtension
   entities:
-  - uid: 259
+  - uid: 248
     components:
     - pos: 3.5,1.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 260
+  - uid: 249
     components:
     - pos: 2.5,1.5
       parent: 1
       type: Transform
-  - uid: 261
+  - uid: 250
     components:
     - pos: 12.5,-30.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 262
+  - uid: 251
     components:
     - pos: 12.5,-31.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 263
+  - uid: 252
     components:
     - pos: 12.5,-29.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 264
+  - uid: 253
     components:
     - pos: 9.5,-28.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 265
+  - uid: 254
     components:
     - pos: 11.5,-29.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 266
+  - uid: 255
     components:
     - pos: 6.5,-4.5
       parent: 1
       type: Transform
-  - uid: 267
+  - uid: 256
     components:
     - pos: 11.5,-27.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 268
+  - uid: 257
     components:
     - pos: 8.5,-30.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 269
+  - uid: 258
     components:
     - pos: 7.5,-30.5
       parent: 1
       type: Transform
-  - uid: 270
+  - uid: 259
     components:
     - pos: 7.5,-31.5
       parent: 1
       type: Transform
-  - uid: 271
+  - uid: 260
     components:
     - pos: 7.5,-32.5
       parent: 1
       type: Transform
-  - uid: 272
+  - uid: 261
     components:
     - pos: 7.5,-33.5
       parent: 1
       type: Transform
-  - uid: 273
+  - uid: 262
     components:
     - pos: 7.5,-34.5
       parent: 1
       type: Transform
-  - uid: 274
+  - uid: 263
     components:
     - pos: 8.5,-34.5
       parent: 1
       type: Transform
-  - uid: 275
+  - uid: 264
     components:
     - pos: 6.5,-34.5
       parent: 1
       type: Transform
-  - uid: 276
+  - uid: 265
     components:
     - pos: 5.5,-34.5
       parent: 1
       type: Transform
-  - uid: 277
+  - uid: 266
     components:
     - pos: 4.5,-34.5
       parent: 1
       type: Transform
-  - uid: 278
+  - uid: 267
     components:
     - pos: 3.5,-34.5
       parent: 1
       type: Transform
-  - uid: 279
+  - uid: 268
     components:
     - pos: 2.5,-34.5
       parent: 1
       type: Transform
-  - uid: 280
+  - uid: 269
     components:
     - pos: 2.5,-33.5
       parent: 1
       type: Transform
-  - uid: 281
+  - uid: 270
     components:
     - pos: 2.5,-32.5
       parent: 1
       type: Transform
-  - uid: 282
+  - uid: 271
     components:
     - pos: 2.5,-31.5
       parent: 1
       type: Transform
-  - uid: 283
+  - uid: 272
     components:
     - pos: 1.5,-31.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
-  - uid: 284
+  - uid: 273
     components:
     - pos: 0.5,-31.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
-  - uid: 285
+  - uid: 274
     components:
     - pos: -0.5,-31.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
-  - uid: 286
+  - uid: 275
     components:
     - pos: -0.5,-30.5
       parent: 1
       type: Transform
-  - uid: 287
+  - uid: 276
     components:
     - pos: -0.5,-29.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 288
+  - uid: 277
     components:
     - pos: -0.5,-28.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 289
+  - uid: 278
     components:
     - pos: 1.5,-33.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 290
+  - uid: 279
     components:
     - pos: 0.5,-33.5
       parent: 1
       type: Transform
-  - uid: 291
+  - uid: 280
     components:
     - pos: -0.5,-33.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 281
+    components:
+    - pos: -2.5,-24.5
+      parent: 1
+      type: Transform
+  - uid: 282
+    components:
+    - pos: -1.5,-34.5
+      parent: 1
+      type: Transform
+  - uid: 283
+    components:
+    - pos: -2.5,-34.5
+      parent: 1
+      type: Transform
+  - uid: 284
+    components:
+    - pos: -3.5,-34.5
+      parent: 1
+      type: Transform
+  - uid: 285
+    components:
+    - pos: -3.5,-33.5
+      parent: 1
+      type: Transform
+  - uid: 286
+    components:
+    - pos: -4.5,-33.5
+      parent: 1
+      type: Transform
+  - uid: 287
+    components:
+    - pos: -5.5,-33.5
+      parent: 1
+      type: Transform
+  - uid: 288
+    components:
+    - pos: -5.5,-34.5
+      parent: 1
+      type: Transform
+  - uid: 289
+    components:
+    - pos: -6.5,-34.5
+      parent: 1
+      type: Transform
+  - uid: 290
+    components:
+    - pos: -7.5,-34.5
+      parent: 1
+      type: Transform
+  - uid: 291
+    components:
+    - pos: -5.5,-32.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
   - uid: 292
     components:
-    - pos: -2.5,-24.5
+    - pos: -5.5,-31.5
       parent: 1
       type: Transform
   - uid: 293
     components:
-    - pos: -1.5,-34.5
-      parent: 1
-      type: Transform
-  - uid: 294
-    components:
-    - pos: -2.5,-34.5
-      parent: 1
-      type: Transform
-  - uid: 295
-    components:
-    - pos: -3.5,-34.5
-      parent: 1
-      type: Transform
-  - uid: 296
-    components:
-    - pos: -3.5,-33.5
-      parent: 1
-      type: Transform
-  - uid: 297
-    components:
-    - pos: -4.5,-33.5
-      parent: 1
-      type: Transform
-  - uid: 298
-    components:
-    - pos: -5.5,-33.5
-      parent: 1
-      type: Transform
-  - uid: 299
-    components:
-    - pos: -5.5,-34.5
-      parent: 1
-      type: Transform
-  - uid: 300
-    components:
-    - pos: -6.5,-34.5
-      parent: 1
-      type: Transform
-  - uid: 301
-    components:
-    - pos: -7.5,-34.5
-      parent: 1
-      type: Transform
-  - uid: 302
-    components:
-    - pos: -5.5,-32.5
-      parent: 1
-      type: Transform
-    - enabled: True
-      type: AmbientSound
-  - uid: 303
-    components:
-    - pos: -5.5,-31.5
-      parent: 1
-      type: Transform
-  - uid: 304
-    components:
     - pos: -5.5,-30.5
       parent: 1
       type: Transform
-  - uid: 305
+  - uid: 294
     components:
     - pos: -4.5,-30.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 306
+  - uid: 295
     components:
     - pos: -5.5,-29.5
       parent: 1
       type: Transform
-  - uid: 307
+  - uid: 296
     components:
     - pos: -6.5,-29.5
       parent: 1
       type: Transform
-  - uid: 308
+  - uid: 297
     components:
     - pos: -7.5,-29.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 309
+  - uid: 298
     components:
     - pos: -8.5,-29.5
       parent: 1
       type: Transform
-  - uid: 310
+  - uid: 299
     components:
     - pos: -9.5,-29.5
       parent: 1
       type: Transform
-  - uid: 311
+  - uid: 300
     components:
     - pos: -10.5,-29.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 312
+  - uid: 301
     components:
     - pos: -11.5,-29.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 313
+  - uid: 302
     components:
     - pos: -11.5,-30.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 314
+  - uid: 303
     components:
     - pos: -11.5,-31.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 315
+  - uid: 304
     components:
     - pos: -3.5,-24.5
       parent: 1
       type: Transform
-  - uid: 316
+  - uid: 305
     components:
     - pos: 6.5,-30.5
       parent: 1
       type: Transform
-  - uid: 317
+  - uid: 306
     components:
     - pos: 6.5,-29.5
       parent: 1
       type: Transform
-  - uid: 318
+  - uid: 307
     components:
     - pos: 6.5,-28.5
       parent: 1
       type: Transform
-  - uid: 319
+  - uid: 308
     components:
     - pos: 6.5,-27.5
       parent: 1
       type: Transform
-  - uid: 320
+  - uid: 309
     components:
     - pos: 7.5,-27.5
       parent: 1
       type: Transform
-  - uid: 321
+  - uid: 310
     components:
     - pos: 8.5,-27.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 322
+  - uid: 311
     components:
     - pos: 9.5,-27.5
       parent: 1
       type: Transform
-  - uid: 323
+  - uid: 312
     components:
     - pos: 10.5,-27.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 324
+  - uid: 313
     components:
     - pos: 6.5,-26.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 325
+  - uid: 314
     components:
     - pos: 6.5,-25.5
       parent: 1
       type: Transform
-  - uid: 326
+  - uid: 315
     components:
     - pos: 6.5,-24.5
       parent: 1
       type: Transform
-  - uid: 327
+  - uid: 316
     components:
     - pos: 6.5,-23.5
       parent: 1
       type: Transform
-  - uid: 328
+  - uid: 317
     components:
     - pos: 5.5,-23.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 329
+  - uid: 318
     components:
     - pos: 4.5,-23.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 330
+  - uid: 319
     components:
     - pos: 4.5,-24.5
       parent: 1
       type: Transform
-  - uid: 331
+  - uid: 320
     components:
     - pos: 3.5,-24.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 332
+  - uid: 321
     components:
     - pos: 2.5,-24.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 333
+  - uid: 322
     components:
     - pos: 1.5,-24.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 334
+  - uid: 323
     components:
     - pos: 0.5,-24.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 335
+  - uid: 324
     components:
     - pos: -0.5,-24.5
       parent: 1
       type: Transform
-  - uid: 336
+  - uid: 325
     components:
     - pos: -1.5,-24.5
       parent: 1
       type: Transform
-  - uid: 337
+  - uid: 326
     components:
     - pos: -3.5,-23.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 338
+  - uid: 327
     components:
     - pos: -4.5,-23.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 339
+  - uid: 328
     components:
     - pos: -1.5,-23.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 340
+  - uid: 329
     components:
     - pos: -1.5,-22.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 341
+  - uid: 330
     components:
     - pos: -1.5,-21.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 342
+  - uid: 331
     components:
     - pos: 4.5,-15.5
       parent: 1
       type: Transform
-  - uid: 343
+  - uid: 332
     components:
     - pos: -3.5,-3.5
       parent: 1
       type: Transform
-  - uid: 344
+  - uid: 333
     components:
     - pos: -2.5,-21.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 345
+  - uid: 334
     components:
     - pos: -0.5,-22.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 346
+  - uid: 335
     components:
     - pos: 0.5,-22.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 347
+  - uid: 336
     components:
     - pos: 1.5,-22.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 348
+  - uid: 337
     components:
     - pos: 2.5,-22.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 349
+  - uid: 338
     components:
     - pos: 2.5,-23.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 350
+  - uid: 339
     components:
     - pos: -5.5,-23.5
       parent: 1
       type: Transform
-  - uid: 351
+  - uid: 340
     components:
     - pos: -5.5,-24.5
       parent: 1
       type: Transform
-  - uid: 352
+  - uid: 341
     components:
     - pos: -5.5,-25.5
       parent: 1
       type: Transform
-  - uid: 353
+  - uid: 342
     components:
     - pos: -5.5,-26.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 354
+  - uid: 343
     components:
     - pos: -5.5,-27.5
       parent: 1
       type: Transform
-  - uid: 355
+  - uid: 344
     components:
     - pos: -5.5,-28.5
       parent: 1
       type: Transform
-  - uid: 356
+  - uid: 345
     components:
     - pos: -5.5,-22.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 357
+  - uid: 346
     components:
     - pos: -5.5,-21.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 358
+  - uid: 347
     components:
     - pos: -5.5,-20.5
       parent: 1
       type: Transform
-  - uid: 359
+  - uid: 348
     components:
     - pos: -5.5,-19.5
       parent: 1
       type: Transform
-  - uid: 360
+  - uid: 349
     components:
     - pos: -5.5,-18.5
       parent: 1
       type: Transform
-  - uid: 361
+  - uid: 350
     components:
     - pos: -4.5,-18.5
       parent: 1
       type: Transform
-  - uid: 362
+  - uid: 351
     components:
     - pos: -3.5,-18.5
       parent: 1
       type: Transform
-  - uid: 363
+  - uid: 352
     components:
     - pos: -3.5,-17.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 364
+  - uid: 353
     components:
     - pos: -3.5,-16.5
       parent: 1
       type: Transform
-  - uid: 365
+  - uid: 354
     components:
     - pos: 6.5,-22.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 366
+  - uid: 355
     components:
     - pos: 6.5,-21.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 367
+  - uid: 356
     components:
     - pos: 6.5,-20.5
       parent: 1
       type: Transform
-  - uid: 368
+  - uid: 357
     components:
     - pos: 6.5,-19.5
       parent: 1
       type: Transform
-  - uid: 369
+  - uid: 358
     components:
     - pos: 6.5,-18.5
       parent: 1
       type: Transform
-  - uid: 370
+  - uid: 359
     components:
     - pos: 5.5,-18.5
       parent: 1
       type: Transform
-  - uid: 371
+  - uid: 360
     components:
     - pos: 4.5,-18.5
       parent: 1
       type: Transform
-  - uid: 372
+  - uid: 361
     components:
     - pos: 4.5,-17.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 373
+  - uid: 362
     components:
     - pos: 4.5,-16.5
       parent: 1
       type: Transform
-  - uid: 374
+  - uid: 363
     components:
     - pos: 3.5,-15.5
       parent: 1
       type: Transform
-  - uid: 375
+  - uid: 364
     components:
     - pos: 2.5,-15.5
       parent: 1
       type: Transform
-  - uid: 376
+  - uid: 365
     components:
     - pos: 1.5,-15.5
       parent: 1
       type: Transform
-  - uid: 377
+  - uid: 366
     components:
     - pos: 0.5,-15.5
       parent: 1
       type: Transform
-  - uid: 378
+  - uid: 367
     components:
     - pos: -0.5,-15.5
       parent: 1
       type: Transform
-  - uid: 379
+  - uid: 368
     components:
     - pos: -1.5,-15.5
       parent: 1
       type: Transform
-  - uid: 380
+  - uid: 369
     components:
     - pos: -2.5,-15.5
       parent: 1
       type: Transform
-  - uid: 381
+  - uid: 370
     components:
     - pos: -3.5,-15.5
       parent: 1
       type: Transform
-  - uid: 382
+  - uid: 371
     components:
     - pos: 0.5,-16.5
       parent: 1
       type: Transform
-  - uid: 383
+  - uid: 372
     components:
     - pos: 0.5,-14.5
       parent: 1
       type: Transform
-  - uid: 384
+  - uid: 373
     components:
     - pos: 0.5,-13.5
       parent: 1
       type: Transform
-  - uid: 385
+  - uid: 374
     components:
     - pos: 0.5,-12.5
       parent: 1
       type: Transform
-  - uid: 386
+  - uid: 375
     components:
     - pos: 0.5,-11.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 387
+  - uid: 376
     components:
     - pos: -5.5,-10.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 388
+  - uid: 377
     components:
     - pos: -5.5,-11.5
       parent: 1
       type: Transform
-  - uid: 389
+  - uid: 378
     components:
     - pos: -5.5,-12.5
       parent: 1
       type: Transform
-  - uid: 390
+  - uid: 379
     components:
     - pos: -5.5,-13.5
       parent: 1
       type: Transform
-  - uid: 391
+  - uid: 380
     components:
     - pos: -5.5,-14.5
       parent: 1
       type: Transform
-  - uid: 392
+  - uid: 381
     components:
     - pos: -5.5,-15.5
       parent: 1
       type: Transform
-  - uid: 393
+  - uid: 382
     components:
     - pos: 6.5,-10.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 394
+  - uid: 383
     components:
     - pos: 6.5,-11.5
       parent: 1
       type: Transform
-  - uid: 395
+  - uid: 384
     components:
     - pos: 6.5,-12.5
       parent: 1
       type: Transform
-  - uid: 396
+  - uid: 385
     components:
     - pos: 6.5,-13.5
       parent: 1
       type: Transform
-  - uid: 397
+  - uid: 386
     components:
     - pos: 6.5,-14.5
       parent: 1
       type: Transform
-  - uid: 398
+  - uid: 387
     components:
     - pos: 6.5,-15.5
       parent: 1
       type: Transform
-  - uid: 399
+  - uid: 388
     components:
     - pos: -5.5,-1.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 400
+  - uid: 389
     components:
     - pos: -5.5,-2.5
       parent: 1
       type: Transform
-  - uid: 401
+  - uid: 390
     components:
     - pos: -5.5,-3.5
       parent: 1
       type: Transform
-  - uid: 402
+  - uid: 391
     components:
     - pos: -4.5,-3.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 403
+  - uid: 392
     components:
     - pos: -3.5,-4.5
       parent: 1
       type: Transform
-  - uid: 404
+  - uid: 393
     components:
     - pos: -5.5,-4.5
       parent: 1
       type: Transform
-  - uid: 405
+  - uid: 394
     components:
     - pos: -5.5,-5.5
       parent: 1
       type: Transform
-  - uid: 406
+  - uid: 395
     components:
     - pos: -5.5,-6.5
       parent: 1
       type: Transform
-  - uid: 407
+  - uid: 396
     components:
     - pos: -3.5,-5.5
       parent: 1
       type: Transform
-  - uid: 408
+  - uid: 397
     components:
     - pos: -3.5,-6.5
       parent: 1
       type: Transform
-  - uid: 409
+  - uid: 398
     components:
     - pos: -3.5,-7.5
       parent: 1
       type: Transform
-  - uid: 410
+  - uid: 399
     components:
     - pos: -3.5,-8.5
       parent: 1
       type: Transform
-  - uid: 411
+  - uid: 400
     components:
     - pos: -3.5,-9.5
       parent: 1
       type: Transform
-  - uid: 412
+  - uid: 401
     components:
     - pos: -3.5,-10.5
       parent: 1
       type: Transform
-  - uid: 413
+  - uid: 402
     components:
     - pos: -3.5,-11.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 414
+  - uid: 403
     components:
     - pos: -3.5,0.5
       parent: 1
       type: Transform
-  - uid: 415
+  - uid: 404
     components:
     - pos: 4.5,0.5
       parent: 1
       type: Transform
-  - uid: 416
+  - uid: 405
     components:
     - pos: -2.5,-9.5
       parent: 1
       type: Transform
-  - uid: 417
+  - uid: 406
     components:
     - pos: -1.5,-9.5
       parent: 1
       type: Transform
-  - uid: 418
+  - uid: 407
     components:
     - pos: -0.5,-9.5
       parent: 1
       type: Transform
-  - uid: 419
+  - uid: 408
     components:
     - pos: 0.5,-9.5
       parent: 1
       type: Transform
-  - uid: 420
+  - uid: 409
     components:
     - pos: 1.5,-9.5
       parent: 1
       type: Transform
-  - uid: 421
+  - uid: 410
     components:
     - pos: 2.5,-9.5
       parent: 1
       type: Transform
-  - uid: 422
+  - uid: 411
     components:
     - pos: 3.5,-9.5
       parent: 1
       type: Transform
-  - uid: 423
+  - uid: 412
     components:
     - pos: 4.5,-9.5
       parent: 1
       type: Transform
-  - uid: 424
+  - uid: 413
     components:
     - pos: 4.5,-10.5
       parent: 1
       type: Transform
-  - uid: 425
+  - uid: 414
     components:
     - pos: 4.5,-11.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 426
+  - uid: 415
     components:
     - pos: 0.5,-8.5
       parent: 1
       type: Transform
-  - uid: 427
+  - uid: 416
     components:
     - pos: 0.5,-7.5
       parent: 1
       type: Transform
-  - uid: 428
+  - uid: 417
     components:
     - pos: 0.5,-6.5
       parent: 1
       type: Transform
-  - uid: 429
+  - uid: 418
     components:
     - pos: 0.5,-5.5
       parent: 1
       type: Transform
-  - uid: 430
+  - uid: 419
     components:
     - pos: 0.5,-4.5
       parent: 1
       type: Transform
-  - uid: 431
+  - uid: 420
     components:
     - pos: 0.5,-3.5
       parent: 1
       type: Transform
-  - uid: 432
+  - uid: 421
     components:
     - pos: 4.5,-8.5
       parent: 1
       type: Transform
-  - uid: 433
+  - uid: 422
     components:
     - pos: 4.5,-7.5
       parent: 1
       type: Transform
-  - uid: 434
+  - uid: 423
     components:
     - pos: 4.5,-6.5
       parent: 1
       type: Transform
-  - uid: 435
+  - uid: 424
     components:
     - pos: 4.5,-5.5
       parent: 1
       type: Transform
-  - uid: 436
+  - uid: 425
     components:
     - pos: 4.5,-4.5
       parent: 1
       type: Transform
-  - uid: 437
+  - uid: 426
     components:
     - pos: 4.5,-3.5
       parent: 1
       type: Transform
-  - uid: 438
+  - uid: 427
     components:
     - pos: 0.5,-0.5
       parent: 1
       type: Transform
-  - uid: 439
+  - uid: 428
     components:
     - pos: 0.5,0.5
       parent: 1
       type: Transform
-  - uid: 440
+  - uid: 429
     components:
     - pos: 0.5,1.5
       parent: 1
       type: Transform
-  - uid: 441
+  - uid: 430
     components:
     - pos: -3.5,-2.5
       parent: 1
       type: Transform
-  - uid: 442
+  - uid: 431
     components:
     - pos: -3.5,-1.5
       parent: 1
       type: Transform
-  - uid: 443
+  - uid: 432
     components:
     - pos: -3.5,-0.5
       parent: 1
       type: Transform
-  - uid: 444
+  - uid: 433
     components:
     - pos: -3.5,1.5
       parent: 1
       type: Transform
-  - uid: 445
+  - uid: 434
     components:
     - pos: -3.5,2.5
       parent: 1
       type: Transform
-  - uid: 446
+  - uid: 435
     components:
     - pos: -1.5,1.5
       parent: 1
       type: Transform
-  - uid: 447
+  - uid: 436
     components:
     - pos: -0.5,1.5
       parent: 1
       type: Transform
-  - uid: 448
+  - uid: 437
     components:
     - pos: -3.5,3.5
       parent: 1
       type: Transform
-  - uid: 449
+  - uid: 438
     components:
     - pos: -2.5,3.5
       parent: 1
       type: Transform
-  - uid: 450
+  - uid: 439
     components:
     - pos: -0.5,4.5
       parent: 1
       type: Transform
-  - uid: 451
+  - uid: 440
     components:
     - pos: -0.5,5.5
       parent: 1
       type: Transform
-  - uid: 452
+  - uid: 441
     components:
     - pos: -0.5,6.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 453
+  - uid: 442
     components:
     - pos: -0.5,7.5
       parent: 1
       type: Transform
-  - uid: 454
+  - uid: 443
     components:
     - pos: -1.5,7.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 455
+  - uid: 444
     components:
     - pos: -2.5,7.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 456
+  - uid: 445
     components:
     - pos: -3.5,7.5
       parent: 1
       type: Transform
-  - uid: 457
+  - uid: 446
     components:
     - pos: -3.5,8.5
       parent: 1
       type: Transform
-  - uid: 458
+  - uid: 447
     components:
     - pos: -3.5,9.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 459
+  - uid: 448
     components:
     - pos: -4.5,7.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 460
+  - uid: 449
     components:
     - pos: -5.5,7.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 461
+  - uid: 450
     components:
     - pos: -5.5,8.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 462
+  - uid: 451
     components:
     - pos: -5.5,6.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 463
+  - uid: 452
     components:
     - pos: -1.5,8.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 464
+  - uid: 453
     components:
     - pos: -1.5,9.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 465
+  - uid: 454
     components:
     - pos: 4.5,-2.5
       parent: 1
       type: Transform
-  - uid: 466
+  - uid: 455
     components:
     - pos: 4.5,-1.5
       parent: 1
       type: Transform
-  - uid: 467
+  - uid: 456
     components:
     - pos: 4.5,-0.5
       parent: 1
       type: Transform
-  - uid: 468
+  - uid: 457
     components:
     - pos: 4.5,1.5
       parent: 1
       type: Transform
-  - uid: 469
+  - uid: 458
     components:
     - pos: 4.5,2.5
       parent: 1
       type: Transform
-  - uid: 470
+  - uid: 459
     components:
     - pos: 4.5,3.5
       parent: 1
       type: Transform
-  - uid: 471
+  - uid: 460
     components:
     - pos: 3.5,3.5
       parent: 1
       type: Transform
-  - uid: 472
+  - uid: 461
     components:
     - pos: 2.5,4.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 473
+  - uid: 462
     components:
     - pos: 1.5,4.5
       parent: 1
       type: Transform
-  - uid: 474
+  - uid: 463
     components:
     - pos: 1.5,5.5
       parent: 1
       type: Transform
-  - uid: 475
+  - uid: 464
     components:
     - pos: 1.5,6.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 476
+  - uid: 465
     components:
     - pos: 1.5,7.5
       parent: 1
       type: Transform
-  - uid: 477
+  - uid: 466
     components:
     - pos: 2.5,7.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 478
+  - uid: 467
     components:
     - pos: 2.5,8.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 479
+  - uid: 468
     components:
     - pos: 2.5,9.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 480
+  - uid: 469
     components:
     - pos: 3.5,7.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 481
+  - uid: 470
     components:
     - pos: 4.5,7.5
       parent: 1
       type: Transform
-  - uid: 482
+  - uid: 471
     components:
     - pos: 4.5,8.5
       parent: 1
       type: Transform
-  - uid: 483
+  - uid: 472
     components:
     - pos: 4.5,9.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 484
+  - uid: 473
     components:
     - pos: 5.5,7.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 485
+  - uid: 474
     components:
     - pos: 6.5,7.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 486
+  - uid: 475
     components:
     - pos: 6.5,8.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 487
+  - uid: 476
     components:
     - pos: 6.5,6.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 488
+  - uid: 477
     components:
     - pos: -4.5,-27.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 489
+  - uid: 478
     components:
     - pos: -2.5,4.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 490
+  - uid: 479
     components:
     - pos: -1.5,4.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 491
+  - uid: 480
     components:
     - pos: 3.5,4.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 492
+  - uid: 481
     components:
     - pos: 9.5,-29.5
       parent: 1
       type: Transform
-  - uid: 493
+  - uid: 482
     components:
     - pos: 10.5,-29.5
       parent: 1
       type: Transform
-  - uid: 494
+  - uid: 483
     components:
     - pos: 6.5,-3.5
       parent: 1
       type: Transform
-  - uid: 495
+  - uid: 484
     components:
     - pos: 5.5,-3.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 496
+  - uid: 485
     components:
     - pos: 6.5,-5.5
       parent: 1
       type: Transform
-  - uid: 497
+  - uid: 486
     components:
     - pos: 6.5,-6.5
       parent: 1
       type: Transform
-  - uid: 498
+  - uid: 487
     components:
     - pos: 5.5,0.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 499
+  - uid: 488
     components:
     - pos: 7.5,0.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 500
+  - uid: 489
     components:
     - pos: -4.5,0.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 501
+  - uid: 490
     components:
     - pos: -5.5,0.5
       parent: 1
       type: Transform
-  - uid: 502
+  - uid: 491
     components:
     - pos: -6.5,0.5
       parent: 1
       type: Transform
-  - uid: 503
+  - uid: 492
     components:
     - pos: 6.5,0.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 504
+  - uid: 493
     components:
     - pos: 1.5,0.5
       parent: 1
       type: Transform
-  - uid: 505
+  - uid: 494
     components:
     - pos: 2.5,0.5
       parent: 1
       type: Transform
-  - uid: 506
+  - uid: 495
     components:
     - pos: -6.5,-27.5
       parent: 1
       type: Transform
-  - uid: 507
+  - uid: 496
     components:
     - pos: -7.5,-27.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 508
+  - uid: 497
     components:
     - pos: -8.5,-27.5
       parent: 1
       type: Transform
-  - uid: 509
+  - uid: 498
     components:
     - pos: -9.5,-27.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 510
+  - uid: 499
     components:
     - pos: -10.5,-27.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 511
+  - uid: 500
     components:
     - pos: -4.5,3.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 512
+  - uid: 501
     components:
     - pos: -5.5,3.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 513
+  - uid: 502
     components:
     - pos: -6.5,3.5
       parent: 1
       type: Transform
-  - uid: 514
+  - uid: 503
     components:
     - pos: 5.5,3.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 515
+  - uid: 504
     components:
     - pos: 6.5,3.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 516
+  - uid: 505
     components:
     - pos: 7.5,3.5
       parent: 1
       type: Transform
-  - uid: 517
+  - uid: 506
     components:
     - pos: 7.5,4.5
       parent: 1
       type: Transform
-  - uid: 518
+  - uid: 507
     components:
     - pos: 7.5,2.5
       parent: 1
       type: Transform
-  - uid: 519
+  - uid: 508
     components:
     - pos: -6.5,4.5
       parent: 1
       type: Transform
-  - uid: 520
+  - uid: 509
     components:
     - pos: -6.5,2.5
       parent: 1
       type: Transform
 - proto: Cablecuffs
   entities:
-  - uid: 521
+  - uid: 510
     components:
     - pos: 7.5698066,-0.081031054
       parent: 1
       type: Transform
 - proto: CableHV
   entities:
-  - uid: 522
+  - uid: 511
     components:
     - pos: -5.5,-18.5
       parent: 1
       type: Transform
-  - uid: 523
+  - uid: 512
     components:
     - pos: 6.5,-30.5
       parent: 1
       type: Transform
-  - uid: 524
+  - uid: 513
     components:
     - pos: 5.5,-30.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 525
+  - uid: 514
     components:
     - pos: 4.5,-30.5
       parent: 1
       type: Transform
-  - uid: 526
+  - uid: 515
     components:
     - pos: 3.5,-30.5
       parent: 1
       type: Transform
-  - uid: 527
+  - uid: 516
     components:
     - pos: 6.5,-31.5
       parent: 1
       type: Transform
-  - uid: 528
+  - uid: 517
     components:
     - pos: 6.5,-32.5
       parent: 1
       type: Transform
-  - uid: 529
+  - uid: 518
     components:
     - pos: 6.5,-33.5
       parent: 1
       type: Transform
-  - uid: 530
+  - uid: 519
     components:
     - pos: 7.5,-33.5
       parent: 1
       type: Transform
-  - uid: 531
+  - uid: 520
     components:
     - pos: 7.5,-32.5
       parent: 1
       type: Transform
-  - uid: 532
+  - uid: 521
     components:
     - pos: 8.5,-33.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 533
+  - uid: 522
     components:
     - pos: 8.5,-32.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 534
+  - uid: 523
     components:
     - pos: 8.5,-31.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 535
+  - uid: 524
     components:
     - pos: 6.5,-29.5
       parent: 1
       type: Transform
-  - uid: 536
+  - uid: 525
     components:
     - pos: 6.5,-28.5
       parent: 1
       type: Transform
-  - uid: 537
+  - uid: 526
     components:
     - pos: 6.5,-27.5
       parent: 1
       type: Transform
-  - uid: 538
+  - uid: 527
     components:
     - pos: 6.5,-26.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 539
+  - uid: 528
     components:
     - pos: 6.5,-25.5
       parent: 1
       type: Transform
-  - uid: 540
+  - uid: 529
     components:
     - pos: 6.5,-24.5
       parent: 1
       type: Transform
-  - uid: 541
+  - uid: 530
     components:
     - pos: 6.5,-23.5
       parent: 1
       type: Transform
-  - uid: 542
+  - uid: 531
     components:
     - pos: 6.5,-22.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 543
+  - uid: 532
     components:
     - pos: 6.5,-21.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 544
+  - uid: 533
     components:
     - pos: 6.5,-20.5
       parent: 1
       type: Transform
-  - uid: 545
+  - uid: 534
     components:
     - pos: 6.5,-19.5
       parent: 1
       type: Transform
-  - uid: 546
+  - uid: 535
     components:
     - pos: 6.5,-18.5
       parent: 1
       type: Transform
-  - uid: 547
+  - uid: 536
     components:
     - pos: 5.5,-18.5
       parent: 1
       type: Transform
-  - uid: 548
+  - uid: 537
     components:
     - pos: 4.5,-18.5
       parent: 1
       type: Transform
-  - uid: 549
+  - uid: 538
     components:
     - pos: 4.5,-17.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 550
+  - uid: 539
     components:
     - pos: 4.5,-16.5
       parent: 1
       type: Transform
-  - uid: 551
+  - uid: 540
     components:
     - pos: 4.5,-15.5
       parent: 1
       type: Transform
-  - uid: 552
+  - uid: 541
     components:
     - pos: 4.5,-14.5
       parent: 1
       type: Transform
-  - uid: 553
+  - uid: 542
     components:
     - pos: 4.5,-13.5
       parent: 1
       type: Transform
-  - uid: 554
+  - uid: 543
     components:
     - pos: 4.5,-12.5
       parent: 1
       type: Transform
-  - uid: 555
+  - uid: 544
     components:
     - pos: 4.5,-11.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 556
+  - uid: 545
     components:
     - pos: 4.5,-10.5
       parent: 1
       type: Transform
-  - uid: 557
+  - uid: 546
     components:
     - pos: 4.5,-9.5
       parent: 1
       type: Transform
-  - uid: 558
+  - uid: 547
     components:
     - pos: 4.5,-8.5
       parent: 1
       type: Transform
-  - uid: 559
+  - uid: 548
     components:
     - pos: 4.5,-7.5
       parent: 1
       type: Transform
-  - uid: 560
+  - uid: 549
     components:
     - pos: 4.5,-6.5
       parent: 1
       type: Transform
-  - uid: 561
+  - uid: 550
     components:
     - pos: 4.5,-5.5
       parent: 1
       type: Transform
-  - uid: 562
+  - uid: 551
     components:
     - pos: 4.5,-4.5
       parent: 1
       type: Transform
-  - uid: 563
+  - uid: 552
     components:
     - pos: 4.5,-3.5
       parent: 1
       type: Transform
-  - uid: 564
+  - uid: 553
     components:
     - pos: 4.5,-2.5
       parent: 1
       type: Transform
-  - uid: 565
+  - uid: 554
     components:
     - pos: 4.5,-1.5
       parent: 1
       type: Transform
-  - uid: 566
+  - uid: 555
     components:
     - pos: 4.5,-0.5
       parent: 1
       type: Transform
-  - uid: 567
+  - uid: 556
     components:
     - pos: 4.5,0.5
       parent: 1
       type: Transform
-  - uid: 568
+  - uid: 557
     components:
     - pos: 4.5,1.5
       parent: 1
       type: Transform
-  - uid: 569
+  - uid: 558
     components:
     - pos: 4.5,2.5
       parent: 1
       type: Transform
-  - uid: 570
+  - uid: 559
     components:
     - pos: 4.5,3.5
       parent: 1
       type: Transform
-  - uid: 571
+  - uid: 560
     components:
     - pos: 3.5,3.5
       parent: 1
       type: Transform
-  - uid: 572
+  - uid: 561
     components:
     - pos: 2.5,-32.5
       parent: 1
       type: Transform
-  - uid: 573
+  - uid: 562
     components:
     - pos: -1.5,-33.5
       parent: 1
       type: Transform
-  - uid: 574
+  - uid: 563
     components:
     - pos: 3.5,7.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 575
+  - uid: 564
     components:
     - pos: 4.5,7.5
       parent: 1
       type: Transform
-  - uid: 576
+  - uid: 565
     components:
     - pos: 4.5,6.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 577
+  - uid: 566
     components:
     - pos: -3.5,6.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 578
+  - uid: 567
     components:
     - pos: -3.5,7.5
       parent: 1
       type: Transform
-  - uid: 579
+  - uid: 568
     components:
     - pos: -2.5,7.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 580
+  - uid: 569
     components:
     - pos: 2.5,3.5
       parent: 1
       type: Transform
-  - uid: 581
+  - uid: 570
     components:
     - pos: 1.5,4.5
       parent: 1
       type: Transform
-  - uid: 582
+  - uid: 571
     components:
     - pos: -1.5,3.5
       parent: 1
       type: Transform
-  - uid: 583
+  - uid: 572
     components:
     - pos: -2.5,3.5
       parent: 1
       type: Transform
-  - uid: 584
+  - uid: 573
     components:
     - pos: -3.5,3.5
       parent: 1
       type: Transform
-  - uid: 585
+  - uid: 574
     components:
     - pos: -3.5,2.5
       parent: 1
       type: Transform
-  - uid: 586
+  - uid: 575
     components:
     - pos: -3.5,1.5
       parent: 1
       type: Transform
-  - uid: 587
+  - uid: 576
     components:
     - pos: -3.5,0.5
       parent: 1
       type: Transform
-  - uid: 588
+  - uid: 577
     components:
     - pos: -3.5,-0.5
       parent: 1
       type: Transform
-  - uid: 589
+  - uid: 578
     components:
     - pos: -3.5,-1.5
       parent: 1
       type: Transform
-  - uid: 590
+  - uid: 579
     components:
     - pos: -3.5,-2.5
       parent: 1
       type: Transform
-  - uid: 591
+  - uid: 580
     components:
     - pos: -3.5,-3.5
       parent: 1
       type: Transform
-  - uid: 592
+  - uid: 581
     components:
     - pos: -3.5,-4.5
       parent: 1
       type: Transform
-  - uid: 593
+  - uid: 582
     components:
     - pos: -3.5,-5.5
       parent: 1
       type: Transform
-  - uid: 594
+  - uid: 583
     components:
     - pos: -3.5,-6.5
       parent: 1
       type: Transform
-  - uid: 595
+  - uid: 584
     components:
     - pos: -3.5,-7.5
       parent: 1
       type: Transform
-  - uid: 596
+  - uid: 585
     components:
     - pos: -3.5,-8.5
       parent: 1
       type: Transform
-  - uid: 597
+  - uid: 586
     components:
     - pos: -3.5,-9.5
       parent: 1
       type: Transform
-  - uid: 598
+  - uid: 587
     components:
     - pos: -3.5,-10.5
       parent: 1
       type: Transform
-  - uid: 599
+  - uid: 588
     components:
     - pos: -3.5,-11.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 600
+  - uid: 589
     components:
     - pos: -3.5,-12.5
       parent: 1
       type: Transform
-  - uid: 601
+  - uid: 590
     components:
     - pos: -3.5,-13.5
       parent: 1
       type: Transform
-  - uid: 602
+  - uid: 591
     components:
     - pos: -3.5,-14.5
       parent: 1
       type: Transform
-  - uid: 603
+  - uid: 592
     components:
     - pos: -3.5,-15.5
       parent: 1
       type: Transform
-  - uid: 604
+  - uid: 593
     components:
     - pos: -3.5,-16.5
       parent: 1
       type: Transform
-  - uid: 605
+  - uid: 594
     components:
     - pos: -3.5,-17.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 606
+  - uid: 595
     components:
     - pos: -3.5,-18.5
       parent: 1
       type: Transform
-  - uid: 607
+  - uid: 596
     components:
     - pos: -4.5,-18.5
       parent: 1
       type: Transform
-  - uid: 608
+  - uid: 597
     components:
     - pos: -5.5,-18.5
       parent: 1
       type: Transform
-  - uid: 609
+  - uid: 598
     components:
     - pos: -5.5,-19.5
       parent: 1
       type: Transform
-  - uid: 610
+  - uid: 599
     components:
     - pos: -5.5,-20.5
       parent: 1
       type: Transform
-  - uid: 611
+  - uid: 600
     components:
     - pos: -5.5,-21.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 612
+  - uid: 601
     components:
     - pos: -5.5,-22.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 613
+  - uid: 602
     components:
     - pos: -5.5,-23.5
       parent: 1
       type: Transform
-  - uid: 614
+  - uid: 603
     components:
     - pos: -5.5,-24.5
       parent: 1
       type: Transform
-  - uid: 615
+  - uid: 604
     components:
     - pos: -5.5,-25.5
       parent: 1
       type: Transform
-  - uid: 616
+  - uid: 605
     components:
     - pos: -5.5,-26.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 617
+  - uid: 606
     components:
     - pos: -5.5,-27.5
       parent: 1
       type: Transform
-  - uid: 618
+  - uid: 607
     components:
     - pos: -5.5,-28.5
       parent: 1
       type: Transform
-  - uid: 619
+  - uid: 608
     components:
     - pos: -5.5,-29.5
       parent: 1
       type: Transform
-  - uid: 620
+  - uid: 609
     components:
     - pos: -5.5,-30.5
       parent: 1
       type: Transform
-  - uid: 621
+  - uid: 610
     components:
     - pos: -5.5,-31.5
       parent: 1
       type: Transform
-  - uid: 622
+  - uid: 611
     components:
     - pos: -5.5,-32.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 623
+  - uid: 612
     components:
     - pos: -5.5,-33.5
       parent: 1
       type: Transform
-  - uid: 624
+  - uid: 613
     components:
     - pos: -4.5,-33.5
       parent: 1
       type: Transform
-  - uid: 625
+  - uid: 614
     components:
     - pos: -3.5,-33.5
       parent: 1
       type: Transform
-  - uid: 626
+  - uid: 615
     components:
     - pos: -2.5,-33.5
       parent: 1
       type: Transform
-  - uid: 627
+  - uid: 616
     components:
     - pos: 1.5,-33.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 628
+  - uid: 617
     components:
     - pos: 0.5,-33.5
       parent: 1
       type: Transform
-  - uid: 629
+  - uid: 618
     components:
     - pos: 2.5,-33.5
       parent: 1
       type: Transform
-  - uid: 630
+  - uid: 619
     components:
     - pos: 2.5,-30.5
       parent: 1
       type: Transform
-  - uid: 631
+  - uid: 620
     components:
     - pos: 2.5,-31.5
       parent: 1
       type: Transform
-  - uid: 632
+  - uid: 621
     components:
     - pos: -0.5,-33.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 633
+  - uid: 622
     components:
     - pos: 1.5,3.5
       parent: 1
       type: Transform
-  - uid: 634
+  - uid: 623
     components:
     - pos: 1.5,5.5
       parent: 1
       type: Transform
-  - uid: 635
+  - uid: 624
     components:
     - pos: 1.5,6.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 636
+  - uid: 625
     components:
     - pos: 1.5,7.5
       parent: 1
       type: Transform
-  - uid: 637
+  - uid: 626
     components:
     - pos: 2.5,7.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 638
+  - uid: 627
     components:
     - pos: -0.5,3.5
       parent: 1
       type: Transform
-  - uid: 639
+  - uid: 628
     components:
     - pos: -0.5,4.5
       parent: 1
       type: Transform
-  - uid: 640
+  - uid: 629
     components:
     - pos: -0.5,5.5
       parent: 1
       type: Transform
-  - uid: 641
+  - uid: 630
     components:
     - pos: -0.5,6.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 642
+  - uid: 631
     components:
     - pos: -0.5,7.5
       parent: 1
       type: Transform
-  - uid: 643
+  - uid: 632
     components:
     - pos: -1.5,7.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 644
+  - uid: 633
     components:
     - pos: -6.5,-18.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 645
+  - uid: 634
     components:
     - pos: 5.5,-23.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 646
+  - uid: 635
     components:
     - pos: 4.5,-23.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 647
+  - uid: 636
     components:
     - pos: 3.5,-23.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 648
+  - uid: 637
     components:
     - pos: 2.5,-23.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 649
+  - uid: 638
     components:
     - pos: 1.5,-23.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 650
+  - uid: 639
     components:
     - pos: 0.5,-23.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 651
+  - uid: 640
     components:
     - pos: -0.5,-23.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 652
+  - uid: 641
     components:
     - pos: -0.5,-22.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 653
+  - uid: 642
     components:
     - pos: -0.5,-21.5
       parent: 1
       type: Transform
-  - uid: 654
+  - uid: 643
     components:
     - pos: 1.5,-31.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
-  - uid: 655
+  - uid: 644
     components:
     - pos: 0.5,-31.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
-  - uid: 656
+  - uid: 645
     components:
     - pos: 0.5,-30.5
       parent: 1
       type: Transform
-  - uid: 657
+  - uid: 646
     components:
     - pos: 0.5,-29.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 658
+  - uid: 647
     components:
     - pos: -0.5,-29.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 659
+  - uid: 648
     components:
     - pos: -1.5,-29.5
       parent: 1
       type: Transform
-  - uid: 660
+  - uid: 649
     components:
     - pos: -6.5,-17.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 661
+  - uid: 650
     components:
     - pos: -6.5,-18.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 662
+  - uid: 651
     components:
     - pos: -6.5,-18.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 663
+  - uid: 652
     components:
     - pos: 7.5,-18.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 664
+  - uid: 653
     components:
     - pos: 7.5,-17.5
       parent: 1
@@ -4467,1379 +4517,1405 @@ entities:
       type: AmbientSound
 - proto: CableMV
   entities:
-  - uid: 665
+  - uid: 654
     components:
     - pos: -6.5,-17.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 666
+  - uid: 655
     components:
     - pos: -5.5,-17.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 667
+  - uid: 656
     components:
     - pos: -5.5,-18.5
       parent: 1
       type: Transform
-  - uid: 668
+  - uid: 657
     components:
     - pos: -5.5,-18.5
       parent: 1
       type: Transform
-  - uid: 669
+  - uid: 658
     components:
     - pos: -5.5,-18.5
       parent: 1
       type: Transform
-  - uid: 670
+  - uid: 659
     components:
     - pos: -5.5,-18.5
       parent: 1
       type: Transform
-  - uid: 671
+  - uid: 660
     components:
     - pos: -5.5,-18.5
       parent: 1
       type: Transform
-  - uid: 672
+  - uid: 661
     components:
     - pos: 10.5,-29.5
       parent: 1
       type: Transform
-  - uid: 673
+  - uid: 662
     components:
     - pos: 9.5,-28.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 674
+  - uid: 663
     components:
     - pos: 9.5,-29.5
       parent: 1
       type: Transform
-  - uid: 675
+  - uid: 664
     components:
     - pos: 10.5,-28.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 676
+  - uid: 665
     components:
     - pos: -0.5,4.5
       parent: 1
       type: Transform
-  - uid: 677
+  - uid: 666
     components:
     - pos: -1.5,7.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 678
+  - uid: 667
     components:
     - pos: -0.5,6.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 679
+  - uid: 668
     components:
     - pos: 1.5,5.5
       parent: 1
       type: Transform
-  - uid: 680
+  - uid: 669
     components:
     - pos: 1.5,6.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 681
+  - uid: 670
     components:
     - pos: 0.5,-4.5
       parent: 1
       type: Transform
-  - uid: 682
+  - uid: 671
     components:
     - pos: 7.5,-30.5
       parent: 1
       type: Transform
-  - uid: 683
+  - uid: 672
     components:
     - pos: 6.5,-29.5
       parent: 1
       type: Transform
-  - uid: 684
+  - uid: 673
     components:
     - pos: -3.5,-23.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 685
+  - uid: 674
     components:
     - pos: 7.5,-31.5
       parent: 1
       type: Transform
-  - uid: 686
+  - uid: 675
     components:
     - pos: 8.5,-30.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 687
+  - uid: 676
     components:
     - pos: 6.5,-30.5
       parent: 1
       type: Transform
-  - uid: 688
+  - uid: 677
     components:
     - pos: 4.5,-14.5
       parent: 1
       type: Transform
-  - uid: 689
+  - uid: 678
     components:
     - pos: 8.5,-31.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 690
+  - uid: 679
     components:
     - pos: 6.5,-28.5
       parent: 1
       type: Transform
-  - uid: 691
+  - uid: 680
     components:
     - pos: 6.5,-27.5
       parent: 1
       type: Transform
-  - uid: 692
+  - uid: 681
     components:
     - pos: 6.5,-26.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 693
+  - uid: 682
     components:
     - pos: 6.5,-25.5
       parent: 1
       type: Transform
-  - uid: 694
+  - uid: 683
     components:
     - pos: 6.5,-24.5
       parent: 1
       type: Transform
-  - uid: 695
+  - uid: 684
     components:
     - pos: 6.5,-23.5
       parent: 1
       type: Transform
-  - uid: 696
+  - uid: 685
     components:
     - pos: 6.5,-22.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 697
+  - uid: 686
     components:
     - pos: 6.5,-21.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 698
+  - uid: 687
     components:
     - pos: 6.5,-20.5
       parent: 1
       type: Transform
-  - uid: 699
+  - uid: 688
     components:
     - pos: 7.5,-27.5
       parent: 1
       type: Transform
-  - uid: 700
+  - uid: 689
     components:
     - pos: 8.5,-27.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 701
+  - uid: 690
     components:
     - pos: 9.5,-27.5
       parent: 1
       type: Transform
-  - uid: 702
+  - uid: 691
     components:
     - pos: 6.5,-19.5
       parent: 1
       type: Transform
-  - uid: 703
+  - uid: 692
     components:
     - pos: 6.5,-18.5
       parent: 1
       type: Transform
-  - uid: 704
+  - uid: 693
     components:
     - pos: 5.5,-18.5
       parent: 1
       type: Transform
-  - uid: 705
+  - uid: 694
     components:
     - pos: 4.5,-18.5
       parent: 1
       type: Transform
-  - uid: 706
+  - uid: 695
     components:
     - pos: 4.5,-17.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 707
+  - uid: 696
     components:
     - pos: 4.5,-16.5
       parent: 1
       type: Transform
-  - uid: 708
+  - uid: 697
     components:
     - pos: 4.5,-15.5
       parent: 1
       type: Transform
-  - uid: 709
+  - uid: 698
     components:
     - pos: 4.5,-13.5
       parent: 1
       type: Transform
-  - uid: 710
+  - uid: 699
     components:
     - pos: 4.5,-12.5
       parent: 1
       type: Transform
-  - uid: 711
+  - uid: 700
     components:
     - pos: 5.5,-12.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 712
+  - uid: 701
     components:
     - pos: 6.5,-12.5
       parent: 1
       type: Transform
-  - uid: 713
+  - uid: 702
     components:
     - pos: 6.5,-11.5
       parent: 1
       type: Transform
-  - uid: 714
+  - uid: 703
     components:
     - pos: 6.5,-10.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 715
+  - uid: 704
     components:
     - pos: 3.5,-13.5
       parent: 1
       type: Transform
-  - uid: 716
+  - uid: 705
     components:
     - pos: 2.5,-13.5
       parent: 1
       type: Transform
-  - uid: 717
+  - uid: 706
     components:
     - pos: 1.5,-13.5
       parent: 1
       type: Transform
-  - uid: 718
+  - uid: 707
     components:
     - pos: 0.5,-13.5
       parent: 1
       type: Transform
-  - uid: 719
+  - uid: 708
     components:
     - pos: 0.5,-12.5
       parent: 1
       type: Transform
-  - uid: 720
+  - uid: 709
     components:
     - pos: 0.5,-11.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 721
+  - uid: 710
     components:
     - pos: -0.5,-13.5
       parent: 1
       type: Transform
-  - uid: 722
+  - uid: 711
     components:
     - pos: -1.5,-13.5
       parent: 1
       type: Transform
-  - uid: 723
+  - uid: 712
     components:
     - pos: -2.5,-13.5
       parent: 1
       type: Transform
-  - uid: 724
+  - uid: 713
     components:
     - pos: -3.5,-13.5
       parent: 1
       type: Transform
-  - uid: 725
+  - uid: 714
     components:
     - pos: -3.5,-12.5
       parent: 1
       type: Transform
-  - uid: 726
+  - uid: 715
     components:
     - pos: -4.5,-12.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 727
+  - uid: 716
     components:
     - pos: -5.5,-12.5
       parent: 1
       type: Transform
-  - uid: 728
+  - uid: 717
     components:
     - pos: -5.5,-11.5
       parent: 1
       type: Transform
-  - uid: 729
+  - uid: 718
     components:
     - pos: -5.5,-10.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 730
+  - uid: 719
     components:
     - pos: -4.5,-23.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 731
+  - uid: 720
     components:
     - pos: -3.5,-11.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 732
+  - uid: 721
     components:
     - pos: -3.5,-10.5
       parent: 1
       type: Transform
-  - uid: 733
+  - uid: 722
     components:
     - pos: -3.5,-9.5
       parent: 1
       type: Transform
-  - uid: 734
+  - uid: 723
     components:
     - pos: -3.5,-8.5
       parent: 1
       type: Transform
-  - uid: 735
+  - uid: 724
     components:
     - pos: -3.5,-7.5
       parent: 1
       type: Transform
-  - uid: 736
+  - uid: 725
     components:
     - pos: -3.5,-6.5
       parent: 1
       type: Transform
-  - uid: 737
+  - uid: 726
     components:
     - pos: -3.5,-5.5
       parent: 1
       type: Transform
-  - uid: 738
+  - uid: 727
     components:
     - pos: -3.5,-4.5
       parent: 1
       type: Transform
-  - uid: 739
+  - uid: 728
     components:
     - pos: -3.5,-3.5
       parent: 1
       type: Transform
-  - uid: 740
+  - uid: 729
     components:
     - pos: -4.5,-3.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 741
+  - uid: 730
     components:
     - pos: -5.5,-3.5
       parent: 1
       type: Transform
-  - uid: 742
+  - uid: 731
     components:
     - pos: -5.5,-2.5
       parent: 1
       type: Transform
-  - uid: 743
+  - uid: 732
     components:
     - pos: -5.5,-1.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 744
+  - uid: 733
     components:
     - pos: 4.5,-11.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 745
+  - uid: 734
     components:
     - pos: 4.5,-10.5
       parent: 1
       type: Transform
-  - uid: 746
+  - uid: 735
     components:
     - pos: 4.5,-9.5
       parent: 1
       type: Transform
-  - uid: 747
+  - uid: 736
     components:
     - pos: 4.5,-8.5
       parent: 1
       type: Transform
-  - uid: 748
+  - uid: 737
     components:
     - pos: 4.5,-7.5
       parent: 1
       type: Transform
-  - uid: 749
+  - uid: 738
     components:
     - pos: 4.5,-6.5
       parent: 1
       type: Transform
-  - uid: 750
+  - uid: 739
     components:
     - pos: 4.5,-5.5
       parent: 1
       type: Transform
-  - uid: 751
+  - uid: 740
     components:
     - pos: 4.5,-4.5
       parent: 1
       type: Transform
-  - uid: 752
+  - uid: 741
     components:
     - pos: 4.5,-3.5
       parent: 1
       type: Transform
-  - uid: 753
+  - uid: 742
     components:
     - pos: 5.5,-3.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 754
+  - uid: 743
     components:
     - pos: 6.5,-3.5
       parent: 1
       type: Transform
-  - uid: 755
+  - uid: 744
     components:
     - pos: 6.5,-2.5
       parent: 1
       type: Transform
-  - uid: 756
+  - uid: 745
     components:
     - pos: 6.5,-1.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 757
+  - uid: 746
     components:
     - pos: 4.5,-2.5
       parent: 1
       type: Transform
-  - uid: 758
+  - uid: 747
     components:
     - pos: 4.5,-1.5
       parent: 1
       type: Transform
-  - uid: 759
+  - uid: 748
     components:
     - pos: -3.5,0.5
       parent: 1
       type: Transform
-  - uid: 760
+  - uid: 749
     components:
     - pos: 4.5,-0.5
       parent: 1
       type: Transform
-  - uid: 761
+  - uid: 750
     components:
     - pos: 4.5,0.5
       parent: 1
       type: Transform
-  - uid: 762
+  - uid: 751
     components:
     - pos: 4.5,1.5
       parent: 1
       type: Transform
-  - uid: 763
+  - uid: 752
     components:
     - pos: 4.5,2.5
       parent: 1
       type: Transform
-  - uid: 764
+  - uid: 753
     components:
     - pos: 4.5,3.5
       parent: 1
       type: Transform
-  - uid: 765
+  - uid: 754
     components:
     - pos: 3.5,3.5
       parent: 1
       type: Transform
-  - uid: 766
+  - uid: 755
     components:
     - pos: -0.5,5.5
       parent: 1
       type: Transform
-  - uid: 767
+  - uid: 756
     components:
     - pos: -0.5,7.5
       parent: 1
       type: Transform
-  - uid: 768
+  - uid: 757
     components:
     - pos: 3.5,4.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 769
+  - uid: 758
     components:
     - pos: 1.5,4.5
       parent: 1
       type: Transform
-  - uid: 770
+  - uid: 759
     components:
     - pos: 3.5,7.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 771
+  - uid: 760
     components:
     - pos: 4.5,7.5
       parent: 1
       type: Transform
-  - uid: 772
+  - uid: 761
     components:
     - pos: 4.5,6.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 773
+  - uid: 762
     components:
     - pos: 4.5,8.5
       parent: 1
       type: Transform
-  - uid: 774
+  - uid: 763
     components:
     - pos: 4.5,9.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 775
+  - uid: 764
     components:
     - pos: 1.5,7.5
       parent: 1
       type: Transform
-  - uid: 776
+  - uid: 765
     components:
     - pos: -2.5,7.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 777
+  - uid: 766
     components:
     - pos: -3.5,7.5
       parent: 1
       type: Transform
-  - uid: 778
+  - uid: 767
     components:
     - pos: -3.5,6.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 779
+  - uid: 768
     components:
     - pos: -3.5,8.5
       parent: 1
       type: Transform
-  - uid: 780
+  - uid: 769
     components:
     - pos: -3.5,9.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 781
+  - uid: 770
     components:
     - pos: 2.5,7.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 782
+  - uid: 771
     components:
     - pos: -2.5,4.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 783
+  - uid: 772
     components:
     - pos: -2.5,3.5
       parent: 1
       type: Transform
-  - uid: 784
+  - uid: 773
     components:
     - pos: -3.5,3.5
       parent: 1
       type: Transform
-  - uid: 785
+  - uid: 774
     components:
     - pos: -3.5,2.5
       parent: 1
       type: Transform
-  - uid: 786
+  - uid: 775
     components:
     - pos: -3.5,1.5
       parent: 1
       type: Transform
-  - uid: 787
+  - uid: 776
     components:
     - pos: -3.5,-0.5
       parent: 1
       type: Transform
-  - uid: 788
+  - uid: 777
     components:
     - pos: -3.5,-1.5
       parent: 1
       type: Transform
-  - uid: 789
+  - uid: 778
     components:
     - pos: -3.5,-2.5
       parent: 1
       type: Transform
-  - uid: 790
+  - uid: 779
     components:
     - pos: -2.5,-3.5
       parent: 1
       type: Transform
-  - uid: 791
+  - uid: 780
     components:
     - pos: -1.5,-3.5
       parent: 1
       type: Transform
-  - uid: 792
+  - uid: 781
     components:
     - pos: -0.5,-3.5
       parent: 1
       type: Transform
-  - uid: 793
+  - uid: 782
     components:
     - pos: 0.5,-3.5
       parent: 1
       type: Transform
-  - uid: 794
+  - uid: 783
     components:
     - pos: 3.5,-3.5
       parent: 1
       type: Transform
-  - uid: 795
+  - uid: 784
     components:
     - pos: 2.5,-3.5
       parent: 1
       type: Transform
-  - uid: 796
+  - uid: 785
     components:
     - pos: 1.5,-3.5
       parent: 1
       type: Transform
-  - uid: 797
+  - uid: 786
     components:
     - pos: 0.5,-2.5
       parent: 1
       type: Transform
-  - uid: 798
+  - uid: 787
     components:
     - pos: 0.5,-1.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 799
+  - uid: 788
     components:
     - pos: 0.5,-0.5
       parent: 1
       type: Transform
-  - uid: 800
+  - uid: 789
     components:
     - pos: 0.5,0.5
       parent: 1
       type: Transform
-  - uid: 801
+  - uid: 790
     components:
     - pos: 1.5,0.5
       parent: 1
       type: Transform
-  - uid: 802
+  - uid: 791
     components:
     - pos: 2.5,0.5
       parent: 1
       type: Transform
-  - uid: 803
+  - uid: 792
     components:
     - pos: 0.5,-5.5
       parent: 1
       type: Transform
-  - uid: 804
+  - uid: 793
     components:
     - pos: 0.5,-6.5
       parent: 1
       type: Transform
-  - uid: 805
+  - uid: 794
     components:
     - pos: 0.5,-7.5
       parent: 1
       type: Transform
-  - uid: 806
+  - uid: 795
     components:
     - pos: 0.5,-8.5
       parent: 1
       type: Transform
-  - uid: 807
+  - uid: 796
     components:
     - pos: 0.5,-9.5
       parent: 1
       type: Transform
-  - uid: 808
+  - uid: 797
     components:
     - pos: 0.5,-10.5
       parent: 1
       type: Transform
-  - uid: 809
+  - uid: 798
     components:
     - pos: -3.5,-14.5
       parent: 1
       type: Transform
-  - uid: 810
+  - uid: 799
     components:
     - pos: -3.5,-15.5
       parent: 1
       type: Transform
-  - uid: 811
+  - uid: 800
     components:
     - pos: -3.5,-16.5
       parent: 1
       type: Transform
-  - uid: 812
+  - uid: 801
     components:
     - pos: -3.5,-17.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 813
+  - uid: 802
     components:
     - pos: -3.5,-18.5
       parent: 1
       type: Transform
-  - uid: 814
+  - uid: 803
     components:
     - pos: -4.5,-18.5
       parent: 1
       type: Transform
-  - uid: 815
+  - uid: 804
     components:
     - pos: -5.5,-18.5
       parent: 1
       type: Transform
-  - uid: 816
+  - uid: 805
     components:
     - pos: -5.5,-19.5
       parent: 1
       type: Transform
-  - uid: 817
+  - uid: 806
     components:
     - pos: -5.5,-20.5
       parent: 1
       type: Transform
-  - uid: 818
+  - uid: 807
     components:
     - pos: -5.5,-21.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 819
+  - uid: 808
     components:
     - pos: -5.5,-22.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 820
+  - uid: 809
     components:
     - pos: -5.5,-23.5
       parent: 1
       type: Transform
-  - uid: 821
+  - uid: 810
     components:
     - pos: -2.5,-21.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 822
+  - uid: 811
     components:
     - pos: -2.5,-23.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 823
+  - uid: 812
     components:
     - pos: -1.5,-23.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 824
+  - uid: 813
     components:
     - pos: -1.5,-22.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 825
+  - uid: 814
     components:
     - pos: -1.5,-21.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 826
+  - uid: 815
     components:
     - pos: -0.5,-23.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 827
+  - uid: 816
     components:
     - pos: 0.5,-23.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 828
+  - uid: 817
     components:
     - pos: 1.5,-23.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 829
+  - uid: 818
     components:
     - pos: 2.5,-23.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 830
+  - uid: 819
     components:
     - pos: 3.5,-23.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 831
+  - uid: 820
     components:
     - pos: 4.5,-23.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 832
+  - uid: 821
     components:
     - pos: 5.5,-23.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 833
+  - uid: 822
     components:
     - pos: -5.5,-24.5
       parent: 1
       type: Transform
-  - uid: 834
+  - uid: 823
     components:
     - pos: -5.5,-25.5
       parent: 1
       type: Transform
-  - uid: 835
+  - uid: 824
     components:
     - pos: -5.5,-26.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 836
+  - uid: 825
     components:
     - pos: -5.5,-27.5
       parent: 1
       type: Transform
-  - uid: 837
+  - uid: 826
     components:
     - pos: -5.5,-28.5
       parent: 1
       type: Transform
-  - uid: 838
+  - uid: 827
     components:
     - pos: -5.5,-29.5
       parent: 1
       type: Transform
-  - uid: 839
+  - uid: 828
     components:
     - pos: -6.5,-29.5
       parent: 1
       type: Transform
-  - uid: 840
+  - uid: 829
     components:
     - pos: -7.5,-29.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 841
+  - uid: 830
     components:
     - pos: -8.5,-29.5
       parent: 1
       type: Transform
-  - uid: 842
+  - uid: 831
     components:
     - pos: -9.5,-29.5
       parent: 1
       type: Transform
-  - uid: 843
+  - uid: 832
     components:
     - pos: -9.5,-28.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 844
+  - uid: 833
     components:
     - pos: -5.5,-30.5
       parent: 1
       type: Transform
-  - uid: 845
+  - uid: 834
     components:
     - pos: -5.5,-31.5
       parent: 1
       type: Transform
-  - uid: 846
+  - uid: 835
     components:
     - pos: -5.5,-32.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 847
+  - uid: 836
     components:
     - pos: -5.5,-33.5
       parent: 1
       type: Transform
-  - uid: 848
+  - uid: 837
     components:
     - pos: -4.5,-33.5
       parent: 1
       type: Transform
-  - uid: 849
+  - uid: 838
     components:
     - pos: -3.5,-33.5
       parent: 1
       type: Transform
-  - uid: 850
+  - uid: 839
     components:
     - pos: -2.5,-33.5
       parent: 1
       type: Transform
-  - uid: 851
+  - uid: 840
     components:
     - pos: -0.5,-33.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 852
+  - uid: 841
     components:
     - pos: 0.5,-33.5
       parent: 1
       type: Transform
-  - uid: 853
+  - uid: 842
     components:
     - pos: 1.5,-33.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 854
+  - uid: 843
     components:
     - pos: 2.5,-33.5
       parent: 1
       type: Transform
-  - uid: 855
+  - uid: 844
     components:
     - pos: 2.5,-34.5
       parent: 1
       type: Transform
-  - uid: 856
+  - uid: 845
     components:
     - pos: 3.5,-34.5
       parent: 1
       type: Transform
-  - uid: 857
+  - uid: 846
     components:
     - pos: 4.5,-34.5
       parent: 1
       type: Transform
-  - uid: 858
+  - uid: 847
     components:
     - pos: 5.5,-34.5
       parent: 1
       type: Transform
-  - uid: 859
+  - uid: 848
     components:
     - pos: 6.5,-34.5
       parent: 1
       type: Transform
-  - uid: 860
+  - uid: 849
     components:
     - pos: 7.5,-34.5
       parent: 1
       type: Transform
-  - uid: 861
+  - uid: 850
     components:
     - pos: 7.5,-33.5
       parent: 1
       type: Transform
-  - uid: 862
+  - uid: 851
     components:
     - pos: 7.5,-32.5
       parent: 1
       type: Transform
-  - uid: 863
+  - uid: 852
     components:
     - pos: 2.5,-32.5
       parent: 1
       type: Transform
-  - uid: 864
+  - uid: 853
     components:
     - pos: 2.5,-31.5
       parent: 1
       type: Transform
-  - uid: 865
+  - uid: 854
     components:
     - pos: 1.5,-31.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
-  - uid: 866
+  - uid: 855
     components:
     - pos: 0.5,-31.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
-  - uid: 867
+  - uid: 856
     components:
     - pos: -0.5,-31.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
-  - uid: 868
+  - uid: 857
     components:
     - pos: -1.5,-31.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
-  - uid: 869
+  - uid: 858
     components:
     - pos: -1.5,-33.5
       parent: 1
       type: Transform
-  - uid: 870
+  - uid: 859
     components:
     - pos: 0.5,-34.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 871
+  - uid: 860
     components:
     - pos: -2.5,-31.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
-  - uid: 872
+  - uid: 861
     components:
     - pos: 0.5,-35.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 873
+  - uid: 862
     components:
     - pos: -1.5,4.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 874
+  - uid: 863
     components:
     - pos: 2.5,4.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 875
+  - uid: 864
     components:
     - pos: 3.5,1.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 876
+  - uid: 865
     components:
     - pos: 2.5,1.5
       parent: 1
       type: Transform
-  - uid: 877
+  - uid: 866
     components:
     - pos: 7.5,-17.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 878
+  - uid: 867
     components:
     - pos: 6.5,-17.5
       parent: 1
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 879
+  - uid: 868
     components:
     - pos: -3.5,3.5
       parent: 1
       type: Transform
 - proto: CableTerminal
   entities:
-  - uid: 880
+  - uid: 869
     components:
     - rot: 1.5707963267948966 rad
       pos: 6.5,-18.5
       parent: 1
       type: Transform
-  - uid: 881
+  - uid: 870
     components:
     - rot: 1.5707963267948966 rad
       pos: 7.5,-32.5
       parent: 1
       type: Transform
-  - uid: 882
+  - uid: 871
     components:
     - rot: 1.5707963267948966 rad
       pos: 7.5,-33.5
       parent: 1
       type: Transform
-  - uid: 883
+  - uid: 872
     components:
     - rot: -1.5707963267948966 rad
       pos: -5.5,-18.5
       parent: 1
       type: Transform
+- proto: CargoPallet
+  entities:
+  - uid: 873
+    components:
+    - pos: 1.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 874
+    components:
+    - pos: -0.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 875
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -1.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 876
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -2.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 877
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 2.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 878
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 3.5,-4.5
+      parent: 1
+      type: Transform
 - proto: Carpet
   entities:
-  - uid: 884
+  - uid: 879
     components:
     - pos: -3.5,-28.5
       parent: 1
       type: Transform
-  - uid: 885
+  - uid: 880
     components:
     - pos: -3.5,-31.5
       parent: 1
       type: Transform
-  - uid: 886
+  - uid: 881
     components:
     - pos: -9.5,-31.5
       parent: 1
       type: Transform
-  - uid: 887
+  - uid: 882
     components:
     - pos: -9.5,-32.5
       parent: 1
       type: Transform
-  - uid: 888
+  - uid: 883
     components:
     - rot: 1.5707963267948966 rad
       pos: -1.5,-0.5
       parent: 1
       type: Transform
-  - uid: 889
+  - uid: 884
     components:
     - rot: 1.5707963267948966 rad
       pos: -1.5,0.5
       parent: 1
       type: Transform
-  - uid: 890
+  - uid: 885
     components:
     - pos: -1.5,1.5
       parent: 1
       type: Transform
 - proto: CarpetBlue
   entities:
-  - uid: 891
+  - uid: 886
     components:
     - rot: -1.5707963267948966 rad
       pos: 4.5,-23.5
       parent: 1
       type: Transform
-  - uid: 892
+  - uid: 887
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,-23.5
       parent: 1
       type: Transform
-  - uid: 893
+  - uid: 888
     components:
     - rot: -1.5707963267948966 rad
       pos: 2.5,-23.5
       parent: 1
       type: Transform
-  - uid: 894
+  - uid: 889
     components:
     - rot: -1.5707963267948966 rad
       pos: 1.5,-23.5
       parent: 1
       type: Transform
-  - uid: 895
+  - uid: 890
     components:
     - rot: -1.5707963267948966 rad
       pos: 0.5,-23.5
       parent: 1
       type: Transform
-  - uid: 896
+  - uid: 891
     components:
     - rot: -1.5707963267948966 rad
       pos: 1.5,-22.5
       parent: 1
       type: Transform
-  - uid: 897
+  - uid: 892
     components:
     - rot: -1.5707963267948966 rad
       pos: 0.5,-22.5
       parent: 1
       type: Transform
-  - uid: 898
+  - uid: 893
     components:
     - rot: -1.5707963267948966 rad
       pos: -0.5,-22.5
       parent: 1
       type: Transform
-  - uid: 899
+  - uid: 894
     components:
     - rot: -1.5707963267948966 rad
       pos: -0.5,-23.5
       parent: 1
       type: Transform
-  - uid: 900
+  - uid: 895
     components:
     - rot: -1.5707963267948966 rad
       pos: -1.5,-23.5
       parent: 1
       type: Transform
-  - uid: 901
+  - uid: 896
     components:
     - rot: -1.5707963267948966 rad
       pos: -2.5,-23.5
       parent: 1
       type: Transform
-  - uid: 902
+  - uid: 897
     components:
     - rot: -1.5707963267948966 rad
       pos: -3.5,-23.5
       parent: 1
       type: Transform
-  - uid: 903
+  - uid: 898
     components:
     - rot: -1.5707963267948966 rad
       pos: -1.5,-22.5
       parent: 1
       type: Transform
-  - uid: 904
+  - uid: 899
     components:
     - rot: -1.5707963267948966 rad
       pos: -1.5,-21.5
       parent: 1
       type: Transform
-  - uid: 905
+  - uid: 900
     components:
     - rot: -1.5707963267948966 rad
       pos: 2.5,-21.5
       parent: 1
       type: Transform
-  - uid: 906
+  - uid: 901
     components:
     - rot: -1.5707963267948966 rad
       pos: 2.5,-22.5
@@ -5847,18 +5923,18 @@ entities:
       type: Transform
 - proto: CarpetGreen
   entities:
-  - uid: 907
+  - uid: 902
     components:
     - pos: 0.5,-31.5
       parent: 1
       type: Transform
-  - uid: 908
+  - uid: 903
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,-31.5
       parent: 1
       type: Transform
-  - uid: 909
+  - uid: 904
     components:
     - rot: 3.141592653589793 rad
       pos: -1.5,-31.5
@@ -5866,152 +5942,594 @@ entities:
       type: Transform
 - proto: CarpetOrange
   entities:
-  - uid: 910
+  - uid: 905
     components:
     - pos: -1.5,-27.5
       parent: 1
       type: Transform
-  - uid: 911
+  - uid: 906
     components:
     - pos: -0.5,-27.5
       parent: 1
       type: Transform
-  - uid: 912
+  - uid: 907
     components:
     - pos: 0.5,-28.5
       parent: 1
       type: Transform
-  - uid: 913
+  - uid: 908
     components:
     - pos: -0.5,-28.5
       parent: 1
       type: Transform
-  - uid: 914
+  - uid: 909
     components:
     - pos: -1.5,-28.5
       parent: 1
       type: Transform
-  - uid: 915
+  - uid: 910
     components:
     - pos: -0.5,-29.5
       parent: 1
       type: Transform
-  - uid: 916
+  - uid: 911
     components:
     - pos: 0.5,-29.5
       parent: 1
       type: Transform
-  - uid: 917
+  - uid: 912
     components:
     - rot: 1.5707963267948966 rad
       pos: 2.5,1.5
       parent: 1
       type: Transform
-  - uid: 918
+  - uid: 913
     components:
     - pos: 2.5,0.5
       parent: 1
       type: Transform
-  - uid: 919
+  - uid: 914
     components:
     - pos: 2.5,1.5
       parent: 1
       type: Transform
-  - uid: 920
+  - uid: 915
     components:
     - rot: 1.5707963267948966 rad
       pos: 1.5,-0.5
       parent: 1
       type: Transform
-  - uid: 921
+  - uid: 916
     components:
     - rot: 1.5707963267948966 rad
       pos: 1.5,0.5
       parent: 1
       type: Transform
-  - uid: 922
+  - uid: 917
     components:
     - pos: 0.5,1.5
       parent: 1
       type: Transform
-  - uid: 923
+  - uid: 918
     components:
     - pos: 1.5,1.5
       parent: 1
       type: Transform
-  - uid: 924
+  - uid: 919
     components:
     - rot: 1.5707963267948966 rad
       pos: 0.5,0.5
       parent: 1
       type: Transform
-  - uid: 925
+  - uid: 920
     components:
     - rot: 1.5707963267948966 rad
       pos: 0.5,-0.5
       parent: 1
       type: Transform
-  - uid: 926
+  - uid: 921
     components:
     - pos: 2.5,-0.5
       parent: 1
       type: Transform
 - proto: CarpetSBlue
   entities:
-  - uid: 927
+  - uid: 922
     components:
     - rot: -1.5707963267948966 rad
       pos: 4.5,-25.5
       parent: 1
       type: Transform
-  - uid: 928
+  - uid: 923
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,-25.5
       parent: 1
       type: Transform
-  - uid: 929
+  - uid: 924
     components:
     - rot: -1.5707963267948966 rad
       pos: 2.5,-25.5
       parent: 1
       type: Transform
-  - uid: 930
+  - uid: 925
     components:
     - rot: -1.5707963267948966 rad
       pos: 2.5,-24.5
       parent: 1
       type: Transform
-  - uid: 931
+  - uid: 926
     components:
     - rot: -1.5707963267948966 rad
       pos: 1.5,-24.5
       parent: 1
       type: Transform
-  - uid: 932
+  - uid: 927
     components:
     - pos: 0.5,-24.5
       parent: 1
       type: Transform
-  - uid: 933
+  - uid: 928
     components:
     - pos: 1.5,-25.5
       parent: 1
       type: Transform
-- proto: Chair
+- proto: Catwalk
   entities:
+  - uid: 929
+    components:
+    - pos: 9.5,-28.5
+      parent: 1
+      type: Transform
+  - uid: 930
+    components:
+    - pos: 8.5,-27.5
+      parent: 1
+      type: Transform
+  - uid: 931
+    components:
+    - pos: 10.5,-27.5
+      parent: 1
+      type: Transform
+  - uid: 932
+    components:
+    - pos: 11.5,-29.5
+      parent: 1
+      type: Transform
+  - uid: 933
+    components:
+    - pos: 6.5,-26.5
+      parent: 1
+      type: Transform
+  - uid: 934
+    components:
+    - pos: -5.5,-26.5
+      parent: 1
+      type: Transform
+  - uid: 935
+    components:
+    - pos: -4.5,-27.5
+      parent: 1
+      type: Transform
+  - uid: 936
+    components:
+    - pos: -4.5,-30.5
+      parent: 1
+      type: Transform
+  - uid: 937
+    components:
+    - pos: -5.5,-32.5
+      parent: 1
+      type: Transform
+  - uid: 938
+    components:
+    - pos: -0.5,-33.5
+      parent: 1
+      type: Transform
+  - uid: 939
+    components:
+    - pos: 1.5,-33.5
+      parent: 1
+      type: Transform
+  - uid: 940
+    components:
+    - pos: 1.5,-31.5
+      parent: 1
+      type: Transform
+  - uid: 941
+    components:
+    - pos: -5.5,-21.5
+      parent: 1
+      type: Transform
+  - uid: 942
+    components:
+    - pos: -3.5,-17.5
+      parent: 1
+      type: Transform
+  - uid: 943
+    components:
+    - pos: 6.5,-21.5
+      parent: 1
+      type: Transform
+  - uid: 944
+    components:
+    - pos: 6.5,-22.5
+      parent: 1
+      type: Transform
+  - uid: 945
+    components:
+    - pos: 4.5,-17.5
+      parent: 1
+      type: Transform
+  - uid: 946
+    components:
+    - pos: -4.5,-12.5
+      parent: 1
+      type: Transform
+  - uid: 947
+    components:
+    - pos: 5.5,-12.5
+      parent: 1
+      type: Transform
+  - uid: 948
+    components:
+    - pos: 4.5,-11.5
+      parent: 1
+      type: Transform
+  - uid: 949
+    components:
+    - pos: -3.5,-11.5
+      parent: 1
+      type: Transform
+  - uid: 950
+    components:
+    - pos: -4.5,-8.5
+      parent: 1
+      type: Transform
+  - uid: 951
+    components:
+    - pos: 5.5,-8.5
+      parent: 1
+      type: Transform
+  - uid: 952
+    components:
+    - pos: -5.5,-0.5
+      parent: 1
+      type: Transform
+  - uid: 953
+    components:
+    - pos: -5.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 954
+    components:
+    - pos: -5.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 955
+    components:
+    - pos: -5.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 956
+    components:
+    - pos: -7.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 957
+    components:
+    - pos: -7.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 958
+    components:
+    - pos: -7.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 959
+    components:
+    - pos: -0.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 960
+    components:
+    - pos: 0.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 961
+    components:
+    - pos: 1.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 962
+    components:
+    - pos: 6.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 963
+    components:
+    - pos: 6.5,3.5
+      parent: 1
+      type: Transform
   - uid: 964
     components:
-    - pos: -5.5,-11.5
+    - pos: 6.5,2.5
       parent: 1
       type: Transform
   - uid: 965
+    components:
+    - pos: -0.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 966
+    components:
+    - pos: 0.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 967
+    components:
+    - pos: 1.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 968
+    components:
+    - pos: 8.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 969
+    components:
+    - pos: 8.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 970
+    components:
+    - pos: 8.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 971
+    components:
+    - pos: 0.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 972
+    components:
+    - pos: -5.5,-22.5
+      parent: 1
+      type: Transform
+  - uid: 973
+    components:
+    - pos: -4.5,-23.5
+      parent: 1
+      type: Transform
+  - uid: 974
+    components:
+    - pos: 5.5,-23.5
+      parent: 1
+      type: Transform
+  - uid: 975
+    components:
+    - pos: -7.5,-31.5
+      parent: 1
+      type: Transform
+  - uid: 976
+    components:
+    - pos: -7.5,-29.5
+      parent: 1
+      type: Transform
+  - uid: 977
+    components:
+    - pos: -10.5,-29.5
+      parent: 1
+      type: Transform
+  - uid: 978
+    components:
+    - pos: -7.5,-27.5
+      parent: 1
+      type: Transform
+  - uid: 979
+    components:
+    - pos: -9.5,-27.5
+      parent: 1
+      type: Transform
+  - uid: 980
+    components:
+    - pos: -4.5,-5.5
+      parent: 1
+      type: Transform
+  - uid: 981
+    components:
+    - pos: -4.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 982
+    components:
+    - pos: -4.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 983
+    components:
+    - pos: -4.5,-2.5
+      parent: 1
+      type: Transform
+  - uid: 984
+    components:
+    - pos: -4.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 985
+    components:
+    - pos: -4.5,-0.5
+      parent: 1
+      type: Transform
+  - uid: 986
+    components:
+    - pos: -4.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 987
+    components:
+    - pos: -4.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 988
+    components:
+    - pos: -4.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 989
+    components:
+    - pos: -4.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 990
+    components:
+    - pos: -4.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 991
+    components:
+    - pos: -3.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 992
+    components:
+    - pos: -2.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 993
+    components:
+    - pos: -1.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 994
+    components:
+    - pos: -1.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 995
+    components:
+    - pos: -1.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 996
+    components:
+    - pos: -1.5,7.5
+      parent: 1
+      type: Transform
+  - uid: 997
+    components:
+    - pos: -1.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 998
+    components:
+    - pos: -1.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 999
+    components:
+    - pos: 2.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 1000
+    components:
+    - pos: 2.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 1001
+    components:
+    - pos: 2.5,7.5
+      parent: 1
+      type: Transform
+  - uid: 1002
+    components:
+    - pos: 2.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 1003
+    components:
+    - pos: 2.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 1004
+    components:
+    - pos: 2.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 1005
+    components:
+    - pos: 3.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 1006
+    components:
+    - pos: 4.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 1007
+    components:
+    - pos: 5.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 1008
+    components:
+    - pos: 5.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 1009
+    components:
+    - pos: 5.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 1010
+    components:
+    - pos: 5.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 1011
+    components:
+    - pos: 5.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 1012
+    components:
+    - pos: 5.5,-0.5
+      parent: 1
+      type: Transform
+  - uid: 1013
+    components:
+    - pos: 5.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 1014
+    components:
+    - pos: 5.5,-2.5
+      parent: 1
+      type: Transform
+  - uid: 1015
+    components:
+    - pos: 5.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 1016
+    components:
+    - pos: 5.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 1017
+    components:
+    - pos: 5.5,-5.5
+      parent: 1
+      type: Transform
+- proto: Chair
+  entities:
+  - uid: 1018
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,-31.5
       parent: 1
       type: Transform
-  - uid: 966
+  - uid: 1019
     components:
     - rot: 1.5707963267948966 rad
       pos: -6.5,0.5
@@ -6019,25 +6537,25 @@ entities:
       type: Transform
 - proto: ChairFolding
   entities:
-  - uid: 967
+  - uid: 1020
     components:
     - rot: 1.5707963267948966 rad
       pos: -0.5,-7.5
       parent: 1
       type: Transform
-  - uid: 968
+  - uid: 1021
     components:
     - rot: 1.5707963267948966 rad
       pos: -0.5,-8.5
       parent: 1
       type: Transform
-  - uid: 969
+  - uid: 1022
     components:
     - rot: -1.5707963267948966 rad
       pos: 1.5,-7.5
       parent: 1
       type: Transform
-  - uid: 970
+  - uid: 1023
     components:
     - rot: -1.5707963267948966 rad
       pos: 1.5,-8.5
@@ -6045,21 +6563,21 @@ entities:
       type: Transform
 - proto: ChairFoldingSpawnFolded
   entities:
-  - uid: 971
+  - uid: 1024
     components:
     - pos: -5.3470545,-8.756538
       parent: 1
       type: Transform
 - proto: ChairOfficeDark
   entities:
-  - uid: 972
+  - uid: 1025
     components:
     - pos: -0.5,-29.5
       parent: 1
       type: Transform
 - proto: ChairOfficeLight
   entities:
-  - uid: 973
+  - uid: 1026
     components:
     - rot: 1.5707963267948966 rad
       pos: -1.5,0.5
@@ -6067,19 +6585,19 @@ entities:
       type: Transform
 - proto: ChairPilotSeat
   entities:
-  - uid: 974
+  - uid: 1027
     components:
     - rot: 3.141592653589793 rad
       pos: 1.5,-22.5
       parent: 1
       type: Transform
-  - uid: 975
+  - uid: 1028
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,-22.5
       parent: 1
       type: Transform
-  - uid: 976
+  - uid: 1029
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,-22.5
@@ -6087,62 +6605,61 @@ entities:
       type: Transform
 - proto: CheapLighter
   entities:
-  - uid: 977
-    components:
-    - pos: -6.827763,-16.46172
-      parent: 1
-      type: Transform
-  - uid: 978
+  - uid: 1030
     components:
     - pos: 7.777271,-16.329456
       parent: 1
       type: Transform
+  - uid: 1031
+    components:
+    - pos: -6.77578,-16.362549
+      parent: 1
+      type: Transform
 - proto: chem_master
   entities:
-  - uid: 979
+  - uid: 1032
     components:
     - pos: 7.5,-12.5
       parent: 1
       type: Transform
 - proto: Cigar
   entities:
-  - uid: 980
+  - uid: 1033
     components:
     - pos: -0.4920463,-17.327991
       parent: 1
       type: Transform
 - proto: Cigarette
   entities:
-  - uid: 981
+  - uid: 1034
     components:
-    - rot: 3.141592653589793 rad
-      pos: -6.721682,-16.35748
+    - pos: -6.46328,-16.028984
       parent: 1
       type: Transform
-  - uid: 982
+  - uid: 1035
     components:
     - pos: 7.607122,-16.079285
       parent: 1
       type: Transform
 - proto: CigarGold
   entities:
-  - uid: 983
+  - uid: 1036
     components:
     - pos: -0.64304274,-30.25811
       parent: 1
       type: Transform
-  - uid: 984
+  - uid: 1037
     components:
     - pos: -0.7390743,0.7418492
       parent: 1
       type: Transform
-  - uid: 985
+  - uid: 1038
     components:
     - rot: -1.5707963267948966 rad
       pos: 1.4902998,-25.30999
       parent: 1
       type: Transform
-  - uid: 986
+  - uid: 1039
     components:
     - rot: -1.5707963267948966 rad
       pos: 1.3340497,-25.372534
@@ -6150,308 +6667,308 @@ entities:
       type: Transform
 - proto: ClosetToolFilled
   entities:
-  - uid: 987
+  - uid: 1040
     components:
     - pos: 7.5,-28.5
       parent: 1
       type: Transform
 - proto: ClosetWallEmergencyFilledRandom
   entities:
-  - uid: 988
+  - uid: 1041
     components:
     - rot: 1.5707963267948966 rad
       pos: -4.5,-31.5
       parent: 1
       type: Transform
-  - uid: 989
+  - uid: 1042
     components:
     - rot: 1.5707963267948966 rad
       pos: -4.5,-28.5
       parent: 1
       type: Transform
-  - uid: 990
+  - uid: 1043
     components:
     - pos: -8.5,-30.5
       parent: 1
       type: Transform
-  - uid: 991
+  - uid: 1044
     components:
     - pos: -2.5,-12.5
       parent: 1
       type: Transform
 - proto: ClosetWallFireFilledRandom
   entities:
-  - uid: 992
+  - uid: 1045
     components:
     - pos: 3.5,-12.5
       parent: 1
       type: Transform
 - proto: ClosetWallMaintenanceFilledRandom
   entities:
-  - uid: 993
+  - uid: 1046
     components:
     - pos: -3.5,-29.5
       parent: 1
       type: Transform
-  - uid: 994
+  - uid: 1047
     components:
     - pos: -3.5,-26.5
       parent: 1
       type: Transform
-  - uid: 995
+  - uid: 1048
     components:
     - pos: -9.5,-30.5
       parent: 1
       type: Transform
 - proto: ClothingBackpackCaptain
   entities:
-  - uid: 230
+  - uid: 219
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 227
+    - parent: 216
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: ClothingBackpackDuffelSurgeryFilled
   entities:
-  - uid: 996
+  - uid: 1049
     components:
-    - pos: -6.4108167,-16.391489
+    - pos: -6.3591137,-16.300005
       parent: 1
       type: Transform
 - proto: ClothingBeltSheathFilled
   entities:
-  - uid: 231
+  - uid: 220
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 227
+    - parent: 216
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: ClothingBeltUtilityEngineering
   entities:
-  - uid: 103
+  - uid: 107
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 100
+    - parent: 103
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 998
+  - uid: 1051
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 997
+    - parent: 1050
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 1002
+  - uid: 1055
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 1001
+    - parent: 1054
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: ClothingEyesGlassesMeson
   entities:
-  - uid: 999
+  - uid: 1052
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 997
+    - parent: 1050
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 1003
+  - uid: 1056
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 1001
+    - parent: 1054
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: ClothingEyesGlassesSecurity
   entities:
-  - uid: 232
+  - uid: 221
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 227
+    - parent: 216
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: ClothingEyesGlassesSunglasses
   entities:
-  - uid: 233
+  - uid: 222
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 227
+    - parent: 216
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: ClothingHandsGlovesCaptain
   entities:
-  - uid: 234
+  - uid: 223
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 227
+    - parent: 216
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: ClothingHeadHatBowlerHat
   entities:
-  - uid: 1005
+  - uid: 1058
     components:
     - pos: 1.3621204,-17.150785
       parent: 1
       type: Transform
 - proto: ClothingHeadHatCaptain
   entities:
-  - uid: 235
+  - uid: 224
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 227
+    - parent: 216
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: ClothingHeadHatCone
   entities:
-  - uid: 1006
+  - uid: 1059
     components:
     - pos: 4.469919,-30.10354
       parent: 1
       type: Transform
 - proto: ClothingHeadHatFancyCrown
   entities:
-  - uid: 104
+  - uid: 108
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 100
+    - parent: 103
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: ClothingHeadHatPirate
   entities:
-  - uid: 1008
+  - uid: 1061
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 1007
+    - parent: 1060
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: ClothingHeadHatQMsoft
   entities:
-  - uid: 105
+  - uid: 109
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 100
+    - parent: 103
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: ClothingHeadHelmetEVA
   entities:
-  - uid: 1012
+  - uid: 1065
     components:
     - pos: 10.221624,-32.356922
       parent: 1
       type: Transform
 - proto: ClothingHeadsetAltCargo
   entities:
-  - uid: 106
+  - uid: 110
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 100
+    - parent: 103
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: ClothingMaskItalianMoustache
   entities:
-  - uid: 236
+  - uid: 225
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 227
+    - parent: 216
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: ClothingNeckCloakCap
   entities:
-  - uid: 237
+  - uid: 226
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 227
+    - parent: 216
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: ClothingNeckCloakCapFormal
   entities:
-  - uid: 238
+  - uid: 227
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 227
+    - parent: 216
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: ClothingNeckCloakPirateCap
   entities:
-  - uid: 1009
+  - uid: 1062
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 1007
+    - parent: 1060
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: ClothingNeckCloakQm
   entities:
-  - uid: 107
+  - uid: 111
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 100
+    - parent: 103
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: ClothingOuterArmorCaptainCarapace
   entities:
-  - uid: 239
+  - uid: 228
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 227
+    - parent: 216
       type: Transform
     - group:
       - hoverMessage: ""
@@ -6487,94 +7004,118 @@ entities:
     - type: InsideEntityStorage
 - proto: ClothingOuterHardsuitEVA
   entities:
-  - uid: 1013
+  - uid: 1066
     components:
     - pos: 10.643499,-32.59146
       parent: 1
       type: Transform
-- proto: ClothingOuterWinterCap
+- proto: ClothingOuterHardsuitMedical
   entities:
-  - uid: 240
+  - uid: 1068
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 227
+    - parent: 1067
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: ClothingOuterWinterCap
+  entities:
+  - uid: 229
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 216
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: ClothingOuterWinterQM
   entities:
-  - uid: 108
+  - uid: 112
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 100
+    - parent: 103
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: ClothingUniformJumpskirtCapFormalDress
   entities:
-  - uid: 241
+  - uid: 230
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 227
+    - parent: 216
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: ClothingUniformJumpskirtCaptain
   entities:
-  - uid: 242
+  - uid: 231
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 227
+    - parent: 216
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: ClothingUniformJumpsuitCapFormal
   entities:
-  - uid: 243
+  - uid: 232
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 227
+    - parent: 216
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: ClothingUniformJumpsuitCaptain
   entities:
-  - uid: 244
+  - uid: 233
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 227
+    - parent: 216
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: ComfyChair
   entities:
-  - uid: 1014
+  - uid: 1069
     components:
     - rot: 3.141592653589793 rad
       pos: -1.5,-17.5
       parent: 1
       type: Transform
-  - uid: 1015
+  - uid: 1070
     components:
     - rot: 3.141592653589793 rad
       pos: 2.5,-17.5
       parent: 1
       type: Transform
+- proto: ComputerCrewMonitoring
+  entities:
+  - uid: 1071
+    components:
+    - pos: -5.5,-11.5
+      parent: 1
+      type: Transform
+  - uid: 1072
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -3.5,-24.5
+      parent: 1
+      type: Transform
 - proto: ComputerPowerMonitoring
   entities:
-  - uid: 1016
+  - uid: 1073
     components:
     - rot: 1.5707963267948966 rad
       pos: -1.5,-29.5
@@ -6582,41 +7123,49 @@ entities:
       type: Transform
 - proto: ComputerRadar
   entities:
-  - uid: 1017
+  - uid: 1074
     components:
     - pos: 1.5,-21.5
       parent: 1
       type: Transform
-  - uid: 1018
+  - uid: 1075
     components:
     - pos: -1.5,1.5
       parent: 1
       type: Transform
 - proto: ComputerSalvageExpedition
   entities:
-  - uid: 1019
+  - uid: 1076
     components:
     - pos: -0.5,-21.5
       parent: 1
       type: Transform
 - proto: ComputerShuttle
   entities:
-  - uid: 1020
+  - uid: 1077
     components:
     - pos: 0.5,-21.5
       parent: 1
       type: Transform
 - proto: ComputerStationRecords
   entities:
-  - uid: 1021
+  - uid: 1078
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,-24.5
       parent: 1
       type: Transform
+- proto: ComputerSurveillanceCameraMonitor
+  entities:
+  - uid: 1079
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -3.5,-25.5
+      parent: 1
+      type: Transform
 - proto: ComputerWallmountWithdrawBankATM
   entities:
-  - uid: 1022
+  - uid: 1080
     components:
     - rot: 1.5707963267948966 rad
       pos: 2.5,-1.5
@@ -6624,368 +7173,368 @@ entities:
       type: Transform
 - proto: ConveyorBelt
   entities:
-  - uid: 1023
+  - uid: 1081
     components:
     - rot: 3.141592653589793 rad
       pos: -4.5,-5.5
       parent: 1
       type: Transform
     - links:
-      - 2075
+      - 2157
       type: DeviceLinkSink
-  - uid: 1024
+  - uid: 1082
     components:
     - rot: 3.141592653589793 rad
       pos: -4.5,-4.5
       parent: 1
       type: Transform
     - links:
-      - 2075
+      - 2157
       type: DeviceLinkSink
-  - uid: 1025
+  - uid: 1083
     components:
     - rot: 3.141592653589793 rad
       pos: -4.5,-3.5
       parent: 1
       type: Transform
     - links:
-      - 2075
+      - 2157
       type: DeviceLinkSink
-  - uid: 1026
+  - uid: 1084
     components:
     - rot: 3.141592653589793 rad
       pos: -4.5,-2.5
       parent: 1
       type: Transform
     - links:
-      - 2075
+      - 2157
       type: DeviceLinkSink
-  - uid: 1027
+  - uid: 1085
     components:
     - rot: 3.141592653589793 rad
       pos: -4.5,-1.5
       parent: 1
       type: Transform
     - links:
-      - 2075
+      - 2157
       type: DeviceLinkSink
-  - uid: 1028
+  - uid: 1086
     components:
     - rot: 3.141592653589793 rad
       pos: -4.5,-0.5
       parent: 1
       type: Transform
     - links:
-      - 2075
+      - 2157
       type: DeviceLinkSink
-  - uid: 1029
+  - uid: 1087
     components:
     - rot: 3.141592653589793 rad
       pos: -4.5,0.5
       parent: 1
       type: Transform
     - links:
-      - 2075
+      - 2157
       type: DeviceLinkSink
-  - uid: 1030
+  - uid: 1088
     components:
     - rot: 3.141592653589793 rad
       pos: -4.5,2.5
       parent: 1
       type: Transform
     - links:
-      - 2075
+      - 2157
       type: DeviceLinkSink
-  - uid: 1031
+  - uid: 1089
     components:
     - rot: 3.141592653589793 rad
       pos: -4.5,3.5
       parent: 1
       type: Transform
     - links:
-      - 2075
+      - 2157
       type: DeviceLinkSink
-  - uid: 1032
+  - uid: 1090
     components:
     - rot: 1.5707963267948966 rad
       pos: -4.5,4.5
       parent: 1
       type: Transform
     - links:
-      - 2075
+      - 2157
       type: DeviceLinkSink
-  - uid: 1033
+  - uid: 1091
     components:
     - rot: 1.5707963267948966 rad
       pos: -3.5,4.5
       parent: 1
       type: Transform
     - links:
-      - 2075
+      - 2157
       type: DeviceLinkSink
-  - uid: 1034
+  - uid: 1092
     components:
     - rot: 1.5707963267948966 rad
       pos: -2.5,4.5
       parent: 1
       type: Transform
     - links:
-      - 2075
+      - 2157
       type: DeviceLinkSink
-  - uid: 1035
+  - uid: 1093
     components:
     - rot: 3.141592653589793 rad
       pos: -1.5,4.5
       parent: 1
       type: Transform
     - links:
-      - 2075
+      - 2157
       type: DeviceLinkSink
-  - uid: 1036
+  - uid: 1094
     components:
     - rot: 3.141592653589793 rad
       pos: -1.5,5.5
       parent: 1
       type: Transform
     - links:
-      - 2075
+      - 2157
       type: DeviceLinkSink
-  - uid: 1037
+  - uid: 1095
     components:
     - rot: 3.141592653589793 rad
       pos: -1.5,6.5
       parent: 1
       type: Transform
     - links:
-      - 2075
+      - 2157
       type: DeviceLinkSink
-  - uid: 1038
+  - uid: 1096
     components:
     - rot: 3.141592653589793 rad
       pos: -1.5,7.5
       parent: 1
       type: Transform
     - links:
-      - 2075
+      - 2157
       type: DeviceLinkSink
-  - uid: 1039
+  - uid: 1097
     components:
     - rot: 3.141592653589793 rad
       pos: -1.5,8.5
       parent: 1
       type: Transform
     - links:
-      - 2075
+      - 2157
       type: DeviceLinkSink
-  - uid: 1040
+  - uid: 1098
     components:
     - rot: 3.141592653589793 rad
       pos: -1.5,9.5
       parent: 1
       type: Transform
     - links:
-      - 2075
+      - 2157
       type: DeviceLinkSink
-  - uid: 1041
+  - uid: 1099
     components:
     - rot: 3.141592653589793 rad
       pos: -1.5,10.5
       parent: 1
       type: Transform
     - links:
-      - 2075
+      - 2157
       type: DeviceLinkSink
-  - uid: 1042
+  - uid: 1100
     components:
     - pos: 2.5,10.5
       parent: 1
       type: Transform
     - links:
-      - 2076
+      - 2158
       type: DeviceLinkSink
-  - uid: 1043
+  - uid: 1101
     components:
     - pos: 2.5,9.5
       parent: 1
       type: Transform
     - links:
-      - 2076
+      - 2158
       type: DeviceLinkSink
-  - uid: 1044
+  - uid: 1102
     components:
     - pos: 2.5,8.5
       parent: 1
       type: Transform
     - links:
-      - 2076
+      - 2158
       type: DeviceLinkSink
-  - uid: 1045
+  - uid: 1103
     components:
     - pos: 2.5,7.5
       parent: 1
       type: Transform
     - links:
-      - 2076
+      - 2158
       type: DeviceLinkSink
-  - uid: 1046
+  - uid: 1104
     components:
     - pos: 2.5,6.5
       parent: 1
       type: Transform
     - links:
-      - 2076
+      - 2158
       type: DeviceLinkSink
-  - uid: 1047
+  - uid: 1105
     components:
     - pos: 2.5,5.5
       parent: 1
       type: Transform
     - links:
-      - 2076
+      - 2158
       type: DeviceLinkSink
-  - uid: 1048
+  - uid: 1106
     components:
     - rot: 1.5707963267948966 rad
       pos: 2.5,4.5
       parent: 1
       type: Transform
     - links:
-      - 2076
+      - 2158
       type: DeviceLinkSink
-  - uid: 1049
+  - uid: 1107
     components:
     - rot: 1.5707963267948966 rad
       pos: 3.5,4.5
       parent: 1
       type: Transform
     - links:
-      - 2076
+      - 2158
       type: DeviceLinkSink
-  - uid: 1050
+  - uid: 1108
     components:
     - rot: 1.5707963267948966 rad
       pos: 4.5,4.5
       parent: 1
       type: Transform
     - links:
-      - 2076
+      - 2158
       type: DeviceLinkSink
-  - uid: 1051
+  - uid: 1109
     components:
     - pos: 5.5,4.5
       parent: 1
       type: Transform
     - links:
-      - 2076
+      - 2158
       type: DeviceLinkSink
-  - uid: 1052
+  - uid: 1110
     components:
     - pos: 5.5,3.5
       parent: 1
       type: Transform
     - links:
-      - 2076
+      - 2158
       type: DeviceLinkSink
-  - uid: 1053
+  - uid: 1111
     components:
     - pos: 5.5,2.5
       parent: 1
       type: Transform
     - links:
-      - 2076
+      - 2158
       type: DeviceLinkSink
-  - uid: 1054
+  - uid: 1112
     components:
     - pos: 5.5,0.5
       parent: 1
       type: Transform
     - links:
-      - 2076
+      - 2158
       type: DeviceLinkSink
-  - uid: 1055
+  - uid: 1113
     components:
     - pos: 5.5,-0.5
       parent: 1
       type: Transform
     - links:
-      - 2076
+      - 2158
       type: DeviceLinkSink
-  - uid: 1056
+  - uid: 1114
     components:
     - pos: 5.5,-1.5
       parent: 1
       type: Transform
     - links:
-      - 2076
+      - 2158
       type: DeviceLinkSink
-  - uid: 1057
+  - uid: 1115
     components:
     - pos: 5.5,-2.5
       parent: 1
       type: Transform
     - links:
-      - 2076
+      - 2158
       type: DeviceLinkSink
-  - uid: 1058
+  - uid: 1116
     components:
     - pos: 5.5,-3.5
       parent: 1
       type: Transform
     - links:
-      - 2076
+      - 2158
       type: DeviceLinkSink
-  - uid: 1059
+  - uid: 1117
     components:
     - pos: 5.5,-4.5
       parent: 1
       type: Transform
     - links:
-      - 2076
+      - 2158
       type: DeviceLinkSink
-  - uid: 1060
+  - uid: 1118
     components:
     - pos: 5.5,-5.5
       parent: 1
       type: Transform
     - links:
-      - 2076
+      - 2158
       type: DeviceLinkSink
 - proto: ConveyorBeltAssembly
   entities:
-  - uid: 1061
+  - uid: 1119
     components:
     - pos: 2.4542723,-2.6279476
       parent: 1
       type: Transform
-  - uid: 1062
+  - uid: 1120
     components:
     - pos: 2.5261548,-2.3826964
       parent: 1
       type: Transform
 - proto: CrateEngineeringAMEJar
   entities:
-  - uid: 1063
+  - uid: 1121
     components:
     - pos: 3.5,-30.5
       parent: 1
       type: Transform
 - proto: CrateEngineeringCableBulk
   entities:
-  - uid: 1064
+  - uid: 1122
     components:
     - pos: 2.5,-30.5
       parent: 1
       type: Transform
 - proto: CrateEngineeringGenerator
   entities:
-  - uid: 1065
+  - uid: 1123
     components:
     - pos: 7.5,-30.5
       parent: 1
       type: Transform
 - proto: CratePirate
   entities:
-  - uid: 1007
+  - uid: 1060
     components:
     - pos: -0.5,-25.5
       parent: 1
@@ -7013,10 +7562,10 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 1011
-          - 1010
-          - 1008
-          - 1009
+          - 1064
+          - 1063
+          - 1061
+          - 1062
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -7024,152 +7573,151 @@ entities:
       type: ContainerContainer
 - proto: CrowbarRed
   entities:
-  - uid: 1066
+  - uid: 1124
     components:
     - pos: 1.4561255,-25.424812
       parent: 1
       type: Transform
 - proto: DefibrillatorCabinetFilled
   entities:
-  - uid: 1067
+  - uid: 1125
     components:
-    - rot: 3.141592653589793 rad
-      pos: -5.5,-17.5
+    - pos: -6.5,-14.5
       parent: 1
       type: Transform
 - proto: DisposalBend
   entities:
-  - uid: 1068
+  - uid: 1126
     components:
     - rot: -1.5707963267948966 rad
       pos: 0.5,-4.5
       parent: 1
       type: Transform
-  - uid: 1069
+  - uid: 1127
     components:
     - rot: -1.5707963267948966 rad
       pos: -3.5,-18.5
       parent: 1
       type: Transform
-  - uid: 1070
+  - uid: 1128
     components:
     - rot: 1.5707963267948966 rad
       pos: -5.5,-18.5
       parent: 1
       type: Transform
-  - uid: 1071
+  - uid: 1129
     components:
     - rot: 3.141592653589793 rad
       pos: -5.5,-33.5
       parent: 1
       type: Transform
-  - uid: 1072
+  - uid: 1130
     components:
     - rot: -1.5707963267948966 rad
       pos: 6.5,-33.5
       parent: 1
       type: Transform
-  - uid: 1073
+  - uid: 1131
     components:
     - pos: 6.5,-18.5
       parent: 1
       type: Transform
-  - uid: 1074
+  - uid: 1132
     components:
     - rot: 3.141592653589793 rad
       pos: 4.5,-18.5
       parent: 1
       type: Transform
-  - uid: 1075
+  - uid: 1133
     components:
     - pos: 4.5,-10.5
       parent: 1
       type: Transform
-  - uid: 1076
+  - uid: 1134
     components:
     - rot: 3.141592653589793 rad
       pos: 3.5,-10.5
       parent: 1
       type: Transform
-  - uid: 1077
+  - uid: 1135
     components:
     - pos: 2.5,-31.5
       parent: 1
       type: Transform
-  - uid: 1078
+  - uid: 1136
     components:
     - rot: -1.5707963267948966 rad
       pos: 1.5,-0.5
       parent: 1
       type: Transform
-  - uid: 1079
+  - uid: 1137
     components:
     - rot: 1.5707963267948966 rad
       pos: 0.5,-0.5
       parent: 1
       type: Transform
-  - uid: 1080
+  - uid: 1138
     components:
     - rot: 1.5707963267948966 rad
       pos: -0.5,-4.5
       parent: 1
       type: Transform
-  - uid: 1081
+  - uid: 1139
     components:
     - pos: 3.5,-8.5
       parent: 1
       type: Transform
-  - uid: 1082
+  - uid: 1140
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,-9.5
       parent: 1
       type: Transform
-  - uid: 1083
+  - uid: 1141
     components:
     - pos: 10.5,-29.5
       parent: 1
       type: Transform
-  - uid: 1084
+  - uid: 1142
     components:
     - rot: 3.141592653589793 rad
       pos: 9.5,-29.5
       parent: 1
       type: Transform
-  - uid: 1085
+  - uid: 1143
     components:
     - pos: 9.5,-27.5
       parent: 1
       type: Transform
-  - uid: 1086
+  - uid: 1144
     components:
     - rot: 3.141592653589793 rad
       pos: 7.5,-27.5
       parent: 1
       type: Transform
-  - uid: 1087
+  - uid: 1145
     components:
     - pos: 7.5,-24.5
       parent: 1
       type: Transform
-  - uid: 1088
+  - uid: 1146
     components:
     - pos: 0.5,-9.5
       parent: 1
       type: Transform
-  - uid: 1089
+  - uid: 1147
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,-8.5
       parent: 1
       type: Transform
-  - uid: 1090
+  - uid: 1148
     components:
     - rot: -1.5707963267948966 rad
       pos: -1.5,-15.5
       parent: 1
       type: Transform
-  - uid: 1091
+  - uid: 1149
     components:
     - rot: 1.5707963267948966 rad
       pos: -3.5,-15.5
@@ -7177,18 +7725,18 @@ entities:
       type: Transform
 - proto: DisposalJunction
   entities:
-  - uid: 1092
+  - uid: 1150
     components:
     - rot: -1.5707963267948966 rad
       pos: 2.5,-33.5
       parent: 1
       type: Transform
-  - uid: 1093
+  - uid: 1151
     components:
     - pos: -5.5,-25.5
       parent: 1
       type: Transform
-  - uid: 1094
+  - uid: 1152
     components:
     - rot: 1.5707963267948966 rad
       pos: -1.5,-33.5
@@ -7196,7 +7744,7 @@ entities:
       type: Transform
 - proto: DisposalJunctionFlipped
   entities:
-  - uid: 1095
+  - uid: 1153
     components:
     - rot: 1.5707963267948966 rad
       pos: 0.5,-24.5
@@ -7204,587 +7752,587 @@ entities:
       type: Transform
 - proto: DisposalPipe
   entities:
-  - uid: 1096
+  - uid: 1154
     components:
     - rot: -1.5707963267948966 rad
       pos: 4.5,-24.5
       parent: 1
       type: Transform
-  - uid: 1097
+  - uid: 1155
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,-3.5
       parent: 1
       type: Transform
-  - uid: 1098
+  - uid: 1156
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,-5.5
       parent: 1
       type: Transform
-  - uid: 1099
+  - uid: 1157
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,-6.5
       parent: 1
       type: Transform
-  - uid: 1100
+  - uid: 1158
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,-7.5
       parent: 1
       type: Transform
-  - uid: 1101
+  - uid: 1159
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,-8.5
       parent: 1
       type: Transform
-  - uid: 1102
+  - uid: 1160
     components:
     - pos: -3.5,-16.5
       parent: 1
       type: Transform
-  - uid: 1103
-    components:
-    - pos: -3.5,-17.5
-      parent: 1
-      type: Transform
-  - uid: 1104
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -4.5,-18.5
-      parent: 1
-      type: Transform
-  - uid: 1105
-    components:
-    - pos: -5.5,-19.5
-      parent: 1
-      type: Transform
-  - uid: 1106
-    components:
-    - pos: -5.5,-20.5
-      parent: 1
-      type: Transform
-  - uid: 1107
-    components:
-    - pos: -5.5,-23.5
-      parent: 1
-      type: Transform
-  - uid: 1108
-    components:
-    - pos: -5.5,-24.5
-      parent: 1
-      type: Transform
-  - uid: 1109
-    components:
-    - pos: -5.5,-22.5
-      parent: 1
-      type: Transform
-  - uid: 1110
-    components:
-    - pos: -5.5,-21.5
-      parent: 1
-      type: Transform
-  - uid: 1111
-    components:
-    - pos: -5.5,-26.5
-      parent: 1
-      type: Transform
-  - uid: 1112
-    components:
-    - pos: -5.5,-27.5
-      parent: 1
-      type: Transform
-  - uid: 1113
-    components:
-    - pos: -5.5,-28.5
-      parent: 1
-      type: Transform
-  - uid: 1114
-    components:
-    - pos: -5.5,-29.5
-      parent: 1
-      type: Transform
-  - uid: 1115
-    components:
-    - pos: -5.5,-30.5
-      parent: 1
-      type: Transform
-  - uid: 1116
-    components:
-    - pos: -5.5,-31.5
-      parent: 1
-      type: Transform
-  - uid: 1117
-    components:
-    - pos: -5.5,-32.5
-      parent: 1
-      type: Transform
-  - uid: 1118
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -4.5,-33.5
-      parent: 1
-      type: Transform
-  - uid: 1119
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -3.5,-33.5
-      parent: 1
-      type: Transform
-  - uid: 1120
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -2.5,-33.5
-      parent: 1
-      type: Transform
-  - uid: 1121
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -0.5,-33.5
-      parent: 1
-      type: Transform
-  - uid: 1122
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 1.5,-33.5
-      parent: 1
-      type: Transform
-  - uid: 1123
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 3.5,-33.5
-      parent: 1
-      type: Transform
-  - uid: 1124
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 4.5,-33.5
-      parent: 1
-      type: Transform
-  - uid: 1125
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 5.5,-33.5
-      parent: 1
-      type: Transform
-  - uid: 1126
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 6.5,-32.5
-      parent: 1
-      type: Transform
-  - uid: 1127
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 6.5,-31.5
-      parent: 1
-      type: Transform
-  - uid: 1128
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 6.5,-30.5
-      parent: 1
-      type: Transform
-  - uid: 1129
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 6.5,-29.5
-      parent: 1
-      type: Transform
-  - uid: 1130
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 6.5,-28.5
-      parent: 1
-      type: Transform
-  - uid: 1131
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 6.5,-27.5
-      parent: 1
-      type: Transform
-  - uid: 1132
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 6.5,-26.5
-      parent: 1
-      type: Transform
-  - uid: 1133
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 6.5,-25.5
-      parent: 1
-      type: Transform
-  - uid: 1134
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 6.5,-24.5
-      parent: 1
-      type: Transform
-  - uid: 1135
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 6.5,-23.5
-      parent: 1
-      type: Transform
-  - uid: 1136
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 6.5,-22.5
-      parent: 1
-      type: Transform
-  - uid: 1137
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 6.5,-22.5
-      parent: 1
-      type: Transform
-  - uid: 1138
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 6.5,-21.5
-      parent: 1
-      type: Transform
-  - uid: 1139
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 6.5,-20.5
-      parent: 1
-      type: Transform
-  - uid: 1140
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 6.5,-19.5
-      parent: 1
-      type: Transform
-  - uid: 1141
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 5.5,-18.5
-      parent: 1
-      type: Transform
-  - uid: 1142
-    components:
-    - pos: 4.5,-17.5
-      parent: 1
-      type: Transform
-  - uid: 1143
-    components:
-    - pos: 4.5,-16.5
-      parent: 1
-      type: Transform
-  - uid: 1144
-    components:
-    - pos: 4.5,-17.5
-      parent: 1
-      type: Transform
-  - uid: 1145
-    components:
-    - pos: 4.5,-15.5
-      parent: 1
-      type: Transform
-  - uid: 1146
-    components:
-    - pos: 4.5,-14.5
-      parent: 1
-      type: Transform
-  - uid: 1147
-    components:
-    - pos: 4.5,-13.5
-      parent: 1
-      type: Transform
-  - uid: 1148
-    components:
-    - pos: 4.5,-12.5
-      parent: 1
-      type: Transform
-  - uid: 1149
-    components:
-    - pos: 4.5,-11.5
-      parent: 1
-      type: Transform
-  - uid: 1150
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 3.5,-9.5
-      parent: 1
-      type: Transform
-  - uid: 1151
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 0.5,-34.5
-      parent: 1
-      type: Transform
-  - uid: 1152
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 0.5,-35.5
-      parent: 1
-      type: Transform
-  - uid: 1153
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 0.5,-36.5
-      parent: 1
-      type: Transform
-  - uid: 1154
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -0.5,-31.5
-      parent: 1
-      type: Transform
-  - uid: 1155
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 0.5,-31.5
-      parent: 1
-      type: Transform
-  - uid: 1156
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 1.5,-31.5
-      parent: 1
-      type: Transform
-  - uid: 1157
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 2.5,-32.5
-      parent: 1
-      type: Transform
-  - uid: 1158
-    components:
-    - pos: 1.5,0.5
-      parent: 1
-      type: Transform
-  - uid: 1159
-    components:
-    - pos: 0.5,-1.5
-      parent: 1
-      type: Transform
-  - uid: 1160
-    components:
-    - pos: 0.5,-2.5
-      parent: 1
-      type: Transform
   - uid: 1161
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 2.5,-8.5
+    - pos: -3.5,-17.5
       parent: 1
       type: Transform
   - uid: 1162
     components:
     - rot: -1.5707963267948966 rad
-      pos: 1.5,-8.5
+      pos: -4.5,-18.5
       parent: 1
       type: Transform
   - uid: 1163
     components:
-    - pos: 0.5,-7.5
+    - pos: -5.5,-19.5
       parent: 1
       type: Transform
   - uid: 1164
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 5.5,-24.5
+    - pos: -5.5,-20.5
       parent: 1
       type: Transform
   - uid: 1165
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 8.5,-27.5
+    - pos: -5.5,-23.5
       parent: 1
       type: Transform
   - uid: 1166
     components:
-    - pos: 7.5,-26.5
+    - pos: -5.5,-24.5
       parent: 1
       type: Transform
   - uid: 1167
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 6.5,-24.5
+    - pos: -5.5,-22.5
       parent: 1
       type: Transform
   - uid: 1168
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 5.5,-24.5
+    - pos: -5.5,-21.5
       parent: 1
       type: Transform
   - uid: 1169
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 3.5,-24.5
+    - pos: -5.5,-26.5
       parent: 1
       type: Transform
   - uid: 1170
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 2.5,-24.5
+    - pos: -5.5,-27.5
       parent: 1
       type: Transform
   - uid: 1171
     components:
-    - rot: 3.141592653589793 rad
-      pos: 0.5,-23.5
+    - pos: -5.5,-28.5
       parent: 1
       type: Transform
   - uid: 1172
     components:
-    - rot: 1.5707963267948966 rad
-      pos: 1.5,-24.5
+    - pos: -5.5,-29.5
       parent: 1
       type: Transform
   - uid: 1173
     components:
-    - rot: 3.141592653589793 rad
-      pos: 0.5,-22.5
+    - pos: -5.5,-30.5
       parent: 1
       type: Transform
   - uid: 1174
     components:
-    - rot: 3.141592653589793 rad
-      pos: 0.5,-21.5
+    - pos: -5.5,-31.5
       parent: 1
       type: Transform
   - uid: 1175
     components:
-    - rot: 3.141592653589793 rad
-      pos: 0.5,-20.5
+    - pos: -5.5,-32.5
       parent: 1
       type: Transform
   - uid: 1176
     components:
-    - rot: 3.141592653589793 rad
-      pos: 0.5,-19.5
+    - rot: 1.5707963267948966 rad
+      pos: -4.5,-33.5
       parent: 1
       type: Transform
   - uid: 1177
     components:
-    - rot: 3.141592653589793 rad
-      pos: 0.5,-18.5
+    - rot: 1.5707963267948966 rad
+      pos: -3.5,-33.5
       parent: 1
       type: Transform
   - uid: 1178
     components:
-    - rot: 3.141592653589793 rad
-      pos: 0.5,-17.5
+    - rot: 1.5707963267948966 rad
+      pos: -2.5,-33.5
       parent: 1
       type: Transform
   - uid: 1179
     components:
-    - rot: 3.141592653589793 rad
-      pos: 0.5,-16.5
+    - rot: -1.5707963267948966 rad
+      pos: -0.5,-33.5
       parent: 1
       type: Transform
   - uid: 1180
     components:
-    - rot: 3.141592653589793 rad
-      pos: 0.5,-15.5
+    - rot: -1.5707963267948966 rad
+      pos: 1.5,-33.5
       parent: 1
       type: Transform
   - uid: 1181
     components:
-    - rot: 3.141592653589793 rad
-      pos: 0.5,-14.5
+    - rot: -1.5707963267948966 rad
+      pos: 3.5,-33.5
       parent: 1
       type: Transform
   - uid: 1182
     components:
-    - rot: 3.141592653589793 rad
-      pos: 0.5,-13.5
+    - rot: -1.5707963267948966 rad
+      pos: 4.5,-33.5
       parent: 1
       type: Transform
   - uid: 1183
     components:
-    - rot: 3.141592653589793 rad
-      pos: 0.5,-12.5
+    - rot: -1.5707963267948966 rad
+      pos: 5.5,-33.5
       parent: 1
       type: Transform
   - uid: 1184
     components:
     - rot: 3.141592653589793 rad
-      pos: 0.5,-11.5
+      pos: 6.5,-32.5
       parent: 1
       type: Transform
   - uid: 1185
     components:
     - rot: 3.141592653589793 rad
-      pos: 0.5,-10.5
+      pos: 6.5,-31.5
       parent: 1
       type: Transform
   - uid: 1186
     components:
-    - rot: -1.5707963267948966 rad
-      pos: -2.5,-15.5
+    - rot: 3.141592653589793 rad
+      pos: 6.5,-30.5
       parent: 1
       type: Transform
   - uid: 1187
     components:
-    - pos: 7.5,-25.5
+    - rot: 3.141592653589793 rad
+      pos: 6.5,-29.5
       parent: 1
       type: Transform
   - uid: 1188
     components:
-    - pos: 7.5,-26.5
+    - rot: 3.141592653589793 rad
+      pos: 6.5,-28.5
       parent: 1
       type: Transform
   - uid: 1189
     components:
     - rot: 3.141592653589793 rad
-      pos: 9.5,-28.5
+      pos: 6.5,-27.5
       parent: 1
       type: Transform
   - uid: 1190
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 6.5,-26.5
+      parent: 1
+      type: Transform
+  - uid: 1191
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 6.5,-25.5
+      parent: 1
+      type: Transform
+  - uid: 1192
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 6.5,-24.5
+      parent: 1
+      type: Transform
+  - uid: 1193
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 6.5,-23.5
+      parent: 1
+      type: Transform
+  - uid: 1194
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 6.5,-22.5
+      parent: 1
+      type: Transform
+  - uid: 1195
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 6.5,-22.5
+      parent: 1
+      type: Transform
+  - uid: 1196
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 6.5,-21.5
+      parent: 1
+      type: Transform
+  - uid: 1197
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 6.5,-20.5
+      parent: 1
+      type: Transform
+  - uid: 1198
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 6.5,-19.5
+      parent: 1
+      type: Transform
+  - uid: 1199
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 5.5,-18.5
+      parent: 1
+      type: Transform
+  - uid: 1200
+    components:
+    - pos: 4.5,-17.5
+      parent: 1
+      type: Transform
+  - uid: 1201
+    components:
+    - pos: 4.5,-16.5
+      parent: 1
+      type: Transform
+  - uid: 1202
+    components:
+    - pos: 4.5,-17.5
+      parent: 1
+      type: Transform
+  - uid: 1203
+    components:
+    - pos: 4.5,-15.5
+      parent: 1
+      type: Transform
+  - uid: 1204
+    components:
+    - pos: 4.5,-14.5
+      parent: 1
+      type: Transform
+  - uid: 1205
+    components:
+    - pos: 4.5,-13.5
+      parent: 1
+      type: Transform
+  - uid: 1206
+    components:
+    - pos: 4.5,-12.5
+      parent: 1
+      type: Transform
+  - uid: 1207
+    components:
+    - pos: 4.5,-11.5
+      parent: 1
+      type: Transform
+  - uid: 1208
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 3.5,-9.5
+      parent: 1
+      type: Transform
+  - uid: 1209
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,-34.5
+      parent: 1
+      type: Transform
+  - uid: 1210
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,-35.5
+      parent: 1
+      type: Transform
+  - uid: 1211
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,-36.5
+      parent: 1
+      type: Transform
+  - uid: 1212
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -0.5,-31.5
+      parent: 1
+      type: Transform
+  - uid: 1213
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 0.5,-31.5
+      parent: 1
+      type: Transform
+  - uid: 1214
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 1.5,-31.5
+      parent: 1
+      type: Transform
+  - uid: 1215
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 2.5,-32.5
+      parent: 1
+      type: Transform
+  - uid: 1216
+    components:
+    - pos: 1.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 1217
+    components:
+    - pos: 0.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 1218
+    components:
+    - pos: 0.5,-2.5
+      parent: 1
+      type: Transform
+  - uid: 1219
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 2.5,-8.5
+      parent: 1
+      type: Transform
+  - uid: 1220
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 1.5,-8.5
+      parent: 1
+      type: Transform
+  - uid: 1221
+    components:
+    - pos: 0.5,-7.5
+      parent: 1
+      type: Transform
+  - uid: 1222
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 5.5,-24.5
+      parent: 1
+      type: Transform
+  - uid: 1223
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 8.5,-27.5
+      parent: 1
+      type: Transform
+  - uid: 1224
+    components:
+    - pos: 7.5,-26.5
+      parent: 1
+      type: Transform
+  - uid: 1225
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 6.5,-24.5
+      parent: 1
+      type: Transform
+  - uid: 1226
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 5.5,-24.5
+      parent: 1
+      type: Transform
+  - uid: 1227
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 3.5,-24.5
+      parent: 1
+      type: Transform
+  - uid: 1228
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 2.5,-24.5
+      parent: 1
+      type: Transform
+  - uid: 1229
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,-23.5
+      parent: 1
+      type: Transform
+  - uid: 1230
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 1.5,-24.5
+      parent: 1
+      type: Transform
+  - uid: 1231
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,-22.5
+      parent: 1
+      type: Transform
+  - uid: 1232
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,-21.5
+      parent: 1
+      type: Transform
+  - uid: 1233
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,-20.5
+      parent: 1
+      type: Transform
+  - uid: 1234
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,-19.5
+      parent: 1
+      type: Transform
+  - uid: 1235
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,-18.5
+      parent: 1
+      type: Transform
+  - uid: 1236
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,-17.5
+      parent: 1
+      type: Transform
+  - uid: 1237
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,-16.5
+      parent: 1
+      type: Transform
+  - uid: 1238
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,-15.5
+      parent: 1
+      type: Transform
+  - uid: 1239
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,-14.5
+      parent: 1
+      type: Transform
+  - uid: 1240
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,-13.5
+      parent: 1
+      type: Transform
+  - uid: 1241
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,-12.5
+      parent: 1
+      type: Transform
+  - uid: 1242
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,-11.5
+      parent: 1
+      type: Transform
+  - uid: 1243
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,-10.5
+      parent: 1
+      type: Transform
+  - uid: 1244
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -2.5,-15.5
+      parent: 1
+      type: Transform
+  - uid: 1245
+    components:
+    - pos: 7.5,-25.5
+      parent: 1
+      type: Transform
+  - uid: 1246
+    components:
+    - pos: 7.5,-26.5
+      parent: 1
+      type: Transform
+  - uid: 1247
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 9.5,-28.5
+      parent: 1
+      type: Transform
+  - uid: 1248
     components:
     - pos: 10.5,-30.5
       parent: 1
       type: Transform
 - proto: DisposalTrunk
   entities:
-  - uid: 1191
+  - uid: 1249
     components:
     - rot: 3.141592653589793 rad
       pos: -1.5,-34.5
       parent: 1
       type: Transform
-  - uid: 1192
+  - uid: 1250
     components:
     - rot: 1.5707963267948966 rad
       pos: -1.5,-31.5
       parent: 1
       type: Transform
-  - uid: 1193
+  - uid: 1251
     components:
     - pos: 1.5,1.5
       parent: 1
       type: Transform
-  - uid: 1194
+  - uid: 1252
     components:
     - rot: 1.5707963267948966 rad
       pos: -0.5,-24.5
       parent: 1
       type: Transform
-  - uid: 1195
+  - uid: 1253
     components:
     - rot: 3.141592653589793 rad
       pos: 10.5,-31.5
       parent: 1
       type: Transform
-  - uid: 1196
+  - uid: 1254
     components:
     - pos: 0.5,-6.5
       parent: 1
       type: Transform
-  - uid: 1197
+  - uid: 1255
     components:
     - pos: -1.5,-14.5
       parent: 1
       type: Transform
-  - uid: 1198
+  - uid: 1256
     components:
     - rot: 1.5707963267948966 rad
       pos: -6.5,-25.5
@@ -7792,7 +8340,7 @@ entities:
       type: Transform
 - proto: DisposalUnit
   entities:
-  - uid: 1199
+  - uid: 1257
     components:
     - pos: 0.5,-6.5
       parent: 1
@@ -7800,64 +8348,64 @@ entities:
     - recentlyEjected:
       - invalid
       type: DisposalUnit
-  - uid: 1200
+  - uid: 1258
     components:
     - pos: -1.5,-31.5
       parent: 1
       type: Transform
-  - uid: 1201
+  - uid: 1259
     components:
     - name: '"disposal unit"'
       type: MetaData
     - pos: 1.5,1.5
       parent: 1
       type: Transform
-  - uid: 1202
+  - uid: 1260
     components:
     - name: '"disposal unit"'
       type: MetaData
     - pos: -0.5,-24.5
       parent: 1
       type: Transform
-  - uid: 1203
+  - uid: 1261
     components:
     - name: '"disposal unit"'
       type: MetaData
     - pos: 10.5,-31.5
       parent: 1
       type: Transform
-  - uid: 1204
+  - uid: 1262
     components:
     - pos: -1.5,-14.5
       parent: 1
       type: Transform
-  - uid: 1205
+  - uid: 1263
     components:
     - pos: -6.5,-25.5
       parent: 1
       type: Transform
-  - uid: 1206
+  - uid: 1264
     components:
     - pos: -1.5,-34.5
       parent: 1
       type: Transform
 - proto: DisposalYJunction
   entities:
-  - uid: 1207
+  - uid: 1265
     components:
     - pos: 0.5,-33.5
       parent: 1
       type: Transform
 - proto: DrinkBeerBottleFull
   entities:
-  - uid: 1208
+  - uid: 1266
     components:
     - pos: -0.40871298,-14.107004
       parent: 1
       type: Transform
 - proto: DrinkCafeLatte
   entities:
-  - uid: 1209
+  - uid: 1267
     components:
     - name: Steve's latte
       type: MetaData
@@ -7866,602 +8414,623 @@ entities:
       type: Transform
 - proto: DrinkCognacBottleFull
   entities:
-  - uid: 1210
+  - uid: 1268
     components:
     - pos: 4.549162,-25.429996
       parent: 1
       type: Transform
 - proto: DrinkFlask
   entities:
-  - uid: 1211
+  - uid: 1269
     components:
     - pos: 4.4121666,-24.277555
       parent: 1
       type: Transform
 - proto: DrinkGlass
   entities:
-  - uid: 1212
+  - uid: 1270
     components:
     - pos: 0.23712039,-14.161533
       parent: 1
       type: Transform
-  - uid: 1213
+  - uid: 1271
     components:
     - pos: 0.08087039,-14.411707
       parent: 1
       type: Transform
-  - uid: 1214
+  - uid: 1272
     components:
     - pos: -0.15871298,-14.192805
       parent: 1
       type: Transform
 - proto: DrinkHotCoffee
   entities:
-  - uid: 1215
+  - uid: 1273
     components:
     - pos: -1.4439895,-21.777922
       parent: 1
       type: Transform
 - proto: DrinkMugDog
   entities:
-  - uid: 245
+  - uid: 234
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 227
+    - parent: 216
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: DrinkRumBottleFull
   entities:
-  - uid: 246
+  - uid: 235
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 227
+    - parent: 216
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: DrinkRumGlass
   entities:
-  - uid: 1216
+  - uid: 1274
     components:
-    - pos: -6.5099874,-15.604878
+    - pos: -5.582541,-16.646059
       parent: 1
       type: Transform
 - proto: DrinkScrewdriverCocktailGlass
   entities:
-  - uid: 1217
+  - uid: 1275
     components:
     - pos: -0.43513387,-27.543575
       parent: 1
       type: Transform
 - proto: DrinkShotGlass
   entities:
-  - uid: 1218
+  - uid: 1276
     components:
     - pos: -0.80478126,1.3002728
       parent: 1
       type: Transform
 - proto: DrinkWhiskeyBottleFull
   entities:
-  - uid: 1219
+  - uid: 1277
     components:
     - pos: 2.414081,1.4204162
       parent: 1
       type: Transform
 - proto: EmergencyLight
   entities:
-  - uid: 1220
+  - uid: 1278
     components:
     - pos: -3.5,-23.5
       parent: 1
       type: Transform
-  - uid: 1221
+  - uid: 1279
     components:
     - pos: 4.5,-23.5
       parent: 1
       type: Transform
-  - uid: 1222
+  - uid: 1280
     components:
     - rot: 1.5707963267948966 rad
       pos: 2.5,-34.5
       parent: 1
       type: Transform
-  - uid: 1223
+  - uid: 1281
     components:
     - rot: -1.5707963267948966 rad
       pos: 8.5,-34.5
       parent: 1
       type: Transform
-  - uid: 1224
+  - uid: 1282
     components:
     - rot: -1.5707963267948966 rad
       pos: 7.5,-29.5
       parent: 1
       type: Transform
-  - uid: 1225
+  - uid: 1283
     components:
     - rot: 1.5707963267948966 rad
       pos: -1.5,-28.5
       parent: 1
       type: Transform
-  - uid: 1226
+  - uid: 1284
     components:
     - pos: 5.5,-27.5
       parent: 1
       type: Transform
-  - uid: 1227
+  - uid: 1285
     components:
     - pos: -3.5,-33.5
       parent: 1
       type: Transform
-  - uid: 1228
+  - uid: 1286
     components:
     - rot: 1.5707963267948966 rad
       pos: -7.5,-33.5
       parent: 1
       type: Transform
-  - uid: 1229
+  - uid: 1287
     components:
     - rot: 3.141592653589793 rad
       pos: 5.5,-34.5
       parent: 1
       type: Transform
-  - uid: 1230
+  - uid: 1288
     components:
     - pos: -3.5,4.5
       parent: 1
       type: Transform
-  - uid: 1231
+  - uid: 1289
     components:
     - pos: 4.5,4.5
       parent: 1
       type: Transform
-  - uid: 1232
+  - uid: 1290
     components:
     - rot: 3.141592653589793 rad
       pos: 2.5,3.5
       parent: 1
       type: Transform
-  - uid: 1233
+  - uid: 1291
     components:
     - rot: 3.141592653589793 rad
       pos: -1.5,3.5
       parent: 1
       type: Transform
-  - uid: 1234
+  - uid: 1292
     components:
     - rot: -1.5707963267948966 rad
       pos: 4.5,-7.5
       parent: 1
       type: Transform
-  - uid: 1235
+  - uid: 1293
     components:
     - rot: 1.5707963267948966 rad
       pos: -3.5,-7.5
       parent: 1
       type: Transform
+- proto: EncryptionKeyCargo
+  entities:
+  - uid: 1294
+    components:
+    - pos: -0.2920506,0.97472227
+      parent: 1
+      type: Transform
+- proto: EncryptionKeyCommand
+  entities:
+  - uid: 1295
+    components:
+    - pos: -1.2307451,-22.015284
+      parent: 1
+      type: Transform
+- proto: EncryptionKeyEngineering
+  entities:
+  - uid: 1296
+    components:
+    - pos: -0.97588915,-30.425823
+      parent: 1
+      type: Transform
 - proto: EnergyCutlass
   entities:
-  - uid: 1010
+  - uid: 1063
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 1007
+    - parent: 1060
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: ExtendedEmergencyOxygenTankFilled
   entities:
-  - uid: 1000
+  - uid: 1053
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 997
+    - parent: 1050
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 1004
+  - uid: 1057
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 1001
+    - parent: 1054
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: FaxMachineShip
   entities:
-  - uid: 1236
+  - uid: 1297
     components:
     - pos: -0.5,1.5
       parent: 1
       type: Transform
 - proto: FireAlarm
   entities:
-  - uid: 1237
+  - uid: 1298
     components:
     - pos: -4.5,5.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 1287
-      - 1297
-      - 1296
-      - 1289
-      - 1290
-      - 1291
-      - 1292
-      - 1283
-      - 1284
-      - 1285
-      - 1293
-      - 1286
-      - 1295
-      - 1294
-      - 1288
-      - 1600
-      - 1585
-      - 1302
+      - 1348
+      - 1358
+      - 1357
+      - 1350
+      - 1351
+      - 1352
+      - 1353
+      - 1344
+      - 1345
+      - 1346
+      - 1354
+      - 1347
+      - 1356
+      - 1355
+      - 1349
+      - 1661
+      - 1646
+      - 1363
       type: DeviceNetwork
     - devices:
-      - 1287
-      - 1297
-      - 1296
-      - 1289
-      - 1290
-      - 1291
-      - 1292
-      - 1283
-      - 1284
-      - 1285
-      - 1293
-      - 1286
-      - 1295
-      - 1294
-      - 1288
-      - 1302
-      - 1585
-      - 1600
+      - 1348
+      - 1358
+      - 1357
+      - 1350
+      - 1351
+      - 1352
+      - 1353
+      - 1344
+      - 1345
+      - 1346
+      - 1354
+      - 1347
+      - 1356
+      - 1355
+      - 1349
+      - 1363
+      - 1646
+      - 1661
       type: DeviceList
-  - uid: 1238
+  - uid: 1299
     components:
     - rot: 3.141592653589793 rad
       pos: -5.5,-7.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 1297
-      - 1287
-      - 1288
-      - 1294
-      - 1253
-      - 1586
-      - 1601
-      - 1257
-      - 1259
-      - 1264
-      - 1258
-      - 1273
-      - 1267
+      - 1358
+      - 1348
+      - 1349
+      - 1355
+      - 1314
+      - 1647
+      - 1662
+      - 1318
+      - 1320
+      - 1325
+      - 1319
+      - 1334
+      - 1328
       type: DeviceNetwork
     - devices:
-      - 1257
-      - 1259
-      - 1264
-      - 1258
-      - 1253
-      - 1273
-      - 1267
-      - 1297
-      - 1287
-      - 1288
-      - 1294
-      - 1586
-      - 1601
+      - 1318
+      - 1320
+      - 1325
+      - 1319
+      - 1314
+      - 1334
+      - 1328
+      - 1358
+      - 1348
+      - 1349
+      - 1355
+      - 1647
+      - 1662
       type: DeviceList
-  - uid: 1239
+  - uid: 1300
     components:
     - rot: 3.141592653589793 rad
       pos: 6.5,-7.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 1297
-      - 1287
-      - 1288
-      - 1294
-      - 1253
-      - 1586
-      - 1601
-      - 1257
-      - 1259
-      - 1264
-      - 1258
-      - 1273
-      - 1267
+      - 1358
+      - 1348
+      - 1349
+      - 1355
+      - 1314
+      - 1647
+      - 1662
+      - 1318
+      - 1320
+      - 1325
+      - 1319
+      - 1334
+      - 1328
       type: DeviceNetwork
     - devices:
-      - 1257
-      - 1259
-      - 1264
-      - 1258
-      - 1253
-      - 1273
-      - 1267
-      - 1297
-      - 1287
-      - 1288
-      - 1294
-      - 1586
-      - 1601
+      - 1318
+      - 1320
+      - 1325
+      - 1319
+      - 1314
+      - 1334
+      - 1328
+      - 1358
+      - 1348
+      - 1349
+      - 1355
+      - 1647
+      - 1662
       type: DeviceList
-  - uid: 1240
+  - uid: 1301
     components:
     - rot: 3.141592653589793 rad
       pos: 5.5,5.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 1288
-      - 1294
-      - 1295
-      - 1286
-      - 1293
-      - 1284
-      - 1285
-      - 1283
-      - 1292
-      - 1291
-      - 1290
-      - 1289
-      - 1296
-      - 1297
-      - 1287
-      - 1600
-      - 1585
-      - 1302
+      - 1349
+      - 1355
+      - 1356
+      - 1347
+      - 1354
+      - 1345
+      - 1346
+      - 1344
+      - 1353
+      - 1352
+      - 1351
+      - 1350
+      - 1357
+      - 1358
+      - 1348
+      - 1661
+      - 1646
+      - 1363
       type: DeviceNetwork
     - devices:
-      - 1287
-      - 1297
-      - 1296
-      - 1289
-      - 1290
-      - 1291
-      - 1292
-      - 1283
-      - 1284
-      - 1285
-      - 1293
-      - 1286
-      - 1295
-      - 1294
-      - 1288
-      - 1302
-      - 1585
-      - 1600
+      - 1348
+      - 1358
+      - 1357
+      - 1350
+      - 1351
+      - 1352
+      - 1353
+      - 1344
+      - 1345
+      - 1346
+      - 1354
+      - 1347
+      - 1356
+      - 1355
+      - 1349
+      - 1363
+      - 1646
+      - 1661
       type: DeviceList
-  - uid: 1241
+  - uid: 1302
     components:
     - rot: -1.5707963267948966 rad
       pos: 8.5,-28.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 1265
-      - 1584
-      - 1604
-      - 1254
-      - 1276
-      - 1263
-      - 1611
+      - 1326
+      - 1645
+      - 1665
+      - 1315
+      - 1337
+      - 1324
+      - 1672
       type: DeviceNetwork
     - devices:
-      - 1263
-      - 1276
-      - 1254
-      - 1265
-      - 1584
-      - 1604
-      - 1611
+      - 1324
+      - 1337
+      - 1315
+      - 1326
+      - 1645
+      - 1665
+      - 1672
       type: DeviceList
-  - uid: 1242
+  - uid: 1303
     components:
     - pos: -4.5,-32.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 1605
-      - 1590
-      - 1255
-      - 1260
+      - 1666
+      - 1651
+      - 1316
+      - 1321
       type: DeviceNetwork
     - devices:
-      - 1260
-      - 1255
-      - 1605
-      - 1590
+      - 1321
+      - 1316
+      - 1666
+      - 1651
       type: DeviceList
-  - uid: 1243
+  - uid: 1304
     components:
     - rot: 1.5707963267948966 rad
       pos: -7.5,-28.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 1606
-      - 1266
-      - 1261
-      - 1255
-      - 1256
-      - 1262
-      - 1275
-      - 1274
-      - 1589
+      - 1667
+      - 1327
+      - 1322
+      - 1316
+      - 1317
+      - 1323
+      - 1336
+      - 1335
+      - 1650
       type: DeviceNetwork
     - devices:
-      - 1606
-      - 1589
-      - 1255
-      - 1262
-      - 1261
-      - 1256
-      - 1274
-      - 1275
-      - 1266
+      - 1667
+      - 1650
+      - 1316
+      - 1323
+      - 1322
+      - 1317
+      - 1335
+      - 1336
+      - 1327
       type: DeviceList
-  - uid: 1244
+  - uid: 1305
     components:
     - rot: -1.5707963267948966 rad
       pos: 8.5,-25.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 1595
-      - 1616
-      - 1263
-      - 1272
-      - 1277
+      - 1656
+      - 1677
+      - 1324
+      - 1333
+      - 1338
       type: DeviceNetwork
     - devices:
-      - 1616
-      - 1595
-      - 1263
-      - 1272
-      - 1277
+      - 1677
+      - 1656
+      - 1324
+      - 1333
+      - 1338
       type: DeviceList
-  - uid: 1245
+  - uid: 1306
     components:
     - pos: -1.5,-11.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 1607
-      - 1608
-      - 1592
-      - 1596
-      - 1279
-      - 1282
-      - 1268
-      - 1281
-      - 1300
-      - 1278
-      - 1298
-      - 1299
-      - 1257
-      - 1259
+      - 1668
+      - 1669
+      - 1653
+      - 1657
+      - 1340
+      - 1343
+      - 1329
+      - 1342
+      - 1361
+      - 1339
+      - 1359
+      - 1360
+      - 1318
+      - 1320
       type: DeviceNetwork
     - devices:
-      - 1281
-      - 1268
-      - 1300
-      - 1607
-      - 1608
-      - 1592
-      - 1596
-      - 1278
-      - 1298
-      - 1299
-      - 1257
-      - 1259
-      - 1279
-      - 1282
+      - 1342
+      - 1329
+      - 1361
+      - 1668
+      - 1669
+      - 1653
+      - 1657
+      - 1339
+      - 1359
+      - 1360
+      - 1318
+      - 1320
+      - 1340
+      - 1343
       type: DeviceList
-  - uid: 1246
+  - uid: 1307
     components:
     - rot: 1.5707963267948966 rad
       pos: -6.5,-11.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 1609
-      - 1300
-      - 1268
-      - 1281
-      - 1593
+      - 1670
+      - 1361
+      - 1329
+      - 1342
+      - 1654
       type: DeviceNetwork
     - devices:
-      - 1609
-      - 1281
-      - 1268
-      - 1300
-      - 1593
+      - 1670
+      - 1342
+      - 1329
+      - 1361
+      - 1654
       type: DeviceList
-  - uid: 1247
+  - uid: 1308
     components:
     - rot: -1.5707963267948966 rad
       pos: 7.5,-11.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 1610
-      - 1299
-      - 1298
-      - 1278
-      - 1594
+      - 1671
+      - 1360
+      - 1359
+      - 1339
+      - 1655
       type: DeviceNetwork
     - devices:
-      - 1610
-      - 1594
-      - 1299
-      - 1298
-      - 1278
+      - 1671
+      - 1655
+      - 1360
+      - 1359
+      - 1339
       type: DeviceList
-  - uid: 1248
+  - uid: 1309
     components:
     - pos: -4.5,-17.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 1279
-      - 1587
-      - 1614
-      - 1269
+      - 1340
+      - 1648
+      - 1675
+      - 1330
       type: DeviceNetwork
     - devices:
-      - 1614
-      - 1587
-      - 1269
-      - 1279
+      - 1675
+      - 1648
+      - 1330
+      - 1340
       type: DeviceList
-  - uid: 1249
+  - uid: 1310
     components:
     - pos: 5.5,-17.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 1282
-      - 1270
-      - 1272
-      - 1602
-      - 1588
+      - 1343
+      - 1331
+      - 1333
+      - 1663
+      - 1649
       type: DeviceNetwork
     - devices:
-      - 1282
-      - 1270
-      - 1272
-      - 1602
-      - 1588
+      - 1343
+      - 1331
+      - 1333
+      - 1663
+      - 1649
       type: DeviceList
 - proto: FireAxeCabinetFilled
   entities:
-  - uid: 1250
+  - uid: 1311
     components:
     - pos: -0.5,-26.5
       parent: 1
       type: Transform
-  - uid: 1251
+  - uid: 1312
     components:
     - pos: 2.5,2.5
       parent: 1
       type: Transform
-  - uid: 1252
+  - uid: 1313
     components:
     - rot: -1.5707963267948966 rad
       pos: 5.5,-25.5
@@ -8469,158 +9038,158 @@ entities:
       type: Transform
 - proto: Firelock
   entities:
-  - uid: 1253
+  - uid: 1314
     components:
     - pos: 0.5,-1.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
       - 14
-      - 1238
-      - 1239
+      - 1299
+      - 1300
       type: DeviceNetwork
-  - uid: 1254
+  - uid: 1315
     components:
     - pos: 1.5,-33.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
       - 5
-      - 1241
+      - 1302
       type: DeviceNetwork
-  - uid: 1255
+  - uid: 1316
     components:
     - pos: -5.5,-32.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
       - 6
-      - 1242
+      - 1303
       - 7
-      - 1243
+      - 1304
       type: DeviceNetwork
-  - uid: 1256
+  - uid: 1317
     components:
     - pos: -5.5,-26.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
       - 7
-      - 1243
+      - 1304
       type: DeviceNetwork
-  - uid: 1257
+  - uid: 1318
     components:
     - pos: 4.5,-11.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 1245
+      - 1306
       - 11
       - 14
-      - 1238
-      - 1239
+      - 1299
+      - 1300
       type: DeviceNetwork
-  - uid: 1258
+  - uid: 1319
     components:
     - pos: -4.5,-8.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
       - 14
-      - 1238
-      - 1239
+      - 1299
+      - 1300
       type: DeviceNetwork
-  - uid: 1259
+  - uid: 1320
     components:
     - pos: -3.5,-11.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 1245
+      - 1306
       - 11
       - 14
-      - 1238
-      - 1239
+      - 1299
+      - 1300
       type: DeviceNetwork
-  - uid: 1260
+  - uid: 1321
     components:
     - pos: -0.5,-33.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
       - 6
-      - 1242
+      - 1303
       type: DeviceNetwork
-  - uid: 1261
+  - uid: 1322
     components:
     - pos: -4.5,-27.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
       - 7
-      - 1243
+      - 1304
       type: DeviceNetwork
-  - uid: 1262
+  - uid: 1323
     components:
     - pos: -4.5,-30.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
       - 7
-      - 1243
+      - 1304
       type: DeviceNetwork
-  - uid: 1263
+  - uid: 1324
     components:
     - pos: 6.5,-26.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
       - 5
-      - 1241
+      - 1302
       - 16
-      - 1244
+      - 1305
       type: DeviceNetwork
-  - uid: 1264
+  - uid: 1325
     components:
     - pos: 5.5,-8.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
       - 14
-      - 1238
-      - 1239
+      - 1299
+      - 1300
       type: DeviceNetwork
-  - uid: 1265
+  - uid: 1326
     components:
     - pos: 1.5,-31.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
       - 5
-      - 1241
+      - 1302
       type: DeviceNetwork
-  - uid: 1266
+  - uid: 1327
     components:
     - pos: -7.5,-31.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
       - 7
-      - 1243
+      - 1304
       type: DeviceNetwork
 - proto: FirelockGlass
   entities:
-  - uid: 1267
+  - uid: 1328
     components:
     - pos: -5.5,0.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
       - 14
-      - 1238
-      - 1239
+      - 1299
+      - 1300
       type: DeviceNetwork
-  - uid: 1268
+  - uid: 1329
     components:
     - pos: -4.5,-13.5
       parent: 1
@@ -8628,80 +9197,80 @@ entities:
     - ShutdownSubscribers:
       - 9
       - 11
-      - 1246
-      - 1245
+      - 1307
+      - 1306
       type: DeviceNetwork
-  - uid: 1269
+  - uid: 1330
     components:
     - pos: -5.5,-21.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
       - 8
-      - 1248
+      - 1309
       type: DeviceNetwork
-  - uid: 1270
+  - uid: 1331
     components:
     - pos: 6.5,-21.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
       - 4
-      - 1249
+      - 1310
       type: DeviceNetwork
-  - uid: 1271
+  - uid: 1332
     components:
     - pos: -5.5,-22.5
       parent: 1
       type: Transform
-  - uid: 1272
+  - uid: 1333
     components:
     - pos: 6.5,-22.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
       - 16
-      - 1244
-      - 1249
+      - 1305
+      - 1310
       type: DeviceNetwork
-  - uid: 1273
+  - uid: 1334
     components:
     - pos: -5.5,-0.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
       - 14
-      - 1238
-      - 1239
+      - 1299
+      - 1300
       type: DeviceNetwork
-  - uid: 1274
+  - uid: 1335
     components:
     - pos: -7.5,-27.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
       - 7
-      - 1243
+      - 1304
       type: DeviceNetwork
-  - uid: 1275
+  - uid: 1336
     components:
     - pos: -7.5,-29.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
       - 7
-      - 1243
+      - 1304
       type: DeviceNetwork
-  - uid: 1276
+  - uid: 1337
     components:
     - pos: 8.5,-27.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
       - 5
-      - 1241
+      - 1302
       type: DeviceNetwork
-  - uid: 1277
+  - uid: 1338
     components:
     - pos: 5.5,-23.5
       parent: 1
@@ -8709,9 +9278,9 @@ entities:
     - ShutdownSubscribers:
       - 16
       - 15
-      - 1244
+      - 1305
       type: DeviceNetwork
-  - uid: 1278
+  - uid: 1339
     components:
     - pos: 5.5,-14.5
       parent: 1
@@ -8719,10 +9288,10 @@ entities:
     - ShutdownSubscribers:
       - 10
       - 11
-      - 1247
-      - 1245
+      - 1308
+      - 1306
       type: DeviceNetwork
-  - uid: 1279
+  - uid: 1340
     components:
     - pos: -3.5,-17.5
       parent: 1
@@ -8730,10 +9299,10 @@ entities:
     - ShutdownSubscribers:
       - 11
       - 8
-      - 1245
-      - 1248
+      - 1306
+      - 1309
       type: DeviceNetwork
-  - uid: 1280
+  - uid: 1341
     components:
     - pos: -4.5,-23.5
       parent: 1
@@ -8741,7 +9310,7 @@ entities:
     - ShutdownSubscribers:
       - 15
       type: DeviceNetwork
-  - uid: 1281
+  - uid: 1342
     components:
     - pos: -4.5,-12.5
       parent: 1
@@ -8749,10 +9318,10 @@ entities:
     - ShutdownSubscribers:
       - 9
       - 11
-      - 1246
-      - 1245
+      - 1307
+      - 1306
       type: DeviceNetwork
-  - uid: 1282
+  - uid: 1343
     components:
     - pos: 4.5,-17.5
       parent: 1
@@ -8760,10 +9329,10 @@ entities:
     - ShutdownSubscribers:
       - 11
       - 4
-      - 1245
-      - 1249
+      - 1306
+      - 1310
       type: DeviceNetwork
-  - uid: 1283
+  - uid: 1344
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,6.5
@@ -8771,10 +9340,10 @@ entities:
       type: Transform
     - ShutdownSubscribers:
       - 13
-      - 1237
-      - 1240
+      - 1298
+      - 1301
       type: DeviceNetwork
-  - uid: 1284
+  - uid: 1345
     components:
     - rot: 3.141592653589793 rad
       pos: 1.5,6.5
@@ -8782,10 +9351,10 @@ entities:
       type: Transform
     - ShutdownSubscribers:
       - 13
-      - 1237
-      - 1240
+      - 1298
+      - 1301
       type: DeviceNetwork
-  - uid: 1285
+  - uid: 1346
     components:
     - rot: 3.141592653589793 rad
       pos: 2.5,6.5
@@ -8793,10 +9362,10 @@ entities:
       type: Transform
     - ShutdownSubscribers:
       - 13
-      - 1237
-      - 1240
+      - 1298
+      - 1301
       type: DeviceNetwork
-  - uid: 1286
+  - uid: 1347
     components:
     - rot: 3.141592653589793 rad
       pos: 6.5,3.5
@@ -8804,10 +9373,10 @@ entities:
       type: Transform
     - ShutdownSubscribers:
       - 13
-      - 1237
-      - 1240
+      - 1298
+      - 1301
       type: DeviceNetwork
-  - uid: 1287
+  - uid: 1348
     components:
     - rot: 3.141592653589793 rad
       pos: -3.5,1.5
@@ -8815,13 +9384,13 @@ entities:
       type: Transform
     - ShutdownSubscribers:
       - 13
-      - 1237
-      - 1238
-      - 1239
-      - 1240
+      - 1298
+      - 1299
+      - 1300
+      - 1301
       - 14
       type: DeviceNetwork
-  - uid: 1288
+  - uid: 1349
     components:
     - rot: 3.141592653589793 rad
       pos: 4.5,1.5
@@ -8829,13 +9398,13 @@ entities:
       type: Transform
     - ShutdownSubscribers:
       - 13
-      - 1237
-      - 1238
-      - 1239
-      - 1240
+      - 1298
+      - 1299
+      - 1300
+      - 1301
       - 14
       type: DeviceNetwork
-  - uid: 1289
+  - uid: 1350
     components:
     - rot: 3.141592653589793 rad
       pos: -5.5,3.5
@@ -8843,10 +9412,10 @@ entities:
       type: Transform
     - ShutdownSubscribers:
       - 13
-      - 1237
-      - 1240
+      - 1298
+      - 1301
       type: DeviceNetwork
-  - uid: 1290
+  - uid: 1351
     components:
     - rot: 3.141592653589793 rad
       pos: -5.5,4.5
@@ -8854,10 +9423,10 @@ entities:
       type: Transform
     - ShutdownSubscribers:
       - 13
-      - 1237
-      - 1240
+      - 1298
+      - 1301
       type: DeviceNetwork
-  - uid: 1291
+  - uid: 1352
     components:
     - rot: 3.141592653589793 rad
       pos: -1.5,6.5
@@ -8865,10 +9434,10 @@ entities:
       type: Transform
     - ShutdownSubscribers:
       - 13
-      - 1237
-      - 1240
+      - 1298
+      - 1301
       type: DeviceNetwork
-  - uid: 1292
+  - uid: 1353
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,6.5
@@ -8876,10 +9445,10 @@ entities:
       type: Transform
     - ShutdownSubscribers:
       - 13
-      - 1237
-      - 1240
+      - 1298
+      - 1301
       type: DeviceNetwork
-  - uid: 1293
+  - uid: 1354
     components:
     - rot: 3.141592653589793 rad
       pos: 6.5,4.5
@@ -8887,10 +9456,10 @@ entities:
       type: Transform
     - ShutdownSubscribers:
       - 13
-      - 1237
-      - 1240
+      - 1298
+      - 1301
       type: DeviceNetwork
-  - uid: 1294
+  - uid: 1355
     components:
     - rot: 3.141592653589793 rad
       pos: 5.5,1.5
@@ -8898,13 +9467,13 @@ entities:
       type: Transform
     - ShutdownSubscribers:
       - 13
-      - 1237
-      - 1238
-      - 1239
-      - 1240
+      - 1298
+      - 1299
+      - 1300
+      - 1301
       - 14
       type: DeviceNetwork
-  - uid: 1295
+  - uid: 1356
     components:
     - rot: 3.141592653589793 rad
       pos: 6.5,2.5
@@ -8912,10 +9481,10 @@ entities:
       type: Transform
     - ShutdownSubscribers:
       - 13
-      - 1237
-      - 1240
+      - 1298
+      - 1301
       type: DeviceNetwork
-  - uid: 1296
+  - uid: 1357
     components:
     - rot: 3.141592653589793 rad
       pos: -5.5,2.5
@@ -8923,10 +9492,10 @@ entities:
       type: Transform
     - ShutdownSubscribers:
       - 13
-      - 1237
-      - 1240
+      - 1298
+      - 1301
       type: DeviceNetwork
-  - uid: 1297
+  - uid: 1358
     components:
     - rot: 3.141592653589793 rad
       pos: -4.5,1.5
@@ -8934,13 +9503,13 @@ entities:
       type: Transform
     - ShutdownSubscribers:
       - 13
-      - 1237
-      - 1238
-      - 1239
-      - 1240
+      - 1298
+      - 1299
+      - 1300
+      - 1301
       - 14
       type: DeviceNetwork
-  - uid: 1298
+  - uid: 1359
     components:
     - pos: 5.5,-13.5
       parent: 1
@@ -8948,10 +9517,10 @@ entities:
     - ShutdownSubscribers:
       - 10
       - 11
-      - 1247
-      - 1245
+      - 1308
+      - 1306
       type: DeviceNetwork
-  - uid: 1299
+  - uid: 1360
     components:
     - pos: 5.5,-12.5
       parent: 1
@@ -8959,10 +9528,10 @@ entities:
     - ShutdownSubscribers:
       - 10
       - 11
-      - 1247
-      - 1245
+      - 1308
+      - 1306
       type: DeviceNetwork
-  - uid: 1300
+  - uid: 1361
     components:
     - pos: -4.5,-14.5
       parent: 1
@@ -8970,15 +9539,15 @@ entities:
     - ShutdownSubscribers:
       - 9
       - 11
-      - 1246
-      - 1245
+      - 1307
+      - 1306
       type: DeviceNetwork
-  - uid: 1301
+  - uid: 1362
     components:
     - pos: 4.5,-30.5
       parent: 1
       type: Transform
-  - uid: 1302
+  - uid: 1363
     components:
     - rot: -1.5707963267948966 rad
       pos: 0.5,2.5
@@ -8987,48 +9556,48 @@ entities:
     - ShutdownSubscribers:
       - 12
       - 13
-      - 1237
-      - 1240
+      - 1298
+      - 1301
       type: DeviceNetwork
 - proto: Flash
   entities:
-  - uid: 109
+  - uid: 113
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 100
+    - parent: 103
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: FoodBoxDonkpocketHonk
   entities:
-  - uid: 1303
+  - uid: 1364
     components:
     - pos: 1.5919714,-14.375789
       parent: 1
       type: Transform
 - proto: FoodBoxPizzaFilled
   entities:
-  - uid: 110
+  - uid: 114
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 100
+    - parent: 103
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: FoodBurgerBacon
   entities:
-  - uid: 1304
+  - uid: 1365
     components:
     - name: Steve's Burger Fort (1/2)
       type: MetaData
     - pos: 2.2029314,-21.799337
       parent: 1
       type: Transform
-  - uid: 1305
+  - uid: 1366
     components:
     - name: Steve's Burger Fort (2/2)
       type: MetaData
@@ -9037,7 +9606,7 @@ entities:
       type: Transform
 - proto: GasMixer
   entities:
-  - uid: 1306
+  - uid: 1367
     components:
     - rot: -1.5707963267948966 rad
       pos: 4.5,-33.5
@@ -9047,7 +9616,7 @@ entities:
       inletOneConcentration: 0.79
       targetPressure: 4500
       type: GasMixer
-  - uid: 1307
+  - uid: 1368
     components:
     - rot: -1.5707963267948966 rad
       pos: 2.5,-33.5
@@ -9061,7 +9630,7 @@ entities:
       type: AtmosPipeColor
 - proto: GasPassiveVent
   entities:
-  - uid: 1308
+  - uid: 1369
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,-36.5
@@ -9069,7 +9638,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1309
+  - uid: 1370
     components:
     - rot: -1.5707963267948966 rad
       pos: 7.5,0.5
@@ -9077,13 +9646,13 @@ entities:
       type: Transform
 - proto: GasPipeBend
   entities:
-  - uid: 1310
+  - uid: 1371
     components:
     - rot: -1.5707963267948966 rad
       pos: 5.5,-33.5
       parent: 1
       type: Transform
-  - uid: 1311
+  - uid: 1372
     components:
     - rot: 1.5707963267948966 rad
       pos: -2.5,-31.5
@@ -9091,9 +9660,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
-  - uid: 1312
+  - uid: 1373
     components:
     - rot: -1.5707963267948966 rad
       pos: -2.5,-33.5
@@ -9101,7 +9668,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1313
+  - uid: 1374
     components:
     - rot: -1.5707963267948966 rad
       pos: -1.5,-34.5
@@ -9109,16 +9676,14 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1314
+  - uid: 1375
     components:
     - pos: 1.5,-31.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
-  - uid: 1315
+  - uid: 1376
     components:
     - rot: 1.5707963267948966 rad
       pos: -1.5,-33.5
@@ -9126,7 +9691,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1316
+  - uid: 1377
     components:
     - rot: 3.141592653589793 rad
       pos: -6.5,-34.5
@@ -9134,7 +9699,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1317
+  - uid: 1378
     components:
     - rot: 1.5707963267948966 rad
       pos: -5.5,-25.5
@@ -9142,7 +9707,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1318
+  - uid: 1379
     components:
     - rot: -1.5707963267948966 rad
       pos: -5.5,-24.5
@@ -9150,7 +9715,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1319
+  - uid: 1380
     components:
     - rot: 1.5707963267948966 rad
       pos: -6.5,-24.5
@@ -9158,7 +9723,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1320
+  - uid: 1381
     components:
     - rot: 1.5707963267948966 rad
       pos: -5.5,-23.5
@@ -9166,7 +9731,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1321
+  - uid: 1382
     components:
     - rot: -1.5707963267948966 rad
       pos: -0.5,-25.5
@@ -9174,7 +9739,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1322
+  - uid: 1383
     components:
     - rot: -1.5707963267948966 rad
       pos: -1.5,-23.5
@@ -9184,14 +9749,14 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1323
+  - uid: 1384
     components:
     - pos: -0.5,-3.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1324
+  - uid: 1385
     components:
     - rot: 1.5707963267948966 rad
       pos: -1.5,1.5
@@ -9199,14 +9764,14 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1325
+  - uid: 1386
     components:
     - pos: 2.5,1.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1326
+  - uid: 1387
     components:
     - rot: 3.141592653589793 rad
       pos: -3.5,-3.5
@@ -9214,7 +9779,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1327
+  - uid: 1388
     components:
     - rot: -1.5707963267948966 rad
       pos: 4.5,-3.5
@@ -9222,7 +9787,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1328
+  - uid: 1389
     components:
     - rot: 1.5707963267948966 rad
       pos: 1.5,-3.5
@@ -9230,7 +9795,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1329
+  - uid: 1390
     components:
     - rot: 3.141592653589793 rad
       pos: 2.5,-23.5
@@ -9240,7 +9805,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1330
+  - uid: 1391
     components:
     - rot: 3.141592653589793 rad
       pos: 1.5,-25.5
@@ -9250,21 +9815,21 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1331
+  - uid: 1392
     components:
     - pos: 6.5,-23.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1332
+  - uid: 1393
     components:
     - pos: 7.5,-24.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1333
+  - uid: 1394
     components:
     - rot: 3.141592653589793 rad
       pos: 1.5,-33.5
@@ -9274,7 +9839,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1334
+  - uid: 1395
     components:
     - rot: 1.5707963267948966 rad
       pos: -5.5,-14.5
@@ -9282,7 +9847,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1335
+  - uid: 1396
     components:
     - rot: 1.5707963267948966 rad
       pos: -3.5,-15.5
@@ -9290,28 +9855,28 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1336
+  - uid: 1397
     components:
     - pos: 6.5,-14.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1337
+  - uid: 1398
     components:
     - pos: 4.5,-15.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1338
+  - uid: 1399
     components:
     - pos: 4.5,3.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1339
+  - uid: 1400
     components:
     - rot: 1.5707963267948966 rad
       pos: -3.5,3.5
@@ -9319,7 +9884,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1340
+  - uid: 1401
     components:
     - rot: -1.5707963267948966 rad
       pos: 0.5,-0.5
@@ -9329,14 +9894,14 @@ entities:
       type: AtmosPipeColor
 - proto: GasPipeFourway
   entities:
-  - uid: 1341
+  - uid: 1402
     components:
     - pos: 1.5,-13.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1342
+  - uid: 1403
     components:
     - pos: -0.5,1.5
       parent: 1
@@ -9345,14 +9910,14 @@ entities:
       type: AtmosPipeColor
 - proto: GasPipeStraight
   entities:
-  - uid: 1343
+  - uid: 1404
     components:
     - pos: -1.5,-2.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1344
+  - uid: 1405
     components:
     - rot: -1.5707963267948966 rad
       pos: 2.5,-13.5
@@ -9360,7 +9925,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1345
+  - uid: 1406
     components:
     - pos: 0.5,-35.5
       parent: 1
@@ -9369,7 +9934,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1346
+  - uid: 1407
     components:
     - pos: 0.5,-34.5
       parent: 1
@@ -9378,7 +9943,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1347
+  - uid: 1408
     components:
     - rot: -1.5707963267948966 rad
       pos: -5.5,-34.5
@@ -9386,7 +9951,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1348
+  - uid: 1409
     components:
     - rot: 3.141592653589793 rad
       pos: -5.5,-18.5
@@ -9394,7 +9959,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1349
+  - uid: 1410
     components:
     - rot: 3.141592653589793 rad
       pos: -5.5,-17.5
@@ -9404,7 +9969,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1350
+  - uid: 1411
     components:
     - rot: -1.5707963267948966 rad
       pos: -2.5,-34.5
@@ -9412,7 +9977,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1351
+  - uid: 1412
     components:
     - pos: -2.5,-32.5
       parent: 1
@@ -9421,7 +9986,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1352
+  - uid: 1413
     components:
     - rot: -1.5707963267948966 rad
       pos: 0.5,-31.5
@@ -9429,9 +9994,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
-  - uid: 1353
+  - uid: 1414
     components:
     - rot: 3.141592653589793 rad
       pos: 1.5,-32.5
@@ -9441,7 +10004,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1354
+  - uid: 1415
     components:
     - rot: -1.5707963267948966 rad
       pos: -4.5,-34.5
@@ -9449,7 +10012,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1355
+  - uid: 1416
     components:
     - rot: -1.5707963267948966 rad
       pos: -3.5,-34.5
@@ -9457,7 +10020,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1356
+  - uid: 1417
     components:
     - rot: -1.5707963267948966 rad
       pos: -4.5,-33.5
@@ -9465,7 +10028,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1357
+  - uid: 1418
     components:
     - rot: 3.141592653589793 rad
       pos: -5.5,-32.5
@@ -9475,7 +10038,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1358
+  - uid: 1419
     components:
     - rot: -1.5707963267948966 rad
       pos: -0.5,-33.5
@@ -9485,7 +10048,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1359
+  - uid: 1420
     components:
     - rot: 3.141592653589793 rad
       pos: -6.5,-32.5
@@ -9495,7 +10058,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1360
+  - uid: 1421
     components:
     - rot: 3.141592653589793 rad
       pos: -6.5,-29.5
@@ -9503,7 +10066,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1361
+  - uid: 1422
     components:
     - rot: 3.141592653589793 rad
       pos: -6.5,-26.5
@@ -9513,7 +10076,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1362
+  - uid: 1423
     components:
     - rot: 3.141592653589793 rad
       pos: -6.5,-25.5
@@ -9521,7 +10084,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1363
+  - uid: 1424
     components:
     - rot: 1.5707963267948966 rad
       pos: -3.5,-33.5
@@ -9529,35 +10092,35 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1364
+  - uid: 1425
     components:
     - pos: -5.5,-31.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1365
+  - uid: 1426
     components:
     - pos: -5.5,-30.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1366
+  - uid: 1427
     components:
     - pos: -5.5,-28.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1367
+  - uid: 1428
     components:
     - pos: -5.5,-27.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1368
+  - uid: 1429
     components:
     - pos: -5.5,-26.5
       parent: 1
@@ -9566,7 +10129,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1369
+  - uid: 1430
     components:
     - rot: 1.5707963267948966 rad
       pos: -4.5,-25.5
@@ -9576,7 +10139,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1370
+  - uid: 1431
     components:
     - rot: 1.5707963267948966 rad
       pos: -3.5,-25.5
@@ -9584,7 +10147,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1371
+  - uid: 1432
     components:
     - rot: -1.5707963267948966 rad
       pos: -2.5,-25.5
@@ -9592,7 +10155,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1372
+  - uid: 1433
     components:
     - rot: -1.5707963267948966 rad
       pos: -4.5,-23.5
@@ -9602,7 +10165,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1373
+  - uid: 1434
     components:
     - rot: -1.5707963267948966 rad
       pos: -3.5,-23.5
@@ -9612,7 +10175,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1374
+  - uid: 1435
     components:
     - rot: 3.141592653589793 rad
       pos: -1.5,-22.5
@@ -9622,7 +10185,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1375
+  - uid: 1436
     components:
     - rot: 3.141592653589793 rad
       pos: -1.5,-21.5
@@ -9632,7 +10195,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1376
+  - uid: 1437
     components:
     - rot: 3.141592653589793 rad
       pos: -1.5,-20.5
@@ -9642,7 +10205,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1377
+  - uid: 1438
     components:
     - rot: 3.141592653589793 rad
       pos: -1.5,-19.5
@@ -9652,7 +10215,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1378
+  - uid: 1439
     components:
     - rot: 3.141592653589793 rad
       pos: -1.5,-18.5
@@ -9662,7 +10225,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1379
+  - uid: 1440
     components:
     - rot: 3.141592653589793 rad
       pos: -1.5,-17.5
@@ -9670,7 +10233,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1380
+  - uid: 1441
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,-24.5
@@ -9678,7 +10241,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1381
+  - uid: 1442
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,-23.5
@@ -9688,7 +10251,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1382
+  - uid: 1443
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,-22.5
@@ -9698,7 +10261,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1383
+  - uid: 1444
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,-21.5
@@ -9706,7 +10269,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1384
+  - uid: 1445
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,-20.5
@@ -9716,7 +10279,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1385
+  - uid: 1446
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,-19.5
@@ -9726,7 +10289,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1386
+  - uid: 1447
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,-18.5
@@ -9736,7 +10299,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1387
+  - uid: 1448
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,-17.5
@@ -9744,7 +10307,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1388
+  - uid: 1449
     components:
     - rot: 3.141592653589793 rad
       pos: -1.5,-13.5
@@ -9752,7 +10315,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1389
+  - uid: 1450
     components:
     - rot: 3.141592653589793 rad
       pos: -1.5,-11.5
@@ -9762,7 +10325,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1390
+  - uid: 1451
     components:
     - rot: 3.141592653589793 rad
       pos: -1.5,-10.5
@@ -9770,7 +10333,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1391
+  - uid: 1452
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,-16.5
@@ -9778,7 +10341,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1392
+  - uid: 1453
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,-14.5
@@ -9786,7 +10349,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1393
+  - uid: 1454
     components:
     - rot: 1.5707963267948966 rad
       pos: -1.5,-15.5
@@ -9794,7 +10357,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1394
+  - uid: 1455
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,-12.5
@@ -9802,7 +10365,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1395
+  - uid: 1456
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,-11.5
@@ -9812,7 +10375,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1396
+  - uid: 1457
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,-10.5
@@ -9820,7 +10383,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1397
+  - uid: 1458
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,-9.5
@@ -9828,7 +10391,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1398
+  - uid: 1459
     components:
     - rot: 3.141592653589793 rad
       pos: -1.5,-9.5
@@ -9836,7 +10399,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1399
+  - uid: 1460
     components:
     - rot: 3.141592653589793 rad
       pos: -1.5,-8.5
@@ -9844,7 +10407,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1400
+  - uid: 1461
     components:
     - rot: 3.141592653589793 rad
       pos: 2.5,-7.5
@@ -9852,7 +10415,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1401
+  - uid: 1462
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,-8.5
@@ -9860,7 +10423,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1402
+  - uid: 1463
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,-7.5
@@ -9868,7 +10431,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1403
+  - uid: 1464
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,-6.5
@@ -9876,7 +10439,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1404
+  - uid: 1465
     components:
     - rot: 3.141592653589793 rad
       pos: -1.5,-6.5
@@ -9884,49 +10447,49 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1405
+  - uid: 1466
     components:
     - pos: -0.5,-4.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1406
+  - uid: 1467
     components:
     - pos: -1.5,-5.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1407
+  - uid: 1468
     components:
     - pos: -1.5,-4.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1408
+  - uid: 1469
     components:
     - pos: -1.5,-3.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1409
+  - uid: 1470
     components:
     - pos: -1.5,-0.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1410
+  - uid: 1471
     components:
     - pos: -1.5,0.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1411
+  - uid: 1472
     components:
     - rot: 1.5707963267948966 rad
       pos: 1.5,1.5
@@ -9934,21 +10497,21 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1412
+  - uid: 1473
     components:
     - pos: 2.5,0.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1413
+  - uid: 1474
     components:
     - pos: 2.5,-0.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1414
+  - uid: 1475
     components:
     - rot: -1.5707963267948966 rad
       pos: -1.5,-3.5
@@ -9956,7 +10519,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1415
+  - uid: 1476
     components:
     - rot: -1.5707963267948966 rad
       pos: -2.5,-3.5
@@ -9964,7 +10527,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1416
+  - uid: 1477
     components:
     - rot: 3.141592653589793 rad
       pos: -3.5,-2.5
@@ -9972,7 +10535,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1417
+  - uid: 1478
     components:
     - rot: 3.141592653589793 rad
       pos: -3.5,-1.5
@@ -9980,7 +10543,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1418
+  - uid: 1479
     components:
     - rot: 3.141592653589793 rad
       pos: -3.5,-0.5
@@ -9988,7 +10551,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1419
+  - uid: 1480
     components:
     - rot: 3.141592653589793 rad
       pos: -3.5,0.5
@@ -9996,7 +10559,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1420
+  - uid: 1481
     components:
     - rot: 3.141592653589793 rad
       pos: -3.5,1.5
@@ -10004,7 +10567,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1421
+  - uid: 1482
     components:
     - rot: 3.141592653589793 rad
       pos: -3.5,2.5
@@ -10012,7 +10575,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1422
+  - uid: 1483
     components:
     - rot: 1.5707963267948966 rad
       pos: -2.5,3.5
@@ -10020,7 +10583,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1423
+  - uid: 1484
     components:
     - rot: 1.5707963267948966 rad
       pos: -1.5,3.5
@@ -10028,7 +10591,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1424
+  - uid: 1485
     components:
     - rot: 1.5707963267948966 rad
       pos: 0.5,1.5
@@ -10036,7 +10599,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1425
+  - uid: 1486
     components:
     - pos: 0.5,2.5
       parent: 1
@@ -10045,7 +10608,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1426
+  - uid: 1487
     components:
     - rot: 1.5707963267948966 rad
       pos: 2.5,3.5
@@ -10053,7 +10616,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1427
+  - uid: 1488
     components:
     - rot: 1.5707963267948966 rad
       pos: 3.5,3.5
@@ -10061,49 +10624,49 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1428
+  - uid: 1489
     components:
     - pos: 4.5,2.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1429
+  - uid: 1490
     components:
     - pos: 4.5,1.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1430
+  - uid: 1491
     components:
     - pos: 4.5,0.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1431
+  - uid: 1492
     components:
     - pos: 4.5,-0.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1432
+  - uid: 1493
     components:
     - pos: 4.5,-1.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1433
+  - uid: 1494
     components:
     - pos: 4.5,-2.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1434
+  - uid: 1495
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,-3.5
@@ -10111,7 +10674,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1435
+  - uid: 1496
     components:
     - rot: -1.5707963267948966 rad
       pos: 2.5,-3.5
@@ -10119,91 +10682,91 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1436
+  - uid: 1497
     components:
     - pos: 1.5,-4.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1437
+  - uid: 1498
     components:
     - pos: 1.5,-6.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1438
+  - uid: 1499
     components:
     - pos: 1.5,-7.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1439
+  - uid: 1500
     components:
     - pos: 1.5,-8.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1440
+  - uid: 1501
     components:
     - pos: 1.5,-9.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1441
+  - uid: 1502
     components:
     - pos: 1.5,-10.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1442
+  - uid: 1503
     components:
     - pos: 2.5,-3.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1443
+  - uid: 1504
     components:
     - pos: 2.5,-4.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1444
+  - uid: 1505
     components:
     - pos: 2.5,-6.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1445
+  - uid: 1506
     components:
     - pos: 2.5,-8.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1446
+  - uid: 1507
     components:
     - pos: 2.5,-9.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1447
+  - uid: 1508
     components:
     - pos: 2.5,-10.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1448
+  - uid: 1509
     components:
     - pos: 1.5,-11.5
       parent: 1
@@ -10212,28 +10775,28 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1449
+  - uid: 1510
     components:
     - pos: 1.5,-12.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1450
+  - uid: 1511
     components:
     - pos: 1.5,-14.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1451
+  - uid: 1512
     components:
     - pos: 1.5,-16.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1452
+  - uid: 1513
     components:
     - pos: 1.5,-18.5
       parent: 1
@@ -10242,7 +10805,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1453
+  - uid: 1514
     components:
     - pos: 1.5,-19.5
       parent: 1
@@ -10251,7 +10814,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1454
+  - uid: 1515
     components:
     - pos: 1.5,-20.5
       parent: 1
@@ -10260,14 +10823,14 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1455
+  - uid: 1516
     components:
     - pos: 1.5,-21.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1456
+  - uid: 1517
     components:
     - pos: 1.5,-22.5
       parent: 1
@@ -10276,7 +10839,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1457
+  - uid: 1518
     components:
     - pos: 1.5,-23.5
       parent: 1
@@ -10285,7 +10848,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1458
+  - uid: 1519
     components:
     - pos: 1.5,-24.5
       parent: 1
@@ -10294,7 +10857,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1459
+  - uid: 1520
     components:
     - pos: 2.5,-11.5
       parent: 1
@@ -10303,7 +10866,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1460
+  - uid: 1521
     components:
     - rot: 3.141592653589793 rad
       pos: 6.5,-16.5
@@ -10311,14 +10874,14 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1461
+  - uid: 1522
     components:
     - pos: 2.5,-13.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1462
+  - uid: 1523
     components:
     - rot: 3.141592653589793 rad
       pos: 6.5,-17.5
@@ -10328,14 +10891,14 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1463
+  - uid: 1524
     components:
     - pos: 2.5,-15.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1464
+  - uid: 1525
     components:
     - rot: 3.141592653589793 rad
       pos: 6.5,-18.5
@@ -10343,14 +10906,14 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1465
+  - uid: 1526
     components:
     - pos: 2.5,-17.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1466
+  - uid: 1527
     components:
     - pos: 2.5,-18.5
       parent: 1
@@ -10359,7 +10922,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1467
+  - uid: 1528
     components:
     - pos: 2.5,-19.5
       parent: 1
@@ -10368,7 +10931,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1468
+  - uid: 1529
     components:
     - pos: 2.5,-20.5
       parent: 1
@@ -10377,7 +10940,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1469
+  - uid: 1530
     components:
     - pos: 2.5,-21.5
       parent: 1
@@ -10386,7 +10949,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1470
+  - uid: 1531
     components:
     - pos: 2.5,-22.5
       parent: 1
@@ -10395,7 +10958,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1471
+  - uid: 1532
     components:
     - rot: 1.5707963267948966 rad
       pos: 4.5,-23.5
@@ -10405,7 +10968,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1472
+  - uid: 1533
     components:
     - rot: 1.5707963267948966 rad
       pos: 5.5,-23.5
@@ -10415,7 +10978,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1473
+  - uid: 1534
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,-25.5
@@ -10425,7 +10988,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1474
+  - uid: 1535
     components:
     - rot: -1.5707963267948966 rad
       pos: 4.5,-25.5
@@ -10435,7 +10998,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1475
+  - uid: 1536
     components:
     - rot: -1.5707963267948966 rad
       pos: 5.5,-25.5
@@ -10445,14 +11008,14 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1476
+  - uid: 1537
     components:
     - pos: 7.5,-25.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1477
+  - uid: 1538
     components:
     - pos: 7.5,-26.5
       parent: 1
@@ -10461,14 +11024,14 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1478
+  - uid: 1539
     components:
     - pos: 7.5,-27.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1479
+  - uid: 1540
     components:
     - rot: 3.141592653589793 rad
       pos: 6.5,-26.5
@@ -10478,7 +11041,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1480
+  - uid: 1541
     components:
     - rot: 3.141592653589793 rad
       pos: 6.5,-27.5
@@ -10486,7 +11049,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1481
+  - uid: 1542
     components:
     - rot: 3.141592653589793 rad
       pos: 6.5,-28.5
@@ -10494,7 +11057,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1482
+  - uid: 1543
     components:
     - rot: 3.141592653589793 rad
       pos: 6.5,-29.5
@@ -10502,7 +11065,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1483
+  - uid: 1544
     components:
     - rot: 3.141592653589793 rad
       pos: 6.5,-30.5
@@ -10510,7 +11073,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1484
+  - uid: 1545
     components:
     - rot: 3.141592653589793 rad
       pos: 6.5,-31.5
@@ -10518,7 +11081,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1485
+  - uid: 1546
     components:
     - rot: 3.141592653589793 rad
       pos: 6.5,-32.5
@@ -10526,7 +11089,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1486
+  - uid: 1547
     components:
     - rot: 1.5707963267948966 rad
       pos: -1.5,-31.5
@@ -10534,9 +11097,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
-  - uid: 1487
+  - uid: 1548
     components:
     - rot: 3.141592653589793 rad
       pos: 7.5,-29.5
@@ -10544,7 +11105,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1488
+  - uid: 1549
     components:
     - rot: 3.141592653589793 rad
       pos: 7.5,-30.5
@@ -10552,7 +11113,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1489
+  - uid: 1550
     components:
     - rot: 3.141592653589793 rad
       pos: 7.5,-31.5
@@ -10560,7 +11121,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1490
+  - uid: 1551
     components:
     - rot: 3.141592653589793 rad
       pos: 7.5,-32.5
@@ -10568,7 +11129,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1491
+  - uid: 1552
     components:
     - rot: 3.141592653589793 rad
       pos: 7.5,-33.5
@@ -10576,7 +11137,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1492
+  - uid: 1553
     components:
     - rot: 3.141592653589793 rad
       pos: -5.5,-16.5
@@ -10584,7 +11145,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1493
+  - uid: 1554
     components:
     - rot: 3.141592653589793 rad
       pos: -5.5,-15.5
@@ -10592,7 +11153,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1494
+  - uid: 1555
     components:
     - rot: 1.5707963267948966 rad
       pos: -5.5,-12.5
@@ -10600,7 +11161,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1495
+  - uid: 1556
     components:
     - rot: 1.5707963267948966 rad
       pos: -4.5,-12.5
@@ -10610,7 +11171,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1496
+  - uid: 1557
     components:
     - rot: -1.5707963267948966 rad
       pos: -3.5,-12.5
@@ -10618,7 +11179,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1497
+  - uid: 1558
     components:
     - rot: -1.5707963267948966 rad
       pos: -2.5,-12.5
@@ -10626,7 +11187,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1498
+  - uid: 1559
     components:
     - rot: -1.5707963267948966 rad
       pos: -5.5,-13.5
@@ -10634,7 +11195,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1499
+  - uid: 1560
     components:
     - rot: -1.5707963267948966 rad
       pos: -4.5,-13.5
@@ -10642,7 +11203,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1500
+  - uid: 1561
     components:
     - rot: -1.5707963267948966 rad
       pos: -3.5,-13.5
@@ -10650,7 +11211,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1501
+  - uid: 1562
     components:
     - rot: -1.5707963267948966 rad
       pos: -2.5,-13.5
@@ -10658,7 +11219,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1502
+  - uid: 1563
     components:
     - rot: -1.5707963267948966 rad
       pos: -1.5,-13.5
@@ -10666,7 +11227,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1503
+  - uid: 1564
     components:
     - rot: 1.5707963267948966 rad
       pos: -4.5,-14.5
@@ -10676,7 +11237,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1504
+  - uid: 1565
     components:
     - rot: 1.5707963267948966 rad
       pos: -3.5,-14.5
@@ -10684,7 +11245,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1505
+  - uid: 1566
     components:
     - rot: 1.5707963267948966 rad
       pos: -2.5,-14.5
@@ -10694,7 +11255,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1506
+  - uid: 1567
     components:
     - pos: -3.5,-17.5
       parent: 1
@@ -10703,14 +11264,14 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1507
+  - uid: 1568
     components:
     - pos: -3.5,-16.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1508
+  - uid: 1569
     components:
     - rot: 1.5707963267948966 rad
       pos: -2.5,-15.5
@@ -10718,7 +11279,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1509
+  - uid: 1570
     components:
     - rot: 3.141592653589793 rad
       pos: -1.5,-15.5
@@ -10726,14 +11287,14 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1510
+  - uid: 1571
     components:
     - pos: 2.5,-5.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1511
+  - uid: 1572
     components:
     - pos: -1.5,-1.5
       parent: 1
@@ -10742,7 +11303,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1512
+  - uid: 1573
     components:
     - pos: 2.5,-1.5
       parent: 1
@@ -10751,14 +11312,14 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1513
+  - uid: 1574
     components:
     - pos: 2.5,-2.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1514
+  - uid: 1575
     components:
     - rot: 3.141592653589793 rad
       pos: 6.5,-15.5
@@ -10766,7 +11327,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1515
+  - uid: 1576
     components:
     - rot: 1.5707963267948966 rad
       pos: 6.5,-12.5
@@ -10774,7 +11335,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1516
+  - uid: 1577
     components:
     - rot: 1.5707963267948966 rad
       pos: 5.5,-12.5
@@ -10784,7 +11345,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1517
+  - uid: 1578
     components:
     - rot: 1.5707963267948966 rad
       pos: 4.5,-12.5
@@ -10792,7 +11353,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1518
+  - uid: 1579
     components:
     - rot: 1.5707963267948966 rad
       pos: 3.5,-12.5
@@ -10802,7 +11363,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1519
+  - uid: 1580
     components:
     - rot: -1.5707963267948966 rad
       pos: 5.5,-14.5
@@ -10812,7 +11373,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1520
+  - uid: 1581
     components:
     - rot: -1.5707963267948966 rad
       pos: 4.5,-14.5
@@ -10820,7 +11381,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1521
+  - uid: 1582
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,-14.5
@@ -10830,7 +11391,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1522
+  - uid: 1583
     components:
     - rot: 3.141592653589793 rad
       pos: 4.5,-17.5
@@ -10840,7 +11401,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1523
+  - uid: 1584
     components:
     - rot: 3.141592653589793 rad
       pos: 4.5,-16.5
@@ -10848,7 +11409,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1524
+  - uid: 1585
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,-15.5
@@ -10856,7 +11417,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1525
+  - uid: 1586
     components:
     - rot: -1.5707963267948966 rad
       pos: 2.5,-15.5
@@ -10864,7 +11425,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1526
+  - uid: 1587
     components:
     - rot: -1.5707963267948966 rad
       pos: -4.5,-30.5
@@ -10874,7 +11435,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1527
+  - uid: 1588
     components:
     - rot: -1.5707963267948966 rad
       pos: -5.5,-30.5
@@ -10882,7 +11443,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1528
+  - uid: 1589
     components:
     - rot: -1.5707963267948966 rad
       pos: -4.5,-27.5
@@ -10892,7 +11453,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1529
+  - uid: 1590
     components:
     - rot: -1.5707963267948966 rad
       pos: -5.5,-27.5
@@ -10900,7 +11461,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1530
+  - uid: 1591
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,-32.5
@@ -10910,7 +11471,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1531
+  - uid: 1592
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,-31.5
@@ -10918,9 +11479,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
-  - uid: 1532
+  - uid: 1593
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,-13.5
@@ -10928,7 +11487,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1533
+  - uid: 1594
     components:
     - rot: -1.5707963267948966 rad
       pos: 4.5,-13.5
@@ -10936,7 +11495,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1534
+  - uid: 1595
     components:
     - rot: -1.5707963267948966 rad
       pos: 5.5,-13.5
@@ -10944,7 +11503,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1535
+  - uid: 1596
     components:
     - rot: -1.5707963267948966 rad
       pos: 6.5,-13.5
@@ -10952,14 +11511,14 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1536
+  - uid: 1597
     components:
     - pos: -0.5,3.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1537
+  - uid: 1598
     components:
     - rot: -1.5707963267948966 rad
       pos: -0.5,-7.5
@@ -10967,7 +11526,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1538
+  - uid: 1599
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,2.5
@@ -10977,7 +11536,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1539
+  - uid: 1600
     components:
     - rot: 3.141592653589793 rad
       pos: 1.5,-5.5
@@ -10985,7 +11544,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1540
+  - uid: 1601
     components:
     - rot: -1.5707963267948966 rad
       pos: -7.5,-31.5
@@ -10993,9 +11552,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
-  - uid: 1541
+  - uid: 1602
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,-23.5
@@ -11005,7 +11562,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1542
+  - uid: 1603
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,2.5
@@ -11015,7 +11572,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1543
+  - uid: 1604
     components:
     - rot: -1.5707963267948966 rad
       pos: 2.5,-25.5
@@ -11025,7 +11582,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1544
+  - uid: 1605
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,0.5
@@ -11033,7 +11590,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1545
+  - uid: 1606
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,1.5
@@ -11041,7 +11598,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1546
+  - uid: 1607
     components:
     - rot: 1.5707963267948966 rad
       pos: -0.5,3.5
@@ -11049,7 +11606,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1547
+  - uid: 1608
     components:
     - rot: -1.5707963267948966 rad
       pos: 5.5,0.5
@@ -11057,7 +11614,7 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-  - uid: 1548
+  - uid: 1609
     components:
     - rot: -1.5707963267948966 rad
       pos: 6.5,0.5
@@ -11067,14 +11624,14 @@ entities:
       type: AmbientSound
 - proto: GasPipeTJunction
   entities:
-  - uid: 1549
+  - uid: 1610
     components:
     - pos: 0.5,3.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1550
+  - uid: 1611
     components:
     - rot: 1.5707963267948966 rad
       pos: 6.5,-24.5
@@ -11082,13 +11639,13 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1551
+  - uid: 1612
     components:
     - rot: 3.141592653589793 rad
       pos: 3.5,-33.5
       parent: 1
       type: Transform
-  - uid: 1552
+  - uid: 1613
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,-31.5
@@ -11096,9 +11653,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
-  - uid: 1553
+  - uid: 1614
     components:
     - rot: 1.5707963267948966 rad
       pos: -5.5,-33.5
@@ -11106,7 +11661,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1554
+  - uid: 1615
     components:
     - rot: -1.5707963267948966 rad
       pos: -6.5,-33.5
@@ -11114,7 +11669,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1555
+  - uid: 1616
     components:
     - rot: 1.5707963267948966 rad
       pos: -6.5,-30.5
@@ -11122,7 +11677,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1556
+  - uid: 1617
     components:
     - rot: -1.5707963267948966 rad
       pos: -6.5,-31.5
@@ -11130,7 +11685,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1557
+  - uid: 1618
     components:
     - rot: 1.5707963267948966 rad
       pos: -6.5,-27.5
@@ -11138,7 +11693,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1558
+  - uid: 1619
     components:
     - rot: -1.5707963267948966 rad
       pos: -5.5,-29.5
@@ -11146,7 +11701,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1559
+  - uid: 1620
     components:
     - rot: -1.5707963267948966 rad
       pos: -1.5,-12.5
@@ -11154,7 +11709,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1560
+  - uid: 1621
     components:
     - rot: -1.5707963267948966 rad
       pos: -0.5,-15.5
@@ -11162,7 +11717,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1561
+  - uid: 1622
     components:
     - rot: -1.5707963267948966 rad
       pos: -1.5,-14.5
@@ -11170,7 +11725,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1562
+  - uid: 1623
     components:
     - rot: -1.5707963267948966 rad
       pos: -1.5,-16.5
@@ -11178,7 +11733,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1563
+  - uid: 1624
     components:
     - rot: -1.5707963267948966 rad
       pos: -0.5,-13.5
@@ -11186,7 +11741,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1564
+  - uid: 1625
     components:
     - rot: 1.5707963267948966 rad
       pos: -1.5,-7.5
@@ -11194,7 +11749,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1565
+  - uid: 1626
     components:
     - rot: 3.141592653589793 rad
       pos: 1.5,3.5
@@ -11202,7 +11757,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1566
+  - uid: 1627
     components:
     - rot: 1.5707963267948966 rad
       pos: 1.5,-15.5
@@ -11210,7 +11765,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1567
+  - uid: 1628
     components:
     - rot: -1.5707963267948966 rad
       pos: 1.5,-17.5
@@ -11218,7 +11773,7 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1568
+  - uid: 1629
     components:
     - pos: -2.5,-23.5
       parent: 1
@@ -11227,7 +11782,7 @@ entities:
       type: AtmosPipeColor
     - enabled: True
       type: AmbientSound
-  - uid: 1569
+  - uid: 1630
     components:
     - rot: 3.141592653589793 rad
       pos: -1.5,-25.5
@@ -11235,14 +11790,14 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1570
+  - uid: 1631
     components:
     - pos: 6.5,-25.5
       parent: 1
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1571
+  - uid: 1632
     components:
     - rot: -1.5707963267948966 rad
       pos: 7.5,-28.5
@@ -11250,7 +11805,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1572
+  - uid: 1633
     components:
     - rot: -1.5707963267948966 rad
       pos: 0.5,-33.5
@@ -11258,7 +11813,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1573
+  - uid: 1634
     components:
     - rot: 1.5707963267948966 rad
       pos: -6.5,-28.5
@@ -11266,7 +11821,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1574
+  - uid: 1635
     components:
     - rot: 1.5707963267948966 rad
       pos: 2.5,-12.5
@@ -11274,7 +11829,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1575
+  - uid: 1636
     components:
     - rot: 1.5707963267948966 rad
       pos: 2.5,-14.5
@@ -11282,7 +11837,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1576
+  - uid: 1637
     components:
     - rot: 1.5707963267948966 rad
       pos: 2.5,-16.5
@@ -11290,7 +11845,7 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1577
+  - uid: 1638
     components:
     - rot: 1.5707963267948966 rad
       pos: -0.5,-5.5
@@ -11300,22 +11855,22 @@ entities:
       type: AtmosPipeColor
 - proto: GasPort
   entities:
-  - uid: 1578
+  - uid: 1639
     components:
     - pos: 4.5,-32.5
       parent: 1
       type: Transform
-  - uid: 1579
+  - uid: 1640
     components:
     - pos: 5.5,-32.5
       parent: 1
       type: Transform
-  - uid: 1580
+  - uid: 1641
     components:
     - pos: 2.5,-32.5
       parent: 1
       type: Transform
-  - uid: 1581
+  - uid: 1642
     components:
     - rot: 1.5707963267948966 rad
       pos: 4.5,0.5
@@ -11323,14 +11878,14 @@ entities:
       type: Transform
 - proto: GasThermoMachineHeater
   entities:
-  - uid: 1582
+  - uid: 1643
     components:
     - pos: 3.5,-32.5
       parent: 1
       type: Transform
 - proto: GasVentPump
   entities:
-  - uid: 1583
+  - uid: 1644
     components:
     - pos: -0.5,-30.5
       parent: 1
@@ -11342,7 +11897,7 @@ entities:
       type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1584
+  - uid: 1645
     components:
     - rot: 3.141592653589793 rad
       pos: 6.5,-33.5
@@ -11350,27 +11905,27 @@ entities:
       type: Transform
     - ShutdownSubscribers:
       - 5
-      - 1241
+      - 1302
       type: DeviceNetwork
     - enabled: False
       type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1585
+  - uid: 1646
     components:
     - pos: 1.5,4.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
       - 13
-      - 1237
-      - 1240
+      - 1298
+      - 1301
       type: DeviceNetwork
     - enabled: False
       type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1586
+  - uid: 1647
     components:
     - rot: -1.5707963267948966 rad
       pos: 0.5,-5.5
@@ -11378,14 +11933,14 @@ entities:
       type: Transform
     - ShutdownSubscribers:
       - 14
-      - 1238
-      - 1239
+      - 1299
+      - 1300
       type: DeviceNetwork
     - enabled: False
       type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1587
+  - uid: 1648
     components:
     - rot: 3.141592653589793 rad
       pos: -3.5,-18.5
@@ -11393,13 +11948,13 @@ entities:
       type: Transform
     - ShutdownSubscribers:
       - 8
-      - 1248
+      - 1309
       type: DeviceNetwork
     - enabled: False
       type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1588
+  - uid: 1649
     components:
     - rot: 3.141592653589793 rad
       pos: 4.5,-18.5
@@ -11407,13 +11962,13 @@ entities:
       type: Transform
     - ShutdownSubscribers:
       - 4
-      - 1249
+      - 1310
       type: DeviceNetwork
     - enabled: False
       type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1589
+  - uid: 1650
     components:
     - rot: 1.5707963267948966 rad
       pos: -6.5,-29.5
@@ -11421,13 +11976,13 @@ entities:
       type: Transform
     - ShutdownSubscribers:
       - 7
-      - 1243
+      - 1304
       type: DeviceNetwork
     - enabled: False
       type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1590
+  - uid: 1651
     components:
     - rot: 3.141592653589793 rad
       pos: -5.5,-34.5
@@ -11435,13 +11990,13 @@ entities:
       type: Transform
     - ShutdownSubscribers:
       - 6
-      - 1242
+      - 1303
       type: DeviceNetwork
     - enabled: False
       type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1591
+  - uid: 1652
     components:
     - pos: -1.5,-24.5
       parent: 1
@@ -11453,7 +12008,7 @@ entities:
       type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1592
+  - uid: 1653
     components:
     - rot: 1.5707963267948966 rad
       pos: 0.5,-13.5
@@ -11461,13 +12016,13 @@ entities:
       type: Transform
     - ShutdownSubscribers:
       - 11
-      - 1245
+      - 1306
       type: DeviceNetwork
     - enabled: False
       type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1593
+  - uid: 1654
     components:
     - rot: 1.5707963267948966 rad
       pos: -6.5,-13.5
@@ -11475,13 +12030,13 @@ entities:
       type: Transform
     - ShutdownSubscribers:
       - 9
-      - 1246
+      - 1307
       type: DeviceNetwork
     - enabled: False
       type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1594
+  - uid: 1655
     components:
     - rot: -1.5707963267948966 rad
       pos: 7.5,-13.5
@@ -11489,13 +12044,13 @@ entities:
       type: Transform
     - ShutdownSubscribers:
       - 10
-      - 1247
+      - 1308
       type: DeviceNetwork
     - enabled: False
       type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1595
+  - uid: 1656
     components:
     - rot: -1.5707963267948966 rad
       pos: 7.5,-25.5
@@ -11503,13 +12058,13 @@ entities:
       type: Transform
     - ShutdownSubscribers:
       - 16
-      - 1244
+      - 1305
       type: DeviceNetwork
     - enabled: False
       type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1596
+  - uid: 1657
     components:
     - rot: 1.5707963267948966 rad
       pos: 0.5,-17.5
@@ -11517,13 +12072,13 @@ entities:
       type: Transform
     - ShutdownSubscribers:
       - 11
-      - 1245
+      - 1306
       type: DeviceNetwork
     - enabled: False
       type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 1597
+  - uid: 1658
     components:
     - rot: 1.5707963267948966 rad
       pos: -0.5,-0.5
@@ -11538,7 +12093,7 @@ entities:
       type: AtmosPipeColor
 - proto: GasVentScrubber
   entities:
-  - uid: 1598
+  - uid: 1659
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,0.5
@@ -11551,7 +12106,7 @@ entities:
       type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1599
+  - uid: 1660
     components:
     - pos: 0.5,-30.5
       parent: 1
@@ -11563,21 +12118,21 @@ entities:
       type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1600
+  - uid: 1661
     components:
     - pos: -0.5,4.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
       - 13
-      - 1237
-      - 1240
+      - 1298
+      - 1301
       type: DeviceNetwork
     - enabled: False
       type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1601
+  - uid: 1662
     components:
     - rot: -1.5707963267948966 rad
       pos: 0.5,-7.5
@@ -11585,14 +12140,14 @@ entities:
       type: Transform
     - ShutdownSubscribers:
       - 14
-      - 1238
-      - 1239
+      - 1299
+      - 1300
       type: DeviceNetwork
     - enabled: False
       type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1602
+  - uid: 1663
     components:
     - rot: 3.141592653589793 rad
       pos: 6.5,-19.5
@@ -11600,13 +12155,13 @@ entities:
       type: Transform
     - ShutdownSubscribers:
       - 4
-      - 1249
+      - 1310
       type: DeviceNetwork
     - enabled: False
       type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1603
+  - uid: 1664
     components:
     - rot: 3.141592653589793 rad
       pos: -2.5,-24.5
@@ -11619,7 +12174,7 @@ entities:
       type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1604
+  - uid: 1665
     components:
     - rot: 3.141592653589793 rad
       pos: 7.5,-34.5
@@ -11627,13 +12182,13 @@ entities:
       type: Transform
     - ShutdownSubscribers:
       - 5
-      - 1241
+      - 1302
       type: DeviceNetwork
     - enabled: False
       type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1605
+  - uid: 1666
     components:
     - rot: 1.5707963267948966 rad
       pos: -7.5,-33.5
@@ -11641,13 +12196,13 @@ entities:
       type: Transform
     - ShutdownSubscribers:
       - 6
-      - 1242
+      - 1303
       type: DeviceNetwork
     - enabled: False
       type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1606
+  - uid: 1667
     components:
     - rot: -1.5707963267948966 rad
       pos: -5.5,-28.5
@@ -11655,13 +12210,13 @@ entities:
       type: Transform
     - ShutdownSubscribers:
       - 7
-      - 1243
+      - 1304
       type: DeviceNetwork
     - enabled: False
       type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1607
+  - uid: 1668
     components:
     - rot: 1.5707963267948966 rad
       pos: -2.5,-16.5
@@ -11669,13 +12224,13 @@ entities:
       type: Transform
     - ShutdownSubscribers:
       - 11
-      - 1245
+      - 1306
       type: DeviceNetwork
     - enabled: False
       type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1608
+  - uid: 1669
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,-16.5
@@ -11683,13 +12238,13 @@ entities:
       type: Transform
     - ShutdownSubscribers:
       - 11
-      - 1245
+      - 1306
       type: DeviceNetwork
     - enabled: False
       type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1609
+  - uid: 1670
     components:
     - rot: 1.5707963267948966 rad
       pos: -6.5,-12.5
@@ -11697,13 +12252,13 @@ entities:
       type: Transform
     - ShutdownSubscribers:
       - 9
-      - 1246
+      - 1307
       type: DeviceNetwork
     - enabled: False
       type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1610
+  - uid: 1671
     components:
     - rot: -1.5707963267948966 rad
       pos: 7.5,-12.5
@@ -11711,13 +12266,13 @@ entities:
       type: Transform
     - ShutdownSubscribers:
       - 10
-      - 1247
+      - 1308
       type: DeviceNetwork
     - enabled: False
       type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1611
+  - uid: 1672
     components:
     - rot: 1.5707963267948966 rad
       pos: 6.5,-28.5
@@ -11725,13 +12280,13 @@ entities:
       type: Transform
     - ShutdownSubscribers:
       - 5
-      - 1241
+      - 1302
       type: DeviceNetwork
     - enabled: False
       type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1612
+  - uid: 1673
     components:
     - rot: -1.5707963267948966 rad
       pos: -3.5,-30.5
@@ -11741,7 +12296,7 @@ entities:
       type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1613
+  - uid: 1674
     components:
     - rot: -1.5707963267948966 rad
       pos: -3.5,-27.5
@@ -11751,7 +12306,7 @@ entities:
       type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1614
+  - uid: 1675
     components:
     - rot: 3.141592653589793 rad
       pos: -5.5,-19.5
@@ -11759,13 +12314,13 @@ entities:
       type: Transform
     - ShutdownSubscribers:
       - 8
-      - 1248
+      - 1309
       type: DeviceNetwork
     - enabled: False
       type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1615
+  - uid: 1676
     components:
     - rot: 1.5707963267948966 rad
       pos: -8.5,-31.5
@@ -11775,7 +12330,7 @@ entities:
       type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 1616
+  - uid: 1677
     components:
     - rot: 3.141592653589793 rad
       pos: 6.5,-25.5
@@ -11783,7 +12338,7 @@ entities:
       type: Transform
     - ShutdownSubscribers:
       - 16
-      - 1244
+      - 1305
       type: DeviceNetwork
     - enabled: False
       type: AmbientSound
@@ -11791,242 +12346,249 @@ entities:
       type: AtmosPipeColor
 - proto: GravityGeneratorMini
   entities:
-  - uid: 1617
+  - uid: 1678
     components:
     - pos: 0.5,-34.5
       parent: 1
       type: Transform
 - proto: Grille
   entities:
-  - uid: 1618
+  - uid: 1679
     components:
     - pos: 1.5,-29.5
       parent: 1
       type: Transform
-  - uid: 1619
+  - uid: 1680
     components:
     - pos: 0.5,-18.5
       parent: 1
       type: Transform
-  - uid: 1620
+  - uid: 1681
     components:
     - pos: 1.5,-18.5
       parent: 1
       type: Transform
-  - uid: 1621
+  - uid: 1682
     components:
     - pos: 2.5,-18.5
       parent: 1
       type: Transform
-  - uid: 1622
+  - uid: 1683
     components:
     - pos: -1.5,-20.5
       parent: 1
       type: Transform
-  - uid: 1623
+  - uid: 1684
     components:
     - pos: -0.5,-20.5
       parent: 1
       type: Transform
-  - uid: 1624
+  - uid: 1685
     components:
     - pos: 1.5,-20.5
       parent: 1
       type: Transform
-  - uid: 1625
+  - uid: 1686
     components:
     - pos: 2.5,-20.5
       parent: 1
       type: Transform
-  - uid: 1626
+  - uid: 1687
     components:
     - pos: -0.5,-18.5
       parent: 1
       type: Transform
-  - uid: 1627
+  - uid: 1688
     components:
     - pos: -1.5,-18.5
       parent: 1
       type: Transform
-  - uid: 1628
+  - uid: 1689
     components:
     - pos: 0.5,-20.5
       parent: 1
       type: Transform
-  - uid: 1629
+  - uid: 1690
     components:
     - pos: -2.5,-22.5
       parent: 1
       type: Transform
-  - uid: 1630
+  - uid: 1691
     components:
     - pos: -3.5,-22.5
       parent: 1
       type: Transform
-  - uid: 1631
+  - uid: 1692
     components:
     - pos: -4.5,-22.5
       parent: 1
       type: Transform
-  - uid: 1632
+  - uid: 1693
     components:
     - pos: -6.5,-22.5
       parent: 1
       type: Transform
-  - uid: 1633
+  - uid: 1694
     components:
     - pos: 3.5,-22.5
       parent: 1
       type: Transform
-  - uid: 1634
+  - uid: 1695
     components:
     - pos: 4.5,-22.5
       parent: 1
       type: Transform
-  - uid: 1635
+  - uid: 1696
     components:
     - pos: 5.5,-22.5
       parent: 1
       type: Transform
-  - uid: 1636
+  - uid: 1697
     components:
     - pos: 7.5,-22.5
       parent: 1
       type: Transform
-  - uid: 1637
+  - uid: 1698
     components:
     - pos: 3.5,-26.5
       parent: 1
       type: Transform
-  - uid: 1638
+  - uid: 1699
     components:
     - rot: -1.5707963267948966 rad
       pos: 8.5,-24.5
       parent: 1
       type: Transform
-  - uid: 1639
+  - uid: 1700
     components:
     - pos: -7.5,-24.5
       parent: 1
       type: Transform
-  - uid: 1640
+  - uid: 1701
     components:
     - rot: 3.141592653589793 rad
       pos: 1.5,-27.5
       parent: 1
       type: Transform
-  - uid: 1641
+  - uid: 1702
     components:
     - rot: 3.141592653589793 rad
       pos: 1.5,-28.5
       parent: 1
       type: Transform
-  - uid: 1642
+  - uid: 1703
     components:
     - rot: 1.5707963267948966 rad
       pos: -7.5,-15.5
       parent: 1
       type: Transform
-  - uid: 1643
+  - uid: 1704
     components:
     - rot: 1.5707963267948966 rad
       pos: -7.5,-16.5
       parent: 1
       type: Transform
-  - uid: 1644
+  - uid: 1705
     components:
     - rot: 3.141592653589793 rad
       pos: 8.5,-16.5
       parent: 1
       type: Transform
-  - uid: 1645
+  - uid: 1706
     components:
     - rot: 3.141592653589793 rad
       pos: 8.5,-15.5
       parent: 1
       type: Transform
-  - uid: 1646
+  - uid: 1707
     components:
     - rot: -1.5707963267948966 rad
       pos: -2.5,0.5
       parent: 1
       type: Transform
-  - uid: 1647
+  - uid: 1708
     components:
     - rot: -1.5707963267948966 rad
       pos: -0.5,2.5
       parent: 1
       type: Transform
-  - uid: 1648
+  - uid: 1709
     components:
     - rot: -1.5707963267948966 rad
       pos: 1.5,2.5
       parent: 1
       type: Transform
-  - uid: 1649
+  - uid: 1710
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,0.5
       parent: 1
       type: Transform
-  - uid: 1650
+  - uid: 1711
     components:
     - rot: 3.141592653589793 rad
       pos: 1.5,-34.5
       parent: 1
       type: Transform
-  - uid: 1651
+  - uid: 1712
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,-34.5
       parent: 1
       type: Transform
-  - uid: 1652
+  - uid: 1713
     components:
     - pos: 4.5,-26.5
       parent: 1
       type: Transform
-  - uid: 1653
+  - uid: 1714
     components:
     - pos: 2.5,-26.5
       parent: 1
       type: Transform
-  - uid: 1654
+  - uid: 1715
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,-32.5
       parent: 1
       type: Transform
-  - uid: 1655
+  - uid: 1716
     components:
     - rot: 3.141592653589793 rad
       pos: -9.5,-33.5
       parent: 1
       type: Transform
-  - uid: 1656
+  - uid: 1717
     components:
     - pos: -0.5,-1.5
       parent: 1
       type: Transform
-  - uid: 1657
+  - uid: 1718
     components:
     - rot: 3.141592653589793 rad
       pos: 3.5,-24.5
       parent: 1
       type: Transform
-  - uid: 1658
+  - uid: 1719
     components:
     - pos: -6.5,-26.5
       parent: 1
       type: Transform
-  - uid: 1659
+  - uid: 1720
     components:
     - pos: 6.5,0.5
       parent: 1
       type: Transform
+- proto: GroundTobacco
+  entities:
+  - uid: 1721
+    components:
+    - pos: 1.7202549,-17.40029
+      parent: 1
+      type: Transform
 - proto: GunSafe
   entities:
-  - uid: 1660
+  - uid: 1722
     components:
     - pos: 0.5,-27.5
       parent: 1
@@ -12056,10 +12618,10 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 1663
-          - 1664
-          - 1661
-          - 1662
+          - 1725
+          - 1726
+          - 1723
+          - 1724
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -12067,58 +12629,57 @@ entities:
       type: ContainerContainer
 - proto: Gyroscope
   entities:
-  - uid: 1665
+  - uid: 1727
     components:
     - pos: 9.5,-26.5
       parent: 1
       type: Transform
-  - uid: 1666
+  - uid: 1728
     components:
     - pos: -8.5,-26.5
       parent: 1
       type: Transform
 - proto: HospitalCurtains
   entities:
-  - uid: 1667
+  - uid: 1729
     components:
     - pos: -3.5,-28.5
       parent: 1
       type: Transform
-  - uid: 1668
+  - uid: 1730
     components:
     - pos: -3.5,-31.5
       parent: 1
       type: Transform
-  - uid: 1669
+  - uid: 1731
     components:
     - pos: -9.5,-31.5
       parent: 1
       type: Transform
 - proto: HospitalCurtainsOpen
   entities:
-  - uid: 1670
+  - uid: 1732
     components:
-    - rot: 1.5707963267948966 rad
-      pos: -6.5,-15.5
+    - pos: -5.5,-16.5
       parent: 1
       type: Transform
-  - uid: 1671
+  - uid: 1733
     components:
     - pos: 2.5,1.5
       parent: 1
       type: Transform
-  - uid: 1672
+  - uid: 1734
     components:
     - pos: -0.5,-27.5
       parent: 1
       type: Transform
-  - uid: 1673
+  - uid: 1735
     components:
     - rot: 1.5707963267948966 rad
       pos: 4.5,-25.5
       parent: 1
       type: Transform
-  - uid: 1674
+  - uid: 1736
     components:
     - rot: 1.5707963267948966 rad
       pos: 7.5,-15.5
@@ -12126,7 +12687,7 @@ entities:
       type: Transform
 - proto: HydroponicsToolHatchet
   entities:
-  - uid: 1675
+  - uid: 1737
     components:
     - name: Steve's hatchet
       type: MetaData
@@ -12135,28 +12696,28 @@ entities:
       type: Transform
 - proto: KitchenMicrowave
   entities:
-  - uid: 1676
+  - uid: 1738
     components:
     - pos: 1.5,-12.5
       parent: 1
       type: Transform
 - proto: KitchenReagentGrinder
   entities:
-  - uid: 1677
+  - uid: 1739
     components:
     - pos: 7.5,-13.5
       parent: 1
       type: Transform
 - proto: Lamp
   entities:
-  - uid: 1678
+  - uid: 1740
     components:
     - pos: -9.682015,-32.198692
       parent: 1
       type: Transform
 - proto: LampGold
   entities:
-  - uid: 1679
+  - uid: 1741
     components:
     - rot: 3.141592653589793 rad
       pos: 4.7820306,-24.235859
@@ -12164,14 +12725,16 @@ entities:
       type: Transform
 - proto: LockerBoozeFilled
   entities:
-  - uid: 1680
+  - uid: 1742
     components:
     - pos: -1.5,-12.5
       parent: 1
       type: Transform
+    - locked: False
+      type: Lock
 - proto: LockerCaptain
   entities:
-  - uid: 227
+  - uid: 216
     components:
     - pos: -1.5,-24.5
       parent: 1
@@ -12199,36 +12762,36 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 253
-          - 254
-          - 252
-          - 248
-          - 236
-          - 247
-          - 255
-          - 245
-          - 246
-          - 239
-          - 234
-          - 256
-          - 241
-          - 243
-          - 238
-          - 230
-          - 257
-          - 232
-          - 237
           - 242
-          - 231
-          - 235
-          - 251
-          - 233
-          - 228
-          - 240
-          - 249
-          - 229
+          - 243
+          - 241
+          - 237
+          - 225
+          - 236
           - 244
-          - 250
+          - 234
+          - 235
+          - 228
+          - 223
+          - 245
+          - 230
+          - 232
+          - 227
+          - 219
+          - 246
+          - 221
+          - 226
+          - 231
+          - 220
+          - 224
+          - 240
+          - 222
+          - 217
+          - 229
+          - 238
+          - 218
+          - 233
+          - 239
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -12236,18 +12799,20 @@ entities:
       type: ContainerContainer
 - proto: LockerChiefEngineerFilled
   entities:
-  - uid: 1681
+  - uid: 209
     components:
     - pos: -1.5,-27.5
       parent: 1
       type: Transform
+    - locked: False
+      type: Lock
     - air:
         volume: 200
         immutable: False
-        temperature: 14.134342
+        temperature: 293.14963
         moles:
-        - 0
-        - 0
+        - 1.7459903
+        - 6.568249
         - 0
         - 0
         - 0
@@ -12264,11 +12829,12 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 1682
-          - 1683
-          - 1684
-          - 1685
-          - 1686
+          - 210
+          - 214
+          - 213
+          - 212
+          - 211
+          - 215
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -12276,7 +12842,7 @@ entities:
       type: ContainerContainer
 - proto: LockerEngineerFilled
   entities:
-  - uid: 997
+  - uid: 1050
     components:
     - pos: 3.5,-34.5
       parent: 1
@@ -12304,15 +12870,15 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 1000
-          - 998
-          - 999
+          - 1052
+          - 1051
+          - 1053
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
           ent: null
       type: ContainerContainer
-  - uid: 1001
+  - uid: 1054
     components:
     - pos: 2.5,-34.5
       parent: 1
@@ -12340,9 +12906,9 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 1003
-          - 1002
-          - 1004
+          - 1056
+          - 1055
+          - 1057
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -12350,18 +12916,51 @@ entities:
       type: ContainerContainer
 - proto: LockerParamedicFilled
   entities:
-  - uid: 1687
+  - uid: 1067
     components:
     - pos: -6.5,-12.5
       parent: 1
       type: Transform
+    - locked: False
+      type: Lock
+    - air:
+        volume: 200
+        immutable: False
+        temperature: 293.1496
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+      type: EntityStorage
+    - containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 1068
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+      type: ContainerContainer
 - proto: LockerQuarterMaster
   entities:
-  - uid: 100
+  - uid: 103
     components:
     - pos: 2.5,-0.5
       parent: 1
       type: Transform
+    - locked: False
+      type: Lock
     - air:
         volume: 200
         immutable: False
@@ -12385,21 +12984,22 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 107
-          - 103
-          - 106
-          - 111
+          - 119
+          - 117
+          - 118
           - 115
-          - 105
-          - 101
+          - 116
+          - 113
+          - 114
+          - 111
           - 112
           - 109
-          - 102
-          - 114
-          - 104
-          - 108
           - 110
-          - 113
+          - 107
+          - 108
+          - 105
+          - 106
+          - 104
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -12407,11 +13007,13 @@ entities:
       type: ContainerContainer
 - proto: LockerSalvageSpecialistFilled
   entities:
-  - uid: 1688
+  - uid: 1743
     components:
     - pos: -2.5,-10.5
       parent: 1
       type: Transform
+    - locked: False
+      type: Lock
     - air:
         volume: 200
         immutable: False
@@ -12435,17 +13037,19 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 1689
+          - 1744
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
           ent: null
       type: ContainerContainer
-  - uid: 1690
+  - uid: 1745
     components:
     - pos: 3.5,-10.5
       parent: 1
       type: Transform
+    - locked: False
+      type: Lock
     - air:
         volume: 200
         immutable: False
@@ -12469,32 +13073,44 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 1691
+          - 1746
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
           ent: null
       type: ContainerContainer
+- proto: LockerWallMedicalDoctorFilled
+  entities:
+  - uid: 1747
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -5.5,-17.5
+      parent: 1
+      type: Transform
+    - locked: False
+      type: Lock
 - proto: LockerWallMedicalFilled
   entities:
-  - uid: 1692
+  - uid: 1748
     components:
     - pos: -1.5,-26.5
       parent: 1
       type: Transform
-  - uid: 1693
+  - uid: 1749
     components:
     - rot: 1.5707963267948966 rad
       pos: -2.5,-0.5
       parent: 1
       type: Transform
+    - locked: False
+      type: Lock
     - air:
         volume: 200
         immutable: False
-        temperature: 99.422104
+        temperature: 293.14972
         moles:
-        - 0
-        - 0
+        - 1.7459903
+        - 6.568249
         - 0
         - 0
         - 0
@@ -12511,12 +13127,12 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 1696
-          - 1694
-          - 1697
-          - 1695
+          - 1751
+          - 1752
+          - 1753
+          - 1750
       type: ContainerContainer
-  - uid: 1698
+  - uid: 1754
     components:
     - rot: 3.141592653589793 rad
       pos: 1.5,-26.5
@@ -12524,118 +13140,117 @@ entities:
       type: Transform
 - proto: LockerWeldingSuppliesFilled
   entities:
-  - uid: 1699
+  - uid: 1755
     components:
     - pos: 7.5,-29.5
       parent: 1
       type: Transform
 - proto: MagazineBoxMagnum
   entities:
-  - uid: 247
+  - uid: 236
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 227
+    - parent: 216
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 248
+  - uid: 237
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 227
+    - parent: 216
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: Matchbox
   entities:
-  - uid: 1700
+  - uid: 1756
     components:
     - pos: -1.2443821,-30.366787
       parent: 1
       type: Transform
-  - uid: 1701
+  - uid: 1757
     components:
     - pos: -0.62868136,1.0963256
       parent: 1
       type: Transform
-  - uid: 1702
+  - uid: 1758
     components:
     - pos: 1.8340497,-25.57059
       parent: 1
       type: Transform
-  - uid: 1703
+  - uid: 1759
     components:
     - pos: -0.47121298,-17.48435
       parent: 1
       type: Transform
 - proto: MedicalBed
   entities:
-  - uid: 1704
-    components:
-    - pos: -6.5,-15.5
-      parent: 1
-      type: Transform
-  - uid: 1705
+  - uid: 1760
     components:
     - pos: 7.5,-15.5
       parent: 1
       type: Transform
+  - uid: 1761
+    components:
+    - pos: -5.5,-16.5
+      parent: 1
+      type: Transform
 - proto: MedkitFilled
   entities:
-  - uid: 1706
+  - uid: 1762
     components:
     - pos: -6.6608167,-13.206823
       parent: 1
       type: Transform
 - proto: MopBucketFull
   entities:
-  - uid: 1707
+  - uid: 1763
     components:
     - pos: -5.4816527,-8.21574
       parent: 1
       type: Transform
 - proto: MopItem
   entities:
-  - uid: 1708
+  - uid: 1764
     components:
     - pos: -5.4608197,-8.6222725
       parent: 1
       type: Transform
 - proto: NitrogenCanister
   entities:
-  - uid: 1709
+  - uid: 1765
     components:
     - pos: 5.5,-32.5
       parent: 1
       type: Transform
 - proto: OperatingTable
   entities:
-  - uid: 1710
+  - uid: 1766
     components:
-    - rot: 3.141592653589793 rad
-      pos: -5.5,-16.5
+    - pos: -6.5,-15.5
       parent: 1
       type: Transform
 - proto: OreProcessor
   entities:
-  - uid: 1711
+  - uid: 1767
     components:
     - pos: -0.5,-2.5
       parent: 1
       type: Transform
 - proto: OxygenCanister
   entities:
-  - uid: 1712
+  - uid: 1768
     components:
     - pos: 4.5,-32.5
       parent: 1
       type: Transform
 - proto: PaintingSkeletonBoof
   entities:
-  - uid: 1713
+  - uid: 1769
     components:
     - rot: 1.5707963267948966 rad
       pos: -2.5,-27.5
@@ -12643,116 +13258,143 @@ entities:
       type: Transform
 - proto: Paper
   entities:
-  - uid: 1682
+  - uid: 211
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 1681
+    - parent: 209
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 1683
+  - uid: 212
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 1681
+    - parent: 209
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 1684
+  - uid: 213
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 1681
+    - parent: 209
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 1685
+  - uid: 214
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 1681
+    - parent: 209
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 1686
+  - uid: 215
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 1681
+    - parent: 209
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: PaperBin10
   entities:
-  - uid: 1714
+  - uid: 1770
     components:
     - pos: -0.5,0.5
       parent: 1
       type: Transform
-  - uid: 1715
+  - uid: 1771
     components:
     - pos: -1.5,-22.5
       parent: 1
       type: Transform
 - proto: PenCap
   entities:
-  - uid: 1716
+  - uid: 1772
     components:
     - pos: -1.3206933,-22.118023
       parent: 1
       type: Transform
 - proto: PhoneInstrument
   entities:
-  - uid: 1717
+  - uid: 1773
     components:
     - pos: -1.5209062,-21.368505
       parent: 1
       type: Transform
+- proto: PillDexalin
+  entities:
+  - uid: 1774
+    components:
+    - pos: -6.629308,-13.535651
+      parent: 1
+      type: Transform
+  - uid: 1775
+    components:
+    - pos: -6.3688912,-13.535651
+      parent: 1
+      type: Transform
+  - uid: 1776
+    components:
+    - pos: -6.285558,-13.420988
+      parent: 1
+      type: Transform
+  - uid: 1777
+    components:
+    - pos: -6.5147247,-13.3792925
+      parent: 1
+      type: Transform
+  - uid: 1778
+    components:
+    - pos: -6.492127,-13.44615
+      parent: 1
+      type: Transform
 - proto: PlasmaReinforcedWindowDirectional
   entities:
-  - uid: 1718
+  - uid: 1779
     components:
     - rot: 3.141592653589793 rad
       pos: 2.5,-31.5
       parent: 1
       type: Transform
-  - uid: 1719
+  - uid: 1780
     components:
     - rot: 3.141592653589793 rad
       pos: 5.5,-31.5
       parent: 1
       type: Transform
-  - uid: 1720
+  - uid: 1781
     components:
     - rot: 3.141592653589793 rad
       pos: 3.5,-31.5
       parent: 1
       type: Transform
-  - uid: 1721
+  - uid: 1782
     components:
     - rot: -1.5707963267948966 rad
       pos: 6.5,-30.5
       parent: 1
       type: Transform
-  - uid: 1722
+  - uid: 1783
     components:
     - rot: -1.5707963267948966 rad
       pos: 6.5,-29.5
       parent: 1
       type: Transform
-  - uid: 1723
+  - uid: 1784
     components:
     - rot: -1.5707963267948966 rad
       pos: 6.5,-28.5
       parent: 1
       type: Transform
-  - uid: 1724
+  - uid: 1785
     components:
     - rot: -1.5707963267948966 rad
       pos: 6.5,-27.5
@@ -12760,82 +13402,81 @@ entities:
       type: Transform
 - proto: PlasticFlapsAirtightClear
   entities:
-  - uid: 1725
+  - uid: 1786
     components:
     - pos: -1.5,6.5
       parent: 1
       type: Transform
-  - uid: 1726
+  - uid: 1787
     components:
     - pos: 2.5,6.5
       parent: 1
       type: Transform
-  - uid: 1727
+  - uid: 1788
     components:
     - pos: 2.5,10.5
       parent: 1
       type: Transform
-  - uid: 1728
+  - uid: 1789
     components:
     - pos: -1.5,10.5
       parent: 1
       type: Transform
 - proto: PlushieBee
   entities:
-  - uid: 1729
+  - uid: 1790
     components:
     - pos: 2.412711,1.4376178
       parent: 1
       type: Transform
 - proto: PlushieHampter
   entities:
-  - uid: 1730
+  - uid: 1791
     components:
     - name: Steve The Hampter
       type: MetaData
     - pos: 2.4989662,-21.250715
       parent: 1
       type: Transform
+- proto: PlushieRouny
+  entities:
+  - uid: 1792
+    components:
+    - pos: -5.4992075,-16.437582
+      parent: 1
+      type: Transform
 - proto: PlushieSpaceLizard
   entities:
-  - uid: 1731
+  - uid: 1793
     components:
     - pos: -0.5601339,-27.595695
       parent: 1
       type: Transform
-- proto: PosterContrabandC20r
-  entities:
-  - uid: 1732
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -4.5,-25.5
-      parent: 1
-      type: Transform
 - proto: PosterContrabandPunchShit
   entities:
-  - uid: 1733
+  - uid: 1795
     components:
     - pos: 3.5,-1.5
       parent: 1
       type: Transform
-- proto: PosterLegit12Gauge
+- proto: PosterLegitAnatomyPoster
   entities:
-  - uid: 1734
+  - uid: 1794
     components:
     - rot: 1.5707963267948966 rad
-      pos: -4.5,-24.5
+      pos: -7.5,-15.5
       parent: 1
       type: Transform
 - proto: PosterLegitBarDrinks
   entities:
-  - uid: 1735
+  - uid: 1797
     components:
     - pos: 1.5,-11.5
       parent: 1
       type: Transform
 - proto: PosterLegitBlessThisSpess
   entities:
-  - uid: 1736
+  - uid: 1798
     components:
     - rot: 1.5707963267948966 rad
       pos: -2.5,1.5
@@ -12843,14 +13484,14 @@ entities:
       type: Transform
 - proto: PosterLegitDontPanic
   entities:
-  - uid: 1737
+  - uid: 1799
     components:
     - pos: 2.5,-11.5
       parent: 1
       type: Transform
 - proto: PosterLegitHelpOthers
   entities:
-  - uid: 1738
+  - uid: 1800
     components:
     - rot: 1.5707963267948966 rad
       pos: -7.5,-30.5
@@ -12858,7 +13499,7 @@ entities:
       type: Transform
 - proto: PosterLegitPizzaHope
   entities:
-  - uid: 1739
+  - uid: 1801
     components:
     - rot: -1.5707963267948966 rad
       pos: -2.5,-1.5
@@ -12866,7 +13507,7 @@ entities:
       type: Transform
 - proto: PosterLegitSafetyInternals
   entities:
-  - uid: 1740
+  - uid: 1802
     components:
     - rot: 1.5707963267948966 rad
       pos: -4.5,8.5
@@ -12874,7 +13515,7 @@ entities:
       type: Transform
 - proto: PosterLegitSMHardhats
   entities:
-  - uid: 1741
+  - uid: 1803
     components:
     - rot: 1.5707963267948966 rad
       pos: -2.5,-29.5
@@ -12882,14 +13523,14 @@ entities:
       type: Transform
 - proto: PosterLegitSMMeth
   entities:
-  - uid: 1742
+  - uid: 1804
     components:
     - pos: 7.5,-14.5
       parent: 1
       type: Transform
 - proto: PosterLegitWorkForAFuture
   entities:
-  - uid: 1743
+  - uid: 1805
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,-21.5
@@ -12897,61 +13538,61 @@ entities:
       type: Transform
 - proto: PottedPlantRandomPlastic
   entities:
-  - uid: 1744
+  - uid: 1806
     components:
     - pos: -6.5,-24.5
       parent: 1
       type: Transform
-  - uid: 1745
+  - uid: 1807
     components:
     - pos: 1.5,-24.5
       parent: 1
       type: Transform
-  - uid: 1746
+  - uid: 1808
     components:
     - pos: 0.5,-17.5
       parent: 1
       type: Transform
-  - uid: 1747
+  - uid: 1809
     components:
     - pos: -6.5,-30.5
       parent: 1
       type: Transform
-  - uid: 1748
+  - uid: 1810
     components:
     - pos: -6.5,-28.5
       parent: 1
       type: Transform
 - proto: PowerCellHyper
   entities:
-  - uid: 249
+  - uid: 238
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 227
+    - parent: 216
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 250
+  - uid: 239
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 227
+    - parent: 216
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: Poweredlight
   entities:
-  - uid: 1749
+  - uid: 1811
     components:
     - pos: 2.5,-2.5
       parent: 1
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 1750
+  - uid: 1812
     components:
     - pos: -2.5,-23.5
       parent: 1
@@ -12959,9 +13600,9 @@ entities:
     - needsPower: False
       type: ApcPowerReceiver
     - links:
-      - 1885
+      - 1950
       type: DeviceLinkSink
-  - uid: 1751
+  - uid: 1813
     components:
     - pos: 3.5,-23.5
       parent: 1
@@ -12969,9 +13610,9 @@ entities:
     - needsPower: False
       type: ApcPowerReceiver
     - links:
-      - 1885
+      - 1950
       type: DeviceLinkSink
-  - uid: 1752
+  - uid: 1814
     components:
     - rot: 3.141592653589793 rad
       pos: 2.5,-0.5
@@ -12980,9 +13621,9 @@ entities:
     - needsPower: False
       type: ApcPowerReceiver
     - links:
-      - 1906
+      - 1970
       type: DeviceLinkSink
-  - uid: 1753
+  - uid: 1815
     components:
     - rot: 3.141592653589793 rad
       pos: -1.5,-0.5
@@ -12991,9 +13632,9 @@ entities:
     - needsPower: False
       type: ApcPowerReceiver
     - links:
-      - 1906
+      - 1970
       type: DeviceLinkSink
-  - uid: 1754
+  - uid: 1816
     components:
     - rot: -1.5707963267948966 rad
       pos: -3.5,2.5
@@ -13001,7 +13642,7 @@ entities:
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 1755
+  - uid: 1817
     components:
     - rot: 3.141592653589793 rad
       pos: 5.5,-6.5
@@ -13009,7 +13650,7 @@ entities:
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 1756
+  - uid: 1818
     components:
     - rot: 1.5707963267948966 rad
       pos: 4.5,2.5
@@ -13017,7 +13658,7 @@ entities:
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 1757
+  - uid: 1819
     components:
     - rot: 3.141592653589793 rad
       pos: -4.5,-6.5
@@ -13025,7 +13666,7 @@ entities:
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 1758
+  - uid: 1820
     components:
     - rot: -1.5707963267948966 rad
       pos: 2.5,9.5
@@ -13033,7 +13674,7 @@ entities:
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 1759
+  - uid: 1821
     components:
     - rot: 1.5707963267948966 rad
       pos: -1.5,9.5
@@ -13041,7 +13682,7 @@ entities:
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 1760
+  - uid: 1822
     components:
     - rot: 3.141592653589793 rad
       pos: 3.5,3.5
@@ -13049,7 +13690,7 @@ entities:
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 1761
+  - uid: 1823
     components:
     - rot: 3.141592653589793 rad
       pos: -2.5,3.5
@@ -13057,7 +13698,7 @@ entities:
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 1762
+  - uid: 1824
     components:
     - rot: 3.141592653589793 rad
       pos: -1.5,-25.5
@@ -13066,9 +13707,9 @@ entities:
     - needsPower: False
       type: ApcPowerReceiver
     - links:
-      - 1885
+      - 1950
       type: DeviceLinkSink
-  - uid: 1763
+  - uid: 1825
     components:
     - rot: 1.5707963267948966 rad
       pos: -1.5,-22.5
@@ -13077,9 +13718,9 @@ entities:
     - enabled: False
       type: AmbientSound
     - links:
-      - 1885
+      - 1950
       type: DeviceLinkSink
-  - uid: 1764
+  - uid: 1826
     components:
     - rot: -1.5707963267948966 rad
       pos: 2.5,-22.5
@@ -13088,16 +13729,16 @@ entities:
     - needsPower: False
       type: ApcPowerReceiver
     - links:
-      - 1885
+      - 1950
       type: DeviceLinkSink
-  - uid: 1765
+  - uid: 1827
     components:
     - pos: -1.5,-2.5
       parent: 1
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 1766
+  - uid: 1828
     components:
     - rot: 1.5707963267948966 rad
       pos: -1.5,-30.5
@@ -13106,9 +13747,9 @@ entities:
     - needsPower: False
       type: ApcPowerReceiver
     - links:
-      - 1904
+      - 1969
       type: DeviceLinkSink
-  - uid: 1767
+  - uid: 1829
     components:
     - rot: 1.5707963267948966 rad
       pos: 2.5,-32.5
@@ -13116,7 +13757,7 @@ entities:
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 1768
+  - uid: 1830
     components:
     - rot: -1.5707963267948966 rad
       pos: 7.5,-28.5
@@ -13124,7 +13765,7 @@ entities:
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 1769
+  - uid: 1831
     components:
     - rot: 1.5707963267948966 rad
       pos: 2.5,-30.5
@@ -13132,14 +13773,14 @@ entities:
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 1770
+  - uid: 1832
     components:
     - pos: -4.5,-33.5
       parent: 1
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 1771
+  - uid: 1833
     components:
     - rot: 1.5707963267948966 rad
       pos: -6.5,-28.5
@@ -13147,35 +13788,35 @@ entities:
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 1772
+  - uid: 1834
     components:
     - pos: -5.5,-18.5
       parent: 1
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 1773
+  - uid: 1835
     components:
     - pos: 6.5,-18.5
       parent: 1
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 1774
+  - uid: 1836
     components:
     - pos: -6.5,-24.5
       parent: 1
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 1775
+  - uid: 1837
     components:
     - pos: 7.5,-24.5
       parent: 1
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 1776
+  - uid: 1838
     components:
     - rot: -1.5707963267948966 rad
       pos: 2.5,-14.5
@@ -13184,9 +13825,9 @@ entities:
     - needsPower: False
       type: ApcPowerReceiver
     - links:
-      - 1907
+      - 1971
       type: DeviceLinkSink
-  - uid: 1777
+  - uid: 1839
     components:
     - rot: 1.5707963267948966 rad
       pos: -1.5,-14.5
@@ -13195,9 +13836,9 @@ entities:
     - needsPower: False
       type: ApcPowerReceiver
     - links:
-      - 1907
+      - 1971
       type: DeviceLinkSink
-  - uid: 1778
+  - uid: 1840
     components:
     - rot: 1.5707963267948966 rad
       pos: -3.5,-9.5
@@ -13205,7 +13846,7 @@ entities:
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 1779
+  - uid: 1841
     components:
     - rot: -1.5707963267948966 rad
       pos: 4.5,-9.5
@@ -13213,7 +13854,7 @@ entities:
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 1780
+  - uid: 1842
     components:
     - rot: -1.5707963267948966 rad
       pos: -3.5,-14.5
@@ -13222,9 +13863,9 @@ entities:
     - needsPower: False
       type: ApcPowerReceiver
     - links:
-      - 1907
+      - 1971
       type: DeviceLinkSink
-  - uid: 1781
+  - uid: 1843
     components:
     - rot: 1.5707963267948966 rad
       pos: 4.5,-14.5
@@ -13233,9 +13874,9 @@ entities:
     - needsPower: False
       type: ApcPowerReceiver
     - links:
-      - 1907
+      - 1971
       type: DeviceLinkSink
-  - uid: 1782
+  - uid: 1844
     components:
     - rot: 1.5707963267948966 rad
       pos: -1.5,-27.5
@@ -13244,9 +13885,9 @@ entities:
     - needsPower: False
       type: ApcPowerReceiver
     - links:
-      - 1904
+      - 1969
       type: DeviceLinkSink
-  - uid: 1783
+  - uid: 1845
     components:
     - rot: 3.141592653589793 rad
       pos: -6.5,-16.5
@@ -13255,9 +13896,9 @@ entities:
     - needsPower: False
       type: ApcPowerReceiver
     - links:
-      - 1905
+      - 1982
       type: DeviceLinkSink
-  - uid: 1784
+  - uid: 1846
     components:
     - rot: 1.5707963267948966 rad
       pos: -6.5,-13.5
@@ -13266,9 +13907,9 @@ entities:
     - needsPower: False
       type: ApcPowerReceiver
     - links:
-      - 1905
+      - 1982
       type: DeviceLinkSink
-  - uid: 1785
+  - uid: 1847
     components:
     - rot: 3.141592653589793 rad
       pos: 7.5,-16.5
@@ -13277,9 +13918,9 @@ entities:
     - enabled: False
       type: AmbientSound
     - links:
-      - 1908
+      - 1972
       type: DeviceLinkSink
-  - uid: 1786
+  - uid: 1848
     components:
     - rot: -1.5707963267948966 rad
       pos: 7.5,-13.5
@@ -13288,11 +13929,29 @@ entities:
     - enabled: False
       type: AmbientSound
     - links:
-      - 1908
+      - 1972
       type: DeviceLinkSink
+- proto: PoweredlightColoredRed
+  entities:
+  - uid: 1849
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 8.5,-8.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+  - uid: 1850
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -7.5,-8.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
 - proto: PoweredSmallLight
   entities:
-  - uid: 1787
+  - uid: 1851
     components:
     - rot: -1.5707963267948966 rad
       pos: -3.5,-30.5
@@ -13301,9 +13960,9 @@ entities:
     - needsPower: False
       type: ApcPowerReceiver
     - links:
-      - 1889
+      - 1954
       type: DeviceLinkSink
-  - uid: 1788
+  - uid: 1852
     components:
     - rot: -1.5707963267948966 rad
       pos: -3.5,-27.5
@@ -13312,9 +13971,9 @@ entities:
     - needsPower: False
       type: ApcPowerReceiver
     - links:
-      - 1892
+      - 1957
       type: DeviceLinkSink
-  - uid: 1789
+  - uid: 1853
     components:
     - rot: 3.141592653589793 rad
       pos: -8.5,-31.5
@@ -13323,9 +13982,9 @@ entities:
     - needsPower: False
       type: ApcPowerReceiver
     - links:
-      - 1893
+      - 1958
       type: DeviceLinkSink
-  - uid: 1790
+  - uid: 1854
     components:
     - pos: 6.5,-8.5
       parent: 1
@@ -13333,96 +13992,103 @@ entities:
     - needsPower: False
       type: ApcPowerReceiver
     - links:
-      - 1897
+      - 1962
       type: DeviceLinkSink
-  - uid: 1791
+  - uid: 1855
     components:
     - rot: 3.141592653589793 rad
       pos: -9.5,-29.5
       parent: 1
       type: Transform
-  - uid: 1792
+  - uid: 1856
     components:
     - rot: 1.5707963267948966 rad
       pos: 9.5,-29.5
       parent: 1
       type: Transform
-  - uid: 1793
+  - uid: 1857
     components:
     - rot: -1.5707963267948966 rad
       pos: 9.5,-26.5
       parent: 1
       type: Transform
-  - uid: 1794
+  - uid: 1858
     components:
     - rot: 1.5707963267948966 rad
       pos: -8.5,-26.5
       parent: 1
       type: Transform
-  - uid: 1795
+  - uid: 1859
     components:
     - rot: 3.141592653589793 rad
       pos: -6.5,-0.5
       parent: 1
       type: Transform
     - links:
-      - 1910
+      - 1974
       type: DeviceLinkSink
-  - uid: 1796
+  - uid: 1860
     components:
     - pos: -5.5,-8.5
       parent: 1
       type: Transform
-  - uid: 1797
+  - uid: 1861
     components:
     - rot: 3.141592653589793 rad
       pos: 7.5,-0.5
       parent: 1
       type: Transform
     - links:
-      - 1912
+      - 1976
       type: DeviceLinkSink
+- proto: Rack
+  entities:
+  - uid: 1862
+    components:
+    - pos: 6.5,-11.5
+      parent: 1
+      type: Transform
 - proto: ReinforcedPlasmaWindow
   entities:
-  - uid: 1798
+  - uid: 1863
     components:
     - pos: 2.5,-26.5
       parent: 1
       type: Transform
-  - uid: 1799
+  - uid: 1864
     components:
     - pos: 1.5,-29.5
       parent: 1
       type: Transform
-  - uid: 1800
+  - uid: 1865
     components:
     - pos: 3.5,-26.5
       parent: 1
       type: Transform
-  - uid: 1801
+  - uid: 1866
     components:
     - rot: 3.141592653589793 rad
       pos: 1.5,-28.5
       parent: 1
       type: Transform
-  - uid: 1802
+  - uid: 1867
     components:
     - rot: 3.141592653589793 rad
       pos: 1.5,-27.5
       parent: 1
       type: Transform
-  - uid: 1803
+  - uid: 1868
     components:
     - pos: 4.5,-26.5
       parent: 1
       type: Transform
-  - uid: 1804
+  - uid: 1869
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,-32.5
       parent: 1
       type: Transform
-  - uid: 1805
+  - uid: 1870
     components:
     - rot: 1.5707963267948966 rad
       pos: 6.5,0.5
@@ -13430,36 +14096,36 @@ entities:
       type: Transform
 - proto: ReinforcedWindow
   entities:
-  - uid: 1806
+  - uid: 1871
     components:
     - rot: -1.5707963267948966 rad
       pos: -0.5,2.5
       parent: 1
       type: Transform
-  - uid: 1807
+  - uid: 1872
     components:
     - rot: -1.5707963267948966 rad
       pos: -2.5,0.5
       parent: 1
       type: Transform
-  - uid: 1808
+  - uid: 1873
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,0.5
       parent: 1
       type: Transform
-  - uid: 1809
+  - uid: 1874
     components:
     - rot: -1.5707963267948966 rad
       pos: 1.5,2.5
       parent: 1
       type: Transform
-  - uid: 1810
+  - uid: 1875
     components:
     - pos: -0.5,-1.5
       parent: 1
       type: Transform
-  - uid: 1811
+  - uid: 1876
     components:
     - rot: 3.141592653589793 rad
       pos: 3.5,-24.5
@@ -13467,517 +14133,517 @@ entities:
       type: Transform
 - proto: RubberStampApproved
   entities:
-  - uid: 1812
+  - uid: 1877
     components:
     - pos: -0.80478126,0.49763185
       parent: 1
       type: Transform
 - proto: RubberStampCaptain
   entities:
-  - uid: 251
+  - uid: 240
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 227
+    - parent: 216
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: RubberStampCE
   entities:
-  - uid: 1813
+  - uid: 1878
     components:
     - pos: -1.7027156,-30.356363
       parent: 1
       type: Transform
 - proto: RubberStampDenied
   entities:
-  - uid: 1814
+  - uid: 1879
     components:
     - pos: -0.81724185,0.883254
       parent: 1
       type: Transform
 - proto: RubberStampQm
   entities:
-  - uid: 111
+  - uid: 115
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 100
+    - parent: 103
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: ShuttersNormal
   entities:
-  - uid: 1815
+  - uid: 1880
     components:
     - pos: -0.5,2.5
       parent: 1
       type: Transform
     - links:
-      - 1894
+      - 1959
       type: DeviceLinkSink
-  - uid: 1816
+  - uid: 1881
     components:
     - pos: 0.5,2.5
       parent: 1
       type: Transform
     - links:
-      - 1894
+      - 1959
       type: DeviceLinkSink
-  - uid: 1817
+  - uid: 1882
     components:
     - pos: 1.5,2.5
       parent: 1
       type: Transform
     - links:
-      - 1894
+      - 1959
       type: DeviceLinkSink
-  - uid: 1818
+  - uid: 1883
     components:
     - pos: 3.5,0.5
       parent: 1
       type: Transform
     - links:
-      - 1894
+      - 1959
       type: DeviceLinkSink
-  - uid: 1819
+  - uid: 1884
     components:
     - pos: -0.5,-1.5
       parent: 1
       type: Transform
     - links:
-      - 1894
+      - 1959
       type: DeviceLinkSink
-  - uid: 1820
+  - uid: 1885
     components:
     - pos: -2.5,0.5
       parent: 1
       type: Transform
     - links:
-      - 1894
+      - 1959
       type: DeviceLinkSink
-  - uid: 1821
+  - uid: 1886
     components:
     - pos: 1.5,-29.5
       parent: 1
       type: Transform
     - links:
-      - 1886
+      - 1951
       type: DeviceLinkSink
-  - uid: 1822
+  - uid: 1887
     components:
     - pos: 0.5,-32.5
       parent: 1
       type: Transform
     - links:
-      - 1886
+      - 1951
       type: DeviceLinkSink
-  - uid: 1823
+  - uid: 1888
     components:
     - pos: 1.5,-28.5
       parent: 1
       type: Transform
     - links:
-      - 1886
+      - 1951
       type: DeviceLinkSink
-  - uid: 1824
+  - uid: 1889
     components:
     - pos: 1.5,-27.5
       parent: 1
       type: Transform
     - links:
-      - 1886
+      - 1951
       type: DeviceLinkSink
-  - uid: 1825
+  - uid: 1890
     components:
     - pos: -5.5,0.5
       parent: 1
       type: Transform
     - links:
-      - 1909
+      - 1973
       type: DeviceLinkSink
 - proto: ShuttersNormalOpen
   entities:
-  - uid: 1826
+  - uid: 1891
     components:
     - pos: 5.5,-13.5
       parent: 1
       type: Transform
     - links:
-      - 1901
+      - 1966
       type: DeviceLinkSink
-  - uid: 1827
+  - uid: 1892
     components:
     - pos: -2.5,-22.5
       parent: 1
       type: Transform
     - links:
-      - 1884
-      - 1898
+      - 1949
+      - 1963
       type: DeviceLinkSink
-  - uid: 1828
+  - uid: 1893
     components:
     - pos: 3.5,-22.5
       parent: 1
       type: Transform
     - links:
-      - 1884
-      - 1898
+      - 1949
+      - 1963
       type: DeviceLinkSink
-  - uid: 1829
+  - uid: 1894
     components:
     - pos: -1.5,-20.5
       parent: 1
       type: Transform
     - links:
-      - 1884
-      - 1898
+      - 1949
+      - 1963
       type: DeviceLinkSink
-  - uid: 1830
+  - uid: 1895
     components:
     - pos: -3.5,-22.5
       parent: 1
       type: Transform
     - links:
-      - 1884
-      - 1898
+      - 1949
+      - 1963
       type: DeviceLinkSink
-  - uid: 1831
+  - uid: 1896
     components:
     - pos: -4.5,-22.5
       parent: 1
       type: Transform
     - links:
-      - 1884
-      - 1898
+      - 1949
+      - 1963
       type: DeviceLinkSink
-  - uid: 1832
+  - uid: 1897
     components:
     - pos: 2.5,-26.5
       parent: 1
       type: Transform
     - links:
-      - 1899
+      - 1964
       type: DeviceLinkSink
-  - uid: 1833
+  - uid: 1898
     components:
     - pos: 4.5,-26.5
       parent: 1
       type: Transform
     - links:
-      - 1899
+      - 1964
       type: DeviceLinkSink
-  - uid: 1834
+  - uid: 1899
     components:
     - pos: 3.5,-26.5
       parent: 1
       type: Transform
     - links:
-      - 1899
+      - 1964
       type: DeviceLinkSink
-  - uid: 1835
+  - uid: 1900
     components:
     - pos: -6.5,-22.5
       parent: 1
       type: Transform
     - links:
-      - 1884
-      - 1898
+      - 1949
+      - 1963
       type: DeviceLinkSink
-  - uid: 1836
+  - uid: 1901
     components:
     - pos: -7.5,-24.5
       parent: 1
       type: Transform
     - links:
-      - 1884
-      - 1898
+      - 1949
+      - 1963
       type: DeviceLinkSink
-  - uid: 1837
+  - uid: 1902
     components:
     - pos: -6.5,-26.5
       parent: 1
       type: Transform
     - links:
-      - 1884
-      - 1898
+      - 1949
+      - 1963
       type: DeviceLinkSink
-  - uid: 1838
+  - uid: 1903
     components:
     - pos: 8.5,-24.5
       parent: 1
       type: Transform
     - links:
-      - 1884
-      - 1898
+      - 1949
+      - 1963
       type: DeviceLinkSink
-  - uid: 1839
+  - uid: 1904
     components:
     - pos: 0.5,-20.5
       parent: 1
       type: Transform
     - links:
-      - 1884
-      - 1898
+      - 1949
+      - 1963
       type: DeviceLinkSink
-  - uid: 1840
+  - uid: 1905
     components:
     - pos: 1.5,-20.5
       parent: 1
       type: Transform
     - links:
-      - 1884
-      - 1898
+      - 1949
+      - 1963
       type: DeviceLinkSink
-  - uid: 1841
+  - uid: 1906
     components:
     - pos: 2.5,-20.5
       parent: 1
       type: Transform
     - links:
-      - 1884
-      - 1898
+      - 1949
+      - 1963
       type: DeviceLinkSink
-  - uid: 1842
+  - uid: 1907
     components:
     - pos: 4.5,-22.5
       parent: 1
       type: Transform
     - links:
-      - 1884
-      - 1898
+      - 1949
+      - 1963
       type: DeviceLinkSink
-  - uid: 1843
+  - uid: 1908
     components:
     - pos: 5.5,-22.5
       parent: 1
       type: Transform
     - links:
-      - 1884
-      - 1898
+      - 1949
+      - 1963
       type: DeviceLinkSink
-  - uid: 1844
+  - uid: 1909
     components:
     - pos: 7.5,-22.5
       parent: 1
       type: Transform
     - links:
-      - 1884
-      - 1898
+      - 1949
+      - 1963
       type: DeviceLinkSink
-  - uid: 1845
+  - uid: 1910
     components:
     - pos: -4.5,-12.5
       parent: 1
       type: Transform
     - links:
-      - 1900
+      - 1965
       type: DeviceLinkSink
-  - uid: 1846
+  - uid: 1911
     components:
     - pos: -0.5,-20.5
       parent: 1
       type: Transform
     - links:
-      - 1884
-      - 1898
+      - 1949
+      - 1963
       type: DeviceLinkSink
-  - uid: 1847
+  - uid: 1912
     components:
     - pos: -4.5,-13.5
       parent: 1
       type: Transform
     - links:
-      - 1900
+      - 1965
       type: DeviceLinkSink
-  - uid: 1848
+  - uid: 1913
     components:
     - pos: -5.5,-14.5
       parent: 1
       type: Transform
     - links:
-      - 1882
+      - 1947
       type: DeviceLinkSink
-  - uid: 1849
+  - uid: 1914
     components:
     - pos: 5.5,-12.5
       parent: 1
       type: Transform
     - links:
-      - 1901
+      - 1966
       type: DeviceLinkSink
-  - uid: 1850
+  - uid: 1915
     components:
     - pos: 6.5,-14.5
       parent: 1
       type: Transform
     - links:
-      - 1902
+      - 1967
       type: DeviceLinkSink
 - proto: ShuttleWindow
   entities:
-  - uid: 1851
+  - uid: 1916
     components:
     - pos: 2.5,-20.5
       parent: 1
       type: Transform
-  - uid: 1852
+  - uid: 1917
     components:
     - pos: 1.5,-20.5
       parent: 1
       type: Transform
-  - uid: 1853
+  - uid: 1918
     components:
     - pos: 0.5,-20.5
       parent: 1
       type: Transform
-  - uid: 1854
+  - uid: 1919
     components:
     - pos: -0.5,-20.5
       parent: 1
       type: Transform
-  - uid: 1855
+  - uid: 1920
     components:
     - pos: -1.5,-20.5
       parent: 1
       type: Transform
-  - uid: 1856
+  - uid: 1921
     components:
     - pos: -1.5,-18.5
       parent: 1
       type: Transform
-  - uid: 1857
+  - uid: 1922
     components:
     - pos: -0.5,-18.5
       parent: 1
       type: Transform
-  - uid: 1858
+  - uid: 1923
     components:
     - pos: 0.5,-18.5
       parent: 1
       type: Transform
-  - uid: 1859
+  - uid: 1924
     components:
     - pos: 1.5,-18.5
       parent: 1
       type: Transform
-  - uid: 1860
+  - uid: 1925
     components:
     - pos: 2.5,-18.5
       parent: 1
       type: Transform
-  - uid: 1861
+  - uid: 1926
     components:
     - pos: 5.5,-22.5
       parent: 1
       type: Transform
-  - uid: 1862
+  - uid: 1927
     components:
     - pos: 4.5,-22.5
       parent: 1
       type: Transform
-  - uid: 1863
+  - uid: 1928
     components:
     - pos: 3.5,-22.5
       parent: 1
       type: Transform
-  - uid: 1864
+  - uid: 1929
     components:
     - pos: 7.5,-22.5
       parent: 1
       type: Transform
-  - uid: 1865
+  - uid: 1930
     components:
     - pos: -2.5,-22.5
       parent: 1
       type: Transform
-  - uid: 1866
+  - uid: 1931
     components:
     - pos: -3.5,-22.5
       parent: 1
       type: Transform
-  - uid: 1867
+  - uid: 1932
     components:
     - pos: -4.5,-22.5
       parent: 1
       type: Transform
-  - uid: 1868
+  - uid: 1933
     components:
     - pos: -6.5,-22.5
       parent: 1
       type: Transform
-  - uid: 1869
+  - uid: 1934
     components:
     - rot: -1.5707963267948966 rad
       pos: 8.5,-24.5
       parent: 1
       type: Transform
-  - uid: 1870
+  - uid: 1935
     components:
     - pos: -7.5,-24.5
       parent: 1
       type: Transform
-  - uid: 1871
+  - uid: 1936
     components:
     - rot: 1.5707963267948966 rad
       pos: -7.5,-16.5
       parent: 1
       type: Transform
-  - uid: 1872
+  - uid: 1937
     components:
     - rot: 1.5707963267948966 rad
       pos: -7.5,-15.5
       parent: 1
       type: Transform
-  - uid: 1873
+  - uid: 1938
     components:
     - rot: 1.5707963267948966 rad
       pos: 8.5,-16.5
       parent: 1
       type: Transform
-  - uid: 1874
+  - uid: 1939
     components:
     - rot: 1.5707963267948966 rad
       pos: 8.5,-15.5
       parent: 1
       type: Transform
-  - uid: 1875
+  - uid: 1940
     components:
     - rot: 3.141592653589793 rad
       pos: 1.5,-34.5
       parent: 1
       type: Transform
-  - uid: 1876
+  - uid: 1941
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,-34.5
       parent: 1
       type: Transform
-  - uid: 1877
+  - uid: 1942
     components:
     - pos: 7.5,-9.5
       parent: 1
       type: Transform
-  - uid: 1878
+  - uid: 1943
     components:
     - rot: 3.141592653589793 rad
       pos: -9.5,-33.5
       parent: 1
       type: Transform
-  - uid: 1879
+  - uid: 1944
     components:
     - pos: -6.5,-26.5
       parent: 1
       type: Transform
-  - uid: 1880
+  - uid: 1945
     components:
     - rot: 1.5707963267948966 rad
       pos: -2.5,-14.5
       parent: 1
       type: Transform
-  - uid: 1881
+  - uid: 1946
     components:
     - rot: 1.5707963267948966 rad
       pos: 3.5,-14.5
@@ -13985,7 +14651,7 @@ entities:
       type: Transform
 - proto: SignalButton
   entities:
-  - uid: 1882
+  - uid: 1947
     components:
     - name: Shutter (surgery)
       type: MetaData
@@ -13994,10 +14660,10 @@ entities:
       parent: 1
       type: Transform
     - linkedPorts:
-        1848:
+        1913:
         - Pressed: Toggle
       type: DeviceLinkSource
-  - uid: 1883
+  - uid: 1948
     components:
     - name: Cargo lockdown (off)
       type: MetaData
@@ -14005,16 +14671,16 @@ entities:
       parent: 1
       type: Transform
     - linkedPorts:
+        203:
+        - Pressed: Open
         200:
         - Pressed: Open
-        197:
+        202:
         - Pressed: Open
-        199:
-        - Pressed: Open
-        198:
+        201:
         - Pressed: Open
       type: DeviceLinkSource
-  - uid: 1884
+  - uid: 1949
     components:
     - name: Bridge lockdown (on)
       type: MetaData
@@ -14022,44 +14688,44 @@ entities:
       parent: 1
       type: Transform
     - linkedPorts:
-        1844:
+        1909:
         - Pressed: Close
-        1838:
+        1903:
         - Pressed: Close
-        1843:
+        1908:
         - Pressed: Close
-        1842:
+        1907:
         - Pressed: Close
-        1828:
+        1893:
         - Pressed: Close
-        1841:
+        1906:
         - Pressed: Close
-        1840:
+        1905:
         - Pressed: Close
-        1839:
+        1904:
         - Pressed: Close
-        1846:
+        1911:
         - Pressed: Close
-        1829:
+        1894:
         - Pressed: Close
-        1827:
+        1892:
         - Pressed: Close
-        1830:
+        1895:
         - Pressed: Close
-        1831:
+        1896:
         - Pressed: Close
-        1835:
+        1900:
         - Pressed: Close
-        1836:
+        1901:
         - Pressed: Close
-        1837:
+        1902:
         - Pressed: Close
-        202:
+        205:
         - Pressed: Close
-        201:
+        204:
         - Pressed: Close
       type: DeviceLinkSource
-  - uid: 1885
+  - uid: 1950
     components:
     - name: Light switch (bridge)
       type: MetaData
@@ -14067,18 +14733,18 @@ entities:
       parent: 1
       type: Transform
     - linkedPorts:
-        1751:
+        1813:
         - Pressed: Toggle
-        1764:
+        1826:
         - Pressed: Toggle
-        1763:
+        1825:
         - Pressed: Toggle
-        1750:
+        1812:
         - Pressed: Toggle
-        1762:
+        1824:
         - Pressed: Toggle
       type: DeviceLinkSource
-  - uid: 1886
+  - uid: 1951
     components:
     - name: Shutters (engine)
       type: MetaData
@@ -14087,16 +14753,16 @@ entities:
       parent: 1
       type: Transform
     - linkedPorts:
-        1822:
+        1887:
         - Pressed: Toggle
-        1821:
+        1886:
         - Pressed: Toggle
-        1823:
+        1888:
         - Pressed: Toggle
-        1824:
+        1889:
         - Pressed: Toggle
       type: DeviceLinkSource
-  - uid: 1887
+  - uid: 1952
     components:
     - name: Service blastdoors (thrusters)
       type: MetaData
@@ -14105,59 +14771,17 @@ entities:
       parent: 1
       type: Transform
     - linkedPorts:
-        175:
+        178:
         - Pressed: Toggle
-        174:
+        177:
         - Pressed: Toggle
       type: DeviceLinkSource
-  - uid: 1888
+  - uid: 1953
     components:
     - name: Service blastdoors (thrusters)
       type: MetaData
     - rot: 3.141592653589793 rad
       pos: 5.2311335,-35.567085
-      parent: 1
-      type: Transform
-    - linkedPorts:
-        178:
-        - Pressed: Toggle
-        177:
-        - Pressed: Toggle
-        176:
-        - Pressed: Toggle
-      type: DeviceLinkSource
-  - uid: 1889
-    components:
-    - name: Light switch
-      type: MetaData
-    - rot: 1.5707963267948966 rad
-      pos: -4.2519836,-31.15297
-      parent: 1
-      type: Transform
-    - linkedPorts:
-        1787:
-        - Pressed: Toggle
-      type: DeviceLinkSource
-  - uid: 1890
-    components:
-    - name: Service blastdoors (thrusters)
-      type: MetaData
-    - rot: 3.141592653589793 rad
-      pos: -5.741566,-35.499596
-      parent: 1
-      type: Transform
-    - linkedPorts:
-        182:
-        - Pressed: Toggle
-        183:
-        - Pressed: Toggle
-      type: DeviceLinkSource
-  - uid: 1891
-    components:
-    - name: Service blastdoors (thrusters)
-      type: MetaData
-    - rot: 3.141592653589793 rad
-      pos: -4.2858586,-35.496902
       parent: 1
       type: Transform
     - linkedPorts:
@@ -14168,7 +14792,49 @@ entities:
         179:
         - Pressed: Toggle
       type: DeviceLinkSource
-  - uid: 1892
+  - uid: 1954
+    components:
+    - name: Light switch
+      type: MetaData
+    - rot: 1.5707963267948966 rad
+      pos: -4.2519836,-31.15297
+      parent: 1
+      type: Transform
+    - linkedPorts:
+        1851:
+        - Pressed: Toggle
+      type: DeviceLinkSource
+  - uid: 1955
+    components:
+    - name: Service blastdoors (thrusters)
+      type: MetaData
+    - rot: 3.141592653589793 rad
+      pos: -5.741566,-35.499596
+      parent: 1
+      type: Transform
+    - linkedPorts:
+        185:
+        - Pressed: Toggle
+        186:
+        - Pressed: Toggle
+      type: DeviceLinkSource
+  - uid: 1956
+    components:
+    - name: Service blastdoors (thrusters)
+      type: MetaData
+    - rot: 3.141592653589793 rad
+      pos: -4.2858586,-35.496902
+      parent: 1
+      type: Transform
+    - linkedPorts:
+        184:
+        - Pressed: Toggle
+        183:
+        - Pressed: Toggle
+        182:
+        - Pressed: Toggle
+      type: DeviceLinkSource
+  - uid: 1957
     components:
     - name: Light switch
       type: MetaData
@@ -14177,10 +14843,10 @@ entities:
       parent: 1
       type: Transform
     - linkedPorts:
-        1788:
+        1852:
         - Pressed: Toggle
       type: DeviceLinkSource
-  - uid: 1893
+  - uid: 1958
     components:
     - name: Light switch
       type: MetaData
@@ -14188,10 +14854,10 @@ entities:
       parent: 1
       type: Transform
     - linkedPorts:
-        1789:
+        1853:
         - Pressed: Toggle
       type: DeviceLinkSource
-  - uid: 1894
+  - uid: 1959
     components:
     - name: Shutters
       type: MetaData
@@ -14199,20 +14865,20 @@ entities:
       parent: 1
       type: Transform
     - linkedPorts:
-        1815:
+        1880:
         - Pressed: Toggle
-        1816:
+        1881:
         - Pressed: Toggle
-        1817:
+        1882:
         - Pressed: Toggle
-        1818:
+        1883:
         - Pressed: Toggle
-        1819:
+        1884:
         - Pressed: Toggle
-        1820:
+        1885:
         - Pressed: Toggle
       type: DeviceLinkSource
-  - uid: 1895
+  - uid: 1960
     components:
     - name: Salvage doors - Close (left)
       type: MetaData
@@ -14223,19 +14889,19 @@ entities:
     - state: True
       type: SignalSwitch
     - linkedPorts:
+        191:
+        - Pressed: Close
+        190:
+        - Pressed: Close
+        189:
+        - Pressed: Close
         188:
         - Pressed: Close
         187:
         - Pressed: Close
-        186:
-        - Pressed: Close
-        185:
-        - Pressed: Close
-        184:
-        - Pressed: Close
       type: DeviceLinkSource
     - type: ItemCooldown
-  - uid: 1896
+  - uid: 1961
     components:
     - name: Salvage doors - Close (right)
       type: MetaData
@@ -14246,19 +14912,19 @@ entities:
     - state: True
       type: SignalSwitch
     - linkedPorts:
-        189:
-        - Pressed: Close
-        190:
-        - Pressed: Close
-        191:
-        - Pressed: Close
         192:
         - Pressed: Close
         193:
         - Pressed: Close
+        194:
+        - Pressed: Close
+        195:
+        - Pressed: Close
+        196:
+        - Pressed: Close
       type: DeviceLinkSource
     - type: ItemCooldown
-  - uid: 1897
+  - uid: 1962
     components:
     - name: Lightswitch
       type: MetaData
@@ -14267,10 +14933,10 @@ entities:
       parent: 1
       type: Transform
     - linkedPorts:
-        1790:
+        1854:
         - Pressed: Toggle
       type: DeviceLinkSource
-  - uid: 1898
+  - uid: 1963
     components:
     - name: Bridge lockdown (off)
       type: MetaData
@@ -14278,44 +14944,44 @@ entities:
       parent: 1
       type: Transform
     - linkedPorts:
-        1838:
+        1903:
         - Pressed: Open
-        1844:
+        1909:
         - Pressed: Open
-        1843:
+        1908:
         - Pressed: Open
-        1842:
+        1907:
         - Pressed: Open
-        1828:
+        1893:
         - Pressed: Open
-        201:
+        204:
         - Pressed: Open
-        1841:
+        1906:
         - Pressed: Open
-        1840:
+        1905:
         - Pressed: Open
-        1839:
+        1904:
         - Pressed: Open
-        1846:
+        1911:
         - Pressed: Open
-        1829:
+        1894:
         - Pressed: Open
-        1827:
+        1892:
         - Pressed: Open
-        1830:
+        1895:
         - Pressed: Open
-        1831:
+        1896:
         - Pressed: Open
-        1835:
+        1900:
         - Pressed: Open
-        202:
+        205:
         - Pressed: Open
-        1836:
+        1901:
         - Pressed: Open
-        1837:
+        1902:
         - Pressed: Open
       type: DeviceLinkSource
-  - uid: 1899
+  - uid: 1964
     components:
     - name: Shutters (Engine)
       type: MetaData
@@ -14323,14 +14989,14 @@ entities:
       parent: 1
       type: Transform
     - linkedPorts:
-        1833:
+        1898:
         - Pressed: Toggle
-        1834:
+        1899:
         - Pressed: Toggle
-        1832:
+        1897:
         - Pressed: Toggle
       type: DeviceLinkSource
-  - uid: 1900
+  - uid: 1965
     components:
     - name: Shutters
       type: MetaData
@@ -14339,12 +15005,12 @@ entities:
       parent: 1
       type: Transform
     - linkedPorts:
-        1845:
+        1910:
         - Pressed: Toggle
-        1847:
+        1912:
         - Pressed: Toggle
       type: DeviceLinkSource
-  - uid: 1901
+  - uid: 1966
     components:
     - name: Shutters
       type: MetaData
@@ -14353,12 +15019,12 @@ entities:
       parent: 1
       type: Transform
     - linkedPorts:
-        1849:
+        1914:
         - Pressed: Toggle
-        1826:
+        1891:
         - Pressed: Toggle
       type: DeviceLinkSource
-  - uid: 1902
+  - uid: 1967
     components:
     - name: Shutter (south)
       type: MetaData
@@ -14367,10 +15033,10 @@ entities:
       parent: 1
       type: Transform
     - linkedPorts:
-        1850:
+        1915:
         - Pressed: Toggle
       type: DeviceLinkSource
-  - uid: 1903
+  - uid: 1968
     components:
     - name: Blastdoor (open door first)
       type: MetaData
@@ -14379,10 +15045,10 @@ entities:
       parent: 1
       type: Transform
     - linkedPorts:
-        203:
+        206:
         - Pressed: Toggle
       type: DeviceLinkSource
-  - uid: 1904
+  - uid: 1969
     components:
     - name: Light switch
       type: MetaData
@@ -14391,25 +15057,12 @@ entities:
       parent: 1
       type: Transform
     - linkedPorts:
-        1766:
+        1828:
         - Pressed: Toggle
-        1782:
-        - Pressed: Toggle
-      type: DeviceLinkSource
-  - uid: 1905
-    components:
-    - name: Light switch
-      type: MetaData
-    - pos: -6.282388,-14.6779995
-      parent: 1
-      type: Transform
-    - linkedPorts:
-        1783:
-        - Pressed: Toggle
-        1784:
+        1844:
         - Pressed: Toggle
       type: DeviceLinkSource
-  - uid: 1906
+  - uid: 1970
     components:
     - name: Light switch
       type: MetaData
@@ -14418,12 +15071,12 @@ entities:
       parent: 1
       type: Transform
     - linkedPorts:
-        1752:
+        1814:
         - Pressed: Toggle
-        1753:
+        1815:
         - Pressed: Toggle
       type: DeviceLinkSource
-  - uid: 1907
+  - uid: 1971
     components:
     - name: Light switch
       type: MetaData
@@ -14431,16 +15084,16 @@ entities:
       parent: 1
       type: Transform
     - linkedPorts:
-        1777:
+        1839:
         - Pressed: Toggle
-        1780:
+        1842:
         - Pressed: Toggle
-        1776:
+        1838:
         - Pressed: Toggle
-        1781:
+        1843:
         - Pressed: Toggle
       type: DeviceLinkSource
-  - uid: 1908
+  - uid: 1972
     components:
     - name: Light switch
       type: MetaData
@@ -14448,12 +15101,12 @@ entities:
       parent: 1
       type: Transform
     - linkedPorts:
-        1785:
+        1847:
         - Pressed: Toggle
-        1786:
+        1848:
         - Pressed: Toggle
       type: DeviceLinkSource
-  - uid: 1909
+  - uid: 1973
     components:
     - name: Shutters
       type: MetaData
@@ -14462,10 +15115,10 @@ entities:
       parent: 1
       type: Transform
     - linkedPorts:
-        1825:
+        1890:
         - Pressed: Toggle
       type: DeviceLinkSource
-  - uid: 1910
+  - uid: 1974
     components:
     - name: Light switch
       type: MetaData
@@ -14474,10 +15127,10 @@ entities:
       parent: 1
       type: Transform
     - linkedPorts:
-        1795:
+        1859:
         - Pressed: Toggle
       type: DeviceLinkSource
-  - uid: 1911
+  - uid: 1975
     components:
     - name: Blastdoor (Inner)
       type: MetaData
@@ -14486,10 +15139,10 @@ entities:
       parent: 1
       type: Transform
     - linkedPorts:
-        194:
+        197:
         - Pressed: Toggle
       type: DeviceLinkSource
-  - uid: 1912
+  - uid: 1976
     components:
     - name: Light switch
       type: MetaData
@@ -14498,10 +15151,10 @@ entities:
       parent: 1
       type: Transform
     - linkedPorts:
-        1797:
+        1861:
         - Pressed: Toggle
       type: DeviceLinkSource
-  - uid: 1913
+  - uid: 1977
     components:
     - name: Blastdoor - Close (Outer)
       type: MetaData
@@ -14510,12 +15163,12 @@ entities:
       parent: 1
       type: Transform
     - linkedPorts:
-        196:
+        199:
         - Pressed: Close
-        195:
+        198:
         - Pressed: Close
       type: DeviceLinkSource
-  - uid: 1914
+  - uid: 1978
     components:
     - name: Blastdoor - Open (Outer)
       type: MetaData
@@ -14524,12 +15177,12 @@ entities:
       parent: 1
       type: Transform
     - linkedPorts:
-        196:
+        199:
         - Pressed: Open
-        195:
+        198:
         - Pressed: Open
       type: DeviceLinkSource
-  - uid: 1915
+  - uid: 1979
     components:
     - name: Salvage doors - Open (right)
       type: MetaData
@@ -14540,19 +15193,19 @@ entities:
     - state: True
       type: SignalSwitch
     - linkedPorts:
-        189:
-        - Pressed: Open
-        190:
-        - Pressed: Open
-        191:
-        - Pressed: Open
         192:
         - Pressed: Open
         193:
         - Pressed: Open
+        194:
+        - Pressed: Open
+        195:
+        - Pressed: Open
+        196:
+        - Pressed: Open
       type: DeviceLinkSource
     - type: ItemCooldown
-  - uid: 1916
+  - uid: 1980
     components:
     - name: Salvage doors - Open (left)
       type: MetaData
@@ -14561,18 +15214,18 @@ entities:
       parent: 1
       type: Transform
     - linkedPorts:
+        191:
+        - Pressed: Open
+        190:
+        - Pressed: Open
+        189:
+        - Pressed: Open
         188:
         - Pressed: Open
         187:
         - Pressed: Open
-        186:
-        - Pressed: Open
-        185:
-        - Pressed: Open
-        184:
-        - Pressed: Open
       type: DeviceLinkSource
-  - uid: 1917
+  - uid: 1981
     components:
     - name: Cargo lockdown (on)
       type: MetaData
@@ -14580,24 +15233,37 @@ entities:
       parent: 1
       type: Transform
     - linkedPorts:
+        203:
+        - Pressed: Close
+        202:
+        - Pressed: Close
+        201:
+        - Pressed: Close
         200:
         - Pressed: Close
-        199:
-        - Pressed: Close
-        198:
-        - Pressed: Close
-        197:
-        - Pressed: Close
+      type: DeviceLinkSource
+  - uid: 1982
+    components:
+    - name: Light switch
+      type: MetaData
+    - pos: -6.109443,-14.565217
+      parent: 1
+      type: Transform
+    - linkedPorts:
+        1845:
+        - Pressed: Toggle
+        1846:
+        - Pressed: Toggle
       type: DeviceLinkSource
 - proto: SignBar
   entities:
-  - uid: 1918
+  - uid: 1983
     components:
     - rot: 1.5707963267948966 rad
       pos: 3.5,-14.5
       parent: 1
       type: Transform
-  - uid: 1919
+  - uid: 1984
     components:
     - rot: -1.5707963267948966 rad
       pos: -2.5,-14.5
@@ -14605,13 +15271,13 @@ entities:
       type: Transform
 - proto: SignBridge
   entities:
-  - uid: 1920
+  - uid: 1985
     components:
     - rot: 1.5707963267948966 rad
       pos: -6.5,-23.5
       parent: 1
       type: Transform
-  - uid: 1921
+  - uid: 1986
     components:
     - rot: -1.5707963267948966 rad
       pos: 7.5,-23.5
@@ -14619,7 +15285,7 @@ entities:
       type: Transform
 - proto: SignCanisters
   entities:
-  - uid: 1922
+  - uid: 1987
     components:
     - rot: -1.5707963267948966 rad
       pos: 9.5,-34.5
@@ -14627,13 +15293,13 @@ entities:
       type: Transform
 - proto: SignCargo
   entities:
-  - uid: 1923
+  - uid: 1988
     components:
     - rot: 1.5707963267948966 rad
       pos: -2.5,2.5
       parent: 1
       type: Transform
-  - uid: 1924
+  - uid: 1989
     components:
     - rot: 1.5707963267948966 rad
       pos: 3.5,2.5
@@ -14641,7 +15307,7 @@ entities:
       type: Transform
 - proto: SignChemistry1
   entities:
-  - uid: 1925
+  - uid: 1990
     components:
     - rot: -1.5707963267948966 rad
       pos: 5.5,-15.5
@@ -14649,88 +15315,88 @@ entities:
       type: Transform
 - proto: SignDirectionalBar
   entities:
-  - uid: 1926
+  - uid: 1991
     components:
     - pos: 5.5252223,-9.237066
       parent: 1
       type: Transform
-  - uid: 1927
+  - uid: 1992
     components:
     - pos: -4.472748,-9.218437
       parent: 1
       type: Transform
 - proto: SignDirectionalBridge
   entities:
-  - uid: 1928
+  - uid: 1993
     components:
     - pos: -4.4623313,-9.791752
       parent: 1
       type: Transform
-  - uid: 1929
+  - uid: 1994
     components:
     - pos: 5.5252223,-9.799957
       parent: 1
       type: Transform
-  - uid: 1930
+  - uid: 1995
     components:
     - pos: 5.531529,-16.596592
       parent: 1
       type: Transform
-  - uid: 1931
+  - uid: 1996
     components:
     - pos: -4.489903,-16.270082
       parent: 1
       type: Transform
 - proto: SignDirectionalChemistry
   entities:
-  - uid: 1932
+  - uid: 1997
     components:
     - pos: 5.5252223,-9.528935
       parent: 1
       type: Transform
 - proto: SignDirectionalDorms
   entities:
-  - uid: 1933
+  - uid: 1998
     components:
     - pos: -4.4623313,-10.062774
       parent: 1
       type: Transform
-  - uid: 1934
+  - uid: 1999
     components:
     - rot: -1.5707963267948966 rad
       pos: 5.5006714,-16.325571
       parent: 1
       type: Transform
-  - uid: 1935
+  - uid: 2000
     components:
     - pos: -4.482943,-16.566992
       parent: 1
       type: Transform
 - proto: SignDirectionalEng
   entities:
-  - uid: 1936
+  - uid: 2001
     components:
     - pos: -4.4623313,-10.344219
       parent: 1
       type: Transform
-  - uid: 1937
+  - uid: 2002
     components:
     - pos: 5.5252223,-10.091826
       parent: 1
       type: Transform
-  - uid: 1938
+  - uid: 2003
     components:
     - pos: 5.5211124,-16.867613
       parent: 1
       type: Transform
-  - uid: 1939
+  - uid: 2004
     components:
     - pos: -4.482943,-16.890133
       parent: 1
       type: Transform
 - proto: SignDirectionalJanitor
   entities:
-  - uid: 1940
+  - uid: 2005
     components:
     - rot: -1.5707963267948966 rad
       pos: -4.5,-7.5
@@ -14738,25 +15404,25 @@ entities:
       type: Transform
 - proto: SignDirectionalMed
   entities:
-  - uid: 1941
+  - uid: 2006
     components:
     - pos: -4.4623313,-9.510307
       parent: 1
       type: Transform
 - proto: SignDirectionalSalvage
   entities:
-  - uid: 1942
+  - uid: 2007
     components:
     - pos: -2.5,8.5
       parent: 1
       type: Transform
-  - uid: 1943
+  - uid: 2008
     components:
     - rot: 3.141592653589793 rad
       pos: -6.5,-20.5
       parent: 1
       type: Transform
-  - uid: 1944
+  - uid: 2009
     components:
     - rot: 3.141592653589793 rad
       pos: 7.5,-20.5
@@ -14764,18 +15430,18 @@ entities:
       type: Transform
 - proto: SignDirectionalSupply
   entities:
-  - uid: 1945
+  - uid: 2010
     components:
     - pos: 3.5,8.5
       parent: 1
       type: Transform
-  - uid: 1946
+  - uid: 2011
     components:
     - rot: 3.141592653589793 rad
       pos: -4.5,-20.5
       parent: 1
       type: Transform
-  - uid: 1947
+  - uid: 2012
     components:
     - rot: 3.141592653589793 rad
       pos: 5.5,-20.5
@@ -14783,19 +15449,19 @@ entities:
       type: Transform
 - proto: SignEngineering
   entities:
-  - uid: 1948
+  - uid: 2013
     components:
     - rot: 3.141592653589793 rad
       pos: 7.5,-26.5
       parent: 1
       type: Transform
-  - uid: 1949
+  - uid: 2014
     components:
     - rot: 3.141592653589793 rad
       pos: -6.5,-32.5
       parent: 1
       type: Transform
-  - uid: 1950
+  - uid: 2015
     components:
     - rot: 1.5707963267948966 rad
       pos: 1.5,-32.5
@@ -14803,14 +15469,14 @@ entities:
       type: Transform
 - proto: SignLastIdiot
   entities:
-  - uid: 1951
+  - uid: 2016
     components:
     - pos: -2.5,-32.5
       parent: 1
       type: Transform
 - proto: SignMedical
   entities:
-  - uid: 1952
+  - uid: 2017
     components:
     - rot: 1.5707963267948966 rad
       pos: -4.5,-15.5
@@ -14818,7 +15484,7 @@ entities:
       type: Transform
 - proto: SignPlaque
   entities:
-  - uid: 1953
+  - uid: 2018
     components:
     - desc: A prestigious golden plaque commemorating the name and commission of the ship.
       name: '"The Praeda"'
@@ -14829,12 +15495,12 @@ entities:
       type: Transform
 - proto: SignRadiation
   entities:
-  - uid: 1954
+  - uid: 2019
     components:
     - pos: 5.5,-26.5
       parent: 1
       type: Transform
-  - uid: 1955
+  - uid: 2020
     components:
     - rot: 1.5707963267948966 rad
       pos: 1.5,-30.5
@@ -14842,79 +15508,79 @@ entities:
       type: Transform
 - proto: SignSecurearea
   entities:
-  - uid: 1956
+  - uid: 2021
     components:
     - pos: 6.5,1.5
       parent: 1
       type: Transform
-  - uid: 1957
+  - uid: 2022
     components:
     - pos: -5.5,1.5
       parent: 1
       type: Transform
 - proto: SignSpace
   entities:
-  - uid: 1958
+  - uid: 2023
     components:
     - rot: 3.141592653589793 rad
       pos: -6.5,1.5
       parent: 1
       type: Transform
-  - uid: 1959
+  - uid: 2024
     components:
     - pos: -8.5,-28.5
       parent: 1
       type: Transform
-  - uid: 1960
+  - uid: 2025
     components:
     - pos: -8.5,-25.5
       parent: 1
       type: Transform
-  - uid: 1961
+  - uid: 2026
     components:
     - pos: 9.5,-25.5
       parent: 1
       type: Transform
-  - uid: 1962
+  - uid: 2027
     components:
     - pos: 9.5,-30.5
       parent: 1
       type: Transform
-  - uid: 1963
+  - uid: 2028
     components:
     - pos: -6.5,5.5
       parent: 1
       type: Transform
-  - uid: 1964
+  - uid: 2029
     components:
     - rot: 1.5707963267948966 rad
       pos: -2.5,9.5
       parent: 1
       type: Transform
-  - uid: 1965
+  - uid: 2030
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,9.5
       parent: 1
       type: Transform
-  - uid: 1966
+  - uid: 2031
     components:
     - pos: 7.5,5.5
       parent: 1
       type: Transform
-  - uid: 1967
+  - uid: 2032
     components:
     - rot: 3.141592653589793 rad
       pos: 7.5,1.5
       parent: 1
       type: Transform
-  - uid: 1968
+  - uid: 2033
     components:
     - rot: -1.5707963267948966 rad
       pos: 5.5,6.5
       parent: 1
       type: Transform
-  - uid: 1969
+  - uid: 2034
     components:
     - rot: 1.5707963267948966 rad
       pos: -4.5,6.5
@@ -14922,7 +15588,7 @@ entities:
       type: Transform
 - proto: Sink
   entities:
-  - uid: 1970
+  - uid: 2035
     components:
     - rot: -1.5707963267948966 rad
       pos: 6.5,-8.5
@@ -14930,246 +15596,244 @@ entities:
       type: Transform
 - proto: SMESBasic
   entities:
-  - uid: 1971
+  - uid: 2036
     components:
     - pos: -6.5,-18.5
       parent: 1
       type: Transform
-  - uid: 1972
+  - uid: 2037
     components:
     - pos: 8.5,-32.5
       parent: 1
       type: Transform
-  - uid: 1973
+  - uid: 2038
     components:
     - pos: 8.5,-33.5
       parent: 1
       type: Transform
-  - uid: 1974
+  - uid: 2039
     components:
     - pos: 7.5,-18.5
       parent: 1
       type: Transform
 - proto: SmokingPipe
   entities:
-  - uid: 1975
+  - uid: 2040
     components:
     - pos: 1.5183704,-17.432232
       parent: 1
       type: Transform
 - proto: Soap
   entities:
-  - uid: 1976
+  - uid: 2041
     components:
     - pos: 6.766353,-9.746599
       parent: 1
       type: Transform
 - proto: soda_dispenser
   entities:
-  - uid: 1977
+  - uid: 2042
     components:
     - pos: 0.5,-12.5
       parent: 1
       type: Transform
 - proto: SpawnPointBartender
   entities:
-  - uid: 1978
+  - uid: 2043
     components:
     - pos: -3.5,-28.5
       parent: 1
       type: Transform
 - proto: SpawnPointCargoTechnician
   entities:
-  - uid: 1979
+  - uid: 2044
     components:
     - pos: 6.5,-9.5
       parent: 1
       type: Transform
 - proto: SpawnPointChiefEngineer
   entities:
-  - uid: 1980
+  - uid: 2045
     components:
     - pos: -0.5,-27.5
       parent: 1
       type: Transform
 - proto: SpawnPointLatejoin
   entities:
-  - uid: 1981
+  - uid: 2046
     components:
     - pos: -8.5,-31.5
       parent: 1
       type: Transform
-  - uid: 1982
+  - uid: 2047
     components:
     - pos: -3.5,-28.5
       parent: 1
       type: Transform
-  - uid: 1983
+  - uid: 2048
     components:
     - pos: -3.5,-31.5
       parent: 1
       type: Transform
-  - uid: 1984
+  - uid: 2049
     components:
     - pos: -9.5,-31.5
       parent: 1
       type: Transform
-  - uid: 1985
+  - uid: 2050
     components:
     - pos: -3.5,-30.5
       parent: 1
       type: Transform
-- proto: SpawnPointParamedic
-  entities:
-  - uid: 1986
-    components:
-    - pos: -6.5,-15.5
-      parent: 1
-      type: Transform
 - proto: SpawnPointQuartermaster
   entities:
-  - uid: 1987
+  - uid: 2051
     components:
     - pos: 2.5,1.5
       parent: 1
       type: Transform
 - proto: SpawnPointSalvageSpecialist
   entities:
-  - uid: 1988
+  - uid: 2052
     components:
     - pos: -9.5,-31.5
       parent: 1
       type: Transform
-  - uid: 1989
+  - uid: 2053
     components:
     - pos: -3.5,-27.5
       parent: 1
       type: Transform
-  - uid: 1990
+  - uid: 2054
     components:
     - pos: -8.5,-31.5
       parent: 1
       type: Transform
 - proto: SpawnPointStationEngineer
   entities:
-  - uid: 1991
+  - uid: 2055
     components:
     - pos: -3.5,-31.5
       parent: 1
       type: Transform
-  - uid: 1992
+  - uid: 2056
     components:
     - pos: -3.5,-30.5
       parent: 1
       type: Transform
 - proto: SpeedLoaderMagnum
   entities:
-  - uid: 252
+  - uid: 241
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 227
+    - parent: 216
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 253
+  - uid: 242
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 227
+    - parent: 216
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 1661
+  - uid: 1723
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 1660
+    - parent: 1722
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 1662
+  - uid: 1724
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 1660
+    - parent: 1722
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 1694
+  - uid: 1751
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 1693
+    - parent: 1749
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 1695
+  - uid: 1753
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 1693
+    - parent: 1749
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
+  - uid: 2057
+    components:
+    - pos: 4.4148893,-24.544632
+      parent: 1
+      type: Transform
 - proto: SpeedLoaderMagnumHighVelocity
   entities:
-  - uid: 254
+  - uid: 243
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 227
+    - parent: 216
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 1663
+  - uid: 1725
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 1660
+    - parent: 1722
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: SpeedLoaderMagnumRubber
   entities:
-  - uid: 1696
+  - uid: 1752
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 1693
+    - parent: 1749
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: StoolBar
   entities:
-  - uid: 1993
+  - uid: 2058
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,-15.5
       parent: 1
       type: Transform
-  - uid: 1994
+  - uid: 2059
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,-15.5
       parent: 1
       type: Transform
-  - uid: 1995
+  - uid: 2060
     components:
     - rot: 3.141592653589793 rad
       pos: 1.5,-15.5
       parent: 1
       type: Transform
-  - uid: 1996
+  - uid: 2061
     components:
     - rot: 3.141592653589793 rad
       pos: 2.5,-15.5
@@ -15177,358 +15841,479 @@ entities:
       type: Transform
 - proto: Stunbaton
   entities:
-  - uid: 112
+  - uid: 116
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 100
+    - parent: 103
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: SubstationBasic
   entities:
-  - uid: 1997
+  - uid: 2062
     components:
     - pos: 8.5,-31.5
       parent: 1
       type: Transform
-  - uid: 1998
+  - uid: 2063
     components:
     - pos: -3.5,6.5
       parent: 1
       type: Transform
-  - uid: 1999
+  - uid: 2064
     components:
     - pos: 4.5,6.5
       parent: 1
       type: Transform
 - proto: SubstationWallBasic
   entities:
-  - uid: 2000
+  - uid: 2065
     components:
     - pos: 7.5,-17.5
       parent: 1
       type: Transform
-  - uid: 2001
+  - uid: 2066
     components:
     - pos: -6.5,-17.5
       parent: 1
       type: Transform
 - proto: SuitStorageCaptain
   entities:
-  - uid: 2002
+  - uid: 2067
     components:
     - pos: -1.5,-25.5
       parent: 1
       type: Transform
 - proto: SuitStorageCE
   entities:
-  - uid: 2003
+  - uid: 2068
     components:
     - pos: -1.5,-28.5
       parent: 1
       type: Transform
 - proto: SuitStorageEngi
   entities:
-  - uid: 2004
+  - uid: 2069
     components:
     - pos: 6.5,-34.5
       parent: 1
       type: Transform
-  - uid: 2005
+  - uid: 2070
     components:
     - pos: 5.5,-34.5
       parent: 1
       type: Transform
 - proto: SuitStorageSalv
   entities:
-  - uid: 2006
+  - uid: 2071
     components:
     - pos: -0.5,-10.5
       parent: 1
       type: Transform
-  - uid: 2007
+  - uid: 2072
     components:
     - pos: -1.5,-10.5
       parent: 1
       type: Transform
-  - uid: 2008
+  - uid: 2073
     components:
     - pos: 1.5,-0.5
       parent: 1
       type: Transform
-  - uid: 2009
+  - uid: 2074
     components:
     - pos: 1.5,-10.5
       parent: 1
       type: Transform
-  - uid: 2010
+  - uid: 2075
     components:
     - pos: 2.5,-10.5
       parent: 1
       type: Transform
+- proto: SurveillanceCameraCommand
+  entities:
+  - uid: 2076
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -7.5,-7.5
+      parent: 1
+      type: Transform
+    - id: Cargo bay - Exterior - Left
+      type: SurveillanceCamera
+  - uid: 2077
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 8.5,-7.5
+      parent: 1
+      type: Transform
+    - id: Cargo bay - Exterior - Right
+      type: SurveillanceCamera
+  - uid: 2078
+    components:
+    - pos: 2.5,3.5
+      parent: 1
+      type: Transform
+    - id: Docking area
+      type: SurveillanceCamera
+  - uid: 2079
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -3.5,-7.5
+      parent: 1
+      type: Transform
+    - id: Cargo bay - Interior - Left
+      type: SurveillanceCamera
+  - uid: 2080
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -1.5,1.5
+      parent: 1
+      type: Transform
+    - id: Cargobay - Quartermaster's office
+      type: SurveillanceCamera
+  - uid: 2081
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 4.5,-7.5
+      parent: 1
+      type: Transform
+    - id: Cargo bay - Interior - Right
+      type: SurveillanceCamera
+  - uid: 2082
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -5.5,-15.5
+      parent: 1
+      type: Transform
+    - id: Medbay
+      type: SurveillanceCamera
+  - uid: 2083
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 6.5,-15.5
+      parent: 1
+      type: Transform
+    - id: Chemistry
+      type: SurveillanceCamera
+  - uid: 2084
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -6.5,-33.5
+      parent: 1
+      type: Transform
+    - id: Engineering - Storage
+      type: SurveillanceCamera
+  - uid: 2085
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 7.5,-30.5
+      parent: 1
+      type: Transform
+    - id: Engineering - Engine Room
+      type: SurveillanceCamera
+  - uid: 2086
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -5.5,-29.5
+      parent: 1
+      type: Transform
+    - id: Dorms
+      type: SurveillanceCamera
+  - uid: 2087
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -1.5,-31.5
+      parent: 1
+      type: Transform
+    - id: Engineering - Chief Engineer's office
+      type: SurveillanceCamera
+- proto: SurveillanceCameraRouterCommand
+  entities:
+  - uid: 2088
+    components:
+    - pos: -7.5,-34.5
+      parent: 1
+      type: Transform
 - proto: SurvivalKnife
   entities:
-  - uid: 2011
+  - uid: 2089
     components:
     - pos: 1.5929434,-25.4159
       parent: 1
       type: Transform
+- proto: SyringeHyronalin
+  entities:
+  - uid: 2090
+    components:
+    - pos: -6.316808,-13.40014
+      parent: 1
+      type: Transform
+  - uid: 2091
+    components:
+    - pos: -6.4522247,-13.3792925
+      parent: 1
+      type: Transform
+  - uid: 2092
+    components:
+    - pos: -6.3376412,-13.441836
+      parent: 1
+      type: Transform
 - proto: Table
   entities:
-  - uid: 2012
-    components:
-    - pos: 2.5,-2.5
-      parent: 1
-      type: Transform
-  - uid: 2013
-    components:
-    - pos: 3.5,-2.5
-      parent: 1
-      type: Transform
-  - uid: 2014
-    components:
-    - pos: -0.5,-12.5
-      parent: 1
-      type: Transform
-  - uid: 2015
-    components:
-    - pos: 0.5,-12.5
-      parent: 1
-      type: Transform
-  - uid: 2016
-    components:
-    - pos: 1.5,-12.5
-      parent: 1
-      type: Transform
-  - uid: 2017
+  - uid: 2093
     components:
     - pos: -6.5,-16.5
       parent: 1
       type: Transform
-  - uid: 2018
+  - uid: 2094
+    components:
+    - pos: 2.5,-2.5
+      parent: 1
+      type: Transform
+  - uid: 2095
+    components:
+    - pos: 3.5,-2.5
+      parent: 1
+      type: Transform
+  - uid: 2096
+    components:
+    - pos: -0.5,-12.5
+      parent: 1
+      type: Transform
+  - uid: 2097
+    components:
+    - pos: 0.5,-12.5
+      parent: 1
+      type: Transform
+  - uid: 2098
+    components:
+    - pos: 1.5,-12.5
+      parent: 1
+      type: Transform
+  - uid: 2099
     components:
     - pos: 7.5,-16.5
       parent: 1
       type: Transform
-  - uid: 2019
+  - uid: 2100
     components:
     - pos: 0.5,-7.5
       parent: 1
       type: Transform
-  - uid: 2020
+  - uid: 2101
     components:
     - pos: 0.5,-8.5
       parent: 1
       type: Transform
-  - uid: 2021
+  - uid: 2102
     components:
     - pos: -5.5,0.5
       parent: 1
       type: Transform
 - proto: TableCarpet
   entities:
-  - uid: 2022
+  - uid: 2103
     components:
     - pos: -0.5,-30.5
       parent: 1
       type: Transform
-  - uid: 2023
+  - uid: 2104
     components:
     - pos: -1.5,-30.5
       parent: 1
       type: Transform
-  - uid: 2024
+  - uid: 2105
     components:
     - pos: -0.5,-17.5
       parent: 1
       type: Transform
-  - uid: 2025
+  - uid: 2106
     components:
     - pos: 1.5,-17.5
       parent: 1
       type: Transform
 - proto: TableCounterWood
   entities:
-  - uid: 2026
+  - uid: 2107
     components:
     - pos: -0.5,-14.5
       parent: 1
       type: Transform
-  - uid: 2027
+  - uid: 2108
     components:
     - pos: 0.5,-14.5
       parent: 1
       type: Transform
-  - uid: 2028
+  - uid: 2109
     components:
     - pos: 1.5,-14.5
       parent: 1
       type: Transform
-  - uid: 2029
+  - uid: 2110
     components:
     - pos: 2.5,-14.5
       parent: 1
       type: Transform
 - proto: TableReinforced
   entities:
-  - uid: 2030
+  - uid: 2111
     components:
     - pos: 5.5,-13.5
       parent: 1
       type: Transform
-  - uid: 2031
+  - uid: 2112
     components:
     - pos: -4.5,-13.5
       parent: 1
       type: Transform
-  - uid: 2032
+  - uid: 2113
     components:
     - pos: 0.5,2.5
       parent: 1
       type: Transform
 - proto: TableReinforcedGlass
   entities:
-  - uid: 2033
+  - uid: 2114
     components:
     - pos: 7.5,-13.5
       parent: 1
       type: Transform
-  - uid: 2034
+  - uid: 2115
     components:
     - pos: -6.5,-13.5
       parent: 1
       type: Transform
 - proto: TableWood
   entities:
-  - uid: 2035
+  - uid: 2116
     components:
     - pos: -9.5,-32.5
       parent: 1
       type: Transform
 - proto: TableWoodReinforced
   entities:
-  - uid: 2036
+  - uid: 2117
     components:
     - pos: 4.5,-24.5
       parent: 1
       type: Transform
-  - uid: 2037
+  - uid: 2118
     components:
     - pos: 1.5,-25.5
       parent: 1
       type: Transform
-  - uid: 2038
+  - uid: 2119
     components:
     - rot: -1.5707963267948966 rad
       pos: 2.5,-21.5
       parent: 1
       type: Transform
-  - uid: 2039
+  - uid: 2120
     components:
     - rot: -1.5707963267948966 rad
       pos: -1.5,-21.5
       parent: 1
       type: Transform
-  - uid: 2040
+  - uid: 2121
     components:
     - rot: -1.5707963267948966 rad
       pos: -1.5,-22.5
       parent: 1
       type: Transform
-  - uid: 2041
+  - uid: 2122
     components:
     - rot: -1.5707963267948966 rad
       pos: 2.5,-22.5
       parent: 1
       type: Transform
-  - uid: 2042
+  - uid: 2123
     components:
     - pos: -0.5,1.5
       parent: 1
       type: Transform
-  - uid: 2043
+  - uid: 2124
     components:
     - pos: -0.5,0.5
       parent: 1
       type: Transform
-- proto: TelecomServerFilled
+- proto: TelecomServer
   entities:
-  - uid: 206
+  - uid: 2125
     components:
-    - pos: -3.5,-25.5
+    - pos: -7.5,-33.5
       parent: 1
       type: Transform
 - proto: Thruster
   entities:
-  - uid: 2044
+  - uid: 2126
     components:
     - rot: 3.141592653589793 rad
       pos: 8.5,-36.5
       parent: 1
       type: Transform
-  - uid: 2045
+  - uid: 2127
     components:
     - rot: 3.141592653589793 rad
       pos: 7.5,-36.5
       parent: 1
       type: Transform
-  - uid: 2046
+  - uid: 2128
     components:
     - rot: 3.141592653589793 rad
       pos: 4.5,-36.5
       parent: 1
       type: Transform
-  - uid: 2047
+  - uid: 2129
     components:
     - rot: 3.141592653589793 rad
       pos: 3.5,-36.5
       parent: 1
       type: Transform
-  - uid: 2048
+  - uid: 2130
     components:
     - rot: 3.141592653589793 rad
       pos: 2.5,-36.5
       parent: 1
       type: Transform
-  - uid: 2049
+  - uid: 2131
     components:
     - rot: 3.141592653589793 rad
       pos: -1.5,-36.5
       parent: 1
       type: Transform
-  - uid: 2050
+  - uid: 2132
     components:
     - rot: 3.141592653589793 rad
       pos: -2.5,-36.5
       parent: 1
       type: Transform
-  - uid: 2051
+  - uid: 2133
     components:
     - rot: 3.141592653589793 rad
       pos: -3.5,-36.5
       parent: 1
       type: Transform
-  - uid: 2052
+  - uid: 2134
     components:
     - rot: 3.141592653589793 rad
       pos: -6.5,-36.5
       parent: 1
       type: Transform
-  - uid: 2053
+  - uid: 2135
     components:
     - rot: 3.141592653589793 rad
       pos: -7.5,-36.5
       parent: 1
       type: Transform
-  - uid: 2054
+  - uid: 2136
     components:
     - rot: 3.141592653589793 rad
       pos: -11.5,-32.5
       parent: 1
       type: Transform
-  - uid: 2055
+  - uid: 2137
     components:
     - rot: 1.5707963267948966 rad
       pos: -12.5,-31.5
@@ -15536,103 +16321,103 @@ entities:
       type: Transform
     - enabled: False
       type: Thruster
-  - uid: 2056
+  - uid: 2138
     components:
     - rot: 1.5707963267948966 rad
       pos: -12.5,-30.5
       parent: 1
       type: Transform
-  - uid: 2057
+  - uid: 2139
     components:
     - rot: 1.5707963267948966 rad
       pos: -12.5,-29.5
       parent: 1
       type: Transform
-  - uid: 2058
+  - uid: 2140
     components:
     - pos: -10.5,-26.5
       parent: 1
       type: Transform
-  - uid: 2059
+  - uid: 2141
     components:
     - rot: 1.5707963267948966 rad
       pos: -6.5,8.5
       parent: 1
       type: Transform
-  - uid: 2060
+  - uid: 2142
     components:
     - rot: 1.5707963267948966 rad
       pos: -6.5,7.5
       parent: 1
       type: Transform
-  - uid: 2061
+  - uid: 2143
     components:
     - rot: 1.5707963267948966 rad
       pos: -6.5,6.5
       parent: 1
       type: Transform
-  - uid: 2062
+  - uid: 2144
     components:
     - rot: -1.5707963267948966 rad
       pos: 7.5,8.5
       parent: 1
       type: Transform
-  - uid: 2063
+  - uid: 2145
     components:
     - rot: -1.5707963267948966 rad
       pos: 7.5,7.5
       parent: 1
       type: Transform
-  - uid: 2064
+  - uid: 2146
     components:
     - rot: -1.5707963267948966 rad
       pos: 7.5,6.5
       parent: 1
       type: Transform
-  - uid: 2065
+  - uid: 2147
     components:
     - pos: 4.5,10.5
       parent: 1
       type: Transform
-  - uid: 2066
+  - uid: 2148
     components:
     - pos: -3.5,10.5
       parent: 1
       type: Transform
-  - uid: 2067
+  - uid: 2149
     components:
     - pos: -11.5,-27.5
       parent: 1
       type: Transform
-  - uid: 2068
+  - uid: 2150
     components:
     - pos: 11.5,-26.5
       parent: 1
       type: Transform
-  - uid: 2069
+  - uid: 2151
     components:
     - pos: 12.5,-27.5
       parent: 1
       type: Transform
-  - uid: 2070
+  - uid: 2152
     components:
     - rot: -1.5707963267948966 rad
       pos: 13.5,-29.5
       parent: 1
       type: Transform
-  - uid: 2071
+  - uid: 2153
     components:
     - rot: -1.5707963267948966 rad
       pos: 13.5,-30.5
       parent: 1
       type: Transform
-  - uid: 2072
+  - uid: 2154
     components:
     - rot: -1.5707963267948966 rad
       pos: 13.5,-31.5
       parent: 1
       type: Transform
-  - uid: 2073
+  - uid: 2155
     components:
     - rot: 3.141592653589793 rad
       pos: 12.5,-32.5
@@ -15640,7 +16425,7 @@ entities:
       type: Transform
 - proto: ToiletEmpty
   entities:
-  - uid: 2074
+  - uid: 2156
     components:
     - rot: 1.5707963267948966 rad
       pos: 6.5,-9.5
@@ -15648,197 +16433,197 @@ entities:
       type: Transform
 - proto: ToyFigurineCaptain
   entities:
-  - uid: 255
+  - uid: 244
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 227
+    - parent: 216
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: ToyFigurineQuartermaster
   entities:
-  - uid: 113
+  - uid: 117
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 100
+    - parent: 103
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: TwoWayLever
   entities:
-  - uid: 2075
+  - uid: 2157
     components:
     - pos: -4.523994,-5.9441257
       parent: 1
       type: Transform
     - linkedPorts:
-        1023:
+        1081:
         - Middle: Off
         - Right: Forward
         - Left: Forward
-        1024:
+        1082:
         - Middle: Off
         - Right: Forward
         - Left: Forward
-        1025:
+        1083:
         - Middle: Off
         - Right: Forward
         - Left: Forward
-        1026:
+        1084:
         - Middle: Off
         - Right: Forward
         - Left: Forward
-        1027:
+        1085:
         - Middle: Off
         - Right: Forward
         - Left: Forward
-        1028:
+        1086:
         - Middle: Off
         - Right: Forward
         - Left: Forward
-        1029:
+        1087:
         - Middle: Off
         - Right: Forward
         - Left: Forward
-        1031:
+        1089:
         - Middle: Off
         - Right: Forward
         - Left: Forward
-        1032:
+        1090:
         - Middle: Off
         - Right: Forward
         - Left: Forward
-        1033:
+        1091:
         - Middle: Off
         - Right: Forward
         - Left: Forward
-        1034:
+        1092:
         - Middle: Off
         - Right: Forward
         - Left: Forward
-        1036:
+        1094:
         - Middle: Off
         - Right: Forward
         - Left: Forward
-        1037:
+        1095:
         - Middle: Off
         - Right: Forward
         - Left: Forward
-        1038:
+        1096:
         - Middle: Off
         - Right: Forward
         - Left: Forward
-        1039:
+        1097:
         - Middle: Off
         - Right: Forward
         - Left: Forward
-        1040:
+        1098:
         - Middle: Off
         - Right: Forward
         - Left: Forward
-        1041:
+        1099:
         - Middle: Off
         - Right: Forward
         - Left: Forward
-        1030:
+        1088:
         - Middle: Off
         - Right: Forward
         - Left: Forward
-        1035:
+        1093:
         - Middle: Off
         - Right: Forward
         - Left: Forward
       type: DeviceLinkSource
-  - uid: 2076
+  - uid: 2158
     components:
     - pos: 5.490258,-5.958462
       parent: 1
       type: Transform
     - linkedPorts:
-        1060:
+        1118:
         - Middle: Off
         - Right: Forward
         - Left: Forward
-        1059:
+        1117:
         - Middle: Off
         - Right: Forward
         - Left: Forward
-        1058:
+        1116:
         - Middle: Off
         - Right: Forward
         - Left: Forward
-        1057:
+        1115:
         - Middle: Off
         - Right: Forward
         - Left: Forward
-        1056:
+        1114:
         - Middle: Off
         - Right: Forward
         - Left: Forward
-        1055:
+        1113:
         - Middle: Off
         - Right: Forward
         - Left: Forward
-        1054:
+        1112:
         - Middle: Off
         - Right: Forward
         - Left: Forward
-        1053:
+        1111:
         - Middle: Off
         - Right: Forward
         - Left: Forward
-        1052:
+        1110:
         - Middle: Off
         - Right: Forward
         - Left: Forward
-        1051:
+        1109:
         - Middle: Off
         - Right: Forward
         - Left: Forward
-        1050:
+        1108:
         - Middle: Off
         - Right: Forward
         - Left: Forward
-        1049:
+        1107:
         - Middle: Off
         - Right: Forward
         - Left: Forward
-        1048:
+        1106:
         - Middle: Off
         - Right: Forward
         - Left: Forward
-        1047:
+        1105:
         - Middle: Off
         - Right: Forward
         - Left: Forward
-        1046:
+        1104:
         - Middle: Off
         - Right: Forward
         - Left: Forward
-        1045:
+        1103:
         - Middle: Off
         - Right: Forward
         - Left: Forward
-        1044:
+        1102:
         - Middle: Off
         - Right: Forward
         - Left: Forward
-        1043:
+        1101:
         - Middle: Off
         - Right: Forward
         - Left: Forward
-        1042:
+        1100:
         - Middle: Off
         - Right: Forward
         - Left: Forward
       type: DeviceLinkSource
 - proto: VendingMachineBooze
   entities:
-  - uid: 2077
+  - uid: 2159
     components:
     - flags: SessionSpecific
       type: MetaData
@@ -15847,7 +16632,7 @@ entities:
       type: Transform
 - proto: VendingMachineCargoDrobe
   entities:
-  - uid: 2078
+  - uid: 2160
     components:
     - flags: SessionSpecific
       type: MetaData
@@ -15856,7 +16641,7 @@ entities:
       type: Transform
 - proto: VendingMachineChemicals
   entities:
-  - uid: 2079
+  - uid: 2161
     components:
     - flags: SessionSpecific
       type: MetaData
@@ -15865,7 +16650,7 @@ entities:
       type: Transform
 - proto: VendingMachineCigs
   entities:
-  - uid: 2080
+  - uid: 2162
     components:
     - flags: SessionSpecific
       type: MetaData
@@ -15874,7 +16659,7 @@ entities:
       type: Transform
 - proto: VendingMachineCoffee
   entities:
-  - uid: 2081
+  - uid: 2163
     components:
     - flags: SessionSpecific
       type: MetaData
@@ -15883,7 +16668,7 @@ entities:
       type: Transform
 - proto: VendingMachineDiscount
   entities:
-  - uid: 2082
+  - uid: 2164
     components:
     - flags: SessionSpecific
       type: MetaData
@@ -15892,7 +16677,7 @@ entities:
       type: Transform
 - proto: VendingMachineMedical
   entities:
-  - uid: 2083
+  - uid: 2165
     components:
     - flags: SessionSpecific
       type: MetaData
@@ -15901,7 +16686,7 @@ entities:
       type: Transform
 - proto: VendingMachineSalvage
   entities:
-  - uid: 2084
+  - uid: 2166
     components:
     - flags: SessionSpecific
       type: MetaData
@@ -15910,14 +16695,14 @@ entities:
       type: Transform
 - proto: VendingMachineTankDispenserEVA
   entities:
-  - uid: 2085
+  - uid: 2167
     components:
     - flags: SessionSpecific
       type: MetaData
     - pos: 0.5,-10.5
       parent: 1
       type: Transform
-  - uid: 2086
+  - uid: 2168
     components:
     - flags: SessionSpecific
       type: MetaData
@@ -15926,1175 +16711,1175 @@ entities:
       type: Transform
 - proto: WallReinforced
   entities:
-  - uid: 2087
+  - uid: 2169
     components:
     - pos: -2.5,-28.5
       parent: 1
       type: Transform
-  - uid: 2088
+  - uid: 2170
     components:
     - rot: 1.5707963267948966 rad
       pos: 1.5,-30.5
       parent: 1
       type: Transform
-  - uid: 2089
+  - uid: 2171
     components:
     - pos: -4.5,-24.5
       parent: 1
       type: Transform
-  - uid: 2090
+  - uid: 2172
     components:
     - pos: -4.5,-25.5
       parent: 1
       type: Transform
-  - uid: 2091
+  - uid: 2173
     components:
     - pos: 5.5,-24.5
       parent: 1
       type: Transform
-  - uid: 2092
+  - uid: 2174
     components:
     - pos: 5.5,-25.5
       parent: 1
       type: Transform
-  - uid: 2093
+  - uid: 2175
     components:
     - pos: -4.5,-26.5
       parent: 1
       type: Transform
-  - uid: 2094
+  - uid: 2176
     components:
     - pos: -3.5,-26.5
       parent: 1
       type: Transform
-  - uid: 2095
+  - uid: 2177
     components:
     - pos: -2.5,-26.5
       parent: 1
       type: Transform
-  - uid: 2096
+  - uid: 2178
     components:
     - pos: -1.5,-26.5
       parent: 1
       type: Transform
-  - uid: 2097
+  - uid: 2179
     components:
     - pos: -0.5,-26.5
       parent: 1
       type: Transform
-  - uid: 2098
+  - uid: 2180
     components:
     - pos: 0.5,-26.5
       parent: 1
       type: Transform
-  - uid: 2099
+  - uid: 2181
     components:
     - pos: 1.5,-26.5
       parent: 1
       type: Transform
-  - uid: 2100
+  - uid: 2182
     components:
     - pos: 5.5,-26.5
       parent: 1
       type: Transform
-  - uid: 2101
+  - uid: 2183
     components:
     - pos: 1.5,-32.5
       parent: 1
       type: Transform
-  - uid: 2102
+  - uid: 2184
     components:
     - rot: 1.5707963267948966 rad
       pos: -2.5,-32.5
       parent: 1
       type: Transform
-  - uid: 2103
+  - uid: 2185
     components:
     - rot: 1.5707963267948966 rad
       pos: -4.5,-31.5
       parent: 1
       type: Transform
-  - uid: 2104
+  - uid: 2186
     components:
     - rot: 1.5707963267948966 rad
       pos: -3.5,-32.5
       parent: 1
       type: Transform
-  - uid: 2105
+  - uid: 2187
     components:
     - rot: 1.5707963267948966 rad
       pos: -4.5,-29.5
       parent: 1
       type: Transform
-  - uid: 2106
+  - uid: 2188
     components:
     - rot: 1.5707963267948966 rad
       pos: -4.5,-32.5
       parent: 1
       type: Transform
-  - uid: 2107
+  - uid: 2189
     components:
     - rot: 1.5707963267948966 rad
       pos: -3.5,-29.5
       parent: 1
       type: Transform
-  - uid: 2108
+  - uid: 2190
     components:
     - rot: 1.5707963267948966 rad
       pos: -2.5,-27.5
       parent: 1
       type: Transform
-  - uid: 2109
+  - uid: 2191
     components:
     - rot: 1.5707963267948966 rad
       pos: -2.5,-29.5
       parent: 1
       type: Transform
-  - uid: 2110
+  - uid: 2192
     components:
     - rot: 1.5707963267948966 rad
       pos: -2.5,-30.5
       parent: 1
       type: Transform
-  - uid: 2111
+  - uid: 2193
     components:
     - pos: -1.5,-32.5
       parent: 1
       type: Transform
-  - uid: 2112
+  - uid: 2194
     components:
     - rot: 1.5707963267948966 rad
       pos: -4.5,-28.5
       parent: 1
       type: Transform
-  - uid: 2113
+  - uid: 2195
     components:
     - pos: -0.5,-32.5
       parent: 1
       type: Transform
-  - uid: 2114
+  - uid: 2196
     components:
     - rot: -1.5707963267948966 rad
       pos: -2.5,-31.5
       parent: 1
       type: Transform
-  - uid: 2115
+  - uid: 2197
     components:
     - pos: 0.5,-25.5
       parent: 1
       type: Transform
 - proto: WallShuttle
   entities:
-  - uid: 2116
+  - uid: 2198
     components:
     - pos: -1.5,-1.5
       parent: 1
       type: Transform
-  - uid: 2117
+  - uid: 2199
     components:
     - pos: 2.5,-1.5
       parent: 1
       type: Transform
-  - uid: 2118
+  - uid: 2200
     components:
     - pos: 8.5,-25.5
       parent: 1
       type: Transform
-  - uid: 2119
+  - uid: 2201
     components:
     - rot: 1.5707963267948966 rad
       pos: 11.5,-30.5
       parent: 1
       type: Transform
-  - uid: 2120
+  - uid: 2202
     components:
     - rot: -1.5707963267948966 rad
       pos: -1.5,2.5
       parent: 1
       type: Transform
-  - uid: 2121
+  - uid: 2203
     components:
     - rot: 3.141592653589793 rad
       pos: -10.5,-31.5
       parent: 1
       type: Transform
-  - uid: 2122
+  - uid: 2204
     components:
     - pos: 11.5,-32.5
       parent: 1
       type: Transform
-  - uid: 2123
+  - uid: 2205
     components:
     - rot: 3.141592653589793 rad
       pos: 10.5,-33.5
       parent: 1
       type: Transform
-  - uid: 2124
+  - uid: 2206
     components:
     - pos: 11.5,-28.5
       parent: 1
       type: Transform
-  - uid: 2125
+  - uid: 2207
     components:
     - pos: 7.5,-26.5
       parent: 1
       type: Transform
-  - uid: 2126
+  - uid: 2208
     components:
     - rot: 3.141592653589793 rad
       pos: -9.5,-30.5
       parent: 1
       type: Transform
-  - uid: 2127
+  - uid: 2209
     components:
     - rot: 3.141592653589793 rad
       pos: -8.5,-32.5
       parent: 1
       type: Transform
-  - uid: 2128
+  - uid: 2210
     components:
     - pos: 1.5,-1.5
       parent: 1
       type: Transform
-  - uid: 2129
+  - uid: 2211
     components:
     - pos: 10.5,-28.5
       parent: 1
       type: Transform
-  - uid: 2130
-    components:
-    - pos: -2.5,-21.5
-      parent: 1
-      type: Transform
-  - uid: 2131
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 3.5,-21.5
-      parent: 1
-      type: Transform
-  - uid: 2132
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -2.5,-18.5
-      parent: 1
-      type: Transform
-  - uid: 2133
-    components:
-    - rot: 3.141592653589793 rad
-      pos: -3.5,-19.5
-      parent: 1
-      type: Transform
-  - uid: 2134
-    components:
-    - rot: 3.141592653589793 rad
-      pos: -4.5,-20.5
-      parent: 1
-      type: Transform
-  - uid: 2135
-    components:
-    - rot: 3.141592653589793 rad
-      pos: -4.5,-21.5
-      parent: 1
-      type: Transform
-  - uid: 2136
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 3.5,-18.5
-      parent: 1
-      type: Transform
-  - uid: 2137
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 4.5,-19.5
-      parent: 1
-      type: Transform
-  - uid: 2138
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 5.5,-20.5
-      parent: 1
-      type: Transform
-  - uid: 2139
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 5.5,-21.5
-      parent: 1
-      type: Transform
-  - uid: 2140
-    components:
-    - pos: 7.5,-23.5
-      parent: 1
-      type: Transform
-  - uid: 2141
-    components:
-    - rot: 3.141592653589793 rad
-      pos: -6.5,-23.5
-      parent: 1
-      type: Transform
-  - uid: 2142
-    components:
-    - pos: -7.5,-25.5
-      parent: 1
-      type: Transform
-  - uid: 2143
-    components:
-    - pos: -8.5,-25.5
-      parent: 1
-      type: Transform
-  - uid: 2144
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 9.5,-25.5
-      parent: 1
-      type: Transform
-  - uid: 2145
-    components:
-    - rot: 3.141592653589793 rad
-      pos: -8.5,-33.5
-      parent: 1
-      type: Transform
-  - uid: 2146
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 8.5,-26.5
-      parent: 1
-      type: Transform
-  - uid: 2147
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 8.5,-28.5
-      parent: 1
-      type: Transform
-  - uid: 2148
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 12.5,-28.5
-      parent: 1
-      type: Transform
-  - uid: 2149
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 11.5,-32.5
-      parent: 1
-      type: Transform
-  - uid: 2150
-    components:
-    - pos: 11.5,-31.5
-      parent: 1
-      type: Transform
-  - uid: 2151
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 9.5,-30.5
-      parent: 1
-      type: Transform
-  - uid: 2152
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 9.5,-31.5
-      parent: 1
-      type: Transform
-  - uid: 2153
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 8.5,-30.5
-      parent: 1
-      type: Transform
-  - uid: 2154
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 8.5,-29.5
-      parent: 1
-      type: Transform
-  - uid: 2155
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 9.5,-32.5
-      parent: 1
-      type: Transform
-  - uid: 2156
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 9.5,-33.5
-      parent: 1
-      type: Transform
-  - uid: 2157
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 9.5,-34.5
-      parent: 1
-      type: Transform
-  - uid: 2158
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 9.5,-35.5
-      parent: 1
-      type: Transform
-  - uid: 2159
-    components:
-    - rot: 3.141592653589793 rad
-      pos: -7.5,-26.5
-      parent: 1
-      type: Transform
-  - uid: 2160
-    components:
-    - rot: 3.141592653589793 rad
-      pos: -11.5,-28.5
-      parent: 1
-      type: Transform
-  - uid: 2161
-    components:
-    - rot: 3.141592653589793 rad
-      pos: -10.5,-28.5
-      parent: 1
-      type: Transform
-  - uid: 2162
-    components:
-    - rot: 3.141592653589793 rad
-      pos: -8.5,-28.5
-      parent: 1
-      type: Transform
-  - uid: 2163
-    components:
-    - rot: 3.141592653589793 rad
-      pos: -9.5,-28.5
-      parent: 1
-      type: Transform
-  - uid: 2164
-    components:
-    - rot: 3.141592653589793 rad
-      pos: -7.5,-28.5
-      parent: 1
-      type: Transform
-  - uid: 2165
-    components:
-    - pos: -6.5,-32.5
-      parent: 1
-      type: Transform
-  - uid: 2166
-    components:
-    - pos: -8.5,-30.5
-      parent: 1
-      type: Transform
-  - uid: 2167
-    components:
-    - pos: -7.5,-30.5
-      parent: 1
-      type: Transform
-  - uid: 2168
-    components:
-    - pos: -7.5,-32.5
-      parent: 1
-      type: Transform
-  - uid: 2169
-    components:
-    - pos: -10.5,-30.5
-      parent: 1
-      type: Transform
-  - uid: 2170
-    components:
-    - pos: -10.5,-32.5
-      parent: 1
-      type: Transform
-  - uid: 2171
-    components:
-    - rot: 3.141592653589793 rad
-      pos: -8.5,-34.5
-      parent: 1
-      type: Transform
-  - uid: 2172
-    components:
-    - rot: 3.141592653589793 rad
-      pos: -8.5,-35.5
-      parent: 1
-      type: Transform
-  - uid: 2173
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -6.5,-21.5
-      parent: 1
-      type: Transform
-  - uid: 2174
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -6.5,-20.5
-      parent: 1
-      type: Transform
-  - uid: 2175
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -6.5,-19.5
-      parent: 1
-      type: Transform
-  - uid: 2176
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -7.5,-19.5
-      parent: 1
-      type: Transform
-  - uid: 2177
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -7.5,-18.5
-      parent: 1
-      type: Transform
-  - uid: 2178
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -7.5,-17.5
-      parent: 1
-      type: Transform
-  - uid: 2179
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -7.5,-14.5
-      parent: 1
-      type: Transform
-  - uid: 2180
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -7.5,-13.5
-      parent: 1
-      type: Transform
-  - uid: 2181
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -7.5,-12.5
-      parent: 1
-      type: Transform
-  - uid: 2182
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -6.5,-14.5
-      parent: 1
-      type: Transform
-  - uid: 2183
-    components:
-    - pos: -6.5,-11.5
-      parent: 1
-      type: Transform
-  - uid: 2184
-    components:
-    - pos: -6.5,-10.5
-      parent: 1
-      type: Transform
-  - uid: 2185
-    components:
-    - pos: -6.5,-9.5
-      parent: 1
-      type: Transform
-  - uid: 2186
-    components:
-    - pos: -5.5,-10.5
-      parent: 1
-      type: Transform
-  - uid: 2187
-    components:
-    - pos: -4.5,-10.5
-      parent: 1
-      type: Transform
-  - uid: 2188
-    components:
-    - pos: -4.5,-11.5
-      parent: 1
-      type: Transform
-  - uid: 2189
-    components:
-    - pos: -5.5,-17.5
-      parent: 1
-      type: Transform
-  - uid: 2190
-    components:
-    - pos: -4.5,-17.5
-      parent: 1
-      type: Transform
-  - uid: 2191
-    components:
-    - pos: -4.5,-16.5
-      parent: 1
-      type: Transform
-  - uid: 2192
-    components:
-    - pos: -4.5,-15.5
-      parent: 1
-      type: Transform
-  - uid: 2193
-    components:
-    - pos: 5.5,-17.5
-      parent: 1
-      type: Transform
-  - uid: 2194
-    components:
-    - pos: 5.5,-16.5
-      parent: 1
-      type: Transform
-  - uid: 2195
-    components:
-    - pos: 5.5,-15.5
-      parent: 1
-      type: Transform
-  - uid: 2196
-    components:
-    - pos: 6.5,-17.5
-      parent: 1
-      type: Transform
-  - uid: 2197
-    components:
-    - pos: 7.5,-17.5
-      parent: 1
-      type: Transform
-  - uid: 2198
-    components:
-    - pos: 8.5,-17.5
-      parent: 1
-      type: Transform
-  - uid: 2199
-    components:
-    - pos: 7.5,-19.5
-      parent: 1
-      type: Transform
-  - uid: 2200
-    components:
-    - pos: 8.5,-18.5
-      parent: 1
-      type: Transform
-  - uid: 2201
-    components:
-    - pos: 8.5,-19.5
-      parent: 1
-      type: Transform
-  - uid: 2202
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 7.5,-20.5
-      parent: 1
-      type: Transform
-  - uid: 2203
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 7.5,-21.5
-      parent: 1
-      type: Transform
-  - uid: 2204
-    components:
-    - pos: -9.5,-26.5
-      parent: 1
-      type: Transform
-  - uid: 2205
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 8.5,-14.5
-      parent: 1
-      type: Transform
-  - uid: 2206
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 7.5,-14.5
-      parent: 1
-      type: Transform
-  - uid: 2207
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 8.5,-13.5
-      parent: 1
-      type: Transform
-  - uid: 2208
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 8.5,-12.5
-      parent: 1
-      type: Transform
-  - uid: 2209
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 7.5,-11.5
-      parent: 1
-      type: Transform
-  - uid: 2210
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 7.5,-10.5
-      parent: 1
-      type: Transform
-  - uid: 2211
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 6.5,-10.5
-      parent: 1
-      type: Transform
   - uid: 2212
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 5.5,-10.5
+    - pos: -2.5,-21.5
       parent: 1
       type: Transform
   - uid: 2213
     components:
     - rot: -1.5707963267948966 rad
-      pos: 5.5,-11.5
+      pos: 3.5,-21.5
       parent: 1
       type: Transform
   - uid: 2214
     components:
     - rot: -1.5707963267948966 rad
-      pos: 7.5,-8.5
+      pos: -2.5,-18.5
       parent: 1
       type: Transform
   - uid: 2215
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 7.5,-7.5
+    - rot: 3.141592653589793 rad
+      pos: -3.5,-19.5
       parent: 1
       type: Transform
   - uid: 2216
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 6.5,-7.5
+    - rot: 3.141592653589793 rad
+      pos: -4.5,-20.5
       parent: 1
       type: Transform
   - uid: 2217
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 5.5,-7.5
+    - rot: 3.141592653589793 rad
+      pos: -4.5,-21.5
       parent: 1
       type: Transform
   - uid: 2218
     components:
-    - rot: -1.5707963267948966 rad
-      pos: -6.5,-8.5
+    - rot: 3.141592653589793 rad
+      pos: 3.5,-18.5
       parent: 1
       type: Transform
   - uid: 2219
     components:
-    - rot: -1.5707963267948966 rad
-      pos: -6.5,-7.5
+    - rot: 3.141592653589793 rad
+      pos: 4.5,-19.5
       parent: 1
       type: Transform
   - uid: 2220
     components:
-    - rot: -1.5707963267948966 rad
-      pos: -5.5,-7.5
+    - rot: 3.141592653589793 rad
+      pos: 5.5,-20.5
       parent: 1
       type: Transform
   - uid: 2221
     components:
-    - rot: -1.5707963267948966 rad
-      pos: -4.5,-7.5
+    - rot: 3.141592653589793 rad
+      pos: 5.5,-21.5
       parent: 1
       type: Transform
   - uid: 2222
     components:
-    - rot: -1.5707963267948966 rad
-      pos: -4.5,-9.5
+    - pos: 7.5,-23.5
       parent: 1
       type: Transform
   - uid: 2223
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 5.5,-9.5
+    - rot: 3.141592653589793 rad
+      pos: -6.5,-23.5
       parent: 1
       type: Transform
   - uid: 2224
     components:
-    - rot: -1.5707963267948966 rad
-      pos: -7.5,1.5
+    - pos: -7.5,-25.5
       parent: 1
       type: Transform
   - uid: 2225
     components:
-    - rot: -1.5707963267948966 rad
-      pos: -6.5,1.5
+    - pos: -8.5,-25.5
       parent: 1
       type: Transform
   - uid: 2226
     components:
     - rot: -1.5707963267948966 rad
-      pos: -5.5,1.5
+      pos: 9.5,-25.5
       parent: 1
       type: Transform
   - uid: 2227
     components:
-    - rot: -1.5707963267948966 rad
-      pos: -7.5,0.5
+    - rot: 3.141592653589793 rad
+      pos: -8.5,-33.5
       parent: 1
       type: Transform
   - uid: 2228
     components:
     - rot: -1.5707963267948966 rad
-      pos: -6.5,5.5
+      pos: 8.5,-26.5
       parent: 1
       type: Transform
   - uid: 2229
     components:
     - rot: -1.5707963267948966 rad
-      pos: -5.5,5.5
+      pos: 8.5,-28.5
       parent: 1
       type: Transform
   - uid: 2230
     components:
     - rot: -1.5707963267948966 rad
-      pos: -4.5,5.5
+      pos: 12.5,-28.5
       parent: 1
       type: Transform
   - uid: 2231
     components:
-    - rot: -1.5707963267948966 rad
-      pos: -3.5,5.5
+    - rot: 3.141592653589793 rad
+      pos: 11.5,-32.5
       parent: 1
       type: Transform
   - uid: 2232
     components:
-    - pos: -2.5,8.5
+    - pos: 11.5,-31.5
       parent: 1
       type: Transform
   - uid: 2233
     components:
-    - pos: -4.5,8.5
+    - rot: 3.141592653589793 rad
+      pos: 9.5,-30.5
       parent: 1
       type: Transform
   - uid: 2234
     components:
-    - pos: -5.5,9.5
+    - rot: 3.141592653589793 rad
+      pos: 9.5,-31.5
       parent: 1
       type: Transform
   - uid: 2235
     components:
-    - pos: -4.5,9.5
+    - rot: 3.141592653589793 rad
+      pos: 8.5,-30.5
       parent: 1
       type: Transform
   - uid: 2236
     components:
-    - pos: -3.5,9.5
+    - rot: 3.141592653589793 rad
+      pos: 8.5,-29.5
       parent: 1
       type: Transform
   - uid: 2237
     components:
-    - pos: -4.5,10.5
+    - rot: 3.141592653589793 rad
+      pos: 9.5,-32.5
       parent: 1
       type: Transform
   - uid: 2238
     components:
-    - pos: -2.5,10.5
+    - rot: 1.5707963267948966 rad
+      pos: 9.5,-33.5
       parent: 1
       type: Transform
   - uid: 2239
     components:
-    - pos: -2.5,9.5
+    - rot: 1.5707963267948966 rad
+      pos: 9.5,-34.5
       parent: 1
       type: Transform
   - uid: 2240
     components:
-    - pos: -2.5,6.5
+    - rot: 1.5707963267948966 rad
+      pos: 9.5,-35.5
       parent: 1
       type: Transform
   - uid: 2241
     components:
-    - pos: -4.5,6.5
+    - rot: 3.141592653589793 rad
+      pos: -7.5,-26.5
       parent: 1
       type: Transform
   - uid: 2242
     components:
-    - rot: 1.5707963267948966 rad
-      pos: 4.5,5.5
+    - rot: 3.141592653589793 rad
+      pos: -11.5,-28.5
       parent: 1
       type: Transform
   - uid: 2243
     components:
-    - rot: 1.5707963267948966 rad
-      pos: 5.5,5.5
+    - rot: 3.141592653589793 rad
+      pos: -10.5,-28.5
       parent: 1
       type: Transform
   - uid: 2244
     components:
-    - rot: 1.5707963267948966 rad
-      pos: 6.5,5.5
+    - rot: 3.141592653589793 rad
+      pos: -8.5,-28.5
       parent: 1
       type: Transform
   - uid: 2245
     components:
-    - rot: 1.5707963267948966 rad
-      pos: 7.5,5.5
+    - rot: 3.141592653589793 rad
+      pos: -9.5,-28.5
       parent: 1
       type: Transform
   - uid: 2246
     components:
-    - pos: -7.5,5.5
+    - rot: 3.141592653589793 rad
+      pos: -7.5,-28.5
       parent: 1
       type: Transform
   - uid: 2247
     components:
-    - rot: -1.5707963267948966 rad
-      pos: -6.5,-1.5
+    - pos: -6.5,-32.5
       parent: 1
       type: Transform
   - uid: 2248
     components:
-    - rot: -1.5707963267948966 rad
-      pos: -5.5,-1.5
+    - pos: -8.5,-30.5
       parent: 1
       type: Transform
   - uid: 2249
     components:
-    - rot: -1.5707963267948966 rad
-      pos: -7.5,-0.5
+    - pos: -7.5,-30.5
       parent: 1
       type: Transform
   - uid: 2250
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 8.5,1.5
+    - pos: -7.5,-32.5
       parent: 1
       type: Transform
   - uid: 2251
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 7.5,1.5
+    - pos: -10.5,-30.5
       parent: 1
       type: Transform
   - uid: 2252
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 6.5,1.5
+    - pos: -10.5,-32.5
       parent: 1
       type: Transform
   - uid: 2253
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 7.5,-1.5
+    - rot: 3.141592653589793 rad
+      pos: -8.5,-34.5
       parent: 1
       type: Transform
   - uid: 2254
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 6.5,-1.5
+    - rot: 3.141592653589793 rad
+      pos: -8.5,-35.5
       parent: 1
       type: Transform
   - uid: 2255
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 8.5,5.5
+    - rot: 1.5707963267948966 rad
+      pos: -6.5,-21.5
       parent: 1
       type: Transform
   - uid: 2256
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 5.5,6.5
+    - rot: 1.5707963267948966 rad
+      pos: -6.5,-20.5
       parent: 1
       type: Transform
   - uid: 2257
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 5.5,8.5
+    - rot: 1.5707963267948966 rad
+      pos: -6.5,-19.5
       parent: 1
       type: Transform
   - uid: 2258
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 5.5,9.5
+    - rot: 1.5707963267948966 rad
+      pos: -7.5,-19.5
       parent: 1
       type: Transform
   - uid: 2259
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 4.5,9.5
+    - rot: 1.5707963267948966 rad
+      pos: -7.5,-18.5
       parent: 1
       type: Transform
   - uid: 2260
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 3.5,9.5
+    - rot: 1.5707963267948966 rad
+      pos: -7.5,-17.5
       parent: 1
       type: Transform
   - uid: 2261
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 3.5,10.5
+    - rot: 1.5707963267948966 rad
+      pos: -7.5,-14.5
       parent: 1
       type: Transform
   - uid: 2262
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 5.5,10.5
+    - rot: 1.5707963267948966 rad
+      pos: -7.5,-13.5
       parent: 1
       type: Transform
   - uid: 2263
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 6.5,9.5
+    - rot: 1.5707963267948966 rad
+      pos: -7.5,-12.5
       parent: 1
       type: Transform
   - uid: 2264
     components:
-    - rot: -1.5707963267948966 rad
-      pos: -2.5,2.5
+    - rot: 1.5707963267948966 rad
+      pos: -6.5,-14.5
       parent: 1
       type: Transform
   - uid: 2265
     components:
-    - rot: -1.5707963267948966 rad
-      pos: -2.5,1.5
+    - pos: -6.5,-11.5
       parent: 1
       type: Transform
   - uid: 2266
     components:
-    - rot: -1.5707963267948966 rad
-      pos: -2.5,-0.5
+    - pos: -6.5,-10.5
       parent: 1
       type: Transform
   - uid: 2267
     components:
-    - rot: -1.5707963267948966 rad
-      pos: -2.5,-1.5
+    - pos: -6.5,-9.5
       parent: 1
       type: Transform
   - uid: 2268
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 3.5,-1.5
+    - pos: -5.5,-10.5
       parent: 1
       type: Transform
   - uid: 2269
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 3.5,-0.5
+    - pos: -4.5,-10.5
       parent: 1
       type: Transform
   - uid: 2270
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 3.5,2.5
+    - pos: -4.5,-11.5
       parent: 1
       type: Transform
   - uid: 2271
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 3.5,1.5
+    - pos: -5.5,-17.5
       parent: 1
       type: Transform
   - uid: 2272
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 2.5,2.5
+    - pos: -4.5,-17.5
       parent: 1
       type: Transform
   - uid: 2273
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 3.5,-11.5
+    - pos: -4.5,-16.5
       parent: 1
       type: Transform
   - uid: 2274
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 2.5,-11.5
+    - pos: -4.5,-15.5
       parent: 1
       type: Transform
   - uid: 2275
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 1.5,-11.5
+    - pos: 5.5,-17.5
       parent: 1
       type: Transform
   - uid: 2276
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 0.5,-11.5
+    - pos: 5.5,-16.5
       parent: 1
       type: Transform
   - uid: 2277
     components:
-    - rot: -1.5707963267948966 rad
-      pos: -0.5,-11.5
+    - pos: 5.5,-15.5
       parent: 1
       type: Transform
   - uid: 2278
     components:
-    - rot: -1.5707963267948966 rad
-      pos: -1.5,-11.5
+    - pos: 6.5,-17.5
       parent: 1
       type: Transform
   - uid: 2279
     components:
-    - rot: -1.5707963267948966 rad
-      pos: -2.5,-11.5
+    - pos: 7.5,-17.5
       parent: 1
       type: Transform
   - uid: 2280
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 3.5,6.5
+    - pos: 8.5,-17.5
       parent: 1
       type: Transform
   - uid: 2281
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 3.5,8.5
+    - pos: 7.5,-19.5
       parent: 1
       type: Transform
   - uid: 2282
     components:
-    - rot: 3.141592653589793 rad
-      pos: -5.5,-35.5
+    - pos: 8.5,-18.5
       parent: 1
       type: Transform
   - uid: 2283
     components:
-    - rot: 3.141592653589793 rad
-      pos: -4.5,-35.5
+    - pos: 8.5,-19.5
       parent: 1
       type: Transform
   - uid: 2284
     components:
     - rot: 3.141592653589793 rad
-      pos: -0.5,-35.5
+      pos: 7.5,-20.5
       parent: 1
       type: Transform
   - uid: 2285
     components:
     - rot: 3.141592653589793 rad
-      pos: 0.5,-35.5
+      pos: 7.5,-21.5
       parent: 1
       type: Transform
   - uid: 2286
+    components:
+    - pos: -9.5,-26.5
+      parent: 1
+      type: Transform
+  - uid: 2287
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 8.5,-14.5
+      parent: 1
+      type: Transform
+  - uid: 2288
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 7.5,-14.5
+      parent: 1
+      type: Transform
+  - uid: 2289
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 8.5,-13.5
+      parent: 1
+      type: Transform
+  - uid: 2290
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 8.5,-12.5
+      parent: 1
+      type: Transform
+  - uid: 2291
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 7.5,-11.5
+      parent: 1
+      type: Transform
+  - uid: 2292
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 7.5,-10.5
+      parent: 1
+      type: Transform
+  - uid: 2293
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 6.5,-10.5
+      parent: 1
+      type: Transform
+  - uid: 2294
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 5.5,-10.5
+      parent: 1
+      type: Transform
+  - uid: 2295
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 5.5,-11.5
+      parent: 1
+      type: Transform
+  - uid: 2296
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 7.5,-8.5
+      parent: 1
+      type: Transform
+  - uid: 2297
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 7.5,-7.5
+      parent: 1
+      type: Transform
+  - uid: 2298
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 6.5,-7.5
+      parent: 1
+      type: Transform
+  - uid: 2299
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 5.5,-7.5
+      parent: 1
+      type: Transform
+  - uid: 2300
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -6.5,-8.5
+      parent: 1
+      type: Transform
+  - uid: 2301
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -6.5,-7.5
+      parent: 1
+      type: Transform
+  - uid: 2302
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -5.5,-7.5
+      parent: 1
+      type: Transform
+  - uid: 2303
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -4.5,-7.5
+      parent: 1
+      type: Transform
+  - uid: 2304
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -4.5,-9.5
+      parent: 1
+      type: Transform
+  - uid: 2305
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 5.5,-9.5
+      parent: 1
+      type: Transform
+  - uid: 2306
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -7.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 2307
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -6.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 2308
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -5.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 2309
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -7.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 2310
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -6.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 2311
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -5.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 2312
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -4.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 2313
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -3.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 2314
+    components:
+    - pos: -2.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 2315
+    components:
+    - pos: -4.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 2316
+    components:
+    - pos: -5.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 2317
+    components:
+    - pos: -4.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 2318
+    components:
+    - pos: -3.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 2319
+    components:
+    - pos: -4.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 2320
+    components:
+    - pos: -2.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 2321
+    components:
+    - pos: -2.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 2322
+    components:
+    - pos: -2.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 2323
+    components:
+    - pos: -4.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 2324
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 4.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 2325
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 5.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 2326
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 6.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 2327
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 7.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 2328
+    components:
+    - pos: -7.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 2329
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -6.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 2330
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -5.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 2331
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -7.5,-0.5
+      parent: 1
+      type: Transform
+  - uid: 2332
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 8.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 2333
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 7.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 2334
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 6.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 2335
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 7.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 2336
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 6.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 2337
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 8.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 2338
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 5.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 2339
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 5.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 2340
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 5.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 2341
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 4.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 2342
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 3.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 2343
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 3.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 2344
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 5.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 2345
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 6.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 2346
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -2.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 2347
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -2.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 2348
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -2.5,-0.5
+      parent: 1
+      type: Transform
+  - uid: 2349
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -2.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 2350
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 3.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 2351
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 3.5,-0.5
+      parent: 1
+      type: Transform
+  - uid: 2352
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 3.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 2353
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 3.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 2354
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 2.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 2355
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 3.5,-11.5
+      parent: 1
+      type: Transform
+  - uid: 2356
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 2.5,-11.5
+      parent: 1
+      type: Transform
+  - uid: 2357
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 1.5,-11.5
+      parent: 1
+      type: Transform
+  - uid: 2358
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 0.5,-11.5
+      parent: 1
+      type: Transform
+  - uid: 2359
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -0.5,-11.5
+      parent: 1
+      type: Transform
+  - uid: 2360
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -1.5,-11.5
+      parent: 1
+      type: Transform
+  - uid: 2361
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -2.5,-11.5
+      parent: 1
+      type: Transform
+  - uid: 2362
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 3.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 2363
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 3.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 2364
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -5.5,-35.5
+      parent: 1
+      type: Transform
+  - uid: 2365
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -4.5,-35.5
+      parent: 1
+      type: Transform
+  - uid: 2366
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -0.5,-35.5
+      parent: 1
+      type: Transform
+  - uid: 2367
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,-35.5
+      parent: 1
+      type: Transform
+  - uid: 2368
     components:
     - rot: 3.141592653589793 rad
       pos: 1.5,-35.5
       parent: 1
       type: Transform
-  - uid: 2287
+  - uid: 2369
     components:
     - rot: 3.141592653589793 rad
       pos: 5.5,-35.5
       parent: 1
       type: Transform
-  - uid: 2288
+  - uid: 2370
     components:
     - rot: 3.141592653589793 rad
       pos: 6.5,-35.5
       parent: 1
       type: Transform
-  - uid: 2289
+  - uid: 2371
     components:
     - pos: 10.5,-26.5
       parent: 1
       type: Transform
-  - uid: 2290
+  - uid: 2372
     components:
     - rot: 3.141592653589793 rad
       pos: -6.5,-17.5
       parent: 1
       type: Transform
-  - uid: 2291
+  - uid: 2373
     components:
     - pos: -2.5,-12.5
       parent: 1
       type: Transform
-  - uid: 2292
+  - uid: 2374
     components:
     - pos: 3.5,-12.5
       parent: 1
       type: Transform
-  - uid: 2293
+  - uid: 2375
     components:
     - rot: 1.5707963267948966 rad
       pos: 10.5,-30.5
@@ -17102,221 +17887,221 @@ entities:
       type: Transform
 - proto: WallShuttleDiagonal
   entities:
-  - uid: 2294
+  - uid: 2376
     components:
     - rot: 1.5707963267948966 rad
       pos: -7.5,-1.5
       parent: 1
       type: Transform
-  - uid: 2295
+  - uid: 2377
     components:
     - rot: 3.141592653589793 rad
       pos: 8.5,-1.5
       parent: 1
       type: Transform
-  - uid: 2296
+  - uid: 2378
     components:
     - rot: 3.141592653589793 rad
       pos: 11.5,-33.5
       parent: 1
       type: Transform
-  - uid: 2297
+  - uid: 2379
     components:
     - rot: 3.141592653589793 rad
       pos: 13.5,-32.5
       parent: 1
       type: Transform
-  - uid: 2298
+  - uid: 2380
     components:
     - rot: 1.5707963267948966 rad
       pos: -12.5,-32.5
       parent: 1
       type: Transform
-  - uid: 2299
+  - uid: 2381
     components:
     - pos: -2.5,-20.5
       parent: 1
       type: Transform
-  - uid: 2300
+  - uid: 2382
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,-20.5
       parent: 1
       type: Transform
-  - uid: 2301
+  - uid: 2383
     components:
     - rot: 3.141592653589793 rad
       pos: -2.5,-19.5
       parent: 1
       type: Transform
-  - uid: 2302
+  - uid: 2384
     components:
     - rot: 3.141592653589793 rad
       pos: -3.5,-20.5
       parent: 1
       type: Transform
-  - uid: 2303
+  - uid: 2385
     components:
     - rot: 1.5707963267948966 rad
       pos: 3.5,-19.5
       parent: 1
       type: Transform
-  - uid: 2304
+  - uid: 2386
     components:
     - rot: 1.5707963267948966 rad
       pos: 4.5,-20.5
       parent: 1
       type: Transform
-  - uid: 2305
+  - uid: 2387
     components:
     - rot: -1.5707963267948966 rad
       pos: 8.5,-23.5
       parent: 1
       type: Transform
-  - uid: 2306
+  - uid: 2388
     components:
     - pos: -7.5,-23.5
       parent: 1
       type: Transform
-  - uid: 2307
+  - uid: 2389
     components:
     - rot: 3.141592653589793 rad
       pos: 9.5,-36.5
       parent: 1
       type: Transform
-  - uid: 2308
+  - uid: 2390
     components:
     - rot: -1.5707963267948966 rad
       pos: 13.5,-28.5
       parent: 1
       type: Transform
-  - uid: 2309
+  - uid: 2391
     components:
     - rot: -1.5707963267948966 rad
       pos: 10.5,-25.5
       parent: 1
       type: Transform
-  - uid: 2310
+  - uid: 2392
     components:
     - pos: -12.5,-28.5
       parent: 1
       type: Transform
-  - uid: 2311
+  - uid: 2393
     components:
     - rot: 1.5707963267948966 rad
       pos: -8.5,-36.5
       parent: 1
       type: Transform
-  - uid: 2312
+  - uid: 2394
     components:
     - rot: 3.141592653589793 rad
       pos: -5.5,-36.5
       parent: 1
       type: Transform
-  - uid: 2313
+  - uid: 2395
     components:
     - rot: 1.5707963267948966 rad
       pos: -4.5,-36.5
       parent: 1
       type: Transform
-  - uid: 2314
+  - uid: 2396
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,-36.5
       parent: 1
       type: Transform
-  - uid: 2315
+  - uid: 2397
     components:
     - rot: 1.5707963267948966 rad
       pos: 1.5,-36.5
       parent: 1
       type: Transform
-  - uid: 2316
+  - uid: 2398
     components:
     - rot: 3.141592653589793 rad
       pos: 5.5,-36.5
       parent: 1
       type: Transform
-  - uid: 2317
+  - uid: 2399
     components:
     - rot: 1.5707963267948966 rad
       pos: 6.5,-36.5
       parent: 1
       type: Transform
-  - uid: 2318
+  - uid: 2400
     components:
     - rot: 1.5707963267948966 rad
       pos: -7.5,-20.5
       parent: 1
       type: Transform
-  - uid: 2319
+  - uid: 2401
     components:
     - pos: -7.5,-11.5
       parent: 1
       type: Transform
-  - uid: 2320
+  - uid: 2402
     components:
     - rot: -1.5707963267948966 rad
       pos: -2.5,-17.5
       parent: 1
       type: Transform
-  - uid: 2321
+  - uid: 2403
     components:
     - pos: 3.5,-17.5
       parent: 1
       type: Transform
-  - uid: 2322
+  - uid: 2404
     components:
     - rot: 3.141592653589793 rad
       pos: 8.5,-20.5
       parent: 1
       type: Transform
-  - uid: 2323
+  - uid: 2405
     components:
     - pos: -9.5,-25.5
       parent: 1
       type: Transform
-  - uid: 2324
+  - uid: 2406
     components:
     - rot: -1.5707963267948966 rad
       pos: 8.5,-11.5
       parent: 1
       type: Transform
-  - uid: 2325
+  - uid: 2407
     components:
     - pos: -5.5,10.5
       parent: 1
       type: Transform
-  - uid: 2326
+  - uid: 2408
     components:
     - pos: -6.5,9.5
       parent: 1
       type: Transform
-  - uid: 2327
+  - uid: 2409
     components:
     - rot: 3.141592653589793 rad
       pos: -2.5,5.5
       parent: 1
       type: Transform
-  - uid: 2328
+  - uid: 2410
     components:
     - rot: 1.5707963267948966 rad
       pos: 3.5,5.5
       parent: 1
       type: Transform
-  - uid: 2329
+  - uid: 2411
     components:
     - rot: -1.5707963267948966 rad
       pos: 6.5,10.5
       parent: 1
       type: Transform
-  - uid: 2330
+  - uid: 2412
     components:
     - rot: -1.5707963267948966 rad
       pos: 7.5,9.5
       parent: 1
       type: Transform
-  - uid: 2331
+  - uid: 2413
     components:
     - rot: 1.5707963267948966 rad
       pos: -10.5,-33.5
@@ -17324,298 +18109,309 @@ entities:
       type: Transform
 - proto: WarningAir
   entities:
-  - uid: 2332
+  - uid: 2414
     components:
     - pos: 2.5,-31.5
       parent: 1
       type: Transform
 - proto: WarningN2
   entities:
-  - uid: 2333
+  - uid: 2415
     components:
     - pos: 5.5,-31.5
       parent: 1
       type: Transform
 - proto: WarningO2
   entities:
-  - uid: 2334
+  - uid: 2416
     components:
     - pos: 4.5,-31.5
       parent: 1
       type: Transform
 - proto: WarpPointShip
   entities:
-  - uid: 2335
+  - uid: 2417
     components:
     - pos: 0.5,-4.5
       parent: 1
       type: Transform
 - proto: WaterTankFull
   entities:
-  - uid: 2336
+  - uid: 2418
     components:
     - pos: -5.5,-9.5
       parent: 1
       type: Transform
 - proto: WeaponCapacitorRecharger
   entities:
-  - uid: 2337
+  - uid: 2419
     components:
     - pos: 2.5,-22.5
       parent: 1
       type: Transform
 - proto: WeaponDisabler
   entities:
-  - uid: 114
+  - uid: 118
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 100
+    - parent: 103
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 256
+  - uid: 245
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 227
+    - parent: 216
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: WeaponFlareGun
   entities:
-  - uid: 115
+  - uid: 119
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 100
+    - parent: 103
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: WeaponLaserGun
   entities:
-  - uid: 257
+  - uid: 246
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 227
+    - parent: 216
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: WeaponProtoKineticAccelerator
   entities:
-  - uid: 1689
+  - uid: 1744
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 1688
+    - parent: 1743
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 1691
+  - uid: 1746
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 1690
+    - parent: 1745
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: WeaponRevolverDeckard
   entities:
-  - uid: 2338
+  - uid: 2420
     components:
     - pos: 2.4326227,-22.201796
       parent: 1
       type: Transform
 - proto: WeaponRevolverPirate
   entities:
-  - uid: 1011
+  - uid: 1064
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 1007
+    - parent: 1060
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: WeaponRevolverPython
   entities:
-  - uid: 1664
+  - uid: 1726
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 1660
+    - parent: 1722
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 1697
+  - uid: 1750
     components:
     - flags: InContainer
+      name: Medical Python
       type: MetaData
-    - parent: 1693
+    - parent: 1749
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: WindoorSecure
   entities:
-  - uid: 2339
+  - uid: 2421
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,2.5
       parent: 1
       type: Transform
-  - uid: 2340
+  - uid: 2422
     components:
     - rot: -1.5707963267948966 rad
       pos: -4.5,-13.5
       parent: 1
       type: Transform
-  - uid: 2341
+  - uid: 2423
     components:
     - rot: 1.5707963267948966 rad
       pos: -4.5,-13.5
       parent: 1
       type: Transform
-  - uid: 2342
+  - uid: 2424
     components:
     - rot: -1.5707963267948966 rad
       pos: 5.5,-13.5
       parent: 1
       type: Transform
-  - uid: 2343
+  - uid: 2425
     components:
     - rot: 1.5707963267948966 rad
       pos: 5.5,-13.5
       parent: 1
       type: Transform
-  - uid: 2344
+  - uid: 2426
     components:
     - pos: 0.5,-27.5
       parent: 1
       type: Transform
-  - uid: 2345
+  - uid: 2427
     components:
     - rot: 1.5707963267948966 rad
       pos: -6.5,-18.5
       parent: 1
       type: Transform
-  - uid: 2346
+  - uid: 2428
     components:
     - rot: -1.5707963267948966 rad
       pos: 7.5,-18.5
       parent: 1
       type: Transform
-  - uid: 2347
+  - uid: 2429
     components:
     - rot: 3.141592653589793 rad
       pos: 4.5,6.5
       parent: 1
       type: Transform
-  - uid: 2348
+  - uid: 2430
     components:
     - rot: 3.141592653589793 rad
       pos: -3.5,6.5
       parent: 1
       type: Transform
-  - uid: 2349
+  - uid: 2431
     components:
     - rot: 3.141592653589793 rad
       pos: 2.5,-24.5
       parent: 1
       type: Transform
-  - uid: 2351
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -3.5,-25.5
-      parent: 1
-      type: Transform
-  - uid: 2352
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -3.5,-24.5
-      parent: 1
-      type: Transform
 - proto: WindoorSecureCargoLocked
   entities:
-  - uid: 2350
+  - uid: 2432
     components:
     - pos: 0.5,2.5
       parent: 1
       type: Transform
+- proto: WindoorSecureCommandLocked
+  entities:
+  - uid: 2433
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -7.5,-33.5
+      parent: 1
+      type: Transform
+  - uid: 2434
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -7.5,-34.5
+      parent: 1
+      type: Transform
 - proto: WindowReinforcedDirectional
   entities:
-  - uid: 2353
+  - uid: 2435
     components:
     - rot: -1.5707963267948966 rad
       pos: 0.5,-27.5
       parent: 1
       type: Transform
-  - uid: 2354
+  - uid: 2436
     components:
     - rot: 3.141592653589793 rad
       pos: -3.5,-24.5
       parent: 1
       type: Transform
-  - uid: 2355
+  - uid: 2437
     components:
     - rot: 3.141592653589793 rad
       pos: 4.5,-24.5
       parent: 1
       type: Transform
-  - uid: 2356
+  - uid: 2438
     components:
     - rot: 1.5707963267948966 rad
       pos: -0.5,-24.5
       parent: 1
       type: Transform
-  - uid: 2357
+  - uid: 2439
     components:
     - rot: 3.141592653589793 rad
       pos: -1.5,-24.5
       parent: 1
       type: Transform
-  - uid: 2358
+  - uid: 2440
     components:
     - rot: -1.5707963267948966 rad
       pos: 1.5,-25.5
       parent: 1
       type: Transform
-  - uid: 2359
+  - uid: 2441
     components:
     - rot: -1.5707963267948966 rad
       pos: 1.5,-24.5
       parent: 1
       type: Transform
-  - uid: 2360
+  - uid: 2442
     components:
     - rot: 3.141592653589793 rad
       pos: 1.5,-24.5
       parent: 1
       type: Transform
-  - uid: 2361
+  - uid: 2443
     components:
     - rot: 1.5707963267948966 rad
       pos: -0.5,-25.5
       parent: 1
       type: Transform
-  - uid: 2362
+  - uid: 2444
     components:
     - rot: -1.5707963267948966 rad
       pos: -3.5,-25.5
       parent: 1
       type: Transform
-  - uid: 2363
+  - uid: 2445
     components:
     - rot: -1.5707963267948966 rad
       pos: -3.5,-24.5
+      parent: 1
+      type: Transform
+    - step: 1
+      edge: 0
+      type: Construction
+  - uid: 2446
+    components:
+    - pos: -7.5,-34.5
       parent: 1
       type: Transform
 ...

--- a/Resources/Prototypes/_NF/Shipyard/praeda.yml
+++ b/Resources/Prototypes/_NF/Shipyard/praeda.yml
@@ -6,13 +6,13 @@
   category: Large
   group: Civilian
   shuttlePath: /Maps/Shuttles/praeda.yml
-  
+
 - type: gameMap
   id: Praeda
   mapName: 'NT Praeda'
   mapPath: /Maps/Shuttles/praeda.yml
   minPlayers: 0
-  stations: 
+  stations:
     Praeda:
       stationProto: StandardFrontierExpeditionVessel
       components:
@@ -31,3 +31,4 @@
             StationEngineer: [ 0, 0 ]
             Bartender: [ 0, 0 ]
             Paramedic: [ 0, 0 ]
+            Mercenary: [ 0, 0 ]


### PR DESCRIPTION
## About the PR
This PR updates a few things about the Praeda.

**Changelog**
:cl: AllfatherHatt
- Command: Added camera system so that Captain can look around the ship
- Command: Added Crew Monitor (I noticed the Pulse ship has one too, so its useful, even if it sees everyone)
- Command: Added 1x Speedloader to bed stand because it was funny to me
- Command: Removed posters where the Gun Lockers used to be
- Engineering: Added Camera Router + Communications Server to Storage area
- Cargo: Added 6x Cargo Pallets to main cargo area
- Medbay: Added CMO hardsuit to paramedic locker, since they'll probably have to get people from space
- Medbay: Added Crew Monitor
- Medbay: Added Oxygen Deprivation meds to table
- Medbay: Added Anti-radiation meds to table
- Medbay: Added anatomy poster plastered over window, because I think its funny
- Medbay: Added baseball bat to bed and renamed it to "medicine stick", self-defense and rp is the reason
- General: Added cameras around the ship and named them
- General: Added catwalks in all doorways (makes more sense)
- Role(s): Added 'Mercenary' as a role that the ship can hire