### PR TITLE
Access config fix

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/artifact_equipment.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/artifact_equipment.yml
@@ -4,7 +4,7 @@
   components:
     - type: Transform
       noRot: true
-#    - type: AccessReader
+    - type: AccessReader
 #      access: [["Research"], ["Salvage"]]
     - type: Lock
     - type: Sprite

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -388,7 +388,7 @@
     priority: Low
   - type: Computer
     board: ResearchComputerCircuitboard
-#  - type: AccessReader
+  - type: AccessReader
 #    access: [["Research"]]
   - type: PointLight
     radius: 1.5
@@ -733,7 +733,7 @@
     autoRot: true
     offset: "0, 0.4" # shine from the top, not bottom of the computer
     castShadows: false
-  #- type: AccessReader
+  - type: AccessReader
     #access: [["Cargo"]]
   - type: DeviceNetwork
     deviceNetId: Wireless

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -876,7 +876,7 @@
       radius: 1.5
       energy: 1.6
       color: "#b89f25"
-#    - type: AccessReader
+    - type: AccessReader
 #      access: [["Salvage"]]
 
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -388,7 +388,7 @@
     priority: Low
   - type: Computer
     board: ResearchComputerCircuitboard
-  - type: AccessReader
+#  - type: AccessReader
 #    access: [["Research"]]
   - type: PointLight
     radius: 1.5
@@ -733,7 +733,7 @@
     autoRot: true
     offset: "0, 0.4" # shine from the top, not bottom of the computer
     castShadows: false
-  - type: AccessReader
+  #- type: AccessReader
     #access: [["Cargo"]]
   - type: DeviceNetwork
     deviceNetId: Wireless

--- a/Resources/Prototypes/Entities/Structures/Machines/anomaly_equipment.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/anomaly_equipment.yml
@@ -140,7 +140,7 @@
     board: APECircuitboard
   - type: Lock
     locked: false
-#  - type: AccessReader
+  - type: AccessReader
 #    access: [[ "Research" ]]
   - type: Emitter
     onState: firing

--- a/Resources/Prototypes/Entities/Structures/Machines/anomaly_equipment.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/anomaly_equipment.yml
@@ -140,7 +140,7 @@
     board: APECircuitboard
   - type: Lock
     locked: false
-  - type: AccessReader
+#  - type: AccessReader
 #    access: [[ "Research" ]]
   - type: Emitter
     onState: firing

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -1781,7 +1781,7 @@
       shader: unshaded
     - state: panel
       map: ["enum.WiresVisualLayers.MaintenancePanel"]
-#  - type: AccessReader
+  - type: AccessReader
 #    access: [["NuclearOperative"], ["SyndicateAgent"]]
 
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -1781,7 +1781,7 @@
       shader: unshaded
     - state: panel
       map: ["enum.WiresVisualLayers.MaintenancePanel"]
-  - type: AccessReader
+#  - type: AccessReader
 #    access: [["NuclearOperative"], ["SyndicateAgent"]]
 
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Power/apc.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/apc.yml
@@ -19,7 +19,7 @@
     castShadows: false
     netsync: false
   - type: Clickable
-#  - type: AccessReader
+  - type: AccessReader
 #    access: [["Engineering"]]
   - type: InteractionOutline
   - type: Transform

--- a/Resources/Prototypes/Entities/Structures/Power/apc.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/apc.yml
@@ -19,7 +19,7 @@
     castShadows: false
     netsync: false
   - type: Clickable
-  - type: AccessReader
+#  - type: AccessReader
 #    access: [["Engineering"]]
   - type: InteractionOutline
   - type: Transform

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
@@ -9,7 +9,7 @@
     stateBaseClosed: cabinet
     stateDoorOpen: cabinet_open
     stateDoorClosed: cabinet_door
-#  - type: AccessReader
+  - type: AccessReader
 #    access: [["Bar"]]
   - type: EntityStorage
     closeSound:
@@ -28,7 +28,7 @@
     stateBaseClosed: qm
     stateDoorOpen: qm_open
     stateDoorClosed: qm_door
-#  - type: AccessReader
+  - type: AccessReader
 #    access: [["Quartermaster"]]
 
 - type: entity
@@ -42,7 +42,7 @@
     stateBaseClosed: mining
     stateDoorOpen: mining_open
     stateDoorClosed: mining_door
