### PR TITLE
Update salvage_rewards.yml

### DIFF
--- a/Resources/Prototypes/Procedural/salvage_rewards.yml
+++ b/Resources/Prototypes/Procedural/salvage_rewards.yml
@@ -69,7 +69,6 @@
     ClothingOuterArmorReflective: 0.5
     MoneyTreeSeeds: 0.5
 
-
 - type: weightedRandomEntity
   id: SalvageRewardEpic
   weights:

--- a/Resources/Prototypes/Procedural/salvage_rewards.yml
+++ b/Resources/Prototypes/Procedural/salvage_rewards.yml
@@ -20,7 +20,9 @@
     SpaceCash1000: 0.75
     SpaceCash2500: 1.25
     # custom NF14
-    CrateFloorsFun: 0.75
+    CrateFloorsFun: 0.1
+    CrateEngineeringJetpack: 0.25
+    CrateMaterialTextiles: 1.0
 
 - type: weightedRandomEntity
   id: SalvageRewardRare
@@ -65,9 +67,10 @@
     ScienceTechFabCircuitboard: 1.0
     SecurityTechFabCircuitboard: 0.25
     MaterialReclaimerMachineCircuitboard: 1.0
-    CratePirateChest: 0.5
+    CrateFunParty: 0.5
     ClothingOuterArmorReflective: 0.5
     MoneyTreeSeeds: 0.5
+    CrateMedicalSupplies: 0.5
 
 - type: weightedRandomEntity
   id: SalvageRewardEpic
@@ -94,6 +97,7 @@
     # Custom NF
     EnergySword: 0.5
     EnergyDagger: 0.5
+    EnergySwordDouble: 0.1
     #EnergyCutlass: 0.5
     Claymore: 0.5
     WeaponLauncherRocket: 0.5

--- a/Resources/Prototypes/Procedural/salvage_rewards.yml
+++ b/Resources/Prototypes/Procedural/salvage_rewards.yml
@@ -13,7 +13,7 @@
     CrateFunATV: 0.25
     CrateFunInstrumentsVariety: 0.25
     CrateSalvageEquipment: 0.25
-    RandomArtifactSpawner: 0.25
+    #RandomArtifactSpawner: 0.25
     # weighted down since it sells for a lot
     NuclearBombKeg: 0.1
     # money

--- a/Resources/Prototypes/Procedural/salvage_rewards.yml
+++ b/Resources/Prototypes/Procedural/salvage_rewards.yml
@@ -95,6 +95,6 @@
     # Custom NF
     EnergySword: 0.5
     EnergyDagger: 0.5
-    EnergyCutlass: 0.5
+    #EnergyCutlass: 0.5
     Claymore: 0.5
     WeaponLauncherRocket: 0.5

--- a/Resources/Prototypes/Procedural/salvage_rewards.yml
+++ b/Resources/Prototypes/Procedural/salvage_rewards.yml
@@ -19,6 +19,8 @@
     # money
     SpaceCash1000: 0.75
     SpaceCash2500: 1.25
+    # custom NF14
+    CrateFloorsFun: 0.75
 
 - type: weightedRandomEntity
   id: SalvageRewardRare
@@ -30,7 +32,7 @@
     SheetUranium: 1.0
     CratePartsT3: 1.0
     CratePartsT3T4: 0.5
-    TechnologyDiskRare: 0.5
+    #TechnologyDiskRare: 0.5
     # cloning boards
     CloningPodMachineCircuitboard: 0.5
     MedicalScannerMachineCircuitboard: 0.5


### PR DESCRIPTION
## About the PR
Small salvage_rewards changes

## Why / Balance
Removed RandomArtifactSpawner - It can still go crazy on spawn.
Added CrateFloorsFun
Added CrateEngineeringJetpack
Added CrateMaterialTextiles
Removed TechnologyDisk - only good for sci, not for everyone.
Replaced CratePirateChest with CrateFunParty
Added CrateMedicalSupplies
Removed EnergyCutlass - Move to pirate vend / pirate ships.
Added EnergySwordDouble - Rare

## Technical details
.yml changes

## Media
- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None

**Changelog**
no cl