### PR TITLE
Adds a crafting recipe for the Security Patrol Hardsuit, and a revert crafting recipe.

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -12,20 +12,18 @@
     sprite: Clothing/OuterClothing/Hardsuits/basic.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/basic.rsi
-  - type: ClothingSpeedModifier
-    walkModifier: 0.80
-    sprintModifier: 0.80
+  - type: ExplosionResistance
+    damageCoefficient: 0.9
   - type: Armor
     modifiers:
       coefficients:
         Blunt: 0.9
         Slash: 0.9
         Piercing: 0.9
-        Heat: 0.9
-        Radiation: 0.9
-        Caustic: 0.85
-  - type: ExplosionResistance
-    damageCoefficient: 0.9
+        Caustic: 0.9
+  - type: ClothingSpeedModifier
+    walkModifier: 0.80
+    sprintModifier: 0.80
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitBasic
   - type: StaticPrice
@@ -44,23 +42,23 @@
     sprite: Clothing/OuterClothing/Hardsuits/atmospherics.rsi
   - type: PressureProtection
     highPressureMultiplier: 0.02
-    lowPressureMultiplier: 10000
-  - type: ClothingSpeedModifier
-    walkModifier: 0.65
-    sprintModifier: 0.65
+    lowPressureMultiplier: 1000
+  - type: TemperatureProtection
+    coefficient: 0.001
+  - type: ExplosionResistance
+    damageCoefficient: 0.5
   - type: Armor
     modifiers:
       coefficients:
         Blunt: 0.9
         Slash: 0.9
         Piercing: 0.9
-        Heat: 0.4
-        Radiation: 0.75
-        Caustic: 0.50
-  - type: TemperatureProtection
-    coefficient: 0.001
-  - type: ExplosionResistance
-    damageCoefficient: 0.2
+        Heat: 0.2
+        Radiation: 0.5
+        Caustic: 0.5
+  - type: ClothingSpeedModifier
+    walkModifier: 0.7
+    sprintModifier: 0.7
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitAtmos
 
@@ -78,21 +76,22 @@
   - type: PressureProtection
     highPressureMultiplier: 0.04
     lowPressureMultiplier: 1000
-  - type: ClothingSpeedModifier
-    walkModifier: 0.65
-    sprintModifier: 0.65
+  - type: TemperatureProtection
+    coefficient: 0.01
+  - type: ExplosionResistance
+    damageCoefficient: 0.5
   - type: Armor
     modifiers:
       coefficients:
         Blunt: 0.9
         Slash: 0.9
-        Piercing: 0.95
-        Heat: 0.7
+        Piercing: 0.9
         Shock: 0.8
-        Caustic: 0.75
-        Radiation: 0.25
-  - type: ExplosionResistance
-    damageCoefficient: 0.2
+        Caustic: 0.5
+        Radiation: 0.2
+  - type: ClothingSpeedModifier
+    walkModifier: 0.7
+    sprintModifier: 0.7
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitEngineering
 
@@ -108,20 +107,19 @@
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/spatio.rsi
   - type: PressureProtection
-    highPressureMultiplier: 0.72
-    lowPressureMultiplier: 10000
-  - type: ClothingSpeedModifier
-    walkModifier: 0.9
-    sprintModifier: 0.8
+    highPressureMultiplier: 0.7
+    lowPressureMultiplier: 1000
   - type: Armor
     modifiers:
       coefficients:
         Blunt: 0.9
         Slash: 0.9
-        Piercing: 0.95
-        Heat: 0.9
-        Radiation: 0.75 #salv is supposed to have radiation hazards in the future
-        Caustic: 0.85
+        Piercing: 0.9
+        Radiation: 0.3 #salv is supposed to have radiation hazards in the future
+        Caustic: 0.8
+  - type: ClothingSpeedModifier
+    walkModifier: 0.9
+    sprintModifier: 0.8
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSpatio
   - type: StaticPrice
@@ -131,7 +129,7 @@
 - type: entity
   parent: ClothingOuterHardsuitBase
   id: ClothingOuterHardsuitSalvage
-  name: salvage hardsuit
+  name: mining hardsuit
   description: A special suit that protects against hazardous, low pressure environments. Has reinforced plating for wildlife encounters.
   components:
   - type: Sprite
@@ -139,22 +137,21 @@
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/salvage.rsi
   - type: PressureProtection
-    highPressureMultiplier: 0.525
-    lowPressureMultiplier: 10000
-  - type: ClothingSpeedModifier
-    walkModifier: 0.6
-    sprintModifier: 0.65
+    highPressureMultiplier: 0.5
+    lowPressureMultiplier: 1000
+  - type: ExplosionResistance
+    damageCoefficient: 0.3
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.75
+        Blunt: 0.7
         Slash: 0.7
-        Piercing: 0.7
-        Heat: 0.85
-        Radiation: 0.50
-        Caustic: 0.75
-  - type: ExplosionResistance
-    damageCoefficient: 0.3
+        Piercing: 0.5
+        Radiation: 0.3
+        Caustic: 0.7
+  - type: ClothingSpeedModifier
+    walkModifier: 0.75
+    sprintModifier: 0.75
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSalvage
 
@@ -170,21 +167,20 @@
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/security.rsi
   - type: PressureProtection
-    highPressureMultiplier: 0.525
-    lowPressureMultiplier: 10000
-  - type: ClothingSpeedModifier
-    walkModifier: 0.85
-    sprintModifier: 0.75
+    highPressureMultiplier: 0.5
+    lowPressureMultiplier: 1000
+  - type: ExplosionResistance
+    damageCoefficient: 0.4
   - type: Armor
     modifiers:
       coefficients:
         Blunt: 0.6
         Slash: 0.6
         Piercing: 0.6
-        Heat: 0.8
-        Caustic: 0.75
-  - type: ExplosionResistance
-    damageCoefficient: 0.4
+        Caustic: 0.7
+  - type: ClothingSpeedModifier
+    walkModifier: 0.75
+    sprintModifier: 0.75
   - type: Construction
     graph: SecPatrolHardsuit
     node: securitypatrolhardsuit
@@ -193,8 +189,8 @@
   - type: Tag
     tags:
     - SecHardsuit
-    
-#Security Patrol Hardsuit
+
+#Security Patrol Hardsuit NF14
 - type: entity
   parent: ClothingOuterHardsuitBase
   id: ClothingOuterHardsuitSecuritypatrol
@@ -243,18 +239,16 @@
     sprite: Clothing/OuterClothing/Hardsuits/brigmedic.rsi
   - type: PressureProtection
     highPressureMultiplier: 0.3
-    lowPressureMultiplier: 5500
-  - type: ClothingSpeedModifier
-    walkModifier: 0.90
-    sprintModifier: 0.85
+    lowPressureMultiplier: 1000
   - type: Armor
     modifiers:
       coefficients:
         Blunt: 0.8
         Slash: 0.8
-        Piercing: 0.75
-        Heat: 0.9
-        Caustic: 0.2
+        Piercing: 0.7
+  - type: ClothingSpeedModifier
+    walkModifier: 0.65
+    sprintModifier: 0.65
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitBrigmedic
 
@@ -263,28 +257,27 @@
   parent: ClothingOuterHardsuitBase
   id: ClothingOuterHardsuitWarden
   name: warden's hardsuit
