### PR TITLE
Stamp

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Crates/service.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/service.yml
@@ -104,6 +104,7 @@
     - id: BoxFolderBlue
     - id: BoxFolderRed
     - id: BoxFolderYellow
+    - id: RubberStampCaptain
 
 - type: entity
   id: CrateServicePersonnel

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/cart.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/cart.yml
@@ -5,10 +5,15 @@
     ClearPDA: 10
     PassengerIDCard: 20
     ClothingHeadsetGrey: 10
+    RubberStampCaptain: 10
     RubberStampApproved: 3
     RubberStampDenied: 3
+    Pen: 10
     Paper: 50
     PaperCaptainsThoughts: 20
+    BoxFolderBlue: 3
+    BoxFolderRed: 3
+    BoxFolderYellow: 3
     EncryptionKeySecurity: 10
     EncryptionKeyCargo: 20
     EncryptionKeyEngineering: 20


### PR DESCRIPTION
## About the PR
Added the captain stamp to the Bureaucracy crate and the SR vend
Also added folders to SR machine for organizing paper work, and some pens.

## Why / Balance
Why not.

## Technical details
yml changes.

## Media
- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None

**Changelog**
:cl: dvir01
- tweak: Captains stamps now show up in Bureaucracy crates, and SR vend machines.
- tweak: SR Vend machine have a bit more items in it, NT hopes the SR will find this useful.
