### PR TITLE
Monkey Fun

### DIFF
--- a/Content.Server/Cargo/Components/MobPriceComponent.cs
+++ b/Content.Server/Cargo/Components/MobPriceComponent.cs
@@ -1,4 +1,4 @@
-﻿namespace Content.Server.Cargo.Components;
+namespace Content.Server.Cargo.Components;
 
 /// <summary>
 /// This is used for calculating the price of mobs.
@@ -23,4 +23,10 @@ public sealed partial class MobPriceComponent : Component
     /// </summary>
     [DataField("deathPenalty")]
     public double DeathPenalty = 0.2f;
+
+    /// <summary>
+    /// The percentage of the actual price that should be granted should the appraised mob be lab grown calc added after DeathPenalty, will use tag "LabGrown".
+    /// </summary>
+    [DataField("labGrownPenalty")]
+    public double LabGrownPenalty = 0.2f;
 }

--- a/Content.Server/Cargo/Systems/PricingSystem.cs
+++ b/Content.Server/Cargo/Systems/PricingSystem.cs
@@ -17,6 +17,7 @@ using Robust.Shared.Containers;
 using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
+using Content.Shared.Tag;
 
 namespace Content.Server.Cargo.Systems;
 
@@ -31,6 +32,8 @@ public sealed class PricingSystem : EntitySystem
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly BodySystem _bodySystem = default!;
     [Dependency] private readonly MobStateSystem _mobStateSystem = default!;
+
+    [Dependency] private readonly TagSystem _tagSystem = default!;
 
     /// <inheritdoc/>
     public override void Initialize()
@@ -103,7 +106,7 @@ public sealed class PricingSystem : EntitySystem
         var partRatio = totalPartsPresent / (double) totalParts;
         var partPenalty = component.Price * (1 - partRatio) * component.MissingBodyPartPenalty;
 
-        args.Price += (component.Price - partPenalty) * (_mobStateSystem.IsAlive(uid, state) ? 1.0 : component.DeathPenalty);
+        args.Price += (component.Price - partPenalty) * (_mobStateSystem.IsAlive(uid, state) ? 1.0 : component.DeathPenalty) * (!_tagSystem.HasTag(uid, "LabGrown") ? 1.0 : component.LabGrownPenalty);
     }
 
     private double GetSolutionPrice(SolutionContainerManagerComponent component)

--- a/Resources/Prototypes/Body/Organs/Animal/animal.yml
+++ b/Resources/Prototypes/Body/Organs/Animal/animal.yml
@@ -7,7 +7,7 @@
   - type: Sprite
     sprite: Mobs/Species/Human/organs.rsi
   - type: StaticPrice
-    price: 50
+    price: 5 # Why will anyone pay big money for animal organs
 
 
 - type: entity

--- a/Resources/Prototypes/Body/Parts/animal.yml
+++ b/Resources/Prototypes/Body/Parts/animal.yml
@@ -19,7 +19,7 @@
       bodypart: !type:Container
         ents: []
   - type: StaticPrice
-    price: 50
+    price: 5 # Why will anyone pay big money for animal organs
   - type: Tag
     tags:
       - Trash

--- a/Resources/Prototypes/Catalog/Cargo/cargo_livestock.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_livestock.yml
@@ -114,7 +114,7 @@
     sprite: Mobs/Animals/monkey.rsi
     state: monkey
   product: CrateNPCMonkeyCube
-  cost: 4500
+  cost: 900
   category: Livestock
   group: market
 

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chefvend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chefvend.yml
@@ -7,15 +7,15 @@
     ReagentContainerRice: 2
     FoodCondimentPacketSalt: 4
     FoodCondimentBottleEnzyme: 2
-    FoodCondimentBottleHotsauce: 1
-    FoodCondimentBottleKetchup: 1
-    FoodCondimentBottleBBQ: 1
+    FoodCondimentBottleHotsauce: 2
+    FoodCondimentBottleKetchup: 2
+    FoodCondimentBottleBBQ: 2
     FoodCondimentBottleVinegar: 2
     ReagentContainerOliveoil: 2
-    MonkeyCubeBox: 1
-    FoodContainerEgg: 1
+    MonkeyCubeBox: 3
+    FoodContainerEgg: 2
     ReagentContainerMilk: 2
-    ReagentContainerMilkSoy: 1
+    ReagentContainerMilkSoy: 2
     FoodButter: 4
-    FoodCheese: 1
+    FoodCheese: 2
     FoodMeat: 6

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -882,6 +882,9 @@
     clumsySound:
       path: /Audio/Animals/monkey_scream.ogg
   - type: IdExaminable
+  - type: Tag
+    tags:
+    - LabGrown
 
 - type: entity
   name: guidebook monkey

--- a/Resources/Prototypes/Entities/Objects/Misc/monkeycube.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/monkeycube.yml
@@ -19,7 +19,7 @@
   - type: StaticPrice
     price: 20
   - type: VendPrice
-    price: 4500 # Yep, same price as the crate
+    price: 900 # 150 per monkey (Meat worth 200)
 
 - type: entity
   parent: BaseItem
@@ -40,7 +40,7 @@
     tags:
     - MonkeyCube
   - type: StaticPrice
-    price: 460 # The same price as dead (-20)
+    price: 55 # The same price as dead (-20)
 
 - type: entity
   parent: BoxCardboard

--- a/Resources/Prototypes/Entities/Objects/Specific/rehydrateable.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/rehydrateable.yml
@@ -47,7 +47,7 @@
         layer:
         - LowImpassable
   - type: StaticPrice
-    price: 460 # The same price as dead (-20)
+    price: 35 # The same price as dead (-20)
 
 - type: entity
   parent: PlushieCarp
@@ -104,7 +104,7 @@
     sound:
       path: /Audio/Effects/bite.ogg
   - type: StaticPrice
-    price: 580 # The same price as dead (-20)
+    price: 220 # The same price as dead (-20)
 
 - type: entity
   parent: BaseItem

--- a/Resources/Prototypes/_NF/tags.yml
+++ b/Resources/Prototypes/_NF/tags.yml
@@ -1,0 +1,5 @@
+- type: Tag
+  id: CaveFactory
+
+- type: Tag
+  id: LabGrown

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -1036,7 +1036,3 @@
 
 - type: Tag
   id: ModularReceiver
-
-##Custom ones here I suppose
-- type: Tag
-  id: CaveFactory


### PR DESCRIPTION
## About the PR
Monkey mob worth less, so monkey cubes price adjusted.
Animal organs worth less, needed to be to fix monkey price. 
ChefVend more full of stock.

## Why / Balance
Allows the monkey cubes to have a normal price.

## Technical details
.yml changes, added a new tag (LabGrown) and a new double (LabGrownPenalty) with added code to allow it to lower the worth of the monkey mob more.

## Media
- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
Overall all mobs will sell for a lower price since the animal organs are worth 10 times less 50<5

**Changelog**
:cl: dvir01
- tweak: Lab grown monkey cubes now cost less.