### PR TITLE
Rebalance laser guns

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -59,8 +59,10 @@
       map: ["enum.GunVisualLayers.MagUnshaded"]
       shader: unshaded
   - type: HitscanBatteryAmmoProvider
-    proto: RedMediumLaser
-    fireCost: 62.5
+    proto: RedLaser
+    fireCost: 83.3
+  - type: Item
+    size: 15
   - type: MagazineVisuals
     magState: mag
     steps: 5
@@ -86,7 +88,7 @@
   - type: Clothing
     sprite: Objects/Weapons/Guns/Battery/makeshift.rsi
   - type: HitscanBatteryAmmoProvider
-    proto: RedLaser
+    proto: RedLightLaser
     fireCost: 62.5
   - type: Battery
     maxCharge: 500
@@ -108,13 +110,15 @@
       shader: unshaded
   - type: Clothing
     sprite: Objects/Weapons/Guns/Battery/laser_gun.rsi
+  - type: Item
+    size: 30
   - type: Gun
     selectedMode: SemiAuto
     availableModes:
     - SemiAuto
   - type: HitscanBatteryAmmoProvider
-    proto: RedLaser
-    fireCost: 62.5
+    proto: RedMediumLaser
+    fireCost: 55.5
 
 - type: entity
   name: practice laser rifle
@@ -235,7 +239,11 @@
       path: /Audio/Weapons/Guns/Gunshots/laser_cannon.ogg
   - type: HitscanBatteryAmmoProvider
     proto: RedHeavyLaser
-    fireCost: 100
+    fireCost: 250
+  - type: Battery
+    maxCharge: 4000
+    startingCharge: 4000
+
 
 - type: entity
   name: x-ray cannon
@@ -258,12 +266,15 @@
       path: /Audio/Weapons/Guns/Gunshots/laser3.ogg
   - type: HitscanBatteryAmmoProvider
     proto: XrayLaser
-    fireCost: 100
+    fireCost: 200
   - type: MagazineVisuals
     magState: mag
     steps: 5
     zeroVisible: true
   - type: Appearance
+  - type: Battery
+    maxCharge: 4000
+    startingCharge: 4000
 
 - type: entity
   name: disabler
@@ -420,7 +431,7 @@
     fireCost: 100
   - type: BatterySelfRecharger
     autoRecharge: true
-    autoRechargeRate: 20
+    autoRechargeRate: 30
   - type: MagazineVisuals
     magState: mag
     steps: 5


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR

This PR changes the ammo and size of some of the laserguns.

Most notably the retro lasergun has been nerfed to be inferior compared to the rest of other laserguns, the stats would end as:

- retro 12 shots 14 damage inv. size 15
- rifle 18 shots 17 damage inv. size 30
- advanced laser now recharges faster 17 damage inv. size 30 
- x-ray now has 20 shots 50 inv. size
- laser cannon now has 16 shots 50 inv. size
- makeshift laser gun deals less damage



:cl:
- tweak: Leander Co has improved the fabrication of most of its laser gun arsenal. 
