### PR TITLE
Fun floor tiles crate

### DIFF
--- a/Resources/Locale/en-US/_NF/prototypes/catalog/cargo/cargo-fun.ftl
+++ b/Resources/Locale/en-US/_NF/prototypes/catalog/cargo/cargo-fun.ftl
@@ -1,0 +1,2 @@
+ent-FloorsFun = { ent-CrateFloorsFun }
+    .desc = { ent-CrateFloorsFun.desc }

--- a/Resources/Locale/en-US/_NF/prototypes/catalog/fills/crates/fun-crates.ftl
+++ b/Resources/Locale/en-US/_NF/prototypes/catalog/fills/crates/fun-crates.ftl
@@ -1,2 +1,2 @@
-ent-CrateFloorsFun = Fun floors tile crate
+ent-CrateFloorsFun = Fun floors tiles crate
     .desc = A crate full of 30 random tiles, used for decommendation.

--- a/Resources/Locale/en-US/_NF/prototypes/catalog/fills/crates/fun-crates.ftl
+++ b/Resources/Locale/en-US/_NF/prototypes/catalog/fills/crates/fun-crates.ftl
@@ -1,0 +1,2 @@
+ent-CrateFloorsFun = Fun floors tile crate
+    .desc = A crate full of 30 random tiles, used for decommendation.

--- a/Resources/Locale/en-US/_NF/prototypes/catalog/fills/crates/fun-crates.ftl
+++ b/Resources/Locale/en-US/_NF/prototypes/catalog/fills/crates/fun-crates.ftl
@@ -1,2 +1,2 @@
 ent-CrateFloorsFun = Fun floors tiles crate
-    .desc = A crate full of 30 random tiles, used for decommendation.
+    .desc = A crate full of 30 random tiles, used for decoration.

--- a/Resources/Prototypes/_NF/Catalog/Cargo/cargo_fun.yml
+++ b/Resources/Prototypes/_NF/Catalog/Cargo/cargo_fun.yml
@@ -1,0 +1,9 @@
+- type: cargoProduct
+  id: FloorsFun
+  icon:
+    sprite: Objects/Tiles/tile.rsi
+    state: arcadeblue
+  product: CrateFloorsFun
+  cost: 500
+  category: Fun
+  group: market

--- a/Resources/Prototypes/_NF/Catalog/Fills/Crates/fun.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/Crates/fun.yml
@@ -1,0 +1,26 @@
+- type: entity
+  id: CrateFloorsFun
+  parent: CrateGenericSteel
+  components:
+  - type: StorageFill
+    contents:
+      - id: FloorTileItemArcadeBlue
+        amount: 30
+        prob: 1
+        orGroup: FloorTileItemArcadeBlue
+      - id: FloorTileItemArcadeBlue2
+        amount: 30
+        prob: 1
+        orGroup: FloorTileItemArcadeBlue
+      - id: FloorTileItemArcadeRed
+        amount: 30
+        prob: 1
+        orGroup: FloorTileItemArcadeBlue
+      - id: FloorTileItemEighties
+        amount: 30
+        prob: 1
+        orGroup: FloorTileItemArcadeBlue
+      - id: FloorTileItemCarpetClown
+        amount: 30
+        prob: 1
+        orGroup: FloorTileItemArcadeBlue


### PR DESCRIPTION
## About the PR
Added the fun floor tiles crate, cost 500 and has 30 tiles from the "fun" type

## Why / Balance
Fun

## Technical details
.yml changes

## Media
- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None

**Changelog**
:cl: dvir01
- add: Added the floor tiles crate for the price of 500, get some fun tiles for your ship!
