### PR TITLE
Event - Syndicate Crate

### DIFF
--- a/Content.Server/StationEvents/Components/BluespaceSyndicateCargoRuleComponent.cs
+++ b/Content.Server/StationEvents/Components/BluespaceSyndicateCargoRuleComponent.cs
@@ -1,0 +1,19 @@
+using Content.Server.StationEvents.Events;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
+
+namespace Content.Server.StationEvents.Components;
+
+/// <summary>
+/// This is used for an event that spawns syndicate crate
+/// somewhere random on the station.
+/// </summary>
+[RegisterComponent, Access(typeof(BluespaceSyndicateCrateRuleComponent))]
+public sealed class BluespaceSyndicateCrateRuleComponent : Component
+{
+    [DataField("syndicateCrateSpawnerPrototype", customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
+    public string SyndicateCrateSpawnerPrototype = "CrateSyndicateLightSurplusBundle";
+
+    [DataField("crateFlashPrototype", customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
+    public string CrateFlashPrototype = "EffectFlashBluespace";
+}

--- a/Content.Server/StationEvents/Events/BluespaceSyndicateCargoRule.cs
+++ b/Content.Server/StationEvents/Events/BluespaceSyndicateCargoRule.cs
@@ -1,0 +1,102 @@
+using Content.Server.GameTicking.Rules.Components;
+using Content.Server.Station.Components;
+using Content.Server.StationEvents.Components;
+using Content.Shared.Physics;
+using Robust.Shared.Map.Components;
+using Robust.Shared.Physics.Components;
+using Robust.Shared.Physics;
+using Robust.Shared.Random;
+using Robust.Shared.Configuration;
+using Content.Server.Atmos.EntitySystems;
+using Content.Shared.CCVar;
+
+namespace Content.Server.StationEvents.Events;
+
+public sealed class BluespaceCrateRule : StationEventSystem<BluespaceSyndicateCrateRuleComponent>
+{
+    [Dependency] private readonly IConfigurationManager _configuration = default!;
+    [Dependency] private readonly AtmosphereSystem _atmosphere = default!;
+    [Dependency] protected readonly IRobustRandom _random = default!;
+
+    protected override void Added(EntityUid uid, BluespaceSyndicateCrateRuleComponent component, GameRuleComponent gameRule, GameRuleAddedEvent args)
+    {
+        base.Added(uid, component, gameRule, args);
+
+        var str = Loc.GetString("bluespace-syndicate-crate-event-announcement");
+        ChatSystem.DispatchGlobalAnnouncement(str, colorOverride: Color.FromHex("#18abf5"));
+    }
+
+    protected override void Started(EntityUid uid, BluespaceSyndicateCrateRuleComponent component, GameRuleComponent gameRule, GameRuleStartedEvent args)
+    {
+        base.Started(uid, component, gameRule, args);
+
+        if (!TryGetRandomStation(out var chosenStation, HasComp<StationJobsComponent>))
+            return;
+
+        if (!TryComp<StationDataComponent>(chosenStation, out var stationData))
+            return;
+
+        var grid = StationSystem.GetLargestGrid(stationData);
+
+        if (grid is null)
+            return;
+
+        var amountToSpawn = Math.Max(1, (int) MathF.Round(GetSeverityModifier() / 1.5f));
+        for (var i = 0; i < amountToSpawn; i++)
+        {
+            SpawnOnRandomGridLocation(grid.Value, component.SyndicateCrateSpawnerPrototype, component.CrateFlashPrototype);
+        }
+    }
+
+    public void SpawnOnRandomGridLocation(EntityUid grid, string toSpawn, string toSpawnFlash)
+    {
+        if (!TryComp<MapGridComponent>(grid, out var gridComp))
+            return;
+
+        var xform = Transform(grid);
+
+        var targetCoords = xform.Coordinates;
+        var gridBounds = gridComp.LocalAABB.Scale(_configuration.GetCVar(CCVars.SyndicateCrateGenerationGridBoundsScale));
+
+        for (var i = 0; i < 25; i++)
+        {
+            var randomX = _random.Next((int) gridBounds.Left, (int) gridBounds.Right);
+            var randomY = _random.Next((int) gridBounds.Bottom, (int) gridBounds.Top);
+
+            var tile = new Vector2i(randomX, randomY);
+
+            // no air-blocked areas.
+            if (_atmosphere.IsTileSpace(grid, xform.MapUid, tile, mapGridComp: gridComp) ||
+                _atmosphere.IsTileAirBlocked(grid, tile, mapGridComp: gridComp))
+            {
+                continue;
+            }
+
+            // don't spawn inside of solid objects
+            var physQuery = GetEntityQuery<PhysicsComponent>();
+            var valid = true;
+            foreach (var ent in gridComp.GetAnchoredEntities(tile))
+            {
+                if (!physQuery.TryGetComponent(ent, out var body))
+                    continue;
+                if (body.BodyType != BodyType.Static ||
+                    !body.Hard ||
+                    (body.CollisionLayer & (int) CollisionGroup.Impassable) == 0)
+                    continue;
+
+                valid = false;
+                break;
+            }
+            if (!valid)
+                continue;
+
+            targetCoords = gridComp.GridTileToLocal(tile);
+            break;
+        }
+
+        Spawn(toSpawn, targetCoords);
+        Spawn(toSpawnFlash, targetCoords);
+
+        Sawmill.Info($"Spawning random syndicate crate at {targetCoords}");
+    }
+}

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -1367,6 +1367,12 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<float> AnomalyGenerationGridBoundsScale =
             CVarDef.Create("anomaly.generation_grid_bounds_scale", 0.6f, CVar.SERVERONLY);
 
+        /// <summary>
+        ///     A scale factor applied to a grid's bounds when trying to find a spot to randomly generate syndicate crate.
+        /// </summary>
+        public static readonly CVarDef<float> SyndicateCrateGenerationGridBoundsScale =
+            CVarDef.Create("syndicatecrate.generation_grid_bounds_scale", 0.6f, CVar.SERVERONLY);
+
         /*
          * VIEWPORT
          */

--- a/Resources/Locale/en-US/_NF/events/bluespace-syndicate-crate.ftl
+++ b/Resources/Locale/en-US/_NF/events/bluespace-syndicate-crate.ftl
@@ -1,0 +1,1 @@
+bluespace-syndicate-crate-event-announcement = We received a report that a crate containing syndicate items has shown up in some area, please notify the security team if you found said crate.

--- a/Resources/Locale/en-US/_NF/prototypes/catalog/fills/crates/syndicate-crates.ftl
+++ b/Resources/Locale/en-US/_NF/prototypes/catalog/fills/crates/syndicate-crates.ftl
@@ -1,0 +1,2 @@
+ent-CrateSyndicateLightSurplusBundle = Syndicate light surplus crate
+    .desc = Contains 30 telecrystals worth of completely random Syndicate items. It can be useless junk or really good.

--- a/Resources/Prototypes/_NF/Catalog/Fills/Crates/syndicate.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/Crates/syndicate.yml
@@ -1,0 +1,7 @@
+- type: entity
+  id: CrateSyndicateLightSurplusBundle
+  parent: CrateSyndicate
+  components:
+    - type: SurplusBundle
+      totalPrice: 30
+      storePreset: StorePresetLightUplink

--- a/Resources/Prototypes/_NF/Events/events.yml
+++ b/Resources/Prototypes/_NF/Events/events.yml
@@ -57,3 +57,18 @@
   - type: BluespaceErrorRule
     gridPath: /Maps/Bluespace/vaultsmall.yml
     rewardFactor: 1
+
+- type: entity
+  id: BluespaceSyndicateCrate
+  parent: BaseGameRule
+  noSpawn: true
+  components:
+  - type: StationEvent
+    startAudio:
+      path: /Audio/Announcements/attention.ogg
+    weight: 1
+    startDelay: 30
+    duration: 35
+    earliestStart: 90
+    minimumPlayers: 20
+  - type: BluespaceSyndicateCrateRule

--- a/Resources/Prototypes/_NF/Store/presets.yml
+++ b/Resources/Prototypes/_NF/Store/presets.yml
@@ -1,0 +1,17 @@
+- type: storePreset
+  id: StorePresetLightUplink
+  storeName: Uplink
+  categories:
+#  - UplinkWeapons
+#  - UplinkAmmo
+#  - UplinkExplosives
+  - UplinkMisc
+#  - UplinkBundles
+#  - UplinkTools
+  - UplinkUtility
+#  - UplinkImplants
+#  - UplinkJob
+  - UplinkArmor
+  - UplinkPointless
+  currencyWhitelist:
+  - Telecrystal


### PR DESCRIPTION
## About the PR
A bit of a late round event that can happen when a light (Mostly safe frontier items) syndicate crate show up on someone ship

**Media**
- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl: dvir01
- add: The syndicates might try and send you a crate with equipment in an attempt to mess with the balance of frontier, please let security know if you found a syndicate crate on your ship!
