### PR TITLE
Lockers Consistent Items

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/cargo.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/cargo.yml
@@ -17,13 +17,8 @@
       - id: HandheldGPSBasic
       - id: RadioHandheld
       - id: OreBag
-        prob: 0.5
       - id: Flare
-        prob: 0.3
-      - id: Flare
-        prob: 0.3
-      - id: Flare
-        prob: 0.3
+        amount: 3
 
 - type: entity
   id: LockerSalvageSpecialistFilled
@@ -39,10 +34,5 @@
       - id: HandheldGPSBasic
       - id: RadioHandheld
       - id: OreBag
-        prob: 0.5
       - id: Flare
-        prob: 0.3
-      - id: Flare
-        prob: 0.3
-      - id: Flare
-        prob: 0.3
+        amount: 3

--- a/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
@@ -112,8 +112,7 @@
     contents:
       - id: BoxSyringe
       - id: BoxBeaker
-      - id: BoxBeaker
-        prob: 0.3
+        amount: 2
       - id: BoxPillCanister
       - id: BoxBottle
       - id: ChemBag
@@ -121,7 +120,6 @@
       - id: ClothingHeadsetMedical
       - id: ClothingMaskSterile
       - id: HandLabeler
-        prob: 0.5
 
 - type: entity
   id: LockerParamedicFilled
@@ -141,4 +139,3 @@
       - id: ClothingHeadsetMedical
       - id: ClothingMaskSterile
       - id: MedkitFilled
-        prob: 0.3

--- a/Resources/Prototypes/Catalog/Fills/Lockers/science.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/science.yml
@@ -12,4 +12,3 @@
       - id: AnomalyScanner
       - id: NodeScanner
       - id: NetworkConfigurator
-        prob: 0.5

--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -7,7 +7,6 @@
     contents:
       - id: FlashlightSeclite
       - id: WeaponDisabler
-        prob: 0.3
       - id: ClothingHeadHatWarden
       - id: ClothingHeadHatBeretWarden
       - id: ClothingBeltSecurityFilled
@@ -33,7 +32,6 @@
     contents:
       - id: FlashlightSeclite
       - id: WeaponDisabler
-        prob: 0.3
       - id: ClothingHeadHatWarden
       - id: ClothingHeadHatBeretWarden
       - id: ClothingBeltSecurityFilled
@@ -57,14 +55,12 @@
   - type: StorageFill
     contents:
       - id: FlashlightSeclite
-        prob: 0.8
       - id: ClothingUniformJumpsuitSecGrey
         prob: 0.3
       - id: ClothingHeadHelmetBasic
       - id: ClothingOuterArmorBasic
       - id: ClothingBeltSecurityFilled
       - id: Flash
-        prob: 0.5
       - id: ClothingEyesGlassesSecurity
       - id: ClothingHeadsetSecurity
       - id: ClothingHandsGlovesColorBlack
@@ -116,7 +112,6 @@
   - type: StorageFill
     contents:
       - id: ClothingEyesHudSecurity
-        prob: 0.3
       - id: ClothingHeadHatFedoraBrown
       - id: ClothingNeckTieDet
       - id: ClothingOuterVestDetective

--- a/Resources/Prototypes/Catalog/Fills/Lockers/service.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/service.yml
@@ -82,7 +82,6 @@
   - type: StorageFill
     contents:
       - id: BriefcaseBrownFilled
-        prob: 0.80
       - id: ClothingOuterRobesJudge
 
 - type: entity
@@ -99,7 +98,6 @@
       - id: HydroponicsToolSpade
       - id: HydroponicsToolMiniHoe
       - id: RobustHarvestChemistryBottle
-        prob: 0.3
       - id: ClothingBeltPlant
       - id: PlantBag ##Some maps don't have nutrivend
       - id: BoxMouthSwab


### PR DESCRIPTION
## About the PR
Consistent lockers content, some items should just be there.
Updated the salvage tool belt back to the "ClothingBeltUtilityEngineering" (It will replace the network tool with multi tool) 

## Why / Balance
Random utility that is needed for a job is dumb, if its something you need for your job it should not be RNG based.

## Technical details
yml changes.

## Media
- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None

**Changelog**
:cl: dvir01
- tweak: Lockers contents a bit more consistent.
