### PR TITLE
ProtectedGridComponent

### DIFF
--- a/Content.Server/Maps/TileSystem.cs
+++ b/Content.Server/Maps/TileSystem.cs
@@ -6,6 +6,7 @@ using Content.Shared.Maps;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Random;
+using Content.Shared.Tiles;
 
 namespace Content.Server.Maps;
 
@@ -95,6 +96,13 @@ public sealed class TileSystem : EntitySystem
             return false;
 
         var mapGrid = _mapManager.GetGrid(tileRef.GridUid);
+
+        var gridUid = mapGrid.Owner;
+        var ev = new FloorTileAttemptEvent();
+        RaiseLocalEvent(mapGrid);
+
+        if ((HasComp<ProtectedGridComponent>(gridUid) || ev.Cancelled) && tileDef.ID == "Plating")
+            return false;
 
         const float margin = 0.1f;
         var bounds = mapGrid.TileSize - margin * 2;

--- a/Content.Shared/Tiles/FloorTileSystem.cs
+++ b/Content.Shared/Tiles/FloorTileSystem.cs
@@ -126,7 +126,7 @@ public sealed class FloorTileSystem : EntitySystem
                 var ev = new FloorTileAttemptEvent();
                 RaiseLocalEvent(mapGrid);
 
-                if (HasComp<ProtectedGridComponent>(gridUid) || ev.Cancelled)
+                if ((HasComp<ProtectedGridComponent>(gridUid) || ev.Cancelled) && currentTileDefinition.ID == "Lattice")
                 {
                     if (_netManager.IsClient && _timing.IsFirstTimePredicted)
                         _popup.PopupEntity(Loc.GetString("invalid-floor-placement"), args.User);


### PR DESCRIPTION
## About the PR
Floors can be replaced on frontier
RCD Remove floor and add floor is blocked
Axe / axe like tools cannot remove plating from the floor

## Why / Balance
Safe zoom tiles actually not bad now.

## Technical details
C#
Used the code from the original "FloorTileSystem" with added changes to make it work for frontier.

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

Frontier Demo:
https://discord.com/channels/1123826877245694004/1127687656084611214/1158156380604219593

Ship Demo (Nothing changed):
https://discord.com/channels/1123826877245694004/1127687656084611214/1158157307427950622

## Breaking changes
None, only effect places with "ProtectedGridComponent"

**Changelog**
:cl: dvir01
- tweak: NT Fixed the floor tiles auto bolt function on frontier so now you can replace the floors.