-  description: A specialized riot suit geared to combat low pressure environments while maintaining agility.
+  description: A specialized riot suit geared to combat low pressure environments.
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Hardsuits/security-warden.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/security-warden.rsi
   - type: PressureProtection
-    highPressureMultiplier: 0.525
-    lowPressureMultiplier: 10000
-  - type: ClothingSpeedModifier
-    walkModifier: 0.85
-    sprintModifier: 0.75
+    highPressureMultiplier: 0.5
+    lowPressureMultiplier: 1000
+  - type: ExplosionResistance
+    damageCoefficient: 0.4
   - type: Armor
     modifiers:
       coefficients:
         Blunt: 0.5
         Slash: 0.6
         Piercing: 0.6
-        Heat: 0.8
-        Caustic: 0.75
-  - type: ExplosionResistance
-    damageCoefficient: 0.4
+        Caustic: 0.7
+  - type: ClothingSpeedModifier
+    walkModifier: 0.7
+    sprintModifier: 0.7
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitWarden
 
@@ -302,20 +295,20 @@
   - type: PressureProtection
     highPressureMultiplier: 0.02
     lowPressureMultiplier: 1000
-  - type: ClothingSpeedModifier
-    walkModifier: 0.8
-    sprintModifier: 0.8
+  - type: ExplosionResistance
+    damageCoefficient: 0.5
   - type: Armor
     modifiers:
       coefficients:
         Blunt: 0.8
         Slash: 0.8
-        Piercing: 0.75
-        Heat: 0.3
-        Radiation: 0.50
+        Piercing: 0.8
+        Heat: 0.5
+        Radiation: 0.5
         Caustic: 0.6
-  - type: ExplosionResistance
-    damageCoefficient: 0.5
+  - type: ClothingSpeedModifier
+    walkModifier: 0.8
+    sprintModifier: 0.8
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitCap
 
@@ -333,20 +326,20 @@
   - type: PressureProtection
     highPressureMultiplier: 0.02
     lowPressureMultiplier: 1000
-  - type: ClothingSpeedModifier
-    walkModifier: 0.75
-    sprintModifier: 0.8
+  - type: ExplosionResistance
+    damageCoefficient: 0.2
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.85
-        Slash: 0.85
+        Blunt: 0.8
+        Slash: 0.8
         Piercing: 0.8
         Heat: 0.4
         Radiation: 0.0
-        Caustic: 0.75
-  - type: ExplosionResistance
-    damageCoefficient: 0.2
+        Caustic: 0.7
+  - type: ClothingSpeedModifier
+    walkModifier: 0.75
+    sprintModifier: 0.8
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitEngineeringWhite
 
@@ -363,15 +356,14 @@
     sprite: Clothing/OuterClothing/Hardsuits/medical.rsi
   - type: PressureProtection
     highPressureMultiplier: 0.3
-    lowPressureMultiplier: 5500
-  - type: ClothingSpeedModifier
-    walkModifier: 0.9
-    sprintModifier: 0.95
+    lowPressureMultiplier: 1000
   - type: Armor
     modifiers:
       coefficients:
-        Heat: 0.90
         Caustic: 0.1
+  - type: ClothingSpeedModifier
+    walkModifier: 0.9
+    sprintModifier: 0.95
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitMedical
 
@@ -380,7 +372,7 @@
   parent: ClothingOuterHardsuitBase
   id: ClothingOuterHardsuitRd
   name: experimental research hardsuit
-  description: A special suit that protects against hazardous, low pressure environments. Has an additional layer of armor.
+  description: A special suit that protects against hazardous, low pressure environments. Has an additional layer of armor. Able to be compressed to small sizes.
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Hardsuits/rd.rsi
@@ -388,27 +380,27 @@
     sprite: Clothing/OuterClothing/Hardsuits/rd.rsi
   - type: PressureProtection
     highPressureMultiplier: 0.02
-    lowPressureMultiplier: 5500
+    lowPressureMultiplier: 1000
   - type: Armor
     modifiers:
       coefficients:
         Blunt: 0.6
         Slash: 0.8
-        Piercing: 0.95
+        Piercing: 0.9
         Heat: 0.3
         Radiation: 0.1
-        Caustic: 0.25
+        Caustic: 0.2
+  - type: ExplosionResistance
+    damageCoefficient: 0.1
   - type: ClothingSpeedModifier
     walkModifier: 0.75
     sprintModifier: 0.75
   - type: Item
-    size: 100
+    size: 50
   - type: Tag
     tags:
     - WhitelistChameleon
     - HighRiskItem
-  - type: ExplosionResistance
-    damageCoefficient: 0.1
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitRd
   - type: StaticPrice
@@ -427,21 +419,20 @@
     sprite: Clothing/OuterClothing/Hardsuits/security-red.rsi
   - type: PressureProtection
     highPressureMultiplier: 0.45
-    lowPressureMultiplier: 10000
-  - type: ClothingSpeedModifier
-    walkModifier: 0.85
-    sprintModifier: 0.75
+    lowPressureMultiplier: 1000
+  - type: ExplosionResistance
+    damageCoefficient: 0.6
   - type: Armor
     modifiers:
       coefficients:
         Blunt: 0.6
         Slash: 0.5
         Piercing: 0.5
-        Heat: 0.8
-        Radiation: 0.25
+        Radiation: 0.5
         Caustic: 0.6
-  - type: ExplosionResistance
-    damageCoefficient: 0.6
+  - type: ClothingSpeedModifier
+    walkModifier: 0.8
+    sprintModifier: 0.8
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSecurityRed
 
@@ -460,20 +451,20 @@
   - type: PressureProtection
     highPressureMultiplier: 0.05
     lowPressureMultiplier: 1000
-  - type: ClothingSpeedModifier
-    walkModifier: 0.9
-    sprintModifier: 0.9
+  - type: ExplosionResistance
+    damageCoefficient: 0.5
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.65
-        Slash: 0.6
+        Blunt: 0.5
+        Slash: 0.5
         Piercing: 0.5
-        Heat: 0.4
-        Radiation: 0.50
-        Caustic: 0.75
-  - type: ExplosionResistance
-    damageCoefficient: 0.5
+        Heat: 0.5
+        Radiation: 0.5
+        Caustic: 0.5
+  - type: ClothingSpeedModifier
+    walkModifier: 0.9
+    sprintModifier: 0.9
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSyndie
 
@@ -491,20 +482,20 @@
   - type: PressureProtection
     highPressureMultiplier: 0.2
     lowPressureMultiplier: 1000
-  - type: ClothingSpeedModifier
-    walkModifier: 0.6
-    sprintModifier: 0.6 #extremely slow
+  - type: ExplosionResistance
+    damageCoefficient: 0.3
   - type: Armor
     modifiers:
       coefficients:
         Blunt: 0.2
         Slash: 0.2
         Piercing: 0.2
-        Heat: 0.5
-        Radiation: 0.25
-        Caustic: 0.35
-  - type: ExplosionResistance
-    damageCoefficient: 0.8
+        Heat: 0.2
+        Radiation: 0.2
+        Caustic: 0.2
+  - type: ClothingSpeedModifier
+    walkModifier: 0.9
+    sprintModifier: 0.65
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitCybersun
 
@@ -522,11 +513,10 @@
   - type: PressureProtection
     highPressureMultiplier: 0.02
     lowPressureMultiplier: 1000
