### PR TITLE
Station-Representative

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -128,9 +128,9 @@
       - id: AccessConfigurator
       - id: MedalCase
       - id: JetpackCaptainFilled
-      - id: ClothingHandsGlovesCaptain
-      - id: ClothingOuterHardsuitCap
-      - id: ClothingMaskGasCaptain
+#      - id: ClothingHandsGlovesCaptain #TODO replace with new item!
+#      - id: ClothingOuterHardsuitCap #TODO replace with new item!
+#      - id: ClothingMaskGasCaptain #TODO replace with new item!
       - id: ClothingBeltSheathFilled
 
 - type: entity

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -127,11 +127,11 @@
 #        prob: 0.5
       - id: AccessConfigurator
       - id: MedalCase
-      - id: JetpackCaptainFilled
+#      - id: JetpackCaptainFilled #TODO replace with new item!
+#      - id: ClothingBeltSheathFilled #TODO replace with new item!
 #      - id: ClothingHandsGlovesCaptain #TODO replace with new item!
 #      - id: ClothingOuterHardsuitCap #TODO replace with new item!
 #      - id: ClothingMaskGasCaptain #TODO replace with new item!
-      - id: ClothingBeltSheathFilled
 
 - type: entity
   id: LockerChiefEngineerFilledHardsuit

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -41,6 +41,7 @@
       - id: ClothingOuterHardsuitCap
       - id: ClothingMaskGasCaptain
       - id: WeaponDisabler
+        prob: 0.25
 #      - id: CommsComputerCircuitboard
 #      - id: ClothingHeadsetAltCommand
 #      - id: SpaceCash1000
@@ -49,14 +50,16 @@
       - id: CigarGoldCase
         prob: 0.25
       - id: ClothingBeltSheathFilled
+        prob: 0.25
 #      - id: DoorRemoteCommand
       - id: ClothingNeckCloakCapFormal
       - id: ClothingUniformJumpsuitCapFormal
       - id: ClothingUniformJumpskirtCapFormalDress
       - id: RubberStampCaptain
       - id: WeaponAntiqueLaser
+        prob: 0.25
       - id: JetpackCaptainFilled
-      - id: MedalCase
+#      - id: MedalCase
 
 - type: entity
   id: LockerCaptainFilled
@@ -73,6 +76,7 @@
       - id: ClothingNeckCloakCap
       - id: ClothingHandsGlovesCaptain
       - id: WeaponDisabler
+        prob: 0.25
 #      - id: CommsComputerCircuitboard
 #      - id: ClothingHeadsetAltCommand
 #      - id: SpaceCash1000
@@ -81,14 +85,16 @@
       - id: CigarGoldCase
         prob: 0.25
       - id: ClothingBeltSheathFilled
+        prob: 0.25
 #      - id: DoorRemoteCommand
       - id: ClothingNeckCloakCapFormal
       - id: ClothingUniformJumpsuitCapFormal
       - id: ClothingUniformJumpskirtCapFormalDress
       - id: RubberStampCaptain
       - id: WeaponAntiqueLaser
+        prob: 0.25
       - id: JetpackCaptainFilled
-      - id: MedalCase
+#      - id: MedalCase
       - id: ClothingHeadHatCapcap
 
 - type: entity
@@ -118,8 +124,14 @@
       - id: BoxEncryptionKeyPassenger
       - id: BoxEncryptionKeyService
       - id: ClothingBackpackIan
-        prob: 0.5
+#        prob: 0.5
       - id: AccessConfigurator
+      - id: MedalCase
+      - id: JetpackCaptainFilled
+      - id: ClothingHandsGlovesCaptain
+      - id: ClothingOuterHardsuitCap
+      - id: ClothingMaskGasCaptain
+      - id: ClothingBeltSheathFilled
 
 - type: entity
   id: LockerChiefEngineerFilledHardsuit

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -40,8 +40,7 @@
       - id: ClothingHandsGlovesCaptain
       - id: ClothingOuterHardsuitCap
       - id: ClothingMaskGasCaptain
-      - id: WeaponDisabler
-        prob: 0.25
+#      - id: WeaponDisabler
 #      - id: CommsComputerCircuitboard
 #      - id: ClothingHeadsetAltCommand
 #      - id: SpaceCash1000
@@ -49,15 +48,13 @@
         prob: 0.1
       - id: CigarGoldCase
         prob: 0.25
-      - id: ClothingBeltSheathFilled
-        prob: 0.25
+#      - id: ClothingBeltSheathFilled
 #      - id: DoorRemoteCommand
       - id: ClothingNeckCloakCapFormal
       - id: ClothingUniformJumpsuitCapFormal
       - id: ClothingUniformJumpskirtCapFormalDress
       - id: RubberStampCaptain
-      - id: WeaponAntiqueLaser
-        prob: 0.25
+#      - id: WeaponAntiqueLaser
       - id: JetpackCaptainFilled
 #      - id: MedalCase
 
@@ -75,8 +72,7 @@
       - id: ClothingHeadHatCaptain
       - id: ClothingNeckCloakCap
       - id: ClothingHandsGlovesCaptain
-      - id: WeaponDisabler
-        prob: 0.25
+#      - id: WeaponDisabler
 #      - id: CommsComputerCircuitboard
 #      - id: ClothingHeadsetAltCommand
 #      - id: SpaceCash1000
@@ -84,15 +80,13 @@
         prob: 0.1
       - id: CigarGoldCase
         prob: 0.25
