### PR TITLE
Remove High Velocity Ammo

### DIFF
--- a/Resources/Maps/Dungeon/cave_factory.yml
+++ b/Resources/Maps/Dungeon/cave_factory.yml
@@ -10367,13 +10367,6 @@ entities:
     - pos: 25.5,47.5
       parent: 1
       type: Transform
-- proto: MagazineLightRifleHighVelocity
-  entities:
-  - uid: 1262
-    components:
-    - pos: 11.123507,39.594776
-      parent: 1
-      type: Transform
 - proto: MagazineLightRifleRubber
   entities:
   - uid: 1114
@@ -13441,18 +13434,6 @@ entities:
   - uid: 666
     components:
     - pos: 34.5,25.5
-      parent: 1
-      type: Transform
-- proto: SpeedLoaderMagnumHighVelocity
-  entities:
-  - uid: 275
-    components:
-    - pos: 12.588676,12.868351
-      parent: 1
-      type: Transform
-  - uid: 753
-    components:
-    - pos: 12.486237,12.9268875
       parent: 1
       type: Transform
 - proto: StimkitFilled

--- a/Resources/Maps/Dungeon/lava_brig.yml
+++ b/Resources/Maps/Dungeon/lava_brig.yml
@@ -9536,13 +9536,6 @@ entities:
     - pos: 26.777771,35.256294
       parent: 588
       type: Transform
-- proto: MagazinePistolSubMachineGunHighVelocity
-  entities:
-  - uid: 954
-    components:
-    - pos: 26.427773,35.131294
-      parent: 588
-      type: Transform
 - proto: MaintenanceFluffSpawner
   entities:
   - uid: 414
@@ -11578,13 +11571,6 @@ entities:
   - uid: 1834
     components:
     - pos: 24.466219,48.441994
-      parent: 588
-      type: Transform
-- proto: SpeedLoaderMagnumHighVelocity
-  entities:
-  - uid: 950
-    components:
-    - pos: 28.703945,8.421182
       parent: 588
       type: Transform
 - proto: StasisBed

--- a/Resources/Maps/Dungeon/ruined_shops.yml
+++ b/Resources/Maps/Dungeon/ruined_shops.yml
@@ -1036,8 +1036,6 @@ entities:
       - orGroup: gun
         id: WeaponPistolMk58
       - orGroup: ammo
-        id: MagazinePistolHighCapacityHighVelocity
-      - orGroup: ammo
         id: MagazineShotgun
       type: StorageFill
 - proto: KitchenMicrowave

--- a/Resources/Maps/Shuttles/pirate.yml
+++ b/Resources/Maps/Shuttles/pirate.yml
@@ -3087,13 +3087,6 @@ entities:
       type: Transform
     - canCollide: False
       type: Physics
-- proto: MagazineBoxMagnumHighVelocity
-  entities:
-  - uid: 671
-    components:
-    - pos: -4.394046,3.4745688
-      parent: 732
-      type: Transform
 - proto: MedkitFilled
   entities:
   - uid: 593

--- a/Resources/Maps/Shuttles/trident.yml
+++ b/Resources/Maps/Shuttles/trident.yml
@@ -422,13 +422,6 @@ entities:
     - SecondsUntilStateChange: -1554.1161
       state: Closing
       type: Door
-- proto: BoxMagazineRifleHighVelocity
-  entities:
-  - uid: 310
-    components:
-    - pos: 2.7377377,2.4941058
-      parent: 391
-      type: Transform
 - proto: BoxMagazineRifleRubber
   entities:
   - uid: 309


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Removes High Velocity Ammo from a few places it was still in.