-  - type: ClothingSpeedModifier
-    walkModifier: 1.0
-    sprintModifier: 1.0
   - type: TemperatureProtection
     coefficient: 0.001
+  - type: ExplosionResistance
+    damageCoefficient: 0.3
   - type: Armor
     modifiers:
       coefficients:
@@ -536,8 +526,9 @@
         Heat: 0.2
         Radiation: 0.25
         Caustic: 0.5
-  - type: ExplosionResistance
-    damageCoefficient: 0.3
+  - type: ClothingSpeedModifier
+    walkModifier: 1.0
+    sprintModifier: 1.0
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSyndieElite
 
@@ -555,20 +546,20 @@
   - type: PressureProtection
     highPressureMultiplier: 0.05
     lowPressureMultiplier: 1000
-  - type: ClothingSpeedModifier
-    walkModifier: 1.0
-    sprintModifier: 1.0
+  - type: ExplosionResistance
+    damageCoefficient: 0.5
   - type: Armor
     modifiers:
       coefficients:
         Blunt: 0.4
         Slash: 0.4
         Piercing: 0.3
-        Heat: 0.3
+        Heat: 0.5
         Radiation: 0.25
         Caustic: 0.4
-  - type: ExplosionResistance
-    damageCoefficient: 0.5
+  - type: ClothingSpeedModifier
+    walkModifier: 1.0
+    sprintModifier: 1.0
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSyndieCommander
 
@@ -586,9 +577,8 @@
   - type: PressureProtection
     highPressureMultiplier: 0.05
     lowPressureMultiplier: 1000
-  - type: ClothingSpeedModifier
-    walkModifier: 0.8
-    sprintModifier: 0.8
+  - type: ExplosionResistance
+    damageCoefficient: 0.5
   - type: Armor
     modifiers:
       coefficients:
@@ -598,8 +588,9 @@
         Heat: 0.25
         Radiation: 0.25
         Caustic: 0.75
-  - type: ExplosionResistance
-    damageCoefficient: 0.5
+  - type: ClothingSpeedModifier
+    walkModifier: 0.8
+    sprintModifier: 0.8
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitWizard
 
@@ -616,10 +607,9 @@
     sprite: Clothing/OuterClothing/Hardsuits/lingspacesuit.rsi
   - type: PressureProtection
     highPressureMultiplier: 0.225
-    lowPressureMultiplier: 10000
-  - type: ClothingSpeedModifier
-    walkModifier: .8
-    sprintModifier: .8
+    lowPressureMultiplier: 1000
+  - type: ExplosionResistance
+    damageCoefficient: 0.2
   - type: Armor
     modifiers:
       coefficients:
@@ -627,8 +617,9 @@
         Slash: 0.95
         Piercing: 1
         Heat: 0.5
-  - type: ExplosionResistance
-    damageCoefficient: 0.2
+  - type: ClothingSpeedModifier
+    walkModifier: 0.8
+    sprintModifier: 0.8
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitLing
 
@@ -645,9 +636,8 @@
     sprite: Clothing/OuterClothing/Hardsuits/pirateeva.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/pirateeva.rsi
-  - type: ClothingSpeedModifier
-    walkModifier: 0.6
-    sprintModifier: 0.6
+  - type: ExplosionResistance
+    damageCoefficient: 0.7
   - type: Armor
     modifiers:
       coefficients:
@@ -656,8 +646,9 @@
         Piercing: 0.9
         Heat: 0.4
         Caustic: 0.75
-  - type: ExplosionResistance
-    damageCoefficient: 0.7
+  - type: ClothingSpeedModifier
+    walkModifier: 0.6
+    sprintModifier: 0.6
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitPirateEVA
 
@@ -675,9 +666,8 @@
   - type: PressureProtection
     highPressureMultiplier: 0.02
     lowPressureMultiplier: 1000
-  - type: ClothingSpeedModifier
-    walkModifier: 0.8
-    sprintModifier: 0.8
+  - type: ExplosionResistance
+    damageCoefficient: 0.6
   - type: Armor
     modifiers:
       coefficients:
@@ -686,8 +676,9 @@
         Piercing: 0.85
         Heat: 0.4
         Caustic: 0.75
-  - type: ExplosionResistance
-    damageCoefficient: 0.6
+  - type: ClothingSpeedModifier
+    walkModifier: 0.8
+    sprintModifier: 0.8
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitPirateCap
 
@@ -773,20 +764,22 @@
   - type: PressureProtection
     highPressureMultiplier: 0.02
     lowPressureMultiplier: 1000
-  - type: ClothingSpeedModifier
-    walkModifier: 1.0
-    sprintModifier: 1.0
+  - type: TemperatureProtection
+    coefficient: 0.001
+  - type: ExplosionResistance
+    damageCoefficient: 0.2
   - type: Armor
     modifiers:
       coefficients:
         Blunt: 0.2 #best armor in the game
         Slash: 0.2
         Piercing: 0.2
-        Heat: 0.2
+        Heat: 0.1
         Radiation: 0.1
         Caustic: 0.2
-  - type: ExplosionResistance
-    damageCoefficient: 0.2
+  - type: ClothingSpeedModifier
+    walkModifier: 1.0
+    sprintModifier: 1.0
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitDeathsquad
 
@@ -804,24 +797,24 @@
   - type: PressureProtection
     highPressureMultiplier: 0.02
     lowPressureMultiplier: 1000
-  - type: ClothingSpeedModifier
-    walkModifier: 1.0
-    sprintModifier: 1.0
   - type: TemperatureProtection
     coefficient: 0.001
+  - type: ExplosionResistance
+    damageCoefficient: 0.7
   - type: Armor
     modifiers:
       coefficients:
         Blunt: 0.7
         Slash: 0.7
         Piercing: 0.6
-        Heat: 0.05
+        Heat: 0.1
         Cold: 0.1
         Shock: 0.1
         Radiation: 0.1
         Caustic: 0.1
-  - type: ExplosionResistance
-    damageCoefficient: 0.7
+  - type: ClothingSpeedModifier
+    walkModifier: 1.0
+    sprintModifier: 1.0
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetCBURN
 
@@ -838,20 +831,20 @@
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/clown.rsi
   - type: PressureProtection
-    highPressureMultiplier: 0.525
-    lowPressureMultiplier: 10000
-  - type: ClothingSpeedModifier
-    walkModifier: 0.9
-    sprintModifier: 0.9
+    highPressureMultiplier: 0.5
+    lowPressureMultiplier: 1000
+  - type: ExplosionResistance
+    damageCoefficient: 0.9
   - type: Armor
     modifiers:
       coefficients:
         Blunt: 0.9
         Slash: 0.9
         Piercing: 0.9
-        Caustic: 0.85
-  - type: ExplosionResistance
-    damageCoefficient: 0.9
+        Caustic: 0.8
+  - type: ClothingSpeedModifier
+    walkModifier: 0.9
+    sprintModifier: 0.9
   - type: Construction
     graph: ClownHardsuit
     node: clownHardsuit

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -12,18 +12,20 @@
     sprite: Clothing/OuterClothing/Hardsuits/basic.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/basic.rsi
-  - type: ExplosionResistance
-    damageCoefficient: 0.9
+  - type: ClothingSpeedModifier
+    walkModifier: 0.80
+    sprintModifier: 0.80
   - type: Armor
     modifiers:
       coefficients:
         Blunt: 0.9
         Slash: 0.9
         Piercing: 0.9
