### PR TITLE
Event Flag - MaximumPlayers

### DIFF
--- a/Content.Server/StationEvents/Components/StationEventComponent.cs
+++ b/Content.Server/StationEvents/Components/StationEventComponent.cs
@@ -1,4 +1,4 @@
-﻿using Robust.Shared.Audio;
+using Robust.Shared.Audio;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Server.StationEvents.Components;
@@ -68,6 +68,15 @@ public sealed partial class StationEventComponent : Component
     /// </remarks>
     [DataField("minimumPlayers")]
     public int MinimumPlayers;
+
+    /// <summary>
+    ///     How many players need to be present on station for the event to not run
+    /// </summary>
+    /// <remarks>
+    ///     To avoid running safe events with high-pop
+    /// </remarks>
+    [DataField("maximumPlayers")]
+    public int MaximumPlayers = 0;
 
     /// <summary>
     ///     How many times this even can occur in a single round

--- a/Content.Server/StationEvents/Components/StationEventComponent.cs
+++ b/Content.Server/StationEvents/Components/StationEventComponent.cs
@@ -76,7 +76,7 @@ public sealed partial class StationEventComponent : Component
     ///     To avoid running safe events with high-pop
     /// </remarks>
     [DataField("maximumPlayers")]
-    public int MaximumPlayers = 0;
+    public int MaximumPlayers = 999;
 
     /// <summary>
     ///     How many times this even can occur in a single round

--- a/Content.Server/StationEvents/EventManagerSystem.cs
+++ b/Content.Server/StationEvents/EventManagerSystem.cs
@@ -192,11 +192,6 @@ public sealed class EventManagerSystem : EntitySystem
             return false;
         }
 
-        if (playerCount > stationEvent.MaximumPlayers)
-        {
-            return false;
-        }
-
         if (currentTime != TimeSpan.Zero && currentTime.TotalMinutes < stationEvent.EarliestStart)
         {
             return false;
@@ -205,6 +200,11 @@ public sealed class EventManagerSystem : EntitySystem
         var lastRun = TimeSinceLastEvent(prototype);
         if (lastRun != TimeSpan.Zero && currentTime.TotalMinutes <
             stationEvent.ReoccurrenceDelay + lastRun.TotalMinutes)
+        {
+            return false;
+        }
+
+        if (playerCount > stationEvent.MaximumPlayers)
         {
             return false;
         }

--- a/Content.Server/StationEvents/EventManagerSystem.cs
+++ b/Content.Server/StationEvents/EventManagerSystem.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using Content.Server.GameTicking;
 using Content.Server.StationEvents.Components;
 using Content.Shared.CCVar;
@@ -188,6 +188,11 @@ public sealed class EventManagerSystem : EntitySystem
         }
 
         if (playerCount < stationEvent.MinimumPlayers)
+        {
+            return false;
+        }
+
+        if (playerCount > stationEvent.MaximumPlayers)
         {
             return false;
         }


### PR DESCRIPTION
## About the PR
To allow us to add events for lower pop shifts

## Why / Balance
SR Do be poor

## Technical details
C#, Added a new flag called MaximumPlayers with a default of 999 to StationEventComponent

The 999 means the it will never false the event (Cancel it) unless you require a lower number to be the max.

## Media
- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None

**Changelog**
No need