### PR TITLE
Tracking Implants for security and SR on spawn.

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -41,7 +41,7 @@
   # - Medical
   special:
   - !type:AddImplantSpecial
-    implants: [ MindShieldImplant ]
+    implants: [ MindShieldImplant, TrackingImplant ]
   - !type:AddComponentSpecial
     components:
       - type: CommandStaff

--- a/Resources/Prototypes/Roles/Jobs/Security/brigmedic.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/brigmedic.yml
@@ -16,3 +16,6 @@
   - Brig
   - Maintenance
   - External
+  special:
+  - !type:AddImplantSpecial
+    implants: [ MindShieldImplant, TrackingImplant ]

--- a/Resources/Prototypes/Roles/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/detective.yml
@@ -18,7 +18,7 @@
   - Detective
   special:
   - !type:AddImplantSpecial
-    implants: [ MindShieldImplant ]
+    implants: [ MindShieldImplant, TrackingImplant ]
 
 - type: startingGear
   id: DetectiveGear

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -38,7 +38,7 @@
   - Detective
   special:
   - !type:AddImplantSpecial
-    implants: [ MindShieldImplant ]
+    implants: [ MindShieldImplant, TrackingImplant ]
   - !type:AddComponentSpecial
     components:
       - type: CommandStaff

--- a/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
@@ -20,7 +20,7 @@
   - Maintenance
   special:
   - !type:AddImplantSpecial
-    implants: [ MindShieldImplant ]
+    implants: [ MindShieldImplant, TrackingImplant ]
 
 - type: startingGear
   id: SecurityCadetGear

--- a/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
@@ -18,7 +18,7 @@
   - External
   special:
   - !type:AddImplantSpecial
-    implants: [ MindShieldImplant ]
+    implants: [ MindShieldImplant, TrackingImplant ]
 
 - type: startingGear
   id: SecurityOfficerGear

--- a/Resources/Prototypes/Roles/Jobs/Security/senior_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/senior_officer.yml
@@ -28,7 +28,7 @@
   - External
   special:
   - !type:AddImplantSpecial
-    implants: [ MindShieldImplant ]
+    implants: [ MindShieldImplant, TrackingImplant ]
 
 - type: startingGear
   id: SeniorOfficerGear

--- a/Resources/Prototypes/Roles/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/warden.yml
@@ -20,7 +20,7 @@
   - Detective
   special:
   - !type:AddImplantSpecial
-    implants: [ MindShieldImplant ]
+    implants: [ MindShieldImplant, TrackingImplant ]
 
 - type: startingGear
   id: WardenGear

--- a/Resources/Prototypes/_Nyano/Roles/Jobs/Security/prisonguard.yml
+++ b/Resources/Prototypes/_Nyano/Roles/Jobs/Security/prisonguard.yml
@@ -5,7 +5,7 @@
   playTimeTracker: JobPrisonGuard
   requirements:
     - !type:OverallPlaytimeRequirement
-      time: 18000
+      time: 1400
   startingGear: PrisonGuardGear
   canBeAntag: false
   icon: "JobIconWarden" 
@@ -15,6 +15,9 @@
   - Security
   - Brig
   - Maintenance
+  special:
+  - !type:AddImplantSpecial
+    implants: [ MindShieldImplant, TrackingImplant ]
 
 - type: startingGear
   id: PrisonGuardGear


### PR DESCRIPTION
## About the PR
Auto inject all the security team and SR with the security implants to make sure they can be found if dead.

## Why / Balance
Might as well.

## Technical details
.yml changes

## Media
- [X] This PR does not require an ingame showcase

## Breaking changes
N/A

**Changelog**
:cl: dvir01
- add: NT is getting mad about SR and the NFSD dying in action without tracking implants, so now they come pre injected.
