### PR TITLE
Lower empress asteroid spawn range

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -103,9 +103,9 @@
     tags:
       - Syndicate
   - type: RadarConsole
-    maxRange: 1600
+    maxRange: 1000
   - type: WorldLoader
-    radius: 600
+    radius: 1000
   - type: PointLight
     radius: 1.5
     energy: 1.6

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -103,9 +103,9 @@
     tags:
       - Syndicate
   - type: RadarConsole
-    maxRange: 1536
+    maxRange: 1600
   - type: WorldLoader
-    radius: 1536
+    radius: 600
   - type: PointLight
     radius: 1.5
     energy: 1.6


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Lowered world generator to 600 and rounded the radar to 1600, you will still be able to use the very long range radar without hurting server performance. will look a lil jank but its in the name of server performance.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Too many asteroids hurt server performance also cleaner radar console.

:cl: Leander

- tweak: Empress no longer hurts the server as much

