### PR TITLE
Bison Hotfix

### DIFF
--- a/Resources/Maps/Shuttles/bison.yml
+++ b/Resources/Maps/Shuttles/bison.yml
@@ -12471,7 +12471,7 @@ entities:
     - pos: 3.6162286,-8.302732
       parent: 1
       type: Transform
-- proto: FoodTinMREOpen
+- proto: FoodTinMRETrash
   entities:
   - uid: 2193
     components:


### PR DESCRIPTION
## About the PR
Bison isn't spawning, quick hotfix.

**Changelog**
:cl:
- fix: Fixed deprecated prototype inside Bison, it can now be purchased again.

