### PR TITLE
Station Bank Deposits

### DIFF
--- a/Content.Client/Bank/BUI/StationBankATMMenuBoundUserInterface.cs
+++ b/Content.Client/Bank/BUI/StationBankATMMenuBoundUserInterface.cs
@@ -18,6 +18,7 @@ public sealed class StationBankATMMenuBoundUserInterface : BoundUserInterface
 
         _menu = new StationBankATMMenu();
         _menu.WithdrawRequest += OnWithdraw;
+        _menu.DepositRequest += OnDeposit;
         _menu.OnClose += Close;
         _menu.PopulateReasons();
         _menu.OpenCentered();
@@ -38,6 +39,14 @@ public sealed class StationBankATMMenuBoundUserInterface : BoundUserInterface
             return;
 
         SendMessage(new StationBankWithdrawMessage(amount, _menu.Reason, _menu.Description));
+    }
+
+    private void OnDeposit()
+    {
+        if (_menu?.Amount is not int amount)
+            return;
+
+        SendMessage(new StationBankDepositMessage(amount, _menu.Reason, _menu.Description));
     }
 
     protected override void UpdateState(BoundUserInterfaceState state)

--- a/Content.Client/Bank/BUI/StationBankATMMenuBoundUserInterface.cs
+++ b/Content.Client/Bank/BUI/StationBankATMMenuBoundUserInterface.cs
@@ -58,5 +58,6 @@ public sealed class StationBankATMMenuBoundUserInterface : BoundUserInterface
 
         _menu?.SetEnabled(bankState.Enabled);
         _menu?.SetBalance(bankState.Balance);
+        _menu?.SetDeposit(bankState.Deposit);
     }
 }

--- a/Content.Client/Bank/UI/StationBankATMMenu.xaml
+++ b/Content.Client/Bank/UI/StationBankATMMenu.xaml
@@ -1,8 +1,8 @@
 <controls:FancyWindow xmlns="https://spacestation14.io"
             xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
             xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
-            SetSize="480 210"
-            MinSize="360 210">
+            SetSize="480 230"
+            MinSize="360 230">
     <BoxContainer Margin="10 2 10 2" Orientation="Vertical">
         <BoxContainer Orientation="Horizontal">
             <Label Text="{Loc 'bank-atm-menu-balance-label'}"
@@ -32,6 +32,12 @@
         <Button Name="WithdrawButton"
                 Text="{Loc 'bank-atm-menu-withdraw-button'}"/>
         <TextureButton VerticalExpand="True" />
+        <BoxContainer Orientation="Horizontal">
+            <Label Text="{Loc 'bank-atm-menu-deposit-label'}"
+                   StyleClasses="LabelKeyText" />
+            <Label Name="DepositLabel"
+                   Text="{Loc 'bank-atm-menu-no-deposit'}" />
+        </BoxContainer>
         <Button Name="DepositButton"
                 Text="{Loc 'bank-atm-menu-deposit-button'}"/>
         <TextureButton VerticalExpand="True" />

--- a/Content.Client/Bank/UI/StationBankATMMenu.xaml
+++ b/Content.Client/Bank/UI/StationBankATMMenu.xaml
@@ -1,8 +1,8 @@
 <controls:FancyWindow xmlns="https://spacestation14.io"
             xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
             xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
-            SetSize="480 180"
-            MinSize="360 180">
+            SetSize="480 210"
+            MinSize="360 210">
     <BoxContainer Margin="10 2 10 2" Orientation="Vertical">
         <BoxContainer Orientation="Horizontal">
             <Label Text="{Loc 'bank-atm-menu-balance-label'}"
@@ -27,10 +27,13 @@
             <Label Text="{Loc 'bank-atm-description-label'}"
                    StyleClasses="LabelKeyText"
                    MinSize="100 0" />
-            <LineEdit Name="WithdrawDescription" MinSize="120 0" HorizontalExpand="True"/>
+            <LineEdit Name="AmountDescription" MinSize="120 0" HorizontalExpand="True"/>
         </BoxContainer>
         <Button Name="WithdrawButton"
                 Text="{Loc 'bank-atm-menu-withdraw-button'}"/>
