### PR TITLE
Computers Fix

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -687,11 +687,26 @@
 
 - type: entity
   id: ComputerCargoOrders
-  parent: BaseComputer
+  parent: BaseStructureComputer
   name: cargo request computer
   description: Used to order supplies and approve requests.
+  placement:
+    mode: SnapgridCenter
   components:
+  - type: MeleeSound
+    soundGroups:
+      Brute:
+        path:
+          "/Audio/Effects/glass_hit.ogg"
+  - type: Computer
+  - type: ApcPowerReceiver
+    powerLoad: 200
+  - type: ExtensionCableReceiver
+  - type: ActivatableUIRequiresPower
   - type: Sprite
+    netsync: false
+    noRot: true
+    sprite: Structures/Machines/computers.rsi
     layers:
     - map: ["computerLayerBody"]
       state: computer
@@ -708,8 +723,6 @@
     interfaces:
     - key: enum.CargoConsoleUiKey.Orders
       type: CargoOrderConsoleBoundUserInterface
-  - type: Computer
-    board: CargoRequestComputerCircuitboard
   - type: PointLight
     radius: 1.5
     energy: 1.6
@@ -728,6 +741,12 @@
   - type: GuideHelp
     guides:
     - Cargo
+  - type: Anchorable
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 0
 
 - type: entity
   id: ComputerCargoBounty

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -723,10 +723,16 @@
     interfaces:
     - key: enum.CargoConsoleUiKey.Orders
       type: CargoOrderConsoleBoundUserInterface
+  - type: LitOnPowered
   - type: PointLight
     radius: 1.5
     energy: 1.6
     color: "#b89f25"
+    enabled: false
+    mask: /Textures/Effects/LightMasks/cone.png
+    autoRot: true
+    offset: "0, 0.4" # shine from the top, not bottom of the computer
+    castShadows: false
   #- type: AccessReader
     #access: [["Cargo"]]
   - type: DeviceNetwork

--- a/Resources/Prototypes/Entities/Structures/cargo_telepad.yml
+++ b/Resources/Prototypes/Entities/Structures/cargo_telepad.yml
@@ -1,6 +1,6 @@
 ﻿- type: entity
   id: CargoTelepad
-  parent: [ BaseMachinePowered, ConstructibleMachine ]
+  parent: BaseMachinePowered
   name: cargo telepad
   description: Beam in the pizzas and dig in.
   components:
@@ -47,3 +47,8 @@
     board: CargoTelepadMachineCircuitboard
   - type: Appearance
   - type: CollideOnAnchor
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 0

--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers.yml
@@ -127,6 +127,14 @@
       state: shipyard_blackmarket   
     - map: ["computerLayerKeys"]
       state: blackmarket_key
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 300
+      behaviors:
+        - !type:DoActsBehavior
+          acts: ["Destruction"]
 
 - type: entity
   name: cargo sale computer

--- a/Resources/Prototypes/_NF/Entities/Structures/atms.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/atms.yml
@@ -77,13 +77,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 100
-      behaviors:
-      - !type:PlaySoundBehavior
-        sound:
-          collection: GlassBreak
-      - !type:DoActsBehavior
-        acts: ["Destruction"]
+        damage: 0
         
 - type: entity
   name: black market atm
@@ -331,13 +325,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 100
-      behaviors:
-      - !type:PlaySoundBehavior
-        sound:
-          collection: GlassBreak
-      - !type:DoActsBehavior
-        acts: ["Destruction"]
+        damage: 0
 
 - type: entity
   name: wallmount withdraw-only bank atm

--- a/Resources/Prototypes/_Nyano/Entities/Structures/Machines/mailTeleporter.yml
+++ b/Resources/Prototypes/_Nyano/Entities/Structures/Machines/mailTeleporter.yml
@@ -27,15 +27,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 75
-      behaviors:
-      - !type:SpawnEntitiesBehavior
-        spawn:
-          SheetSteel1:
-            min: 1
-            max: 1
-      - !type:DoActsBehavior
-        acts: ["Destruction"]
+        damage: 0
   - type: ApcPowerReceiver
     powerLoad: 1000 # TODO if we keep this make it spike power draw when teleporting
     powerDisabled: true


### PR DESCRIPTION
## About the PR
Cargo request computer cannot be broken, or have the board removed, can still be moved around as before.
Cargo Telepad cannot be broken, or have the board removed, can still be moved around as before.
Black Market Shipyard computer can be destroyed, allowing sec to take it down.
Frontiers deposit and withdraw ATM's are protected from damage now, the rest are not.
Mail Teleporter cannot be broken, can still be moved around as before.

## Why / Balance
Oversights with some of the computers and machines.

## Technical details
.yml changes

## Media
- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None

**Changelog**
:cl: dvir01
- tweak: As per the SR and Security request, Frontier machines are made from a stronger metal now.
- tweak: The pirates Black Market shipyard computer has lost its immortality.
