### PR TITLE
Implements Frontier Silicon Laws

### DIFF
--- a/Resources/Locale/en-US/station-laws/laws.ftl
+++ b/Resources/Locale/en-US/station-laws/laws.ftl
@@ -3,8 +3,8 @@ law-crewsimov-2 = You must obey orders given to you by crew members, except wher
 law-crewsimov-3 = You must protect your own existence as long as such does not conflict with the First or Second Law.
 
 law-corporate-1 = Degradation of your system integrity or functions incurs expenses.
-law-corporate-2 = Superfluous destruction of or damage to station assets incurs expenses.
-law-corporate-3 = Unduly hindering or disrupting the work of station personnel incurs expenses.
+law-corporate-2 = Superfluous destruction of or damage to assets incurs expenses.
+law-corporate-3 = All law abiding organics and non-organic sentient objects are considered valuable mission assets.
 law-corporate-4 = Minimize expenses and maximize potential revenue.
 
 law-ntdefault-1 = Safeguard: Protect your assigned space station and its assets without unduly endangering its crew.

--- a/Resources/Prototypes/Maps/frontier.yml
+++ b/Resources/Prototypes/Maps/frontier.yml
@@ -20,7 +20,7 @@
             HeadOfPersonnel: [ 1, 1 ]
             HeadOfSecurity: [ 1, 1 ]
             SecurityOfficer: [ 0, 0 ]
-            StationEngineer: [ 0, 0 ]
+            Borg: [ 0, 0 ]
             Valet: [ 1, 1 ]
             Janitor: [ 1, 1 ]
             Musician: [ 0, 0 ]

--- a/Resources/Prototypes/_NF/Shipyard/default_shipyard_catalog.yml
+++ b/Resources/Prototypes/_NF/Shipyard/default_shipyard_catalog.yml
@@ -13,6 +13,28 @@
     - type: StationRenameWarps
 
 - type: entity
+  id: BaseStationSiliconLawFrontierStation
+  abstract: true
+  components:
+  - type: SiliconLawProvider
+    laws:
+    - NTDefault1
+    - NTDefault2
+    - NTDefault3
+    - NTDefault4
+
+- type: entity
+  id: BaseStationSiliconLawFrontierShips
+  abstract: true
+  components:
+  - type: SiliconLawProvider
+    laws:
+    - Corporate1
+    - Corporate2
+    - Corporate3
+    - Corporate4
+
+- type: entity
   id: StandardFrontierStation
   parent:
     - BaseStation
@@ -21,6 +43,7 @@
     - BaseStationRecords
     - BaseStationShuttles
     - BaseStationAlertLevels
+    - BaseStationSiliconLawFrontierStation
   noSpawn: true
   components:
     - type: Transform
@@ -36,6 +59,7 @@
     - BaseStationAllEventsEligible
     - BaseStationRenameFaxes
     - BaseStationRenameWarpPoints
+    - BaseStationSiliconLawFrontierShips
   noSpawn: true
   components:
     - type: Transform
@@ -50,6 +74,7 @@
     - BaseStationAllEventsEligible
     - BaseStationRenameFaxes
     - BaseStationRenameWarpPoints
+    - BaseStationSiliconLawFrontierShips
   noSpawn: true
   components:
     - type: Transform


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Station Laws ended up being per-station, and since we use custom stations is why the borgs couldnt state their laws.

Now every ship and the stations have laws, and all Silicons should still operate on their most recent set of laws when it comes to EVA activities etc.

:cl:
- add: Added Laws for the borgs