-#  - type: AccessReader
+  - type: AccessReader
 #    access: [["Salvage"]]
 
 # Command
@@ -83,7 +83,7 @@
     stateBaseClosed: ce
     stateDoorOpen: ce_open
     stateDoorClosed: ce_door
-#  - type: AccessReader
+  - type: AccessReader
 #    access: [ [ "ChiefEngineer" ] ]
 
 # Electrical supplies
@@ -97,7 +97,7 @@
     stateBaseClosed: eng
     stateDoorOpen: eng_open
     stateDoorClosed: eng_elec_door
-#  - type: AccessReader
+  - type: AccessReader
 #    access: [ [ "Engineering" ] ]
 
 # Welding supplies
@@ -111,7 +111,7 @@
     stateBaseClosed: eng
     stateDoorOpen: eng_open
     stateDoorClosed: eng_weld_door
-#  - type: AccessReader
+  - type: AccessReader
 #    access: [ [ "Engineering" ] ]
 
 # Atmos tech
@@ -125,7 +125,7 @@
     stateBaseClosed: atmos
     stateDoorOpen: atmos_open
     stateDoorClosed: atmos_door
-#  - type: AccessReader
+  - type: AccessReader
 #    access: [ [ "Atmospherics" ] ]
 
 # Engineer
@@ -139,7 +139,7 @@
     stateBaseClosed: eng_secure
     stateDoorOpen: eng_secure_open
     stateDoorClosed: eng_secure_door
-#  - type: AccessReader
+  - type: AccessReader
 #    access: [ [ "Engineering" ] ]
 
 # Freezer
@@ -163,8 +163,8 @@
   parent: LockerFreezerBase
   name: freezer
   suffix: Kitchen, Locked
-#  components:
-#  - type: AccessReader
+  components:
+  - type: AccessReader
 #    access: [ [ "Kitchen" ] ]
 
 # Botanist
@@ -178,7 +178,7 @@
     stateBaseClosed: hydro
     stateDoorOpen: hydro_open
     stateDoorClosed: hydro_door
-#  - type: AccessReader
+  - type: AccessReader
 #    access: [ [ "Hydroponics" ] ]
 
 # Medicine
@@ -193,7 +193,7 @@
     stateBaseClosed: med
     stateDoorOpen: med_open
     stateDoorClosed: med_door
-#  - type: AccessReader
+  - type: AccessReader
 #    access: [ [ "Medical" ] ]
 
 # Medical doctor
@@ -207,7 +207,7 @@
     stateBaseClosed: med_secure
     stateDoorOpen: med_secure_open
     stateDoorClosed: med_secure_door
-#  - type: AccessReader
+  - type: AccessReader
 #    access: [ [ "Medical" ] ]
 
 # Paramedic
@@ -221,7 +221,7 @@
     stateBaseClosed: paramed
     stateDoorOpen: paramed_open
     stateDoorClosed: paramed_door
-#  - type: AccessReader
+  - type: AccessReader
 #    access: [ [ "Medical" ] ]
 
 
@@ -236,7 +236,7 @@
     stateBaseClosed: med
     stateDoorOpen: med_open
     stateDoorClosed: chemical_door
-#  - type: AccessReader
+  - type: AccessReader
 #    access: [ [ "Chemistry" ] ]
 
 # CMO
@@ -250,7 +250,7 @@
     stateBaseClosed: cmo
     stateDoorOpen: cmo_open
     stateDoorClosed: cmo_door
-#  - type: AccessReader
+  - type: AccessReader
 #    access: [ [ "ChiefMedicalOfficer" ] ]
 
 # Science
@@ -264,7 +264,7 @@
     stateBaseClosed: rd
     stateDoorOpen: rd_open
     stateDoorClosed: rd_door
-#  - type: AccessReader
+  - type: AccessReader
 #    access: [ [ "ResearchDirector" ] ]
 
 - type: entity
@@ -277,7 +277,7 @@
     stateBaseClosed: science
     stateDoorOpen: science_open
     stateDoorClosed: science_door
-#  - type: AccessReader
+  - type: AccessReader
 #    access: [ [ "Research" ] ]
 
 # HoS

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
@@ -9,7 +9,7 @@
     stateBaseClosed: cabinet
     stateDoorOpen: cabinet_open
     stateDoorClosed: cabinet_door
-  - type: AccessReader
+#  - type: AccessReader
 #    access: [["Bar"]]
   - type: EntityStorage
     closeSound:
