### PR TITLE
Crates-Fix

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Crates/botany.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/botany.yml
@@ -1,6 +1,6 @@
 - type: entity
   id: CrateHydroponicsSeedsExotic
-  parent: CrateHydroponics
+  parent: CrateHydroSecure
   components:
   - type: StorageFill
     contents:
@@ -23,7 +23,7 @@
 
 - type: entity
   id: CrateHydroponicsSeedsMedicinal
-  parent: CrateHydroponics
+  parent: CrateHydroSecure
   components:
   - type: StorageFill
     contents:

--- a/Resources/Prototypes/Catalog/Fills/Crates/chemistry.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/chemistry.yml
@@ -1,6 +1,6 @@
 - type: entity
   id: CrateChemistryP
-  parent: CrateChemistrySupplies
+  parent: CrateChemistrySecure
   components:
     - type: StorageFill
       contents:
@@ -27,7 +27,7 @@
 
 - type: entity
   id: CrateChemistryS
-  parent: CrateChemistrySupplies
+  parent: CrateChemistrySecure
   components:
     - type: StorageFill
       contents:
@@ -48,7 +48,7 @@
 
 - type: entity
   id: CrateChemistryD
-  parent: CrateChemistrySupplies
+  parent: CrateChemistrySecure
   components:
     - type: StorageFill
       contents:

--- a/Resources/Prototypes/Catalog/Fills/Crates/circuitboards.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/circuitboards.yml
@@ -1,6 +1,6 @@
 ﻿- type: entity
   id: CrateCrewMonitoringBoards
-  parent: CrateEngineering
+  parent: CrateEngineeringSecure
   components:
     - type: StorageFill
       contents:

--- a/Resources/Prototypes/Catalog/Fills/Crates/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/emergency.yml
@@ -1,6 +1,6 @@
 - type: entity
   id: CrateEmergencyExplosive
-  parent: CrateScience
+  parent: CrateScienceSecure
   components:
   - type: StorageFill
     contents:

--- a/Resources/Prototypes/Catalog/Fills/Crates/engineering.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/engineering.yml
@@ -119,7 +119,7 @@
 
 - type: entity
   id: CrateEvaKit
-  parent: CrateGenericSteel
+  parent: CrateEngineeringSecure
   components:
   - type: StorageFill
     contents:

--- a/Resources/Prototypes/Catalog/Fills/Crates/engines.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/engines.yml
@@ -2,7 +2,7 @@
 
 - type: entity
   id: CrateEngineeringAMEShielding
-  parent: CrateEngineering
+  parent: CrateEngineeringSecure
   components:
   - type: StorageFill
     contents:
@@ -11,7 +11,7 @@
 
 - type: entity
   id: CrateEngineeringAMEJar
-  parent: CrateEngineering
+  parent: CrateEngineeringSecure
   components:
   - type: StorageFill
     contents:
@@ -20,7 +20,7 @@
 
 - type: entity
   id: CrateEngineeringAMEControl
-  parent: CrateEngineering
+  parent: CrateEngineeringSecure
   components:
   - type: StorageFill
     contents:
@@ -30,7 +30,7 @@
 
 - type: entity
   id: CrateEngineeringSingularityEmitter
-  parent: CrateEngineering
+  parent: CrateEngineeringSecure
   components:
   - type: StorageFill
     contents:
@@ -38,7 +38,7 @@
 
 - type: entity
   id: CrateEngineeringSingularityCollector
-  parent: CrateEngineering
+  parent: CrateEngineeringSecure
   components:
   - type: StorageFill
     contents:
@@ -46,7 +46,7 @@
 
 - type: entity
   id: CrateEngineeringSingularityContainment
-  parent: CrateEngineering
+  parent: CrateEngineeringSecure
   components:
   - type: StorageFill
     contents:
@@ -54,7 +54,7 @@
 
 - type: entity
   id: CrateEngineeringSingularityGenerator
-  parent: CrateEngineering
+  parent: CrateEngineeringSecure
   components:
   - type: StorageFill
     contents:
@@ -64,7 +64,7 @@
 
 - type: entity
   id: CrateEngineeringParticleAccelerator
-  parent: CrateEngineering
+  parent: CrateEngineeringSecure
   components:
   - type: StorageFill
     contents:
@@ -82,7 +82,7 @@
 #  id: CrateEngineeringSingularity
 #  name: singularity crate
 #  description: "Prank the station!"
