### PR TITLE
Secure Security Headset

### DIFF
--- a/Resources/Maps/Dungeon/lava_brig.yml
+++ b/Resources/Maps/Dungeon/lava_brig.yml
@@ -8419,13 +8419,6 @@ entities:
     - pos: 30.5,24.5
       parent: 588
       type: Transform
-- proto: EncryptionKeySecurity
-  entities:
-  - uid: 376
-    components:
-    - pos: 3.5739155,0.63120204
-      parent: 588
-      type: Transform
 - proto: ExtinguisherCabinetFilled
   entities:
   - uid: 867

--- a/Resources/Maps/Shuttles/dart.yml
+++ b/Resources/Maps/Shuttles/dart.yml
@@ -1190,13 +1190,6 @@ entities:
     - pos: -4.4936705,5.6566277
       parent: 1
       type: Transform
-- proto: BoxEncryptionKeySecurity
-  entities:
-  - uid: 981
-    components:
-    - pos: -4.3061705,5.4847527
-      parent: 1
-      type: Transform
 - proto: BoxTrashbag
   entities:
   - uid: 853

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -314,8 +314,7 @@
       - id: ClothingOuterHardsuitSecurityRed
       - id: ClothingMaskGasSwat
       - id: ClothingBeltSecurityFilled
-#      - id: ClothingHeadsetAltSecurity
-      - id: ClothingHeadsetAltCommand
+      - id: ClothingHeadsetAltSecurity
       - id: ClothingEyesGlassesSecurity
       - id: ClothingShoesBootsJack
       - id: CigarGoldCase
@@ -345,8 +344,7 @@
       - id: ClothingUniformJumpskirtHoSAlt
       - id: ClothingUniformJumpsuitHoSAlt
       - id: ClothingBeltSecurityFilled
-#      - id: ClothingHeadsetAltSecurity
-      - id: ClothingHeadsetAltCommand
+      - id: ClothingHeadsetAltSecurity
       - id: ClothingEyesGlassesSecurity
       - id: ClothingShoesBootsJack
       - id: CigarGoldCase

--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -62,7 +62,7 @@
       - id: ClothingBeltSecurityFilled
       - id: Flash
       - id: ClothingEyesGlassesSecurity
-      - id: ClothingHeadsetSecurity
+      - id: ClothingHeadsetSecuritySafe # Ask SR or Sheriff for keys
       - id: ClothingHandsGlovesColorBlack
       - id: ClothingShoesBootsJack
       - id: WeaponMeleeNeedle

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/detdrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/detdrobe.yml
@@ -13,4 +13,4 @@
     ClothingHeadHatFedoraGrey: 2
     ClothingHandsGlovesColorBlack: 2
     ClothingHandsGlovesLatex: 2
-    ClothingHeadsetSecurity: 2
+    ClothingHeadsetSecuritySafe: 2 # Ask SR or Sheriff for keys

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/secdrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/secdrobe.yml
@@ -15,7 +15,7 @@
     ClothingUniformJumpsuitSecGrey: 3
     ClothingUniformJumpskirtSecGrey: 3
     ClothingUniformJumpsuitSecBlue: 3
-    ClothingHeadsetSecurity: 3
+    ClothingHeadsetSecuritySafe: 3 # Ask SR or Sheriff for keys
     ClothingOuterWinterSec: 2
     ClothingOuterArmorBasic: 2
     ClothingOuterArmorBasicSlim: 2 

--- a/Resources/Prototypes/Entities/Clothing/Ears/headsets_alt.yml
+++ b/Resources/Prototypes/Entities/Clothing/Ears/headsets_alt.yml
@@ -105,9 +105,10 @@
   - type: ContainerFill
     containers:
       key_slots:
-      - EncryptionKeySecurity
-      - EncryptionKeyCommand
-      - EncryptionKeyCommon
+#      - EncryptionKeySecurity
+#      - EncryptionKeyCommand
+#      - EncryptionKeyCommon
+      - EncryptionKeyStationMaster
   - type: Sprite
     sprite: Clothing/Ears/Headsets/security.rsi
   - type: Clothing

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -54,7 +54,7 @@
     head: ClothingHeadHatBeretHoS
     id: HoSPDA
     gloves: ClothingHandsGlovesCombat
-    ears: ClothingHeadsetAltCommand
+    ears: ClothingHeadsetAltSecurity
     belt: ClothingBeltSecurityFilled
     pocket1: WeaponPistolMk58Nonlethal
   innerClothingSkirt: ClothingUniformJumpskirtHoS

--- a/Resources/Prototypes/_NF/Entities/Clothing/Ears/headsets.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Ears/headsets.yml
@@ -1,0 +1,9 @@
+- type: entity
+  parent: ClothingHeadsetSecurity
+  id: ClothingHeadsetSecuritySafe # Ask SR or Sheriff for keys
+  suffix: Safe
+  components:
+  - type: ContainerFill
+    containers:
+      key_slots:
+      - EncryptionKeyCommon


### PR DESCRIPTION
## About the PR
Gave the sheriff his headset back but replaced the key to command so it match with his look, but he wont loss anything.
Added the "ClothingHeadsetSecuritySafe", the security headset but without the security key, new security hires will need to ask SR or Sheriff for keys, meaning they will have to be registered and accounted for.

## Why / Balance
Since getting a security key was simple as going on a single expo and getting a key from a hacked vend machine, using the security channel was useless.

## Technical details
.yml changes

## Media
- [X] This PR does not require an ingame showcase

## Breaking changes
N/A

**Changelog**
:cl: dvir01
- tweak: The security radio channel is a bit more secured now.