-        Caustic: 0.9
-  - type: ClothingSpeedModifier
-    walkModifier: 0.80
-    sprintModifier: 0.80
+        Heat: 0.9
+        Radiation: 0.9
+        Caustic: 0.85
+  - type: ExplosionResistance
+    damageCoefficient: 0.9
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitBasic
   - type: StaticPrice
@@ -42,23 +44,23 @@
     sprite: Clothing/OuterClothing/Hardsuits/atmospherics.rsi
   - type: PressureProtection
     highPressureMultiplier: 0.02
-    lowPressureMultiplier: 1000
-  - type: TemperatureProtection
-    coefficient: 0.001
-  - type: ExplosionResistance
-    damageCoefficient: 0.5
+    lowPressureMultiplier: 10000
+  - type: ClothingSpeedModifier
+    walkModifier: 0.65
+    sprintModifier: 0.65
   - type: Armor
     modifiers:
       coefficients:
         Blunt: 0.9
         Slash: 0.9
         Piercing: 0.9
-        Heat: 0.2
-        Radiation: 0.5
-        Caustic: 0.5
-  - type: ClothingSpeedModifier
-    walkModifier: 0.7
-    sprintModifier: 0.7
+        Heat: 0.4
+        Radiation: 0.75
+        Caustic: 0.50
+  - type: TemperatureProtection
+    coefficient: 0.001
+  - type: ExplosionResistance
+    damageCoefficient: 0.2
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitAtmos
 
@@ -76,22 +78,21 @@
   - type: PressureProtection
     highPressureMultiplier: 0.04
     lowPressureMultiplier: 1000
-  - type: TemperatureProtection
-    coefficient: 0.01
-  - type: ExplosionResistance
-    damageCoefficient: 0.5
+  - type: ClothingSpeedModifier
+    walkModifier: 0.65
+    sprintModifier: 0.65
   - type: Armor
     modifiers:
       coefficients:
         Blunt: 0.9
         Slash: 0.9
-        Piercing: 0.9
+        Piercing: 0.95
+        Heat: 0.7
         Shock: 0.8
-        Caustic: 0.5
-        Radiation: 0.2
-  - type: ClothingSpeedModifier
-    walkModifier: 0.7
-    sprintModifier: 0.7
+        Caustic: 0.75
+        Radiation: 0.25
+  - type: ExplosionResistance
+    damageCoefficient: 0.2
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitEngineering
 
@@ -107,19 +108,20 @@
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/spatio.rsi
   - type: PressureProtection
-    highPressureMultiplier: 0.7
-    lowPressureMultiplier: 1000
+    highPressureMultiplier: 0.72
+    lowPressureMultiplier: 10000
+  - type: ClothingSpeedModifier
+    walkModifier: 0.9
+    sprintModifier: 0.8
   - type: Armor
     modifiers:
       coefficients:
         Blunt: 0.9
         Slash: 0.9
-        Piercing: 0.9
-        Radiation: 0.3 #salv is supposed to have radiation hazards in the future
-        Caustic: 0.8
-  - type: ClothingSpeedModifier
-    walkModifier: 0.9
-    sprintModifier: 0.8
+        Piercing: 0.95
+        Heat: 0.9
+        Radiation: 0.75 #salv is supposed to have radiation hazards in the future
+        Caustic: 0.85
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSpatio
   - type: StaticPrice
@@ -129,7 +131,7 @@
 - type: entity
   parent: ClothingOuterHardsuitBase
   id: ClothingOuterHardsuitSalvage
-  name: mining hardsuit
+  name: salvage hardsuit
   description: A special suit that protects against hazardous, low pressure environments. Has reinforced plating for wildlife encounters.
   components:
   - type: Sprite
@@ -137,21 +139,22 @@
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/salvage.rsi
   - type: PressureProtection
-    highPressureMultiplier: 0.5
-    lowPressureMultiplier: 1000
-  - type: ExplosionResistance
-    damageCoefficient: 0.3
+    highPressureMultiplier: 0.525
+    lowPressureMultiplier: 10000
+  - type: ClothingSpeedModifier
+    walkModifier: 0.6
+    sprintModifier: 0.65
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.7
+        Blunt: 0.75
         Slash: 0.7
-        Piercing: 0.5
-        Radiation: 0.3
-        Caustic: 0.7
-  - type: ClothingSpeedModifier
-    walkModifier: 0.75
-    sprintModifier: 0.75
+        Piercing: 0.7
+        Heat: 0.85
+        Radiation: 0.50
+        Caustic: 0.75
+  - type: ExplosionResistance
+    damageCoefficient: 0.3
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSalvage
 
@@ -167,24 +170,31 @@
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/security.rsi
   - type: PressureProtection
-    highPressureMultiplier: 0.5
-    lowPressureMultiplier: 1000
-  - type: ExplosionResistance
-    damageCoefficient: 0.4
+    highPressureMultiplier: 0.525
+    lowPressureMultiplier: 10000
+  - type: ClothingSpeedModifier
+    walkModifier: 0.85
+    sprintModifier: 0.75
   - type: Armor
     modifiers:
       coefficients:
         Blunt: 0.6
         Slash: 0.6
         Piercing: 0.6
-        Caustic: 0.7
-  - type: ClothingSpeedModifier
-    walkModifier: 0.75
-    sprintModifier: 0.75
+        Heat: 0.8
+        Caustic: 0.75
+  - type: ExplosionResistance
+    damageCoefficient: 0.4
+  - type: Construction
+    graph: SecPatrolHardsuit
+    node: securitypatrolhardsuit
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSecurity
-
-#Security Patrol Hardsuit NF14
+  - type: Tag
+    tags:
+    - SecHardsuit
+    
+#Security Patrol Hardsuit
 - type: entity
   parent: ClothingOuterHardsuitBase
   id: ClothingOuterHardsuitSecuritypatrol
@@ -211,8 +221,14 @@
         Caustic: 0.8
   - type: ExplosionResistance
     damageCoefficient: 0.5
+  - type: Construction
+    graph: SecPatrolHardsuit
+    node: securitypatrolhardsuit
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSecuritypatrol
+  - type: Tag
+    tags: 
+    - SecPatrolHardsuit
 
 #Brigmedic Hardsuit
 - type: entity
@@ -227,16 +243,18 @@
     sprite: Clothing/OuterClothing/Hardsuits/brigmedic.rsi
   - type: PressureProtection
     highPressureMultiplier: 0.3
-    lowPressureMultiplier: 1000
+    lowPressureMultiplier: 5500
+  - type: ClothingSpeedModifier
+    walkModifier: 0.90
+    sprintModifier: 0.85
   - type: Armor
     modifiers:
       coefficients:
         Blunt: 0.8
         Slash: 0.8
-        Piercing: 0.7
-  - type: ClothingSpeedModifier
-    walkModifier: 0.65
-    sprintModifier: 0.65
+        Piercing: 0.75
+        Heat: 0.9
+        Caustic: 0.2
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitBrigmedic
 
@@ -245,27 +263,28 @@
   parent: ClothingOuterHardsuitBase
   id: ClothingOuterHardsuitWarden
   name: warden's hardsuit
