### PR TITLE
crew_monitor_server.yml

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/crew_monitor_server.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/crew_monitor_server.yml
@@ -28,7 +28,7 @@
       receiveFrequencyId: SuitSensor
       autoConnect: false
     - type: WirelessNetworkConnection
-      range: 500
+      range: 10000
     - type: StationLimitedNetwork
     - type: ApcPowerReceiver
       powerLoad: 200


### PR DESCRIPTION
## About the PR
Up the crew monitor range 500<10000

## Why / Balance
500 isnt usefull for frontier

## Technical details
.yml change

## Media
- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None

**Changelog**
:cl: dvir01
- tweak: Crew monitor range 500<10000
