### PR TITLE
Captain Stamp

### DIFF
--- a/Content.Shared/Paper/StampComponent.cs
+++ b/Content.Shared/Paper/StampComponent.cs
@@ -22,6 +22,9 @@ public partial struct StampDisplayInfo
 
     [DataField("stampedColor")]
     public Color StampedColor;
+
+    [DataField("stampedPersonal")]
+    public bool StampedPersonal = false;
 };
 
 [RegisterComponent]
@@ -49,4 +52,17 @@ public sealed partial class StampComponent : Component
     {
         Params = AudioParams.Default.WithVolume(-2f).WithMaxDistance(5f)
     };
+
+    /// <summary>
+    /// The stamp using the person name on it
+    /// </summary>
+    [DataField("stampedPersonal")]
+    public bool StampedPersonal = false;
+
+    [ViewVariables]
+    public EntityUid? StampedIdUser = null;
+
+    [ViewVariables(VVAccess.ReadWrite)]
+    [DataField("nameSetUser")]
+    public bool NameSetUser { get; set; }
 }

--- a/Resources/Locale/en-US/_NF/paper/stamp-component.ftl
+++ b/Resources/Locale/en-US/_NF/paper/stamp-component.ftl
@@ -1,0 +1,2 @@
+stamp-component-unknown-name = Unknown
+stamp-component-unknown-job = No job

--- a/Resources/Prototypes/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/paper.yml
@@ -497,6 +497,7 @@
     stampedName: stamp-component-stamped-name-captain
     stampedColor: "#3681bb"
     stampState: "paper_stamp-cap"
+    stampedPersonal: true
   - type: Sprite
     sprite: Objects/Misc/bureaucracy.rsi
     state: stamp-cap


### PR DESCRIPTION
## About the PR
The captain stamp is now used to stamp the using player name instead of the word "captain".
Its working by using the equipped card, so a syndicate ID can be used to fake a paper stamp.

## Why / Balance
Captain stamp was useless, now it has an actual use.

## Technical details
Added a new component to stamps, when used it will replace the stamp name with your card name when you pick it up and use it to stamp.

## Media
- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
Nothing

**Changelog**
:cl: dvir01
- tweak: Captain stamp will use your card name for the stamp.
