### PR TITLE
Disable Chasms

### DIFF
--- a/Resources/Prototypes/Procedural/biome_templates.yml
+++ b/Resources/Prototypes/Procedural/biome_templates.yml
@@ -311,19 +311,19 @@
       entities:
         - WallRockBasalt
     # chasm time
-    - !type:BiomeEntityLayer
-      allowedTiles:
-      - FloorBasalt
-      threshold: 0.6
-      noise:
-        seed: 3
-        frequency: 0.02
-        fractalType: FBm
-        octaves: 5
-        lacunarity: 2
-        gain: 0.4
-      entities:
-      - FloorChasmEntity
+    # - !type:BiomeEntityLayer
+      # allowedTiles:
+      # - FloorBasalt
+      # threshold: 0.6
+      # noise:
+        # seed: 3
+        # frequency: 0.02
+        # fractalType: FBm
+        # octaves: 5
+        # lacunarity: 2
+        # gain: 0.4
+      # entities:
+      # - FloorChasmEntity
     - !type:BiomeDummyLayer
       id: Loot
     # Fill basalt


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
chasms are neat code and make a funny sound but gameplay wise are really *really* punishing so we are going to just disable these insane things until they have some better gameplay behind them.

:cl:
- tweak: Disables chasms spawning on expeditions