@@ -28,7 +28,7 @@
     stateBaseClosed: qm
     stateDoorOpen: qm_open
     stateDoorClosed: qm_door
-  - type: AccessReader
+#  - type: AccessReader
 #    access: [["Quartermaster"]]
 
 - type: entity
@@ -42,7 +42,7 @@
     stateBaseClosed: mining
     stateDoorOpen: mining_open
     stateDoorClosed: mining_door
-  - type: AccessReader
+#  - type: AccessReader
 #    access: [["Salvage"]]
 
 # Command
@@ -83,7 +83,7 @@
     stateBaseClosed: ce
     stateDoorOpen: ce_open
     stateDoorClosed: ce_door
-  - type: AccessReader
+#  - type: AccessReader
 #    access: [ [ "ChiefEngineer" ] ]
 
 # Electrical supplies
@@ -97,7 +97,7 @@
     stateBaseClosed: eng
     stateDoorOpen: eng_open
     stateDoorClosed: eng_elec_door
-  - type: AccessReader
+#  - type: AccessReader
 #    access: [ [ "Engineering" ] ]
 
 # Welding supplies
@@ -111,7 +111,7 @@
     stateBaseClosed: eng
     stateDoorOpen: eng_open
     stateDoorClosed: eng_weld_door
-  - type: AccessReader
+#  - type: AccessReader
 #    access: [ [ "Engineering" ] ]
 
 # Atmos tech
@@ -125,7 +125,7 @@
     stateBaseClosed: atmos
     stateDoorOpen: atmos_open
     stateDoorClosed: atmos_door
-  - type: AccessReader
+#  - type: AccessReader
 #    access: [ [ "Atmospherics" ] ]
 
 # Engineer
@@ -139,7 +139,7 @@
     stateBaseClosed: eng_secure
     stateDoorOpen: eng_secure_open
     stateDoorClosed: eng_secure_door
-  - type: AccessReader
+#  - type: AccessReader
 #    access: [ [ "Engineering" ] ]
 
 # Freezer
@@ -164,7 +164,7 @@
   name: freezer
   suffix: Kitchen, Locked
 #  components:
-  - type: AccessReader
+#  - type: AccessReader
 #    access: [ [ "Kitchen" ] ]
 
 # Botanist
@@ -178,7 +178,7 @@
     stateBaseClosed: hydro
     stateDoorOpen: hydro_open
     stateDoorClosed: hydro_door
-  - type: AccessReader
+#  - type: AccessReader
 #    access: [ [ "Hydroponics" ] ]
 
 # Medicine
@@ -193,7 +193,7 @@
     stateBaseClosed: med
     stateDoorOpen: med_open
     stateDoorClosed: med_door
-  - type: AccessReader
+#  - type: AccessReader
 #    access: [ [ "Medical" ] ]
 
 # Medical doctor
@@ -207,7 +207,7 @@
     stateBaseClosed: med_secure
     stateDoorOpen: med_secure_open
     stateDoorClosed: med_secure_door
-  - type: AccessReader
+#  - type: AccessReader
 #    access: [ [ "Medical" ] ]
 
 # Paramedic
@@ -221,7 +221,7 @@
     stateBaseClosed: paramed
     stateDoorOpen: paramed_open
     stateDoorClosed: paramed_door
-  - type: AccessReader
+#  - type: AccessReader
 #    access: [ [ "Medical" ] ]
 
 
@@ -236,7 +236,7 @@
     stateBaseClosed: med
     stateDoorOpen: med_open
     stateDoorClosed: chemical_door
-  - type: AccessReader
+#  - type: AccessReader
 #    access: [ [ "Chemistry" ] ]
 
 # CMO
@@ -250,7 +250,7 @@
     stateBaseClosed: cmo
     stateDoorOpen: cmo_open
     stateDoorClosed: cmo_door
-  - type: AccessReader
+#  - type: AccessReader
 #    access: [ [ "ChiefMedicalOfficer" ] ]
 
 # Science
@@ -264,7 +264,7 @@
     stateBaseClosed: rd
     stateDoorOpen: rd_open
     stateDoorClosed: rd_door
-  - type: AccessReader
+#  - type: AccessReader
 #    access: [ [ "ResearchDirector" ] ]
 
 - type: entity
