### PR TITLE
Update events.yml

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -1,25 +1,25 @@
-- type: entity
-  id: AnomalySpawn
-  parent: BaseGameRule
-  noSpawn: true
-  components:
-  - type: StationEvent
-    weight: 10
-    minimumPlayers: 110
-    startDelay: 30
-    duration: 35
-  - type: AnomalySpawnRule
+# - type: entity
+  # id: AnomalySpawn
+  # parent: BaseGameRule
+  # noSpawn: true
+  # components:
+  # - type: StationEvent
+    # weight: 10
+    # minimumPlayers: 110
+    # startDelay: 30
+    # duration: 35
+  # - type: AnomalySpawnRule
 
-- type: entity
-  id: BluespaceArtifact
-  parent: BaseGameRule
-  noSpawn: true
-  components:
-  - type: StationEvent
-    weight: 5
-    startDelay: 30
-    duration: 35
-  - type: BluespaceArtifactRule
+# - type: entity
+  # id: BluespaceArtifact
+  # parent: BaseGameRule
+  # noSpawn: true
+  # components:
+  # - type: StationEvent
+    # weight: 5
+    # startDelay: 30
+    # duration: 35
+  # - type: BluespaceArtifactRule
 
 - type: entity
   id: BluespaceLocker
@@ -44,43 +44,43 @@
     minimumPlayers: 15
   - type: BreakerFlipRule
 
-- type: entity
-  id: BureaucraticError
-  parent: BaseGameRule
-  noSpawn: true
-  components:
-  - type: StationEvent
-    startAnnouncement: station-event-bureaucratic-error-announcement
-    minimumPlayers: 25
-    weight: 5
-    duration: 1
-  - type: BureaucraticErrorRule
+# - type: entity
+  # id: BureaucraticError
+  # parent: BaseGameRule
+  # noSpawn: true
+  # components:
+  # - type: StationEvent
+    # startAnnouncement: station-event-bureaucratic-error-announcement
+    # minimumPlayers: 25
+    # weight: 5
+    # duration: 1
+  # - type: BureaucraticErrorRule
 
-- type: entity
-  parent: BaseGameRule
-  id: Dragon
-  noSpawn: true
-  components:
-  - type: StationEvent
-    weight: 1
-    duration: 1
-    earliestStart: 45
-    minimumPlayers: 60
-  - type: RandomSpawnRule
-    prototype: SpawnPointGhostDragon
+# - type: entity
+  # parent: BaseGameRule
+  # id: Dragon
+  # noSpawn: true
+  # components:
+  # - type: StationEvent
+    # weight: 1
+    # duration: 1
+    # earliestStart: 45
+    # minimumPlayers: 60
+  # - type: RandomSpawnRule
+    # prototype: SpawnPointGhostDragon
 
-- type: entity
-  parent: BaseGameRule
-  id: RevenantSpawn
-  noSpawn: true
-  components:
-  - type: StationEvent
-    weight: 5
-    duration: 1
-    earliestStart: 45
-    minimumPlayers: 60
-  - type: RandomSpawnRule
-    prototype: MobRevenant
+# - type: entity
+  # parent: BaseGameRule
+  # id: RevenantSpawn
+  # noSpawn: true
+  # components:
+  # - type: StationEvent
+    # weight: 5
+    # duration: 1
+    # earliestStart: 45
+    # minimumPlayers: 60
+  # - type: RandomSpawnRule
+    # prototype: MobRevenant
 
 - type: entity
   id: FalseAlarm
@@ -92,53 +92,53 @@
     duration: 1
   - type: FalseAlarmRule
 
-- type: entity
-  id: GasLeak
-  parent: BaseGameRule
-  noSpawn: true
-  components:
-  - type: StationEvent
-    startAnnouncement: station-event-gas-leak-start-announcement
-    startAudio:
-      path: /Audio/Announcements/attention.ogg
-    endAnnouncement: station-event-gas-leak-end-announcement
-    earliestStart: 10
-    minimumPlayers: 5
-    weight: 5
-    startDelay: 20
-  - type: GasLeakRule
+# - type: entity
+  # id: GasLeak
+  # parent: BaseGameRule
+  # noSpawn: true
+  # components:
+  # - type: StationEvent
+    # startAnnouncement: station-event-gas-leak-start-announcement
+    # startAudio:
+      # path: /Audio/Announcements/attention.ogg
+    # endAnnouncement: station-event-gas-leak-end-announcement
+    # earliestStart: 10
+    # minimumPlayers: 5
+    # weight: 5
+    # startDelay: 20
+  # - type: GasLeakRule
 
