### PR TITLE
Update ResearchSystem.Client.cs

### DIFF
--- a/Content.Server/Research/Systems/ResearchSystem.Client.cs
+++ b/Content.Server/Research/Systems/ResearchSystem.Client.cs
@@ -60,7 +60,10 @@ public sealed partial class ResearchSystem
     {
         var allServers = EntityQuery<ResearchServerComponent>(true).ToArray();
         if (allServers.Length > 0)
+        {
             RegisterClient(uid, allServers[0].Owner, component, allServers[0]);
+            UnregisterClient(uid, component); // Unrigister a new computer from servers, this is need right after to make sure it didnt register unser someone else server.
+        }
     }
 
     private void OnClientShutdown(EntityUid uid, ResearchClientComponent component, ComponentShutdown args)


### PR DESCRIPTION
## About the PR
Unregistered servers soon after you build them, making sure they wont auto register with first server that exists.

## Why / Balance
The bug exists since when building R&D computers before servers they auto link with server number 1, we will force unrigister on init to fix it.

## Technical details
Added 1 line in C#

## Media
- [X] This PR does not require an ingame showcase

## Breaking changes
Its going to be a bit annoying to have to link servers, but less issues for players that gets points and techs stolen.

**Changelog**
:cl: dvir01
- fix: Fixed the R&D computers linking to someone else servers when you build a computer before a server.