@@ -277,7 +277,7 @@
     stateBaseClosed: science
     stateDoorOpen: science_open
     stateDoorClosed: science_door
-  - type: AccessReader
+#  - type: AccessReader
 #    access: [ [ "Research" ] ]
 
 # HoS

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
@@ -9,7 +9,7 @@
     stateBaseClosed: cabinet
     stateDoorOpen: cabinet_open
     stateDoorClosed: cabinet_door
-#  - type: AccessReader
+  - type: AccessReader
 #    access: [["Bar"]]
   - type: EntityStorage
     closeSound:
@@ -28,7 +28,7 @@
     stateBaseClosed: qm
     stateDoorOpen: qm_open
     stateDoorClosed: qm_door
-#  - type: AccessReader
+  - type: AccessReader
 #    access: [["Quartermaster"]]
 
 - type: entity
@@ -42,7 +42,7 @@
     stateBaseClosed: mining
     stateDoorOpen: mining_open
     stateDoorClosed: mining_door
-#  - type: AccessReader
+  - type: AccessReader
 #    access: [["Salvage"]]
 
 # Command
@@ -83,7 +83,7 @@
     stateBaseClosed: ce
     stateDoorOpen: ce_open
     stateDoorClosed: ce_door
-#  - type: AccessReader
+  - type: AccessReader
 #    access: [ [ "ChiefEngineer" ] ]
 
 # Electrical supplies
@@ -97,7 +97,7 @@
     stateBaseClosed: eng
     stateDoorOpen: eng_open
     stateDoorClosed: eng_elec_door
-#  - type: AccessReader
+  - type: AccessReader
 #    access: [ [ "Engineering" ] ]
 
 # Welding supplies
@@ -111,7 +111,7 @@
     stateBaseClosed: eng
     stateDoorOpen: eng_open
     stateDoorClosed: eng_weld_door
-#  - type: AccessReader
+  - type: AccessReader
 #    access: [ [ "Engineering" ] ]
 
 # Atmos tech
@@ -125,7 +125,7 @@
     stateBaseClosed: atmos
     stateDoorOpen: atmos_open
     stateDoorClosed: atmos_door
-#  - type: AccessReader
+  - type: AccessReader
 #    access: [ [ "Atmospherics" ] ]
 
 # Engineer
@@ -139,7 +139,7 @@
     stateBaseClosed: eng_secure
     stateDoorOpen: eng_secure_open
     stateDoorClosed: eng_secure_door
-#  - type: AccessReader
+  - type: AccessReader
 #    access: [ [ "Engineering" ] ]
 
 # Freezer
@@ -164,7 +164,7 @@
   name: freezer
   suffix: Kitchen, Locked
 #  components:
-#  - type: AccessReader
+  - type: AccessReader
 #    access: [ [ "Kitchen" ] ]
 
 # Botanist
@@ -178,7 +178,7 @@
     stateBaseClosed: hydro
     stateDoorOpen: hydro_open
     stateDoorClosed: hydro_door
-#  - type: AccessReader
+  - type: AccessReader
 #    access: [ [ "Hydroponics" ] ]
 
 # Medicine
@@ -193,7 +193,7 @@
     stateBaseClosed: med
     stateDoorOpen: med_open
     stateDoorClosed: med_door
-#  - type: AccessReader
+  - type: AccessReader
 #    access: [ [ "Medical" ] ]
 
 # Medical doctor
@@ -207,7 +207,7 @@
     stateBaseClosed: med_secure
     stateDoorOpen: med_secure_open
     stateDoorClosed: med_secure_door
-#  - type: AccessReader
+  - type: AccessReader
 #    access: [ [ "Medical" ] ]
 
 # Paramedic
@@ -221,7 +221,7 @@
     stateBaseClosed: paramed
     stateDoorOpen: paramed_open
     stateDoorClosed: paramed_door
-#  - type: AccessReader
+  - type: AccessReader
 #    access: [ [ "Medical" ] ]
 
 
@@ -236,7 +236,7 @@
     stateBaseClosed: med
     stateDoorOpen: med_open
     stateDoorClosed: chemical_door
-#  - type: AccessReader
+  - type: AccessReader
 #    access: [ [ "Chemistry" ] ]
 
 # CMO
@@ -250,7 +250,7 @@
     stateBaseClosed: cmo
     stateDoorOpen: cmo_open
     stateDoorClosed: cmo_door
