### PR TITLE
Medical implant list specie

### DIFF
--- a/Content.Server/Explosion/EntitySystems/TriggerSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/TriggerSystem.cs
@@ -343,16 +343,5 @@ namespace Content.Server.Explosion.EntitySystems
                     _appearance.SetData(uid, TriggerVisuals.VisualState, TriggerVisualState.Unprimed, appearance);
             }
         }
-        private string GetSpeciesRepresentation(string speciesId)
-        {
-            if (_prototypeManager.TryIndex<SpeciesPrototype>(speciesId, out var species))
-            {
-                return Loc.GetString(species.Name);
-            }
-            else
-            {
-                return Loc.GetString("humanoid-appearance-component-unknown-species");
-            }
-        }
     }
 }

--- a/Content.Server/Explosion/EntitySystems/TriggerSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/TriggerSystem.cs
@@ -24,7 +24,6 @@ using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Weapons.Ranged.Events;
 using Content.Server.Station.Systems;
-using Content.Shared.Humanoid.Prototypes;
 using Content.Shared.Humanoid;
 
 namespace Content.Server.Explosion.EntitySystems

--- a/Resources/Locale/en-US/implant/implant.ftl
+++ b/Resources/Locale/en-US/implant/implant.ftl
@@ -20,5 +20,5 @@ scramble-implant-activated-popup = Your appearance shifts and changes!
 
 ## Implant Messages
 
-deathrattle-implant-dead-message = {$user} has died at {$grid}{$position}.
-deathrattle-implant-critical-message = {$user} life signs critical, immediate assistance required at {$grid}{$position}.
+deathrattle-implant-dead-message = {$user}{$specie} has died at {$grid}{$position}.
+deathrattle-implant-critical-message = {$user}{$specie} life signs critical, immediate assistance required at {$grid}{$position}.


### PR DESCRIPTION
## About the PR
Add the specie name to the tracking implants report

## Why / Balance
With the added names to pets, its getting harder to know what specie is the dead report on (Player? pet?)

## Technical details
Adding a test to grab the specie name, if not existing leave empty or mob number.

## Media
- [X] This PR does not require an ingame showcase

## Breaking changes
None

**Changelog**
:cl: dvir01
- add: Tracking implant (Security and medical) will now list your specie!