-      - id: ClothingBeltSheathFilled
-        prob: 0.25
+#      - id: ClothingBeltSheathFilled
 #      - id: DoorRemoteCommand
       - id: ClothingNeckCloakCapFormal
       - id: ClothingUniformJumpsuitCapFormal
       - id: ClothingUniformJumpskirtCapFormalDress
       - id: RubberStampCaptain
-      - id: WeaponAntiqueLaser
-        prob: 0.25
+#      - id: WeaponAntiqueLaser
       - id: JetpackCaptainFilled
 #      - id: MedalCase
       - id: ClothingHeadHatCapcap

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/cart.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/cart.yml
@@ -1,16 +1,19 @@
 - type: vendingMachineInventory
   id: PTechInventory
   startingInventory:
-    PassengerPDA: 5
-    ClearPDA: 5
+    PassengerPDA: 10
+    ClearPDA: 10
     PassengerIDCard: 20
-    ClothingHeadsetGrey: 5
-    RubberStampApproved: 1
-    RubberStampDenied: 1
-    Paper: 100
+    ClothingHeadsetGrey: 10
+    RubberStampApproved: 3
+    RubberStampDenied: 3
+    Paper: 50
+    PaperCaptainsThoughts: 20
+    EncryptionKeySecurity: 10
     EncryptionKeyCargo: 20
     EncryptionKeyEngineering: 20
     EncryptionKeyMedical: 20
     EncryptionKeyScience: 20
-    EncryptionKeySecurity: 10
+    EncryptionKeyCommon: 30
     EncryptionKeyService: 30
+    EncryptionKeyCommand: 30

--- a/Resources/Prototypes/Entities/Objects/Devices/encryption_keys.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/encryption_keys.yml
@@ -10,6 +10,8 @@
     sprite: Objects/Devices/encryption_keys.rsi
   - type: Sprite
     sprite: Objects/Devices/encryption_keys.rsi
+  - type: StaticPrice
+    price: 2
 
 - type: entity
   parent: EncryptionKey
@@ -92,8 +94,6 @@
     layers:
     - state: crypt_silver
     - state: com_label
-  - type: StaticPrice
-    price: 7.5
 
 - type: entity
   parent: EncryptionKey

--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -107,6 +107,8 @@
     - DoorBumpOpener
   - type: Input
     context: "human"
+  - type: StaticPrice
+    price: 20 # The card need to cost less then the PDA that comes with a card and a pen in it.
   - type: CargoSellBlacklist # Liltenhead moment
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
@@ -20,7 +20,7 @@
     tags:
     - DoorBumpOpener
   - type: StaticPrice
-    price: 150
+    price: 5 # The card need to cost less then the PDA that comes with a card and a pen in it.
   - type: CargoSellBlacklist # Liltenhead moment
 
 #IDs with layers

--- a/Resources/Prototypes/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/paper.yml
@@ -106,7 +106,8 @@
   name: station representative thoughts
   parent: Paper
   id: PaperCaptainsThoughts
-  description: "A page of the station representative journal. In luxurious lavender."
+  description: "A page of the captain's journal. In luxurious lavender."
+  #description: "A page of the station representative journal. In luxurious lavender."
   components:
   - type: Sprite
     sprite: Objects/Misc/bureaucracy.rsi

--- a/Resources/Prototypes/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/paper.yml
@@ -103,7 +103,8 @@
     maxWritableArea: 400.0, 0.0
 
 - type: entity
-  name: station representative thoughts
+  name: captain's thoughts
+  #name: station representative thoughts
   parent: Paper
   id: PaperCaptainsThoughts
   description: "A page of the captain's journal. In luxurious lavender."

--- a/Resources/Prototypes/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/paper.yml
@@ -103,10 +103,10 @@
     maxWritableArea: 400.0, 0.0
 
 - type: entity
-  name: captain's thoughts
+  name: station representative thoughts
   parent: Paper
   id: PaperCaptainsThoughts
-  description: "A page of the captain's journal. In luxurious lavender."
+  description: "A page of the station representative journal. In luxurious lavender."
   components:
   - type: Sprite
     sprite: Objects/Misc/bureaucracy.rsi
@@ -251,6 +251,8 @@
   - type: PhysicalComposition
     materialComposition:
       Steel: 25
+  - type: StaticPrice
+    price: 1
 
 - type: entity
   name: Cybersun pen
@@ -279,6 +281,8 @@
     sprite: Objects/Misc/bureaucracy.rsi
     heldPrefix: overpriced_pen
     size: 2
+  - type: StaticPrice
+    price: 20
 
 - type: entity
   name: captain's fountain pen
@@ -289,6 +293,8 @@
   - type: Sprite
     sprite: Objects/Misc/bureaucracy.rsi
     state: pen_cap
+  - type: StaticPrice
+    price: 10
 
 - type: entity
   name: Centcom pen
@@ -312,6 +318,8 @@
   - type: Sprite
     sprite: Objects/Misc/bureaucracy.rsi
     state: pen_hop
+  - type: StaticPrice
+    price: 10
 
 - type: entity
   id: BoxFolderBase
@@ -475,6 +483,8 @@
       params:
         volume: -2
         maxdistance: 5
+  - type: StaticPrice
+    price: 3
 
 - type: entity
   name: captain's rubber stamp


### PR DESCRIPTION
## About the PR
Station Representative related update
After playing as SR for sometime I noted few small issues with his locker content and the vend machine content, this PR meant to fix the issues.

**Changelog**
:cl: dvir01
- add: Station Representative had their lockers content balanced, now with added items!
- tweak: Station Representative had their vend machine items updated.
- tweak: Captains lockers items should be more organized.