-#  parent: CrateEngineering
+#  parent: CrateEngineeringSecure
 #  components:
 #  - type: StorageFill
 #    contents:
@@ -108,7 +108,7 @@
 
 - type: entity
   id: CrateEngineeringShuttle
-  parent: CrateEngineering
+  parent: CrateEngineeringSecure
   components:
   - type: StorageFill
     contents:

--- a/Resources/Prototypes/Catalog/Fills/Crates/medical.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/medical.yml
@@ -116,7 +116,7 @@
 
 - type: entity
   id: CrateVirologyBiosuit
-  parent: CrateMedical
+  parent: CrateMedicalSecure
   components:
   - type: StorageFill
     contents:

--- a/Resources/Prototypes/Catalog/Fills/Crates/science.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/science.yml
@@ -1,6 +1,6 @@
 - type: entity
   id: CrateScienceBiosuit
-  parent: CrateScience
+  parent: CrateScienceSecure
   components:
   - type: StorageFill
     contents:

--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
@@ -186,8 +186,8 @@
     sprite: Structures/Storage/Crates/engicrate_secure.rsi
   - type: Sprite
     sprite: Structures/Storage/Crates/engicrate_secure.rsi
-  - type: AccessReader
-    access: [["Engineering"]]
+#  - type: AccessReader
+#    access: [["Engineering"]]
 
 - type: entity
   parent: CrateBaseSecure
@@ -198,8 +198,8 @@
     sprite: Structures/Storage/Crates/medicalcrate_secure.rsi
   - type: Sprite
     sprite: Structures/Storage/Crates/medicalcrate_secure.rsi
-  - type: AccessReader
-    access: [["Medical"]]
+#  - type: AccessReader
+#    access: [["Medical"]]
 
 - type: entity
   parent: CrateBaseSecure
@@ -210,8 +210,8 @@
       sprite: Structures/Storage/Crates/chemcrate_secure.rsi
     - type: Sprite
       sprite: Structures/Storage/Crates/chemcrate_secure.rsi
-    - type: AccessReader
-      access: [["Chemistry"]]
+#    - type: AccessReader
+#      access: [["Chemistry"]]
 
 - type: entity
   parent: CrateBaseSecure
@@ -232,8 +232,8 @@
     sprite: Structures/Storage/Crates/scicrate_secure.rsi
   - type: Sprite
     sprite: Structures/Storage/Crates/scicrate_secure.rsi
-  - type: AccessReader
-    access: [["Research"]]
+#  - type: AccessReader
+#    access: [["Research"]]
 
 - type: entity
   parent: CrateBaseSecure
@@ -244,8 +244,8 @@
     sprite: Structures/Storage/Crates/plasma.rsi
   - type: Sprite
     sprite: Structures/Storage/Crates/plasma.rsi
-  - type: AccessReader
-    access: [["Engineering"], ["Research"], ["Chemistry"]]
+#  - type: AccessReader
+#    access: [["Engineering"], ["Research"], ["Chemistry"]]
 
 - type: entity
   parent: CrateBaseSecure
@@ -266,8 +266,8 @@
     sprite: Structures/Storage/Crates/hydro_secure.rsi
   - type: Sprite
     sprite: Structures/Storage/Crates/hydro_secure.rsi
-  - type: AccessReader
-    access: [["Hydroponics"]]
+#  - type: AccessReader
+#    access: [["Hydroponics"]]
 
 - type: entity
   parent: CrateBaseSecure
@@ -291,7 +291,7 @@
   - type: Sprite
     sprite: Structures/Storage/Crates/command.rsi
   - type: AccessReader
-    access: [["Command"]]
+    access: [["HeadOfPersonnel"], ["HeadOfSecurity"]]
 
 - type: entity
   parent: CrateGeneric
@@ -557,5 +557,5 @@
     sprite: Structures/Storage/Crates/trashcart_jani.rsi
   - type: Sprite
     sprite: Structures/Storage/Crates/trashcart_jani.rsi
-  - type: AccessReader
-    access: [["Janitor"]]
+#  - type: AccessReader
+#    access: [["Janitor"]]


### PR DESCRIPTION
## About the PR
Restored many of the crates to be the "Secured" version, but now the crates just have the "AccessReader" removed.
After the changes with the new plasma crate this is for the best as it will allow faster changes to crates later.

## Why / Balance
About the same, more easy to make changes.

## Technical details
yml edits

## Media
- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None

**Changelog**
:cl: dvir01
- tweak: NT Has updated the locks on the cargo crates again, the crates should open again as expected, 