-  description: A specialized riot suit geared to combat low pressure environments.
+  description: A specialized riot suit geared to combat low pressure environments while maintaining agility.
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Hardsuits/security-warden.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/security-warden.rsi
   - type: PressureProtection
-    highPressureMultiplier: 0.5
-    lowPressureMultiplier: 1000
-  - type: ExplosionResistance
-    damageCoefficient: 0.4
+    highPressureMultiplier: 0.525
+    lowPressureMultiplier: 10000
+  - type: ClothingSpeedModifier
+    walkModifier: 0.85
+    sprintModifier: 0.75
   - type: Armor
     modifiers:
       coefficients:
         Blunt: 0.5
         Slash: 0.6
         Piercing: 0.6
-        Caustic: 0.7
-  - type: ClothingSpeedModifier
-    walkModifier: 0.7
-    sprintModifier: 0.7
+        Heat: 0.8
+        Caustic: 0.75
+  - type: ExplosionResistance
+    damageCoefficient: 0.4
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitWarden
 
@@ -283,20 +302,20 @@
   - type: PressureProtection
     highPressureMultiplier: 0.02
     lowPressureMultiplier: 1000
-  - type: ExplosionResistance
-    damageCoefficient: 0.5
+  - type: ClothingSpeedModifier
+    walkModifier: 0.8
+    sprintModifier: 0.8
   - type: Armor
     modifiers:
       coefficients:
         Blunt: 0.8
         Slash: 0.8
-        Piercing: 0.8
-        Heat: 0.5
-        Radiation: 0.5
+        Piercing: 0.75
+        Heat: 0.3
+        Radiation: 0.50
         Caustic: 0.6
-  - type: ClothingSpeedModifier
-    walkModifier: 0.8
-    sprintModifier: 0.8
+  - type: ExplosionResistance
+    damageCoefficient: 0.5
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitCap
 
@@ -314,20 +333,20 @@
   - type: PressureProtection
     highPressureMultiplier: 0.02
     lowPressureMultiplier: 1000
-  - type: ExplosionResistance
-    damageCoefficient: 0.2
-  - type: Armor
-    modifiers:
-      coefficients:
-        Blunt: 0.8
-        Slash: 0.8
-        Piercing: 0.8
-        Heat: 0.4
-        Radiation: 0.0
-        Caustic: 0.7
   - type: ClothingSpeedModifier
     walkModifier: 0.75
     sprintModifier: 0.8
+  - type: Armor
+    modifiers:
+      coefficients:
+        Blunt: 0.85
+        Slash: 0.85
+        Piercing: 0.8
+        Heat: 0.4
+        Radiation: 0.0
+        Caustic: 0.75
+  - type: ExplosionResistance
+    damageCoefficient: 0.2
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitEngineeringWhite
 
@@ -344,14 +363,15 @@
     sprite: Clothing/OuterClothing/Hardsuits/medical.rsi
   - type: PressureProtection
     highPressureMultiplier: 0.3
-    lowPressureMultiplier: 1000
-  - type: Armor
-    modifiers:
-      coefficients:
-        Caustic: 0.1
+    lowPressureMultiplier: 5500
   - type: ClothingSpeedModifier
     walkModifier: 0.9
     sprintModifier: 0.95
+  - type: Armor
+    modifiers:
+      coefficients:
+        Heat: 0.90
+        Caustic: 0.1
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitMedical
 
@@ -360,7 +380,7 @@
   parent: ClothingOuterHardsuitBase
   id: ClothingOuterHardsuitRd
   name: experimental research hardsuit
-  description: A special suit that protects against hazardous, low pressure environments. Has an additional layer of armor. Able to be compressed to small sizes.
+  description: A special suit that protects against hazardous, low pressure environments. Has an additional layer of armor.
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Hardsuits/rd.rsi
@@ -368,27 +388,27 @@
     sprite: Clothing/OuterClothing/Hardsuits/rd.rsi
   - type: PressureProtection
     highPressureMultiplier: 0.02
-    lowPressureMultiplier: 1000
+    lowPressureMultiplier: 5500
   - type: Armor
     modifiers:
       coefficients:
         Blunt: 0.6
         Slash: 0.8
-        Piercing: 0.9
+        Piercing: 0.95
         Heat: 0.3
         Radiation: 0.1
-        Caustic: 0.2
-  - type: ExplosionResistance
-    damageCoefficient: 0.1
+        Caustic: 0.25
   - type: ClothingSpeedModifier
     walkModifier: 0.75
     sprintModifier: 0.75
   - type: Item
-    size: 50
+    size: 100
   - type: Tag
     tags:
     - WhitelistChameleon
     - HighRiskItem
+  - type: ExplosionResistance
+    damageCoefficient: 0.1
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitRd
   - type: StaticPrice
@@ -407,20 +427,21 @@
     sprite: Clothing/OuterClothing/Hardsuits/security-red.rsi
   - type: PressureProtection
     highPressureMultiplier: 0.45
-    lowPressureMultiplier: 1000
-  - type: ExplosionResistance
-    damageCoefficient: 0.6
+    lowPressureMultiplier: 10000
+  - type: ClothingSpeedModifier
+    walkModifier: 0.85
+    sprintModifier: 0.75
   - type: Armor
     modifiers:
       coefficients:
         Blunt: 0.6
         Slash: 0.5
         Piercing: 0.5
-        Radiation: 0.5
+        Heat: 0.8
+        Radiation: 0.25
         Caustic: 0.6
-  - type: ClothingSpeedModifier
-    walkModifier: 0.8
-    sprintModifier: 0.8
+  - type: ExplosionResistance
+    damageCoefficient: 0.6
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSecurityRed
 
@@ -439,20 +460,20 @@
   - type: PressureProtection
     highPressureMultiplier: 0.05
     lowPressureMultiplier: 1000
-  - type: ExplosionResistance
-    damageCoefficient: 0.5
-  - type: Armor
-    modifiers:
-      coefficients:
-        Blunt: 0.5
-        Slash: 0.5
-        Piercing: 0.5
-        Heat: 0.5
-        Radiation: 0.5
-        Caustic: 0.5
   - type: ClothingSpeedModifier
     walkModifier: 0.9
     sprintModifier: 0.9
+  - type: Armor
+    modifiers:
+      coefficients:
+        Blunt: 0.65
+        Slash: 0.6
+        Piercing: 0.5
+        Heat: 0.4
+        Radiation: 0.50
+        Caustic: 0.75
+  - type: ExplosionResistance
+    damageCoefficient: 0.5
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSyndie
 
@@ -470,20 +491,20 @@
   - type: PressureProtection
     highPressureMultiplier: 0.2
     lowPressureMultiplier: 1000
-  - type: ExplosionResistance
-    damageCoefficient: 0.3
+  - type: ClothingSpeedModifier
+    walkModifier: 0.6
+    sprintModifier: 0.6 #extremely slow
   - type: Armor
     modifiers:
       coefficients:
         Blunt: 0.2
         Slash: 0.2
         Piercing: 0.2
-        Heat: 0.2
-        Radiation: 0.2
-        Caustic: 0.2
-  - type: ClothingSpeedModifier
-    walkModifier: 0.9
-    sprintModifier: 0.65
+        Heat: 0.5
+        Radiation: 0.25
+        Caustic: 0.35
+  - type: ExplosionResistance
+    damageCoefficient: 0.8
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitCybersun
 