+        <TextureButton VerticalExpand="True" />
+        <Button Name="DepositButton"
+                Text="{Loc 'bank-atm-menu-deposit-button'}"/>
         <TextureButton VerticalExpand="True" />
     </BoxContainer>
 </controls:FancyWindow>

--- a/Content.Client/Bank/UI/StationBankATMMenu.xaml.cs
+++ b/Content.Client/Bank/UI/StationBankATMMenu.xaml.cs
@@ -9,6 +9,7 @@ namespace Content.Client.Bank.UI;
 public sealed partial class StationBankATMMenu : FancyWindow
 {
     public Action? WithdrawRequest;
+    public Action? DepositRequest;
     public int Amount;
     private readonly List<string> _reasonStrings = new();
     public string? Reason;
@@ -17,10 +18,11 @@ public sealed partial class StationBankATMMenu : FancyWindow
     {
         RobustXamlLoader.Load(this);
         WithdrawButton.OnPressed += OnWithdrawPressed;
+        DepositButton.OnPressed += OnDepositPressed;
         Title = Loc.GetString("station-bank-atm-menu-title");
         WithdrawEdit.OnTextChanged += OnAmountChanged;
         Reasons.OnItemSelected += OnReasonSelected;
-        WithdrawDescription.OnTextChanged += OnDescChanged;
+        AmountDescription.OnTextChanged += OnDescChanged;
     }
 
     private void SetReasonText(int id)
@@ -40,11 +42,17 @@ public sealed partial class StationBankATMMenu : FancyWindow
     public void SetEnabled(bool enabled)
     {
         WithdrawButton.Disabled = !enabled;
+        DepositButton.Disabled = !enabled;
     }
 
     private void OnWithdrawPressed(BaseButton.ButtonEventArgs obj)
     {
         WithdrawRequest?.Invoke();
+    }
+
+    private void OnDepositPressed(BaseButton.ButtonEventArgs obj)
+    {
+        DepositRequest?.Invoke();
     }
 
     private void OnAmountChanged(LineEdit.LineEditEventArgs args)

--- a/Content.Client/Bank/UI/StationBankATMMenu.xaml.cs
+++ b/Content.Client/Bank/UI/StationBankATMMenu.xaml.cs
@@ -39,6 +39,12 @@ public sealed partial class StationBankATMMenu : FancyWindow
         BalanceLabel.Text = Loc.GetString("cargo-console-menu-points-amount", ("amount", amount.ToString()));
     }
 
+    public void SetDeposit(int amount)
+    {
+        DepositButton.Disabled = amount <= 0;
+        DepositLabel.Text = Loc.GetString("cargo-console-menu-points-amount", ("amount", amount.ToString()));
+    }
+
     public void SetEnabled(bool enabled)
     {
         WithdrawButton.Disabled = !enabled;

--- a/Content.Server/Cargo/Systems/CargoSystem.Orders.cs
+++ b/Content.Server/Cargo/Systems/CargoSystem.Orders.cs
@@ -453,12 +453,6 @@ namespace Content.Server.Cargo.Systems
             Dirty(component);
         }
 
-        public void IncreaseFunds(StationBankAccountComponent component, int amount)
-        {
-            component.Balance = Math.Max(0, component.Balance + amount);
-            Dirty(component);
-        }
-
         #region Station
 
         private StationBankAccountComponent? GetBankAccount(EntityUid uid, CargoOrderConsoleComponent _)

--- a/Content.Server/Cargo/Systems/CargoSystem.Orders.cs
+++ b/Content.Server/Cargo/Systems/CargoSystem.Orders.cs
@@ -453,6 +453,12 @@ namespace Content.Server.Cargo.Systems
             Dirty(component);
         }
 
+        public void IncreaseFunds(StationBankAccountComponent component, int amount)
+        {
+            component.Balance = Math.Max(0, component.Balance + amount);
+            Dirty(component);
+        }
+
         #region Station
 
         private StationBankAccountComponent? GetBankAccount(EntityUid uid, CargoOrderConsoleComponent _)

