### PR TITLE
Prevent multiple changelog commits at once

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,4 +1,5 @@
 name: PR Changelogs
+concurrency: commit_action
 on:
   pull_request_target:
     types: [closed]

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -47,6 +47,7 @@ jobs:
 
       - name: Commit Changelog
         run: |
+          git pull origin master
           git add *.yml
           git commit -m "${{ vars.CHANGELOG_MESSAGE }} (#${{ env.PR_NUMBER }})"
           git push


### PR DESCRIPTION
## About the PR
Prevent multiple changelog actions from running at once via [job concurrency](https://docs.github.com/en/actions/using-jobs/using-concurrency). This means they get queued instead of all ran at once. If there are ever any future actions that will commit directly to the repository, they should also run under the `commit_action` group.


**Changelog**

No CL no fun
