### PR TITLE
Emotional Support Animals

### DIFF
--- a/Resources/Locale/en-US/_NF/ghost/roles/ghost-role-component.ftl
+++ b/Resources/Locale/en-US/_NF/ghost/roles/ghost-role-component.ftl
@@ -1,0 +1,2 @@
+ghost-role-information-emotional-support-name = Emotional support pet
+ghost-role-information-emotional-support-description = You're an emotional support pet! Loyal to your owner, make sure to cheer them up!

--- a/Resources/Locale/en-US/_NF/prototypes/catalog/cargo/cargo-livestock.ftl
+++ b/Resources/Locale/en-US/_NF/prototypes/catalog/cargo/cargo-livestock.ftl
@@ -1,0 +1,2 @@
+ent-LivestockEmotionalSupport = { ent-CrateNPCEmotionalSupport }
+    .desc = { ent-CrateNPCEmotionalSupport.desc }

--- a/Resources/Locale/en-US/_NF/prototypes/catalog/fills/crates/livestock-crates.ftl
+++ b/Resources/Locale/en-US/_NF/prototypes/catalog/fills/crates/livestock-crates.ftl
@@ -1,0 +1,2 @@
+ent-CrateNPCEmotionalSupport = Emotional support pet crate
+    .desc = A crate containing a single emotional support pet.

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -2020,6 +2020,21 @@
     interactFailureString: petting-failure-generic
     interactSuccessSound:
       path: /Audio/Animals/cat_meow.ogg
+  - type: Barotrauma
+    damage:
+      types:
+        Blunt: 0.0 #per second, scales with pressure and other constants.
+  - type: Temperature
+    heatDamageThreshold: 360
+    coldDamageThreshold: 0
+    currentTemperature: 310.15
+    coldDamage:
+      types:
+        Cold : 0.1 #per second, scales with temperature & other constants
+    specificHeat: 42
+    heatDamage:
+      types:
+        Heat : 0.1 #per second, scales with temperature & other constants
 
 - type: entity
   name: caracal cat

--- a/Resources/Prototypes/_NF/Catalog/Cargo/cargo_livestock.yml
+++ b/Resources/Prototypes/_NF/Catalog/Cargo/cargo_livestock.yml
@@ -1,0 +1,9 @@
+- type: cargoProduct
+  id: LivestockEmotionalSupport
+  icon:
+    sprite: Mobs/Pets/cat.rsi
+    state: cat
+  product: CrateNPCEmotionalSupport
+  cost: 10000
+  category: Livestock
+  group: market

--- a/Resources/Prototypes/_NF/Catalog/Fills/Crates/npc.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/Crates/npc.yml
@@ -1,0 +1,27 @@
+- type: entity
+  id: CrateNPCEmotionalSupport
+  parent: CrateLivestock
+  components:
+  - type: StorageFill
+    contents:
+      - id: MobCatGhost
+        prob: 1
+        orGroup: MobCatGhost
+      - id: MobCatCalicoGhost
+        prob: 1
+        orGroup: MobCatGhost
+      - id: MobCatCaracalGhost
+        prob: 0.15
+        orGroup: MobCatGhost
+      - id: MobBingusGhost
+        prob: 0.15
+        orGroup: MobCatGhost
+      - id: MobCatSpaceGhost
+        prob: 0.15
+        orGroup: MobCatGhost
+      - id: MobCorgiGhost
+        prob: 1
+        orGroup: MobCatGhost
+      - id: MobCorgiPuppyGhost
+        prob: 0.15
+        orGroup: MobCatGhost

--- a/Resources/Prototypes/_NF/Catalog/Fills/Crates/npc.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/Crates/npc.yml
@@ -25,3 +25,6 @@
       - id: MobCorgiPuppyGhost
         prob: 0.15
         orGroup: MobCatGhost
+      - id: MobChickenGhost
+        prob: 0.15
+        orGroup: MobCatGhost

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/emotionalsupportanimals.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/emotionalsupportanimals.yml
@@ -189,3 +189,32 @@
   - type: Grammar
     attributes:
       gender: epicene
+
+- type: entity
+  name: chicken
+  suffix: Ghost
+  parent: MobChicken
+  id: MobChickenGhost
+  description: Comes before an egg, and IS a dinosaur!
+  components:
+  - type: GhostRole
+    name: ghost-role-information-emotional-support-name
+    description: ghost-role-information-emotional-support-description
+    makeSentient: true
+    allowSpeech: true
+    allowMovement: true
+  - type: GhostTakeoverAvailable
+  - type: CombatMode
+    combatToggleAction:
+      enabled: false
+      autoPopulate: false
+      name: action-name-combat
+  - type: ReplacementAccent
+    accent: chicken
+  - type: Grammar
+    attributes:
+      gender: epicene
+  - type: Tag
+    tags:
+    - CannotSuicide
+    - DoorBumpOpener

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/emotionalsupportanimals.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/emotionalsupportanimals.yml
@@ -22,6 +22,12 @@
   - type: Grammar
     attributes:
       gender: epicene