--- a/Content.Server/_NF/Bank/ATMSystem.cs
+++ b/Content.Server/_NF/Bank/ATMSystem.cs
@@ -182,9 +182,9 @@ public sealed partial class BankSystem
             new BankATMMenuInterfaceState(bank.Balance, true, 0));
         return;
     }
+
     private void OnCashSlotChanged(EntityUid uid, BankATMComponent component, ContainerModifiedMessage args)
     {
-
         var bankUi = _uiSystem.GetUiOrNull(uid, BankATMMenuUiKey.ATM) ?? _uiSystem.GetUiOrNull(uid, BankATMMenuUiKey.BlackMarket);
 
         var uiUser = bankUi!.SubscribedSessions.FirstOrDefault();

--- a/Content.Server/_NF/Bank/BankSystem.cs
+++ b/Content.Server/_NF/Bank/BankSystem.cs
@@ -6,6 +6,7 @@ using Content.Shared.Bank.Components;
 using Content.Shared.Preferences;
 using Robust.Shared.GameStates;
 using Robust.Shared.Network;
+using Content.Server.Cargo.Components;
 
 namespace Content.Server.Bank;
 

--- a/Content.Server/_NF/Bank/StationATMSystem.cs
+++ b/Content.Server/_NF/Bank/StationATMSystem.cs
@@ -189,7 +189,7 @@ public sealed partial class BankSystem
             return;
         }
 
-        _cargo.IncreaseFunds(stationBank, args.Amount);
+        _cargo.DeductFunds(stationBank, -args.Amount);
         ConsolePopup(args.Session, Loc.GetString("bank-atm-menu-deposit-successful"));
         PlayConfirmSound(uid, component);
         _log.Info($"{args.Session.UserId} {args.Session.Name} deposited {args.Amount}, '{args.Reason}': {args.Description}");

--- a/Content.Shared/_NF/Bank/BUI/StationBankATMMenuInterfaceState.cs
+++ b/Content.Shared/_NF/Bank/BUI/StationBankATMMenuInterfaceState.cs
@@ -15,9 +15,15 @@ public sealed class StationBankATMMenuInterfaceState : BoundUserInterfaceState
     /// </summary>
     public bool Enabled;
 
-    public StationBankATMMenuInterfaceState(int balance, bool enabled)
+    /// <summary>
+    /// how much cash is inserted
+    /// </summary>
+    public int Deposit;
+
+    public StationBankATMMenuInterfaceState(int balance, bool enabled, int deposit)
     {
         Balance = balance;
         Enabled = enabled;
+        Deposit = deposit;
     }
 }

--- a/Content.Shared/_NF/Bank/Components/StationBankATMComponent.cs
+++ b/Content.Shared/_NF/Bank/Components/StationBankATMComponent.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Containers.ItemSlots;
 using Content.Shared.Stacks;
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
@@ -11,6 +12,11 @@ public sealed partial class StationBankATMComponent : Component
 {
     [ViewVariables(VVAccess.ReadWrite), DataField("cashType", customTypeSerializer:typeof(PrototypeIdSerializer<StackPrototype>))]
     public string CashType = "Credit";
+
+    public static string CashSlotSlotId = "station-bank-ATM-cashSlot";
+
+    [DataField("station-bank-ATM-cashSlot")]
+    public ItemSlot CashSlot = new();
 
     [DataField("soundError")]
     public SoundSpecifier ErrorSound =

--- a/Content.Shared/_NF/Bank/Events/StationBankDepositMessage.cs
+++ b/Content.Shared/_NF/Bank/Events/StationBankDepositMessage.cs
@@ -1,0 +1,22 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.Bank.Events;
+
+/// <summary>
+/// Raised on a client bank deposit
+/// </summary>
+[Serializable, NetSerializable]
+
+public sealed class StationBankDepositMessage : BoundUserInterfaceMessage
+{
+    //amount to deposit. validation is happening server side but we still need client input from a text field.
+    public int Amount;
+    public string? Reason;
+    public string? Description;
+    public StationBankDepositMessage(int amount, string? reason, string? description)
+    {
+        Amount = amount;
+        Reason = reason;
+        Description = description;
+    }
+}

--- a/Content.Shared/_NF/Bank/SharedBankSystem.cs
+++ b/Content.Shared/_NF/Bank/SharedBankSystem.cs
@@ -22,6 +22,8 @@ public sealed partial class SharedBankSystem : EntitySystem
         SubscribeLocalEvent<BankAccountComponent, ComponentHandleState>(OnHandleState);
         SubscribeLocalEvent<BankATMComponent, ComponentInit>(OnComponentInit);
         SubscribeLocalEvent<BankATMComponent, ComponentRemove>(OnComponentRemove);
+        SubscribeLocalEvent<StationBankATMComponent, ComponentInit>(OnComponentInit);
+        SubscribeLocalEvent<StationBankATMComponent, ComponentRemove>(OnComponentRemove);
     }
 
     private void OnComponentInit(EntityUid uid, BankATMComponent component, ComponentInit args)