-#  - type: AccessReader
+  - type: AccessReader
 #    access: [ [ "ChiefMedicalOfficer" ] ]
 
 # Science
@@ -264,7 +264,7 @@
     stateBaseClosed: rd
     stateDoorOpen: rd_open
     stateDoorClosed: rd_door
-#  - type: AccessReader
+  - type: AccessReader
 #    access: [ [ "ResearchDirector" ] ]
 
 - type: entity
@@ -277,7 +277,7 @@
     stateBaseClosed: science
     stateDoorOpen: science_open
     stateDoorClosed: science_door
-#  - type: AccessReader
+  - type: AccessReader
 #    access: [ [ "Research" ] ]
 
 # HoS

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/wall_lockers.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/wall_lockers.yml
@@ -162,5 +162,5 @@
     stateBaseClosed: med
     stateDoorOpen: med_open
     stateDoorClosed: med_door
-#  - type: AccessReader
+  - type: AccessReader
 #    access: [["Medical"]]

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/wall_lockers.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/wall_lockers.yml
@@ -162,5 +162,5 @@
     stateBaseClosed: med
     stateDoorOpen: med_open
     stateDoorClosed: med_door
-  - type: AccessReader
+#  - type: AccessReader
 #    access: [["Medical"]]

--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
@@ -186,7 +186,7 @@
     sprite: Structures/Storage/Crates/engicrate_secure.rsi
   - type: Sprite
     sprite: Structures/Storage/Crates/engicrate_secure.rsi
-  - type: AccessReader
+#  - type: AccessReader
 #    access: [["Engineering"]]
 
 - type: entity
@@ -198,7 +198,7 @@
     sprite: Structures/Storage/Crates/medicalcrate_secure.rsi
   - type: Sprite
     sprite: Structures/Storage/Crates/medicalcrate_secure.rsi
-  - type: AccessReader
+#  - type: AccessReader
 #    access: [["Medical"]]
 
 - type: entity
@@ -232,7 +232,7 @@
     sprite: Structures/Storage/Crates/scicrate_secure.rsi
   - type: Sprite
     sprite: Structures/Storage/Crates/scicrate_secure.rsi
-  - type: AccessReader
+#  - type: AccessReader
 #    access: [["Research"]]
 
 - type: entity
@@ -244,7 +244,7 @@
     sprite: Structures/Storage/Crates/plasma.rsi
   - type: Sprite
     sprite: Structures/Storage/Crates/plasma.rsi
-  - type: AccessReader
+#  - type: AccessReader
 #    access: [["Engineering"], ["Research"], ["Chemistry"]]
 
 - type: entity
@@ -266,7 +266,7 @@
     sprite: Structures/Storage/Crates/hydro_secure.rsi
   - type: Sprite
     sprite: Structures/Storage/Crates/hydro_secure.rsi
-  - type: AccessReader
+#  - type: AccessReader
 #    access: [["Hydroponics"]]
 
 - type: entity
@@ -557,5 +557,5 @@
     sprite: Structures/Storage/Crates/trashcart_jani.rsi
   - type: Sprite
     sprite: Structures/Storage/Crates/trashcart_jani.rsi
-  - type: AccessReader
+#  - type: AccessReader
 #    access: [["Janitor"]]

--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
@@ -186,7 +186,7 @@
     sprite: Structures/Storage/Crates/engicrate_secure.rsi
   - type: Sprite
     sprite: Structures/Storage/Crates/engicrate_secure.rsi
-#  - type: AccessReader
+  - type: AccessReader
 #    access: [["Engineering"]]
 
 - type: entity
@@ -198,7 +198,7 @@
     sprite: Structures/Storage/Crates/medicalcrate_secure.rsi
   - type: Sprite
     sprite: Structures/Storage/Crates/medicalcrate_secure.rsi
-#  - type: AccessReader
+  - type: AccessReader
 #    access: [["Medical"]]
 
 - type: entity
@@ -232,7 +232,7 @@
     sprite: Structures/Storage/Crates/scicrate_secure.rsi
   - type: Sprite
     sprite: Structures/Storage/Crates/scicrate_secure.rsi
-#  - type: AccessReader
+  - type: AccessReader
 #    access: [["Research"]]
 
 - type: entity
@@ -244,7 +244,7 @@
     sprite: Structures/Storage/Crates/plasma.rsi
   - type: Sprite
     sprite: Structures/Storage/Crates/plasma.rsi
