### PR TITLE
Computers Update 2

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers.yml
@@ -74,6 +74,11 @@
       ShipyardConsole-targetId: !type:ContainerSlot {}
   - type: Anchorable
     delay: 999999
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 0
 
 - type: entity
   id: ComputerShipyardSecurity
@@ -165,6 +170,11 @@
     delay: 999999
   - type: MarketModifier
     mod: 1.00
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 0
 
 - type: entity
   parent: ComputerPalletConsoleNFNormalMarket

--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/cryo_sleep_pod.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/cryo_sleep_pod.yml
@@ -13,16 +13,6 @@
     delay: 999999
   - type: Physics
     bodyType: Static
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 100
-      behaviors:
-      - !type:ChangeConstructionNodeBehavior
-        node: machineFrame
-      - !type:DoActsBehavior
-        acts: ["Destruction"]
   - type: MaterialStorage
   - type: Appearance
   - type: Climbable
@@ -30,3 +20,8 @@
   - type: ContainerContainer
     containers:
       body_container: !type:ContainerSlot  
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 0

--- a/Resources/Prototypes/_NF/Entities/Structures/atms.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/atms.yml
@@ -70,6 +70,20 @@
       bank-ATM-cashSlot: !type:ContainerSlot {}
   - type: Anchorable
     delay: 999999
+  - type: Damageable
+    damageContainer: Inorganic
+    damageModifierSet: Metallic
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 100
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          collection: GlassBreak
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
 
 - type: entity
   name: withdraw-only bank atm
@@ -137,6 +151,17 @@
         type: WithdrawBankATMMenuBoundUserInterface
   - type: Anchorable
     delay: 999999
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 100
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          collection: GlassBreak
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
 
 - type: entity
   name: wallmount bank atm
@@ -215,6 +240,17 @@
       bank-ATM-cashSlot: !type:ContainerSlot {}
   - type: Anchorable
     delay: 999999
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 100
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          collection: GlassBreak
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
 
 - type: entity
   name: wallmount withdraw-only bank atm
@@ -287,6 +323,17 @@
         type: WithdrawBankATMMenuBoundUserInterface
   - type: Anchorable
     delay: 999999
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 100
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          collection: GlassBreak
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
 
 - type: entity
   name: station administration console
@@ -351,3 +398,8 @@
       type: StationBankATMMenuBoundUserInterface
   - type: AccessReader
     access: [["HeadOfPersonnel"]]
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 0


### PR DESCRIPTION
Frontier critical machines are now damage protected

Except ATM's, they just drop nothing.

:cl: dvir01
- tweak: Critical machines in frontier wont break anymore.