-- type: entity
-  id: KudzuGrowth
-  parent: BaseGameRule
-  noSpawn: true
-  components:
-  - type: StationEvent
-    earliestStart: 15
-    minimumPlayers: 15
-    weight: 5
-    startDelay: 50
-    duration: 240
-  - type: KudzuGrowthRule
+# - type: entity
+  # id: KudzuGrowth
+  # parent: BaseGameRule
+  # noSpawn: true
+  # components:
+  # - type: StationEvent
+    # earliestStart: 15
+    # minimumPlayers: 15
+    # weight: 5
+    # startDelay: 50
+    # duration: 240
+  # - type: KudzuGrowthRule
 
-- type: entity
-  id: MeteorSwarm
-  parent: BaseGameRule
-  noSpawn: true
-  components:
-  - type: StationEvent
-    earliestStart: 30
-    weight: 5
-    minimumPlayers: 20
-    startAnnouncement: station-event-meteor-swarm-start-announcement
-    endAnnouncement: station-event-meteor-swarm-end-announcement
-    startAudio:
-      path: /Audio/Announcements/meteors.ogg
-      params:
-        volume: -4
-    duration: null #ending is handled by MeteorSwarmRule
-    startDelay: 30
-  - type: MeteorSwarmRule
+# - type: entity
+  # id: MeteorSwarm
+  # parent: BaseGameRule
+  # noSpawn: true
+  # components:
+  # - type: StationEvent
+    # earliestStart: 30
+    # weight: 5
+    # minimumPlayers: 20
+    # startAnnouncement: station-event-meteor-swarm-start-announcement
+    # endAnnouncement: station-event-meteor-swarm-end-announcement
+    # startAudio:
+      # path: /Audio/Announcements/meteors.ogg
+      # params:
+        # volume: -4
+    # duration: null #ending is handled by MeteorSwarmRule
+    # startDelay: 30
+  # - type: MeteorSwarmRule
 
 - type: entity
   id: MouseMigration
@@ -164,23 +164,23 @@
     - id: SpawnPointGhostRatKing
       prob: 0.005
 
-- type: entity
-  id: PowerGridCheck
-  parent: BaseGameRule
-  noSpawn: true
-  components:
-  - type: StationEvent
-    weight: 10
-    startAnnouncement: station-event-power-grid-check-start-announcement
-    endAnnouncement: station-event-power-grid-check-end-announcement
-    startAudio:
-      path: /Audio/Announcements/power_off.ogg
-      params:
-       volume: -4
-    startDelay: 12
-    duration: 60
-    maxDuration: 120
-  - type: PowerGridCheckRule
+# - type: entity
+  # id: PowerGridCheck
+  # parent: BaseGameRule
+  # noSpawn: true
+  # components:
+  # - type: StationEvent
+    # weight: 10
+    # startAnnouncement: station-event-power-grid-check-start-announcement
+    # endAnnouncement: station-event-power-grid-check-end-announcement
+    # startAudio:
+      # path: /Audio/Announcements/power_off.ogg
+      # params:
+       # volume: -4
+    # startDelay: 12
+    # duration: 60
+    # maxDuration: 120
+  # - type: PowerGridCheckRule
 
 - type: entity
   id: RandomSentience
@@ -216,90 +216,90 @@
     lightBreakChancePerSecond: 0.0003
     doorToggleChancePerSecond: 0.001
 