-#  - type: AccessReader
+  - type: AccessReader
 #    access: [["Engineering"], ["Research"], ["Chemistry"]]
 
 - type: entity
@@ -266,7 +266,7 @@
     sprite: Structures/Storage/Crates/hydro_secure.rsi
   - type: Sprite
     sprite: Structures/Storage/Crates/hydro_secure.rsi
-#  - type: AccessReader
+  - type: AccessReader
 #    access: [["Hydroponics"]]
 
 - type: entity
@@ -557,5 +557,5 @@
     sprite: Structures/Storage/Crates/trashcart_jani.rsi
   - type: Sprite
     sprite: Structures/Storage/Crates/trashcart_jani.rsi
-#  - type: AccessReader
+  - type: AccessReader
 #    access: [["Janitor"]]

--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
@@ -210,7 +210,7 @@
       sprite: Structures/Storage/Crates/chemcrate_secure.rsi
     - type: Sprite
       sprite: Structures/Storage/Crates/chemcrate_secure.rsi
-#    - type: AccessReader
+    - type: AccessReader
 #      access: [["Chemistry"]]
 
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/fireaxe_cabinet.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/fireaxe_cabinet.yml
@@ -31,8 +31,8 @@
     openState: glass-up
     closedState: glass
   - type: Appearance
-#  - type: Lock
-#  - type: AccessReader
+  - type: Lock
+  - type: AccessReader
 #    access: [["Atmospherics"], ["Command"]]
   - type: ItemSlots
   - type: ContainerContainer

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/fireaxe_cabinet.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/fireaxe_cabinet.yml
@@ -32,7 +32,7 @@
     closedState: glass
   - type: Appearance
 #  - type: Lock
-#  - type: AccessReader
+  - type: AccessReader
 #    access: [["Atmospherics"], ["Command"]]
   - type: ItemSlots
   - type: ContainerContainer

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/fireaxe_cabinet.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/fireaxe_cabinet.yml
@@ -32,7 +32,7 @@
     closedState: glass
   - type: Appearance
 #  - type: Lock
-  - type: AccessReader
+#  - type: AccessReader
 #    access: [["Atmospherics"], ["Command"]]
   - type: ItemSlots
   - type: ContainerContainer

--- a/Resources/Prototypes/_NF/Entities/Structures/Storage/Crates/base_structurecrates.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Storage/Crates/base_structurecrates.yml
@@ -6,7 +6,7 @@
   - type: TradeCrate
   - type: Lock
   - type: AccessReader
-#    access: [[""]]
+    access: [[""]]
   - type: Icon
     sprite: Structures/Storage/Crates/secure.rsi
     state: icon

--- a/Resources/Prototypes/_NF/Entities/Structures/Storage/Crates/base_structurecrates.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Storage/Crates/base_structurecrates.yml
@@ -6,7 +6,7 @@
   - type: TradeCrate
   - type: Lock
   - type: AccessReader
-    access: [[""]]
+#    access: [[""]]
   - type: Icon
     sprite: Structures/Storage/Crates/secure.rsi
     state: icon


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Fixed Access Configurators not working on certain objects that should definitely have access configuration.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Ended up being forced to unload a shotgun round as SR into some guy who was (successfully) managing to loose a sentient artifact while I was trying to work out the logistics of letting it stay aboard in a crate, after said sentient artifact fried both my translator and disabler. He had to be dragged to medbay, revived, and the artifact chucked into space, which was not a good outcome for anyone involved.

Station Representative is the only one with access to an access configurator, so all should be well still.

Separately, I found out that Cargo Trade Crates just straight-up couldn't be unlocked or opened, even with AA. Fixed that.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Re-enables the blank `AccessReader` component in objects where it was previously disabled, allowing for Access Configuration functionality. As the component's `access` field is blanked by default, anyone can still interact with these objects unless the SR reconfigures them with their Access Configurator.

Also comments out the invalid `access` field on trade crates which changes it from "nobody can open this, ever" to "anybody can open this, and access can be modified."

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://github.com/new-frontiers-14/frontier-station-14/assets/74548962/ccc514ed-f581-4880-9366-5baeeba7c944)
_* Screenshot not indicative of actual default permissions, which are normally empty._

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
N/A

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl:
- fix: Lockable objects that previously could not be configured are now configurable again.