+  - type: Vocal
+    sounds:
+      Male: Cat
+      Female: Cat
+      Unsexed: Cat
+    wilhelmProbability: 0.001
   - type: Tag
     tags:
     - CannotSuicide
@@ -127,6 +133,12 @@
   - type: Grammar
     attributes:
       gender: epicene
+  - type: Vocal
+    sounds:
+      Male: Cat
+      Female: Cat
+      Unsexed: Cat
+    wilhelmProbability: 0.001
   - type: Tag
     tags:
     - CannotSuicide
@@ -156,6 +168,12 @@
   - type: Grammar
     attributes:
       gender: epicene
+  - type: Vocal
+    sounds:
+      Male: Dog
+      Female: Dog
+      Unsexed: Dog
+    wilhelmProbability: 0.001
   - type: Tag
     tags:
     - CannotSuicide
@@ -184,11 +202,6 @@
         Base: puppy
       Dead:
         Base: puppy_dead
-  - type: ReplacementAccent
-    accent: dog
-  - type: Grammar
-    attributes:
-      gender: epicene
 
 - type: entity
   name: chicken
@@ -214,6 +227,12 @@
   - type: Grammar
     attributes:
       gender: epicene
+  - type: Vocal
+    sounds:
+      Male: Chicken
+      Female: Chicken
+      Unsexed: Chicken
+    wilhelmProbability: 0.001
   - type: Tag
     tags:
     - CannotSuicide

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/emotionalsupportanimals.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/emotionalsupportanimals.yml
@@ -1,0 +1,191 @@
+- type: entity
+  name: cat
+  suffix: Ghost
+  parent: MobCat
+  id: MobCatGhost
+  description: Feline pet, very funny.
+  components:
+  - type: GhostRole
+    name: ghost-role-information-emotional-support-name
+    description: ghost-role-information-emotional-support-description
+    makeSentient: true
+    allowSpeech: true
+    allowMovement: true
+  - type: GhostTakeoverAvailable
+  - type: CombatMode
+    combatToggleAction:
+      enabled: false
+      autoPopulate: false
+      name: action-name-combat
+  - type: ReplacementAccent
+    accent: cat
+  - type: Grammar
+    attributes:
+      gender: epicene
+  - type: Tag
+    tags:
+    - CannotSuicide
+    - DoorBumpOpener
+
+- type: entity
+  name: calico cat
+  suffix: Ghost
+  id: MobCatCalicoGhost
+  parent: MobCatGhost
+  description: Feline pet, very funny.
+  components:
+  - type: Sprite
+    layers:
+    - map: ["enum.DamageStateVisualLayers.Base"]
+      state: cat2
+  - type: DamageStateVisuals
+    states:
+      Alive:
+        Base: cat2
+      Dead:
+        Base: cat2_dead
+
+- type: entity
+  name: caracal cat
+  suffix: Ghost
+  id: MobCatCaracalGhost
+  parent: MobCatGhost
+  description: Hilarious.
+  components:
+  - type: Sprite
+    sprite: Mobs/Pets/caracal.rsi
+    layers:
+    - map: ["enum.DamageStateVisualLayers.Base"]
+      state: caracal_flop
+  - type: DamageStateVisuals
+    states:
+      Alive:
+        Base: caracal_flop
+      Dead:
+        Base: caracal_dead
+
+- type: entity
+  name: space cat
+  suffix: Ghost
+  parent: MobCatGhost
+  id: MobCatSpaceGhost
+  description: Feline pet, prepared for the worst.
+  components:
+  - type: Sprite
+    layers:
+    - map: ["enum.DamageStateVisualLayers.Base"]
+      state: spacecat
+  - type: DamageStateVisuals
+    states:
+      Alive:
+        Base: spacecat
+      Dead:
+        Base: spacecat_dead
+  - type: InteractionPopup
+    successChance: 0.7
+    interactSuccessString: petting-success-space-cat
+    interactFailureString: petting-failure-generic
+    interactSuccessSound:
+      path: /Audio/Animals/cat_meow.ogg
+  - type: Barotrauma
+    damage:
+      types:
+        Blunt: 0.0 #per second, scales with pressure and other constants.
+  - type: Temperature
+    heatDamageThreshold: 360
+    coldDamageThreshold: 0
+    currentTemperature: 310.15
+    coldDamage:
+      types:
+        Cold : 0.1 #per second, scales with temperature & other constants
+    specificHeat: 42
+    heatDamage:
+      types:
+        Heat : 0.1 #per second, scales with temperature & other constants
+
+- type: entity
+  name: bingus
+  suffix: Ghost
+  parent: MobBingus
+  id: MobBingusGhost
+  description: Bingus my beloved...
+  components:
+  - type: GhostRole
+    name: ghost-role-information-emotional-support-name
+    description: ghost-role-information-emotional-support-description
+    makeSentient: true
+    allowSpeech: true
+    allowMovement: true
+  - type: GhostTakeoverAvailable
+  - type: CombatMode
+    combatToggleAction:
+      enabled: false
+      autoPopulate: false
+      name: action-name-combat
+  - type: ReplacementAccent
+    accent: cat
+  - type: Grammar
+    attributes:
+      gender: epicene
+  - type: Tag
+    tags:
+    - CannotSuicide
+    - DoorBumpOpener
+
+- type: entity
+  name: corgi
+  suffix: Ghost
+  parent: MobCorgi
+  id: MobCorgiGhost
+  description: Finally, a space corgi!
+  components:
+  - type: GhostRole
+    name: ghost-role-information-emotional-support-name
+    description: ghost-role-information-emotional-support-description
+    makeSentient: true
+    allowSpeech: true
+    allowMovement: true
+  - type: GhostTakeoverAvailable
+  - type: CombatMode
+    combatToggleAction:
+      enabled: false
+      autoPopulate: false
+      name: action-name-combat
+  - type: ReplacementAccent
+    accent: dog
+  - type: Grammar
+    attributes:
+      gender: epicene
+  - type: Tag
+    tags:
+    - CannotSuicide
+    - DoorBumpOpener
+
+- type: entity
+  name: corgi puppy
+  suffix: Ghost
+  parent: MobCorgiGhost
+  id: MobCorgiPuppyGhost
+  description: A little corgi! Aww...
+  components:
+  - type: Sprite
+    drawdepth: Mobs
+    sprite: Mobs/Pets/corgi.rsi
+    layers:
+    - map: ["enum.DamageStateVisualLayers.Base"]
+      state: puppy
+  - type: Inventory
+    speciesId: puppy
+    templateId: pet
+  - type: InventorySlots
+  - type: DamageStateVisuals
+    states:
+      Alive:
+        Base: puppy
+      Dead:
+        Base: puppy_dead
+  - type: ReplacementAccent
+    accent: dog
+  - type: Grammar
+    attributes:
+      gender: epicene

