### PR TITLE
Update default_shipyard_catalog.yml

### DIFF
--- a/Resources/Prototypes/_NF/Shipyard/default_shipyard_catalog.yml
+++ b/Resources/Prototypes/_NF/Shipyard/default_shipyard_catalog.yml
@@ -300,7 +300,7 @@
   minPlayers: 0
   stations:
     Condor:
-      stationProto: StandardFrontierExpeditionVessel
+      stationProto: StandardFrontierVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: '{0} Condor {1}'


### PR DESCRIPTION
## About the PR
Condor fixed to "StandardFrontierVessel" from "StandardFrontierExpeditionVessel"
Seem that it was left on the yml, but the ship has no computer for it.