### PR TITLE
Update ammunition.yml

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Boxes/ammunition.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/ammunition.yml
@@ -289,7 +289,7 @@
     containers:
       ballistic-ammo: !type:Container
   - type: Item
-    size: 30
+    size: 20
   - type: Sprite
     sprite: Objects/Storage/boxes.rsi
 
@@ -302,7 +302,7 @@
       whitelist:
         tags:
         - ShellShotgun
-      capacity: 30
+      capacity: 20
 
 # Shotgun Shells
 - type: entity

--- a/Resources/Prototypes/Catalog/Fills/Boxes/ammunition.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/ammunition.yml
@@ -302,7 +302,7 @@
       whitelist:
         tags:
         - ShellShotgun
-      capacity: 12
+      capacity: 30
 
 # Shotgun Shells
 - type: entity


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Increases the shell capacity of Shotgun Shell Dispensers from 12 to 30, to match with their weight.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

The capacity of shotgun shell dispensers is significantly less efficient than either storing the shells raw in your backpack (1:1), or inside of shell drum magazines (1:1.6), or even inside of Survival Boxes.

I think dispensers should be an efficient method of storing shotgun shells, as they're boxes specifically meant for storing those shells. It being a 1:1 ratio for organization seems reasonable, if only because of the parallel between them and Survival Boxes.


AN alternative would be reducing the weight to 20, and bringing the capacity up to match, or going down to 12-12. The reason for that would be avoiding excessive ammo storage by individual people buying it from the Libertyvend, though ultimately the price of shotgun shells from that vendor is negligible, so all this would do is increase the _total_ stock of shells within the vendor.

**TLDR:** Even if the price of shell dispensers within the Libertyvend was tripled to over-match the new capacity, it would still be the entirely negligible price of $666.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
.yml change.

## Media


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


:cl:
- tweak: Changed capacity for Shotgun Shell Dispensers to match the storage ratio of putting the shells inside your backpack.


