### PR TITLE
DoorRemoteFirefight Remove From Lockers

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
@@ -89,7 +89,7 @@
       - id: GasAnalyzer
       - id: MedkitOxygenFilled
       - id: HolofanProjector
-      - id: DoorRemoteFirefight
+#      - id: DoorRemoteFirefight
 
 - type: entity
   id: LockerAtmosphericsFilled
@@ -104,7 +104,7 @@
       - id: GasAnalyzer
       - id: MedkitOxygenFilled
       - id: HolofanProjector
-      - id: DoorRemoteFirefight
+#      - id: DoorRemoteFirefight
 
 - type: entity
   id: LockerEngineerFilledHardsuit


### PR DESCRIPTION
## About the PR
Remove from lockers like the other remotes, used for trolling

## Why / Balance
Remove from lockers like the other remotes, used for trolling

## Technical details
.yml changes

## Media
- [X] This PR does not require an ingame showcase

## Breaking changes
None

**Changelog**
N/A