@@ -30,6 +32,16 @@ public sealed partial class SharedBankSystem : EntitySystem
     }
 
     private void OnComponentRemove(EntityUid uid, BankATMComponent component, ComponentRemove args)
+    {
+        _itemSlotsSystem.RemoveItemSlot(uid, component.CashSlot);
+    }
+
+    private void OnComponentInit(EntityUid uid, StationBankATMComponent component, ComponentInit args)
+    {
+        _itemSlotsSystem.AddItemSlot(uid, StationBankATMComponent.CashSlotSlotId, component.CashSlot);
+    }
+
+    private void OnComponentRemove(EntityUid uid, StationBankATMComponent component, ComponentRemove args)
     {
         _itemSlotsSystem.RemoveItemSlot(uid, component.CashSlot);
     }

--- a/Resources/Locale/en-US/_NF/bank/bank-ATM-component.ftl
+++ b/Resources/Locale/en-US/_NF/bank/bank-ATM-component.ftl
@@ -22,3 +22,4 @@ station-bank-bounty = Bounty
 station-bank-other = Other
 station-bank-required = {"("}Required{")"}
 station-bank-requires-reason = NT Requires transaction details
+station-bank-unauthorized = Unauthorized!

--- a/Resources/Prototypes/_NF/Entities/Structures/atms.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/atms.yml
@@ -465,6 +465,15 @@
     sound:
       collection: Keyboard
   - type: StationBankATM
+    station-bank-ATM-cashSlot:
+      name: station-bank-ATM-cashSlot
+      insertSound: /Audio/Machines/scanning.ogg
+      ejectSound: /Audio/Machines/tray_eject.ogg
+      ejectOnBreak: true
+      swap: false
+      whitelist:
+        components:
+          - Currency
   - type: ActivatableUI
     key: enum.BankATMMenuUiKey.ATM
   - type: UserInterface
@@ -473,6 +482,10 @@
       type: StationBankATMMenuBoundUserInterface
   - type: AccessReader
     access: [["HeadOfPersonnel"]]
+  - type: ItemSlots
+  - type: ContainerContainer
+    containers:
+      station-bank-ATM-cashSlot: !type:ContainerSlot {}
   - type: Destructible
     thresholds:
     - trigger:


### PR DESCRIPTION
## About the PR
Allow the SE to deposit money back into the bank, needed for SR mistakes, fines and recovered assets from sells related to contraband found by security.

## Why / Balance
Much needed and requested.

## Technical details
Added a new deposit function to the station bank computer, this one isn't the same as the normal ATM since it require you to provide logic for logs when you insert money into it, and also allow multi deposits to be done to the inserted money.

## Media
On the discord
https://discord.com/channels/1123826877245694004/1127687656084611214/1156642734174634034

## Breaking changes
None, testes it to make sure it wont have exploits or issues.

**Changelog**
:cl: dvir01
- tweak: NT Now allows the SR to deposit money into the station bank.