### PR TITLE
Rehydrateable Balance

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/monkeycube.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/monkeycube.yml
@@ -16,6 +16,10 @@
   - type: Sprite
     sprite: Objects/Misc/monkeycube.rsi
     state: box
+  - type: StaticPrice
+    price: 20
+  - type: VendPrice
+    price: 4500 # Yep, same price as the crate
 
 - type: entity
   parent: BaseItem
@@ -35,6 +39,8 @@
   - type: Tag
     tags:
     - MonkeyCube
+  - type: StaticPrice
+    price: 460 # The same price as dead (-20)
 
 - type: entity
   parent: BoxCardboard
@@ -55,6 +61,8 @@
   - type: Sprite
     sprite: Objects/Misc/monkeycube.rsi
     state: box
+  - type: StaticPrice
+    price: 0 # Syndicate
 
 - type: entity
   parent: BaseItem
@@ -74,3 +82,5 @@
   - type: Tag
     tags:
     - MonkeyCube
+  - type: StaticPrice
+    price: 0 # Syndicate

--- a/Resources/Prototypes/Entities/Objects/Specific/rehydrateable.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/rehydrateable.yml
@@ -46,6 +46,8 @@
         hard: false
         layer:
         - LowImpassable
+  - type: StaticPrice
+    price: 460 # The same price as dead (-20)
 
 - type: entity
   parent: PlushieCarp
@@ -101,6 +103,8 @@
     handle: false
     sound:
       path: /Audio/Effects/bite.ogg
+  - type: StaticPrice
+    price: 580 # The same price as dead (-20)
 
 - type: entity
   parent: BaseItem
@@ -160,3 +164,5 @@
         hard: false
         layer:
         - LowImpassable
+  - type: StaticPrice
+    price: 0 # Syndicate


### PR DESCRIPTION
## About the PR
Making the rehydrateable price match the mobs inside, no point in having to spawn a carp or a monkey just to get the money for it after it died.

And also fixing the monkey cube box price for the ChefVend (It used to cost 50 when the price should have been 4500)

## Why / Balance
The price was off, and there is no real need to kill carps / monkey to get the price for the dry animal.

## Technical details
yml changes

## Media
- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None

**Changelog**
:cl: dvir01
- tweak: ChefVend Monkey cube price fixed
- tweak: Dry monkey cube and dry carps has the same price as the dead mob.