@@ -501,10 +522,11 @@
   - type: PressureProtection
     highPressureMultiplier: 0.02
     lowPressureMultiplier: 1000
+  - type: ClothingSpeedModifier
+    walkModifier: 1.0
+    sprintModifier: 1.0
   - type: TemperatureProtection
     coefficient: 0.001
-  - type: ExplosionResistance
-    damageCoefficient: 0.3
   - type: Armor
     modifiers:
       coefficients:
@@ -514,9 +536,8 @@
         Heat: 0.2
         Radiation: 0.25
         Caustic: 0.5
-  - type: ClothingSpeedModifier
-    walkModifier: 1.0
-    sprintModifier: 1.0
+  - type: ExplosionResistance
+    damageCoefficient: 0.3
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSyndieElite
 
@@ -534,20 +555,20 @@
   - type: PressureProtection
     highPressureMultiplier: 0.05
     lowPressureMultiplier: 1000
-  - type: ExplosionResistance
-    damageCoefficient: 0.5
+  - type: ClothingSpeedModifier
+    walkModifier: 1.0
+    sprintModifier: 1.0
   - type: Armor
     modifiers:
       coefficients:
         Blunt: 0.4
         Slash: 0.4
         Piercing: 0.3
-        Heat: 0.5
+        Heat: 0.3
         Radiation: 0.25
         Caustic: 0.4
-  - type: ClothingSpeedModifier
-    walkModifier: 1.0
-    sprintModifier: 1.0
+  - type: ExplosionResistance
+    damageCoefficient: 0.5
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSyndieCommander
 
@@ -565,8 +586,9 @@
   - type: PressureProtection
     highPressureMultiplier: 0.05
     lowPressureMultiplier: 1000
-  - type: ExplosionResistance
-    damageCoefficient: 0.5
+  - type: ClothingSpeedModifier
+    walkModifier: 0.8
+    sprintModifier: 0.8
   - type: Armor
     modifiers:
       coefficients:
@@ -576,9 +598,8 @@
         Heat: 0.25
         Radiation: 0.25
         Caustic: 0.75
-  - type: ClothingSpeedModifier
-    walkModifier: 0.8
-    sprintModifier: 0.8
+  - type: ExplosionResistance
+    damageCoefficient: 0.5
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitWizard
 
@@ -595,9 +616,10 @@
     sprite: Clothing/OuterClothing/Hardsuits/lingspacesuit.rsi
   - type: PressureProtection
     highPressureMultiplier: 0.225
-    lowPressureMultiplier: 1000
-  - type: ExplosionResistance
-    damageCoefficient: 0.2
+    lowPressureMultiplier: 10000
+  - type: ClothingSpeedModifier
+    walkModifier: .8
+    sprintModifier: .8
   - type: Armor
     modifiers:
       coefficients:
@@ -605,9 +627,8 @@
         Slash: 0.95
         Piercing: 1
         Heat: 0.5
-  - type: ClothingSpeedModifier
-    walkModifier: 0.8
-    sprintModifier: 0.8
+  - type: ExplosionResistance
+    damageCoefficient: 0.2
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitLing
 
@@ -624,8 +645,9 @@
     sprite: Clothing/OuterClothing/Hardsuits/pirateeva.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/pirateeva.rsi
-  - type: ExplosionResistance
-    damageCoefficient: 0.7
+  - type: ClothingSpeedModifier
+    walkModifier: 0.6
+    sprintModifier: 0.6
   - type: Armor
     modifiers:
       coefficients:
@@ -634,9 +656,8 @@
         Piercing: 0.9
         Heat: 0.4
         Caustic: 0.75
-  - type: ClothingSpeedModifier
-    walkModifier: 0.6
-    sprintModifier: 0.6
+  - type: ExplosionResistance
+    damageCoefficient: 0.7
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitPirateEVA
 
@@ -654,8 +675,9 @@
   - type: PressureProtection
     highPressureMultiplier: 0.02
     lowPressureMultiplier: 1000
-  - type: ExplosionResistance
-    damageCoefficient: 0.6
+  - type: ClothingSpeedModifier
+    walkModifier: 0.8
+    sprintModifier: 0.8
   - type: Armor
     modifiers:
       coefficients:
@@ -664,9 +686,8 @@
         Piercing: 0.85
         Heat: 0.4
         Caustic: 0.75
-  - type: ClothingSpeedModifier
-    walkModifier: 0.8
-    sprintModifier: 0.8
+  - type: ExplosionResistance
+    damageCoefficient: 0.6
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitPirateCap
 
@@ -752,22 +773,20 @@
   - type: PressureProtection
     highPressureMultiplier: 0.02
     lowPressureMultiplier: 1000
-  - type: TemperatureProtection
-    coefficient: 0.001
-  - type: ExplosionResistance
-    damageCoefficient: 0.2
+  - type: ClothingSpeedModifier
+    walkModifier: 1.0
+    sprintModifier: 1.0
   - type: Armor
     modifiers:
       coefficients:
         Blunt: 0.2 #best armor in the game
         Slash: 0.2
         Piercing: 0.2
-        Heat: 0.1
+        Heat: 0.2
         Radiation: 0.1
         Caustic: 0.2
-  - type: ClothingSpeedModifier
-    walkModifier: 1.0
-    sprintModifier: 1.0
+  - type: ExplosionResistance
+    damageCoefficient: 0.2
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitDeathsquad
 
@@ -785,24 +804,24 @@
   - type: PressureProtection
     highPressureMultiplier: 0.02
     lowPressureMultiplier: 1000
+  - type: ClothingSpeedModifier
+    walkModifier: 1.0
+    sprintModifier: 1.0
   - type: TemperatureProtection
     coefficient: 0.001
-  - type: ExplosionResistance
-    damageCoefficient: 0.7
   - type: Armor
     modifiers:
       coefficients:
         Blunt: 0.7
         Slash: 0.7
         Piercing: 0.6
-        Heat: 0.1
+        Heat: 0.05
         Cold: 0.1
         Shock: 0.1
         Radiation: 0.1
         Caustic: 0.1
-  - type: ClothingSpeedModifier
-    walkModifier: 1.0
-    sprintModifier: 1.0
+  - type: ExplosionResistance
+    damageCoefficient: 0.7
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetCBURN
 
@@ -819,20 +838,20 @@
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/clown.rsi
   - type: PressureProtection
-    highPressureMultiplier: 0.5
-    lowPressureMultiplier: 1000
-  - type: ExplosionResistance
-    damageCoefficient: 0.9
+    highPressureMultiplier: 0.525
+    lowPressureMultiplier: 10000
+  - type: ClothingSpeedModifier
+    walkModifier: 0.9
+    sprintModifier: 0.9
   - type: Armor
     modifiers:
       coefficients:
         Blunt: 0.9
         Slash: 0.9
         Piercing: 0.9
-        Caustic: 0.8
-  - type: ClothingSpeedModifier
-    walkModifier: 0.9
-    sprintModifier: 0.9
+        Caustic: 0.85
+  - type: ExplosionResistance
+    damageCoefficient: 0.9
   - type: Construction
     graph: ClownHardsuit
     node: clownHardsuit