-- type: entity
-  id: VentClog
-  parent: BaseGameRule
-  noSpawn: true
-  components:
-  - type: StationEvent
-    startAnnouncement: station-event-vent-clog-start-announcement
-    startAudio:
-      path: /Audio/Announcements/attention.ogg
-    earliestStart: 15
-    minimumPlayers: 15
-    weight: 5
-    startDelay: 50
-    duration: 60
-  - type: VentClogRule
+# - type: entity
+  # id: VentClog
+  # parent: BaseGameRule
+  # noSpawn: true
+  # components:
+  # - type: StationEvent
+    # startAnnouncement: station-event-vent-clog-start-announcement
+    # startAudio:
+      # path: /Audio/Announcements/attention.ogg
+    # earliestStart: 15
+    # minimumPlayers: 15
+    # weight: 5
+    # startDelay: 50
+    # duration: 60
+  # - type: VentClogRule
 
-- type: entity
-  id: VentCritters
-  parent: BaseGameRule
-  noSpawn: true
-  components:
-  - type: StationEvent
-    id: VentCritters
-    earliestStart: 15
-    minimumPlayers: 15
-    weight: 5
-    duration: 60
-  - type: VentCrittersRule
-    entries:
-    - id: MobMouse
-      prob: 0.02
-    - id: MobMouse1
-      prob: 0.02
-    - id: MobMouse2
-      prob: 0.02
+# - type: entity
+  # id: VentCritters
+  # parent: BaseGameRule
+  # noSpawn: true
+  # components:
+  # - type: StationEvent
+    # id: VentCritters
+    # earliestStart: 15
+    # minimumPlayers: 15
+    # weight: 5
+    # duration: 60
+  # - type: VentCrittersRule
+    # entries:
+    # - id: MobMouse
+      # prob: 0.02
+    # - id: MobMouse1
+      # prob: 0.02
+    # - id: MobMouse2
+      # prob: 0.02
 
-- type: entity
-  id: SlimesSpawn
-  parent: BaseGameRule
-  noSpawn: true
-  components:
-  - type: StationEvent
-    earliestStart: 20
-    minimumPlayers: 35
-    weight: 5
-    duration: 60
-  - type: VentCrittersRule
-    entries:
-    - id: MobAdultSlimesBlueAngry
-      prob: 0.02
-    - id: MobAdultSlimesGreenAngry
-      prob: 0.02
-    - id: MobAdultSlimesYellowAngry
-      prob: 0.02
+# - type: entity
+  # id: SlimesSpawn
+  # parent: BaseGameRule
+  # noSpawn: true
+  # components:
+  # - type: StationEvent
+    # earliestStart: 20
+    # minimumPlayers: 35
+    # weight: 5
+    # duration: 60
+  # - type: VentCrittersRule
+    # entries:
+    # - id: MobAdultSlimesBlueAngry
+      # prob: 0.02
+    # - id: MobAdultSlimesGreenAngry
+      # prob: 0.02
+    # - id: MobAdultSlimesYellowAngry
+      # prob: 0.02
 
-- type: entity
-  id: SpiderSpawn
-  parent: BaseGameRule
-  noSpawn: true
-  components:
-  - type: StationEvent
-    earliestStart: 20
-    minimumPlayers: 15
-    weight: 5
-    duration: 60
-  - type: VentCrittersRule
-    entries:
-    - id: MobGiantSpiderAngry
-      prob: 0.05
+# - type: entity
+  # id: SpiderSpawn
+  # parent: BaseGameRule
+  # noSpawn: true
+  # components:
+  # - type: StationEvent
+    # earliestStart: 20
+    # minimumPlayers: 15
+    # weight: 5
+    # duration: 60
+  # - type: VentCrittersRule
+    # entries:
+    # - id: MobGiantSpiderAngry
+      # prob: 0.05
 
-- type: entity
-  id: SpiderClownSpawn
-  parent: BaseGameRule
-  noSpawn: true
-  components:
-  - type: StationEvent
-    earliestStart: 20
-    minimumPlayers: 15
-    weight: 2
-    duration: 60
-  - type: VentCrittersRule
-    entries:
-    - id: MobClownSpider
-      prob: 0.05
+# - type: entity
+  # id: SpiderClownSpawn
+  # parent: BaseGameRule
+  # noSpawn: true
+  # components:
+  # - type: StationEvent
+    # earliestStart: 20
+    # minimumPlayers: 15
+    # weight: 2
+    # duration: 60
+  # - type: VentCrittersRule
+    # entries:
+    # - id: MobClownSpider
+      # prob: 0.05
 
 #- type: entity
 #  id: ZombieOutbreak
