### PR TITLE
Kestrel Cockpit Fixes

### DIFF
--- a/Resources/Maps/Shuttles/Kestrel.yml
+++ b/Resources/Maps/Shuttles/Kestrel.yml
@@ -470,6 +470,12 @@ entities:
       type: Transform
 - proto: Airlock
   entities:
+  - uid: 143
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,-1.5
+      parent: 3
+      type: Transform
   - uid: 149
     components:
     - rot: 1.5707963267948966 rad
@@ -1793,18 +1799,18 @@ entities:
       pos: 3.5,-0.5
       parent: 3
       type: Transform
-- proto: ComputerCrewMonitoring
-  entities:
-  - uid: 49
-    components:
-    - pos: 1.5,1.5
-      parent: 3
-      type: Transform
 - proto: ComputerShuttle
   entities:
   - uid: 138
     components:
     - pos: 0.5,1.5
+      parent: 3
+      type: Transform
+- proto: ComputerStationRecords
+  entities:
+  - uid: 49
+    components:
+    - pos: 1.5,1.5
       parent: 3
       type: Transform
 - proto: CrateGenericSteel
@@ -1904,6 +1910,13 @@ entities:
     components:
     - rot: 1.5707963267948966 rad
       pos: 0.5,-2.5
+      parent: 3
+      type: Transform
+- proto: FaxMachineShip
+  entities:
+  - uid: 410
+    components:
+    - pos: 1.5,-0.5
       parent: 3
       type: Transform
 - proto: GasPipeStraight
@@ -2270,13 +2283,6 @@ entities:
       type: Transform
     - enabled: False
       type: AmbientSound
-  - uid: 274
-    components:
-    - pos: 2.5,-1.5
-      parent: 3
-      type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 288
     components:
     - rot: -1.5707963267948966 rad
@@ -2313,6 +2319,13 @@ entities:
     components:
     - rot: 1.5707963267948966 rad
       pos: 0.5,-3.5
+      parent: 3
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+  - uid: 380
+    components:
+    - pos: 1.5,-2.5
       parent: 3
       type: Transform
     - enabled: False
@@ -2788,6 +2801,13 @@ entities:
     components:
     - rot: 1.5707963267948966 rad
       pos: 5.5,-6.5
+      parent: 3
+      type: Transform
+- proto: TableReinforced
+  entities:
+  - uid: 94
+    components:
+    - pos: 1.5,-0.5
       parent: 3
       type: Transform
 - proto: Thruster
@@ -3290,11 +3310,6 @@ entities:
       pos: 8.5,-7.5
       parent: 3
       type: Transform
-  - uid: 94
-    components:
-    - pos: 1.5,-0.5
-      parent: 3
-      type: Transform
   - uid: 106
     components:
     - pos: -3.5,-8.5
@@ -3332,6 +3347,12 @@ entities:
     components:
     - rot: 1.5707963267948966 rad
       pos: -4.5,-18.5
+      parent: 3
+      type: Transform
+  - uid: 274
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 2.5,-1.5
       parent: 3
       type: Transform
   - uid: 285


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Replaces the crew monitor with a station records computer (whoopsie) as well as adding a fax machine to the cockpit.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- add: Station Records Computer for requesting crew members
- add: Fax machine to cockpit.