--- a/Resources/Prototypes/Recipes/Construction/Graphs/clothing/security_hardsuit.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/clothing/security_hardsuit.yml
@@ -1,0 +1,25 @@
+﻿- type: constructionGraph
+  id: SecHardsuit
+  start: start
+  graph:
+    - node: start
+      edges:
+        - to: securityhardsuit
+          steps:
+            - tag: SecPatrolHardsuit
+              name: A Security Patrol Hardsuit
+              icon: 
+                sprite: Clothing/OuterClothing/Hardsuits/security-patrol.rsi
+                state: icon
+            - material: Plasteel
+              amount: 2
+              doAfter: 2
+            - material: Durathread
+              amount: 5
+              doAfter: 8
+          completed:
+            - !type:PopupUser
+              cursor: true
+              text: You've refasten the outer composite armor
+    - node: securityhardsuit
+      entity: ClothingOuterHardsuitSecurity

--- a/Resources/Prototypes/Recipes/Construction/Graphs/clothing/security_patrol_hardsuit.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/clothing/security_patrol_hardsuit.yml
@@ -1,0 +1,26 @@
+﻿- type: constructionGraph
+  id: SecPatrolHardsuit
+  start: start
+  graph:
+    - node: start
+      edges:
+        - to: securitypatrolhardsuit
+          steps:
+            - tag: SecHardsuit
+              name: A Security Hardsuit
+              icon: 
+                sprite: Clothing/OuterClothing/Hardsuits/security.rsi
+                state: icon
+              doAfter: 10
+          completed:
+            - !type:SpawnPrototype
+              prototype: SheetPlasteel1
+              amount: 2
+            - !type:SpawnPrototype
+              prototype: MaterialDurathread1
+              amount: 5
+            - !type:PopupUser
+              cursor: true
+              text: You've removed the outer composite armor
+    - node: securitypatrolhardsuit
+      entity: ClothingOuterHardsuitSecuritypatrol

--- a/Resources/Prototypes/Recipes/Construction/clothing.yml
+++ b/Resources/Prototypes/Recipes/Construction/clothing.yml
@@ -8,3 +8,25 @@
   description: A modified hardsuit fit for a clown.
   icon: { sprite: Clothing/OuterClothing/Hardsuits/clown.rsi, state: icon }
   objectType: Item
+  
+- type: construction
+  name: security patrol hardsuit
+  id: SecPatrolHardsuit
+  graph: SecPatrolHardsuit
+  startNode: start
+  targetNode: securitypatrolhardsuit
+  category: construction-category-clothing
+  description: Remove the layer of outer composite armor.
+  icon: { sprite: Clothing/OuterClothing/Hardsuits/security-patrol.rsi, state: icon }
+  objectType: Item
+  
+- type: construction
+  name: security patrol hardsuit
+  id: SecHardsuit
+  graph: SecHardsuit
+  startNode: start
+  targetNode: securityhardsuit
+  category: construction-category-clothing
+  description: Reattach the outer layer of composite armor.
+  icon: { sprite: Clothing/OuterClothing/Hardsuits/security.rsi, state: icon }
+  objectType: Item

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -8,9 +8,6 @@
   id: AirSensor
 
 - type: Tag
-  id: Ambrosia
-
-- type: Tag
   id: AppraisalTool
 
 - type: Tag
@@ -23,13 +20,7 @@
   id: Baguette
 
 - type: Tag
-  id: Balloon
-
-- type: Tag
   id: BaseballBat
-
-- type: Tag
-  id: BBQsauce
 
 - type: Tag
   id: Bee
@@ -50,130 +41,16 @@
   id: BorgArm
 
 - type: Tag
-  id: BorgEngineerHead
-
-- type: Tag
-  id: BorgEngineerLArm
-
-- type: Tag
-  id: BorgEngineerLLeg
-
-- type: Tag
-  id: BorgEngineerRArm
-
-- type: Tag
-  id: BorgEngineerRLeg
-
-- type: Tag
-  id: BorgEngineerTorso
-
-- type: Tag
-  id: BorgGenericHead
-
-- type: Tag
-  id: BorgGenericLArm
-
-- type: Tag
-  id: BorgGenericLLeg
-
-- type: Tag
-  id: BorgGenericRArm
-
-- type: Tag
-  id: BorgGenericRLeg
-
-- type: Tag
-  id: BorgGenericTorso
-
-- type: Tag
   id: BorgHead
-
-- type: Tag
-  id: BorgJanitorHead
-
-- type: Tag
-  id: BorgJanitorLLeg
-
-- type: Tag
-  id: BorgJanitorRLeg
-
-- type: Tag
-  id: BorgJanitorTorso
 
 - type: Tag
   id: BorgLeg
 
 - type: Tag
-  id: BorgMedicalHead
+  id: BorgLeftLeg
 
 - type: Tag
-  id: BorgMedicalLArm
-
-- type: Tag
-  id: BorgMedicalLLeg
-
-- type: Tag
-  id: BorgMedicalRArm
-
-- type: Tag
-  id: BorgMedicalRLeg
-
-- type: Tag
-  id: BorgMedicalTorso
-
-- type: Tag
-  id: BorgMiningHead
-
-- type: Tag
-  id: BorgMiningLArm
-
-- type: Tag
-  id: BorgMiningLLeg
-
-- type: Tag
-  id: BorgMiningRArm
-
-- type: Tag
-  id: BorgMiningRLeg
-
-- type: Tag
-  id: BorgMiningTorso
-
-- type: Tag
-  id: BorgModuleCargo
-
-- type: Tag
-  id: BorgModuleEngineering
-
-- type: Tag
-  id: BorgModuleGeneric
-
-- type: Tag
-  id: BorgModuleJanitor
-
-- type: Tag
-  id: BorgModuleMedical
-
-- type: Tag
-  id: BorgModuleService
-
-- type: Tag
-  id: BorgServiceHead
-
-- type: Tag
-  id: BorgServiceLArm
-
-- type: Tag
-  id: BorgServiceLLeg
-
-- type: Tag
-  id: BorgServiceRArm
-
-- type: Tag
-  id: BorgServiceRLeg
-
-- type: Tag
-  id: BorgServiceTorso
+  id: BorgRightLeg
 
 - type: Tag
   id: BotanyHatchet
@@ -213,9 +90,6 @@
 
 - type: Tag
   id: CableCoil
-
-- type: Tag
-  id: CapacitorStockPart
 
 - type: Tag
   id: Carrot
@@ -288,9 +162,6 @@
   id: CigPack
 
 - type: Tag
-  id: ClothMade
-
-- type: Tag
   id: ClownMask
 
 - type: Tag
@@ -307,9 +178,6 @@
 
 - type: Tag #Ohioans die happy
   id: Corn
-
-- type: Tag
-  id: Coldsauce
 
 - type: Tag
   id: Cow
@@ -399,9 +267,6 @@
   id: Donut
 
 - type: Tag
-  id: DrinkSpaceGlue
-
-- type: Tag
   id: DroneUsable
 
 - type: Tag
@@ -454,9 +319,6 @@
 
 - type: Tag
   id: Folder
-
-- type: Tag
-  id: FoodSnack
 
 - type: Tag
   id: FootstepSound
@@ -580,9 +442,6 @@
 - type: Tag
   id: HonkerRArm
 
-- type: Tag
-  id: Hotsauce
-
 - type: Tag #Drop this innate tool instead of deleting it.
   id: InnateDontDelete
 
@@ -607,8 +466,6 @@
 - type: Tag
   id: Kangaroo
 
