### PR TITLE
Dungeon Fix

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
@@ -233,8 +233,6 @@
   - type: Tag
     tags:
     - CannotSuicide
-  - type: ReplacementAccent
-    accent: genericAggressive
 
 - type: entity
   name: Ravager

--- a/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
@@ -158,3 +158,4 @@
     spawned:
     - id: FoodMeatDragon
       amount: 1
+  - type: SalvageMobRestrictions

--- a/Resources/Prototypes/Procedural/salvage_factions.yml
+++ b/Resources/Prototypes/Procedural/salvage_factions.yml
@@ -32,7 +32,7 @@
   configs:
     DefenseStructure: XenoWardingTower
     Mining: Xenos
-    Megafauna: MobXenoQueen
+    Megafauna: MobXenoQueenDungeon
 
 - type: salvageFaction
   id: Carps

--- a/Resources/Prototypes/Procedural/salvage_rewards.yml
+++ b/Resources/Prototypes/Procedural/salvage_rewards.yml
@@ -8,8 +8,8 @@
     CrateMaterialSteel: 1.0
     # things the station might want
     CrateEngineeringAMEJar: 0.25
-    CrateFoodPizzaLarge: 0.25
-    CrateFoodSoftdrinks: 0.25
+    #CrateFoodPizzaLarge: 0.25
+    #CrateFoodSoftdrinks: 0.25
     CrateFunATV: 0.25
     CrateFunInstrumentsVariety: 0.25
     CrateSalvageEquipment: 0.25

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/xeno.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/xeno.yml
@@ -1,0 +1,47 @@
+- type: entity
+  parent: MobXenoQueen
+  id: MobXenoQueenDungeon
+  suffix: Dungeon
+  components:
+  - type: Sprite
+    drawdepth: Mobs
+    sprite: Mobs/Aliens/Xenos/queen.rsi
+    offset: 0,0.4
+    layers:
+    - map: ["enum.DamageStateVisualLayers.Base"]
+      state: running
+  - type: MobThresholds
+    thresholds:
+      0: Alive
+      300: Dead
+  - type: Stamina
+    critThreshold: 1500
+  - type: MovementSpeedModifier
+    baseWalkSpeed: 2.8
+    baseSprintSpeed: 3.8
+  - type: MeleeWeapon
+    hidden: true
+    damage:
+     groups:
+       Brute: 20
+  - type: SlowOnDamage
+    speedModifierThresholds:
+      250: 0.4
+      200: 0.7
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeCircle
+          radius: 0.45
+        density: 15500
+        mask:
+        - MobMask
+        layer:
+        - MobLayer
+  - type: Tag
+    tags:
+    - CannotSuicide
+  - type: SalvageMobRestrictions
+  - type: ReplacementAccent
+    accent: Xeno

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/xeno.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/xeno.yml
@@ -44,4 +44,4 @@
     - CannotSuicide
   - type: SalvageMobRestrictions
   - type: ReplacementAccent
-    accent: Xeno
+    accent: xeno

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/xeno.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/xeno.yml
@@ -1,44 +1,8 @@
 - type: entity
+  name: Queen
   parent: MobXenoQueen
   id: MobXenoQueenDungeon
-  suffix: Dungeon
   components:
-  - type: Sprite
-    drawdepth: Mobs
-    sprite: Mobs/Aliens/Xenos/queen.rsi
-    offset: 0,0.4
-    layers:
-    - map: ["enum.DamageStateVisualLayers.Base"]
-      state: running
-  - type: MobThresholds
-    thresholds:
-      0: Alive
-      300: Dead
-  - type: Stamina
-    critThreshold: 1500
-  - type: MovementSpeedModifier
-    baseWalkSpeed: 2.8
-    baseSprintSpeed: 3.8
-  - type: MeleeWeapon
-    hidden: true
-    damage:
-     groups:
-       Brute: 20
-  - type: SlowOnDamage
-    speedModifierThresholds:
-      250: 0.4
-      200: 0.7
-  - type: Fixtures
-    fixtures:
-      fix1:
-        shape:
-          !type:PhysShapeCircle
-          radius: 0.45
-        density: 15500
-        mask:
-        - MobMask
-        layer:
-        - MobLayer
   - type: Tag
     tags:
     - CannotSuicide


### PR DESCRIPTION
## About the PR
Xeno queen and dragon will get removed if they try to leave the planet they live on.

Tested this isn't breaking the rewards.
If it died before the end it will complete as normal
If it was left on the planet the expo will not be completed
If it was left on the planet and you called to leave before timer ended the expo will not be completed
If it was left on your ship alive expo will not be completed

This PR also fix 2 missing crate rewards that where no longer in the game.

I will try to add some rare dragon egg later to allow spawn of a mini dragon.
