### PR TITLE
Fix whitelist not being sent to client

### DIFF
--- a/Content.Client/Nyanotrasen/Players/PlayTimeTracking/JobRequirementsManager.Whitelist.cs
+++ b/Content.Client/Nyanotrasen/Players/PlayTimeTracking/JobRequirementsManager.Whitelist.cs
@@ -12,6 +12,7 @@ public sealed partial class JobRequirementsManager
 
     private void RxWhitelist(MsgWhitelist message)
     {
+        _sawmill.Debug($"Received new whitelist status: {message.Whitelisted}, previously {_whitelisted}");
         _whitelisted = message.Whitelisted;
     }
 

--- a/Content.Server/GameTicking/GameTicker.Player.cs
+++ b/Content.Server/GameTicking/GameTicker.Player.cs
@@ -1,6 +1,5 @@
 using Content.Server.Database;
 using Content.Server.Players;
-using Content.Server.Players.PlayTimeTracking;
 using Content.Shared.GameTicking;
 using Content.Shared.GameWindow;
 using Content.Shared.Players;

--- a/Content.Server/GameTicking/GameTicker.Player.cs
+++ b/Content.Server/GameTicking/GameTicker.Player.cs
@@ -1,5 +1,6 @@
 using Content.Server.Database;
 using Content.Server.Players;
+using Content.Server.Players.PlayTimeTracking;
 using Content.Shared.GameTicking;
 using Content.Shared.GameWindow;
 using Content.Shared.Players;

--- a/Content.Server/Nyanotrasen/Players/PlayTimeTracking/PlayTimeTrackingManager.Whitelist.cs
+++ b/Content.Server/Nyanotrasen/Players/PlayTimeTracking/PlayTimeTrackingManager.Whitelist.cs
@@ -6,7 +6,7 @@ namespace Content.Server.Players.PlayTimeTracking;
 
 public sealed partial class PlayTimeTrackingManager
 {
-    public void SendWhitelistCached(IPlayerSession playerSession)
+    private void SendWhitelistCached(IPlayerSession playerSession)
     {
         var whitelist = playerSession.ContentData()?.Whitelisted ?? false;
 
@@ -16,5 +16,14 @@ public sealed partial class PlayTimeTrackingManager
         };
 
         _net.ServerSendMessage(msg, playerSession.ConnectedClient);
+    }
+
+    /// <summary>
+    /// Queue sending whitelist status to the client.
+    /// </summary>
+    public void QueueSendWhitelist(IPlayerSession player)
+    {
+        if (DirtyPlayer(player) is { } data)
+            data.NeedRefreshWhitelist = true;
     }
 }

--- a/Content.Server/Players/PlayTimeTracking/PlayTimeTrackingManager.cs
+++ b/Content.Server/Players/PlayTimeTracking/PlayTimeTrackingManager.cs
@@ -131,8 +131,13 @@ public sealed partial class PlayTimeTrackingManager
             if (data.NeedSendTimers)
             {
                 SendPlayTimes(player);
-                SendWhitelist(player);
                 data.NeedSendTimers = false;
+            }
+
+            if (data.NeedRefreshWhitelist)
+            {
+                SendWhitelistCached(player);
+                data.NeedRefreshWhitelist = false;
             }
 
             data.IsDirty = false;
@@ -213,17 +218,6 @@ public sealed partial class PlayTimeTrackingManager
         };
 
         _net.ServerSendMessage(msg, pSession.ConnectedClient);
-    }
-    public async void SendWhitelist(IPlayerSession playerSession)
-    {
-        var whitelist = await _db.GetWhitelistStatusAsync(playerSession.UserId);
-
-        var msg = new MsgWhitelist
-        {
-            Whitelisted = whitelist
-        };
-
-        _net.ServerSendMessage(msg, playerSession.ConnectedClient);
     }
 
     /// <summary>
@@ -325,10 +319,13 @@ public sealed partial class PlayTimeTrackingManager
             data.TrackerTimes.Add(timer.Tracker, timer.TimeSpent);
         }
 
+        session.ContentData()!.Whitelisted = await _db.GetWhitelistStatusAsync(session.UserId); // Nyanotrasen - Whitelist
+
         data.Initialized = true;
 
         QueueRefreshTrackers(session);
         QueueSendTimers(session);
+        QueueSendWhitelist(session);
     }
 
     public void ClientDisconnected(IPlayerSession session)
@@ -434,6 +431,7 @@ public sealed partial class PlayTimeTrackingManager
         public bool IsDirty;
         public bool NeedRefreshTackers;
         public bool NeedSendTimers;
+        public bool NeedRefreshWhitelist;
 
         // Active tracking info
         public readonly HashSet<string> ActiveTrackers = new();

--- a/Content.Server/Players/PlayTimeTracking/PlayTimeTrackingSystem.cs
+++ b/Content.Server/Players/PlayTimeTracking/PlayTimeTrackingSystem.cs
@@ -154,6 +154,7 @@ public sealed class PlayTimeTrackingSystem : EntitySystem
         _tracking.QueueRefreshTrackers(ev.PlayerSession);
         // Send timers to client when they join lobby, so the UIs are up-to-date.
         _tracking.QueueSendTimers(ev.PlayerSession);
+        _tracking.QueueSendWhitelist(ev.PlayerSession); // Nyanotrasen - Send whitelist
     }
 
     public bool IsAllowed(IPlayerSession player, string role)

--- a/Content.Server/Whitelist/WhitelistCommands.cs
+++ b/Content.Server/Whitelist/WhitelistCommands.cs
@@ -47,7 +47,7 @@ public sealed class AddWhitelistCommand : IConsoleCommand
                 player.TryGetSessionByUsername(name, out var session))
             {
                 playerData.ContentData()!.Whitelisted = true;
-                playtime.SendWhitelistCached(session);
+                playtime.QueueSendWhitelist(session);
             }
 
             shell.WriteLine(Loc.GetString("command-whitelistadd-added", ("username", data.Username)));
@@ -94,7 +94,7 @@ public sealed class RemoveWhitelistCommand : IConsoleCommand
                 player.TryGetSessionByUsername(name, out var session))
             {
                 playerData.ContentData()!.Whitelisted = false;
-                playtime.SendWhitelistCached(session);
+                playtime.QueueSendWhitelist(session);
             }
 
             shell.WriteLine(Loc.GetString("command-whitelistremove-removed", ("username", data.Username)));


### PR DESCRIPTION
## About the PR
I made an oopsie and forgot the bit of code that sends clients their whitelist status, meaning they'd only be aware of their whitelist while connected, for the duration of that connection.

Closes #465

**Changelog**
:cl:
- fix: Whitelists should now work properly again.