### PR TITLE
ID&PDA-CargoSellBlacklist

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -107,6 +107,7 @@
     - DoorBumpOpener
   - type: Input
     context: "human"
+  - type: CargoSellBlacklist # Liltenhead moment
 
 - type: entity
   parent: BasePDA

--- a/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
@@ -21,6 +21,7 @@
     - DoorBumpOpener
   - type: StaticPrice
     price: 150
+  - type: CargoSellBlacklist # Liltenhead moment
 
 #IDs with layers
 


### PR DESCRIPTION
## About the PR
You can no longer sell PDA or ID cards by mistake.

:cl: dvir01
- tweak: Nanotrasen wont pay you anymore for your used PDA and ID cards.