@@ -346,17 +346,17 @@
     sounds:
       collection: Paracusia
 
-- type: entity
-  id: ImmovableRodSpawn
-  parent: BaseGameRule
-  noSpawn: true
-  components:
-  - type: StationEvent
-    startAnnouncement: station-event-immovable-rod-start-announcement
-    startAudio:
-      path: /Audio/Announcements/attention.ogg
-    weight: 1
-    duration: 1
-    earliestStart: 45
-    minimumPlayers: 20
-  - type: ImmovableRodRule
+# - type: entity
+  # id: ImmovableRodSpawn
+  # parent: BaseGameRule
+  # noSpawn: true
+  # components:
+  # - type: StationEvent
+    # startAnnouncement: station-event-immovable-rod-start-announcement
+    # startAudio:
+      # path: /Audio/Announcements/attention.ogg
+    # weight: 1
+    # duration: 1
+    # earliestStart: 45
+    # minimumPlayers: 20
+  # - type: ImmovableRodRule

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -182,17 +182,17 @@
     # maxDuration: 120
   # - type: PowerGridCheckRule
 
-- type: entity
-  id: RandomSentience
-  parent: BaseGameRule
-  noSpawn: true
-  components:
-  - type: StationEvent
-    weight: 10
-    duration: 1
-    startAudio:
-      path: /Audio/Announcements/attention.ogg
-  - type: RandomSentienceRule
+# - type: entity
+  # id: RandomSentience
+  # parent: BaseGameRule
+  # noSpawn: true
+  # components:
+  # - type: StationEvent
+    # weight: 10
+    # duration: 1
+    # startAudio:
+      # path: /Audio/Announcements/attention.ogg
+  # - type: RandomSentienceRule
 
 - type: entity
   id: SolarFlare


### PR DESCRIPTION
## About the PR
Removed events:

AnomalySpawn: 
Meat / Gravity / Bluespace spawn on someone ship and ending their small 1 man ship life in the most annoying of ways.

BluespaceArtifact:
Few cases when it spawned on someone ship, and either started to spawn carps and kill someone without any time to fight back, started to explode, or get a ghost role on spawn and got abused.

GasLeak:
Few cases when it spawned on someone ship, and insta killed them with trit / plasma without not much time to react, worst on ships without air flow to clear it out, and service ships of people that don't have air ready for a short notice leak.

VentClog: 
Can spawn on ship and kill someone without a warning using toxic smoke.
On some rare cases it can make someone into a zombie.

KudzuGrowth:
Few cases when it spawned on someone ship, and killed them when they had no place to run to, an issue on a single room / 2 rooms ships.

MeteorSwarm:
Other then the fact its not working right now, this will just hit ships that wont have the time to recover or hide from it, and its a "Well time to quit" moment.

ImmovableRodSpawn: 
That one shift it spawned on frontier itself and ended it.

PowerGridCheck: 
Just not working as intended, not the same as the trip APC event that is working, this one have some errors that its making every time its trying run, need to be fixed and then put back.

BureaucraticError: 
Not logical on frontier settings with how shifts and ship crew working.

Mobs spawn events, the type of events that if they happen on a 1 man ship its a "Time to quit" moment:
Dragon, RevenantSpawn, SlimesSpawn, SpiderSpawn, SpiderClownSpawn

VentCritters:
The worst one since its used to easy robust peoples on ships with the rat king.

RandomSentience: 
Has the unintended effect that if someone control a VendMachine / Arti / Mob on your ship and they go SSD or don't talk at all its hard to find them and fix the issue so you can sell the ship.

## What need to be done to fix some events
All the mobs events will need a code rewrite to test grid size, and block spawn on small grids, after we fix it we can restore all mobs events so they only show up on big grids ships.

Same with the AnomalySpawn, BluespaceArtifact, GasLeak, VentClog, KudzuGrowth, we have to rework the code to allow the events on big ships only.