### PR TITLE
Medical insurance tracking implant

### DIFF
--- a/Content.Server/Explosion/EntitySystems/TriggerSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/TriggerSystem.cs
@@ -23,6 +23,7 @@ using Robust.Shared.Physics.Systems;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Weapons.Ranged.Events;
+using Content.Server.Station.Systems;
 
 namespace Content.Server.Explosion.EntitySystems
 {
@@ -61,6 +62,7 @@ namespace Content.Server.Explosion.EntitySystems
         [Dependency] private readonly SharedTransformSystem _transformSystem = default!;
         [Dependency] private readonly RadioSystem _radioSystem = default!;
         [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+        [Dependency] private readonly StationSystem _station = default!;
 
         public override void Initialize()
         {
@@ -167,8 +169,21 @@ namespace Content.Server.Explosion.EntitySystems
             var y = (int) pos.Y;
             var posText = $"({x}, {y})";
 
-            var critMessage = Loc.GetString(component.CritMessage, ("user", implanted.ImplantedEntity.Value), ("position", posText));
-            var deathMessage = Loc.GetString(component.DeathMessage, ("user", implanted.ImplantedEntity.Value), ("position", posText));
+            // Gets station location of the implant
+            var station = _station.GetOwningStation(uid);
+            var stationName = station is null ? null : Name(station.Value);
+
+            if (!(stationName == null))
+            {
+                stationName += " ";
+            }
+            else
+            {
+                stationName = "";
+            }
+
+            var critMessage = Loc.GetString(component.CritMessage, ("user", implanted.ImplantedEntity.Value), ("grid", stationName!), ("position", posText));
+            var deathMessage = Loc.GetString(component.DeathMessage, ("user", implanted.ImplantedEntity.Value), ("grid", stationName!), ("position", posText));
 
             if (!TryComp<MobStateComponent>(implanted.ImplantedEntity, out var mobstate))
                 return;

--- a/Resources/Locale/en-US/_NF/paper/book-medical-insurance.ftl
+++ b/Resources/Locale/en-US/_NF/paper/book-medical-insurance.ftl
@@ -1,0 +1,21 @@
+book-medical-insurance = This form is a contract made with the medical frovider:
+      --------------------------------------------------------------------------------------
+      SECTION 1:  Info
+      --------------------------------------------------------------------------------------
+      
+      Full Name  :
+      Race       :
+      Blood Type :
+      
+      --------------------------------------------------------------------------------------
+      SECTION 3:  Services
+      --------------------------------------------------------------------------------------
+      
+      As part of our service we will attemp to come and aid you in the case of your medical implant going off.
+      
+      (X) Revive = Up to 5k
+      (X) Clone  = Up to 10k
+      
+      In the case were unable to clone you, with your brain still intact, you also agree to be borged:
+      
+      ( ) Borg  = Up to 20k

--- a/Resources/Locale/en-US/_NF/paper/book-medical-insurance.ftl
+++ b/Resources/Locale/en-US/_NF/paper/book-medical-insurance.ftl
@@ -13,7 +13,7 @@ book-medical-insurance = This form is a contract made with the medical frovider:
       
       As part of our service we will attemp to come and aid you in the case of your medical implant going off.
       
-      (X) Revive = Up to 5k
+      (X) Revive = Up to 8k
       (X) Clone  = Up to 10k
       
       In the case were unable to clone you, with your brain still intact, you also agree to be borged:

--- a/Resources/Locale/en-US/_NF/paper/book-medical-insurance.ftl
+++ b/Resources/Locale/en-US/_NF/paper/book-medical-insurance.ftl
@@ -2,15 +2,13 @@ book-medical-insurance = This form is a contract made with the medical frovider:
       --------------------------------------------------------------------------------------
       SECTION 1:  Info
       --------------------------------------------------------------------------------------
-      
       Full Name  :
       Race       :
       Blood Type :
       
       --------------------------------------------------------------------------------------
-      SECTION 3:  Services
+      SECTION 2:  Services
       --------------------------------------------------------------------------------------
-      
       As part of our service we will attemp to come and aid you in the case of your medical implant going off.
       
       (X) Revive = Up to 8k

--- a/Resources/Locale/en-US/_NF/paper/book-medical-insurance.ftl
+++ b/Resources/Locale/en-US/_NF/paper/book-medical-insurance.ftl
@@ -5,6 +5,7 @@ book-medical-insurance = This form is a contract made with the medical frovider:
       Full Name  :
       Race       :
       Blood Type :
+      Ship       :
       
       --------------------------------------------------------------------------------------
       SECTION 2:  Services

--- a/Resources/Locale/en-US/_NF/prototypes/catalog/cargo/cargo-medical.ftl
+++ b/Resources/Locale/en-US/_NF/prototypes/catalog/cargo/cargo-medical.ftl
@@ -1,0 +1,2 @@
+ent-MedicalTrackingImplants = { ent-CrateMedicalTrackingImplants }
+    .desc = { ent-CrateMedicalTrackingImplants.desc }

--- a/Resources/Locale/en-US/_NF/prototypes/catalog/fills/crates/medical-crates.ftl
+++ b/Resources/Locale/en-US/_NF/prototypes/catalog/fills/crates/medical-crates.ftl
@@ -1,0 +1,2 @@
+ent-CrateMedicalTrackingImplants = Medical insurance tracking implants
+    .desc = Contains a handful of medical insurance tracking implanters. make sure to sign with a provider, or hope for an independent medical help.

--- a/Resources/Locale/en-US/implant/implant.ftl
+++ b/Resources/Locale/en-US/implant/implant.ftl
@@ -20,5 +20,5 @@ scramble-implant-activated-popup = Your appearance shifts and changes!
 
 ## Implant Messages
 
-deathrattle-implant-dead-message = {$user} has died at {$position}.
-deathrattle-implant-critical-message = {$user} life signs critical, immediate assistance required at {$position}.
+deathrattle-implant-dead-message = {$user} has died at {$grid}{$position}.
+deathrattle-implant-critical-message = {$user} life signs critical, immediate assistance required at {$grid}{$position}.

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/medical.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/medical.yml
@@ -7,3 +7,4 @@
     Bloodpack: 15
     EpinephrineChemistryBottle: 9
     Syringe: 15
+    BoxMedicalTrackingImplants: 15

--- a/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
@@ -91,7 +91,7 @@
       transmitFrequencyId: SuitSensor
     - type: StationLimitedNetwork
     - type: WirelessNetworkConnection
-      range: 500
+      range: 10000
     - type: TriggerOnMobstateChange
       mobState:
       - Critical

--- a/Resources/Prototypes/_NF/Catalog/Cargo/cargo_medical.yml
+++ b/Resources/Prototypes/_NF/Catalog/Cargo/cargo_medical.yml
@@ -1,0 +1,9 @@
+- type: cargoProduct
+  id: MedicalTrackingImplant
+  icon:
+    sprite: Objects/Specific/Chemistry/syringe.rsi
+    state: syringe_base0
+  product: CrateMedicalTrackingImplants
+  cost: 1000
+  category: Medical
+  group: market

--- a/Resources/Prototypes/_NF/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/Boxes/general.yml
@@ -22,3 +22,5 @@
     layers:
       - state: box
       - state: syringe
+  - type: VendPrice
+    price: 200 # Single Implant Box (5 are 1000)

--- a/Resources/Prototypes/_NF/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/Boxes/general.yml
@@ -14,8 +14,6 @@
         amount: 1
       - id: PaperMedicalInsurance
         amount: 1
-      - id: RubberStampCaptain
-        amount: 1
   - type: Storage
     capacity: 60
   - type: Sprite

--- a/Resources/Prototypes/_NF/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/Boxes/general.yml
@@ -1,0 +1,24 @@
+- type: entity
+  name: medical insurance tracking implant box
+  parent: BoxCardboard
+  id: BoxMedicalTrackingImplants
+  description: Medical insurance implant kit.
+  components:
+  - type: Item
+    size: 60
+  - type: StorageFill
+    contents:
+      - id: MedicalTrackingImplanter
+        amount: 1
+      - id: HandheldGPSBasic
+        amount: 1
+      - id: PaperMedicalInsurance
+        amount: 1
+      - id: RubberStampCaptain
+        amount: 1
+  - type: Storage
+    capacity: 60
+  - type: Sprite
+    layers:
+      - state: box
+      - state: syringe

--- a/Resources/Prototypes/_NF/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/Boxes/general.yml
@@ -10,8 +10,6 @@
     contents:
       - id: MedicalTrackingImplanter
         amount: 1
-      - id: HandheldGPSBasic
-        amount: 1
       - id: PaperMedicalInsurance
         amount: 1
       - id: RubberStampCaptain

--- a/Resources/Prototypes/_NF/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/Boxes/general.yml
@@ -10,6 +10,8 @@
     contents:
       - id: MedicalTrackingImplanter
         amount: 1
+      - id: HandheldGPSBasic
+        amount: 1
       - id: PaperMedicalInsurance
         amount: 1
       - id: RubberStampCaptain

--- a/Resources/Prototypes/_NF/Catalog/Fills/Crates/medical.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/Crates/medical.yml
@@ -4,5 +4,5 @@
   components:
   - type: StorageFill
     contents:
-      - id: MedicalTrackingImplanter
+      - id: BoxMedicalTrackingImplants
         amount: 5

--- a/Resources/Prototypes/_NF/Catalog/Fills/Crates/medical.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/Crates/medical.yml
@@ -1,0 +1,8 @@
+- type: entity
+  id: CrateMedicalTrackingImplants
+  parent: CrateMedical
+  components:
+  - type: StorageFill
+    contents:
+      - id: MedicalTrackingImplanter
+        amount: 5

--- a/Resources/Prototypes/_NF/Entities/Objects/Misc/implanters.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Misc/implanters.yml
@@ -1,0 +1,9 @@
+#Medical implanters
+
+- type: entity
+  id: MedicalTrackingImplanter
+  name: medical insurance tracking implanter
+  parent: BaseImplantOnlyImplanter
+  components:
+    - type: Implanter
+      implant: MedicalTrackingImplant

--- a/Resources/Prototypes/_NF/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Misc/paper.yml
@@ -1,5 +1,5 @@
 - type: entity
-  name: Medical record form for insurance.
+  name: Medical record form for insurance
   parent: Paper
   id: PaperMedicalInsurance
   description: 'Provide this papar for an insurance provider.'

--- a/Resources/Prototypes/_NF/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Misc/paper.yml
@@ -1,0 +1,29 @@
+- type: entity
+  name: Medical record form for insurance.
+  parent: Paper
+  id: PaperMedicalInsurance
+  description: 'Provide this papar for an insurance provider.'
+  components:
+  - type: Paper
+    contentSize: 10000
+    escapeFormatting: false
+    content: book-medical-insurance
+  - type: Sprite
+    sprite: Objects/Misc/bureaucracy.rsi
+    layers:
+      - state: paper
+        color: "#cccccc"
+      - state: paper_words
+        map: ["enum.PaperVisualLayers.Writing"]
+        color: "#cccccc" #aaaaaaaaaaaaaaaaaaaaaaa
+        visible: false
+      - state: paper_stamp-generic
+        map: ["enum.PaperVisualLayers.Stamp"]
+        visible: false
+  - type: PaperVisuals
+    backgroundImagePath: "/Textures/Interface/Paper/paper_background_default.svg.96dpi.png"
+    contentImagePath: "/Textures/Interface/Paper/paper_content_lined.svg.96dpi.png"
+    backgroundModulate: "#cccccc"
+    contentImageModulate: "#cccccc"
+    backgroundPatchMargin: 16.0, 16.0, 16.0, 16.0
+    contentMargin: 16.0, 16.0, 16.0, 16.0

--- a/Resources/Prototypes/_NF/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Misc/paper.yml
@@ -1,5 +1,5 @@
 - type: entity
-  name: Medical record form for insurance
+  name: Medical insurance form
   parent: Paper
   id: PaperMedicalInsurance
   description: 'Provide this papar for an insurance provider.'

--- a/Resources/Prototypes/_NF/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Misc/subdermal_implants.yml
@@ -1,0 +1,27 @@
+#Medical implants
+
+- type: entity
+  parent: BaseSubdermalImplant
+  id: MedicalTrackingImplant
+  name: medical insurance tracking implant
+  description: This implant has a tracking device attached to the suit sensor network, as well as a condition monitor for the Medical radio channel.
+  noSpawn: true
+  components:
+    - type: SubdermalImplant
+    - type: SuitSensor
+      randomMode: false
+      controlsLocked: true
+      mode: SensorCords
+      activationContainer: "implant"
+    - type: DeviceNetwork
+      deviceNetId: Wireless
+      transmitFrequencyId: SuitSensor
+    - type: StationLimitedNetwork
+    - type: WirelessNetworkConnection
+      range: 10000
+    - type: TriggerOnMobstateChange
+      mobState:
+      - Critical
+      - Dead
+    - type: Rattle
+      radioChannel: "Medical"


### PR DESCRIPTION
## About the PR
Added a new implant to help new and coming medical insurance providers, or private medical teams find and save people who are using the implants.
There isn't any hard "terms of use" as of now, I did add a template for an agreement a player can have with a medical team to make sure he will be saved for a fixed rate.

I also made the implants report grid names with cords, or just cords if missing a grid (Space)

## Why / Balance
Giving medical teams a lot more to do, making sure people have an RP way to be saved from dying in deep space.

## Technical details
yml mostly, c# for added function to tracking implants to also report grid names.

## Media
- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None

**Changelog**
:cl: dvir01
- add: Medical implants added to cargo, sign a contract with an insurance providers, or hope for a private medical team to come ans save you, you can now buy a kit and have your critical life support status sent back to any medical radio.
- tweak: All tracking implants will also attempt to report you ship name with cords.