-- type: Tag
-  id: Ketchup
 
 - type: Tag
   id: KeyedInstrument
@@ -723,6 +580,8 @@
 - type: Tag
   id: Multitool
 
+- type: Tag
+  id: NoSpinOnThrow
 
 - type: Tag
   id: NoBlockAnchoring
@@ -795,9 +654,6 @@
 
 
 - type: Tag
-  id: PowerCellSmall
-
-- type: Tag
   id: Powerdrill
 
 - type: Tag
@@ -854,6 +710,12 @@
 
 - type: Tag
   id: SecBeltEquip
+  
+- type: Tag
+  id: SecHardsuit
+  
+- type: Tag
+  id: SecPatrolHardsuit
 
 - type: Tag
   id: SecwayKeys
@@ -977,12 +839,6 @@
 
 - type: Tag
   id: VehicleKey
-
-- type: Tag
-  id: VimPilot
-
-- type: Tag
-  id: VoiceTrigger
 
 - type: Tag
   id: Wall

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -8,6 +8,9 @@
   id: AirSensor
 
 - type: Tag
+  id: Ambrosia
+
+- type: Tag
   id: AppraisalTool
 
 - type: Tag
@@ -20,7 +23,13 @@
   id: Baguette
 
 - type: Tag
+  id: Balloon
+
+- type: Tag
   id: BaseballBat
+
+- type: Tag
+  id: BBQsauce
 
 - type: Tag
   id: Bee
@@ -41,16 +50,130 @@
   id: BorgArm
 
 - type: Tag
+  id: BorgEngineerHead
+
+- type: Tag
+  id: BorgEngineerLArm
+
+- type: Tag
+  id: BorgEngineerLLeg
+
+- type: Tag
+  id: BorgEngineerRArm
+
+- type: Tag
+  id: BorgEngineerRLeg
+
+- type: Tag
+  id: BorgEngineerTorso
+
+- type: Tag
+  id: BorgGenericHead
+
+- type: Tag
+  id: BorgGenericLArm
+
+- type: Tag
+  id: BorgGenericLLeg
+
+- type: Tag
+  id: BorgGenericRArm
+
+- type: Tag
+  id: BorgGenericRLeg
+
+- type: Tag
+  id: BorgGenericTorso
+
+- type: Tag
   id: BorgHead
+
+- type: Tag
+  id: BorgJanitorHead
+
+- type: Tag
+  id: BorgJanitorLLeg
+
+- type: Tag
+  id: BorgJanitorRLeg
+
+- type: Tag
+  id: BorgJanitorTorso
 
 - type: Tag
   id: BorgLeg
 
 - type: Tag
-  id: BorgLeftLeg
+  id: BorgMedicalHead
 
 - type: Tag
-  id: BorgRightLeg
+  id: BorgMedicalLArm
+
+- type: Tag
+  id: BorgMedicalLLeg
+
+- type: Tag
+  id: BorgMedicalRArm
+
+- type: Tag
+  id: BorgMedicalRLeg
+
+- type: Tag
+  id: BorgMedicalTorso
+
+- type: Tag
+  id: BorgMiningHead
+
+- type: Tag
+  id: BorgMiningLArm
+
+- type: Tag
+  id: BorgMiningLLeg
+
+- type: Tag
+  id: BorgMiningRArm
+
+- type: Tag
+  id: BorgMiningRLeg
+
+- type: Tag
+  id: BorgMiningTorso
+
+- type: Tag
+  id: BorgModuleCargo
+
+- type: Tag
+  id: BorgModuleEngineering
+
+- type: Tag
+  id: BorgModuleGeneric
+
+- type: Tag
+  id: BorgModuleJanitor
+
+- type: Tag
+  id: BorgModuleMedical
+
+- type: Tag
+  id: BorgModuleService
+
+- type: Tag
+  id: BorgServiceHead
+
+- type: Tag
+  id: BorgServiceLArm
+
+- type: Tag
+  id: BorgServiceLLeg
+
+- type: Tag
+  id: BorgServiceRArm
+
+- type: Tag
+  id: BorgServiceRLeg
+
+- type: Tag
+  id: BorgServiceTorso
 
 - type: Tag
   id: BotanyHatchet
@@ -90,6 +213,9 @@
 
 - type: Tag
   id: CableCoil
+
+- type: Tag
+  id: CapacitorStockPart
 
 - type: Tag
   id: Carrot
@@ -162,6 +288,9 @@
   id: CigPack
 
 - type: Tag
+  id: ClothMade
+
+- type: Tag
   id: ClownMask
 
 - type: Tag
@@ -178,6 +307,9 @@
 
 - type: Tag #Ohioans die happy
   id: Corn
+
+- type: Tag
+  id: Coldsauce
 
 - type: Tag
   id: Cow
@@ -267,6 +399,9 @@
   id: Donut
 
 - type: Tag
+  id: DrinkSpaceGlue
+
+- type: Tag
   id: DroneUsable
 
 - type: Tag
@@ -319,6 +454,9 @@
 
 - type: Tag
   id: Folder
+
+- type: Tag
+  id: FoodSnack
 
 - type: Tag
   id: FootstepSound
@@ -442,6 +580,9 @@
 - type: Tag
   id: HonkerRArm
 
+- type: Tag
+  id: Hotsauce
+
 - type: Tag #Drop this innate tool instead of deleting it.
   id: InnateDontDelete
 
@@ -466,6 +607,8 @@
 - type: Tag
   id: Kangaroo
 
+- type: Tag
+  id: Ketchup
 
 - type: Tag
   id: KeyedInstrument
@@ -580,8 +723,6 @@
 - type: Tag
   id: Multitool
 
-- type: Tag
-  id: NoSpinOnThrow
 
 - type: Tag
   id: NoBlockAnchoring
@@ -654,6 +795,9 @@
 
 
 - type: Tag
+  id: PowerCellSmall
+
+- type: Tag
   id: Powerdrill
 
 - type: Tag
@@ -710,13 +854,13 @@
 
 - type: Tag
   id: SecBeltEquip
-  
+
 - type: Tag
   id: SecHardsuit
   
 - type: Tag
   id: SecPatrolHardsuit
-
+  
 - type: Tag
   id: SecwayKeys
 
@@ -839,6 +983,12 @@
 
 - type: Tag
   id: VehicleKey
+
+- type: Tag
+  id: VimPilot
+
+- type: Tag
+  id: VoiceTrigger
 
 - type: Tag
   id: Wall


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
This PR adds two new crafting recipes to utilize the Security Patrol Hardsuit and hopefully get it into the players hands. The first recipe uses a regular Security Hardsuit to craft a Security Patrol Hardsuit while giving two plasteel and five durathread (the stripped armor from the crafting process). The second recipe takes the materials recieved from stripping the armor and the Patrol Hardsuit to craft a Regular Hardsuit. Both crafting recipes have a 10 second doafter for each to complete, and the recipes are found through the in game crafting (G) menu. The video below shows both recipes in usage.


**Media**

https://github.com/new-frontiers-14/frontier-station-14/assets/108775472/c187aa25-1a14-4791-84ce-03b9fc47ab87





:cl:
- Add: Adds a new crafting recipe for the Security Patrol Hardsuit using a regular Security Hardsuit
- Add: Adds a new crafting recipe for the regular Security Hardsuit using a Security Patrol Hardsuit, 2 plasteel, and 5 durathread.