--- a/Resources/Prototypes/_NF/Markers/Spawners/Random/emotionalsupportanimals.yml
+++ b/Resources/Prototypes/_NF/Markers/Spawners/Random/emotionalsupportanimals.yml
@@ -21,4 +21,5 @@
       - MobBingusGhost
       - MobCatSpaceGhost
       - MobCorgiPuppyGhost
+      - MobChickenGhost
     rareChance: 0.15

--- a/Resources/Prototypes/_NF/Markers/Spawners/Random/emotionalsupportanimals.yml
+++ b/Resources/Prototypes/_NF/Markers/Spawners/Random/emotionalsupportanimals.yml
@@ -1,0 +1,24 @@
+- type: entity
+  name: Random Animal Spawner
+  suffix: Emotional Support
+  parent: MarkerBase
+  id: RandomAnimalSpawnerEmotionalSupport
+  components:
+  - type: Sprite
+    layers:
+      - state: red
+      - sprite: Mobs/Animals/chicken.rsi
+        state: icon-1
+  - type: RandomSpawner
+    offset: 0
+    prototypes:
+      - MobCatGhost
+      - MobCatCalicoGhost
+      - MobCatCaracalGhost
+      - MobCorgiGhost
+    chance: 1
+    rarePrototypes:
+      - MobBingusGhost
+      - MobCatSpaceGhost
+      - MobCorgiPuppyGhost
+    rareChance: 0.15

--- a/Resources/Prototypes/_NF/Voice/speech_emote_sounds.yml
+++ b/Resources/Prototypes/_NF/Voice/speech_emote_sounds.yml
@@ -57,3 +57,24 @@
       path: /Audio/Voice/Moth/scream_moth.ogg
     Laugh:
       path: /Audio/Voice/Moth/laugh_moth.ogg
+
+- type: emoteSounds
+  id: Cat
+  sound:
+    path: /Audio/Animals/cat_meow.ogg
+    params:
+      variation: 0.125
+
+- type: emoteSounds
+  id: Dog
+  sound:
+    path: /Audio/Animals/small_dog_bark_happy.ogg
+    params:
+      variation: 0.125
+
+- type: emoteSounds
+  id: Chicken
+  sound:
+    path: /Audio/Animals/chicken_cluck_happy.ogg
+    params:
+      variation: 0.125


### PR DESCRIPTION
## About the PR
Added a crate and spawner for emotional support animals.

It will spawn one of:
Cat
Cat Calico
Cat Caracal
Corgi

Rare:
Cat Bingus
Cat Space
Corgi Puppy
Chicken

They all have ghost role.
They all have animal speech (Cats or dogs), cog wont work on them (Code issue from upstream)
They all have combat disabled, and cannot suicide.
They all can open doors (Unless no rights to open a door. AKA they have door bump)
They all can use emote (The sound they make on pet) as a "scream"

The crate could be bought in cargo for 10k, might be removed from cargo later if it will be an issue, as this is still useful for admins and ship makers to add a ship pet.

This PR also make the space cat space suit act like a space suit.

**Media**
https://discord.com/channels/1123826877245694004/1127687656084611214/1139561423039627365