### PR TITLE
Various ship minifixes

### DIFF
--- a/Resources/Maps/Shuttles/helix.yml
+++ b/Resources/Maps/Shuttles/helix.yml
@@ -1388,14 +1388,12 @@ entities:
   entities:
   - uid: 176
     components:
-    - rot: 3.141592653589793 rad
-      pos: -1.5,9.5
+    - pos: -1.5,9.5
       parent: 1
       type: Transform
   - uid: 177
     components:
-    - rot: 3.141592653589793 rad
-      pos: -3.5,7.5
+    - pos: -3.5,7.5
       parent: 1
       type: Transform
   - uid: 178

--- a/Resources/Maps/Shuttles/rosebudmki.yml
+++ b/Resources/Maps/Shuttles/rosebudmki.yml
@@ -18,7 +18,7 @@ entities:
   entities:
   - uid: 1
     components:
-    - name: RosebudMKII
+    - name: RosebudMKI
       type: MetaData
     - pos: -0.66406155,-0.5000076
       parent: invalid
@@ -781,7 +781,7 @@ entities:
       type: GridAtmosphere
     - type: GasTileOverlay
     - type: RadiationGridResistance
-    - id: RosebudMKII
+    - id: RosebudMKI
       type: BecomesStation
 - proto: AirlockAtmosphericsGlass
   entities:
@@ -3061,29 +3061,19 @@ entities:
     - pos: -10.5,5.5
       parent: 1
       type: Transform
-  - uid: 566
-    components:
-    - pos: -11.5,5.5
-      parent: 1
-      type: Transform
   - uid: 567
     components:
-    - pos: -11.5,6.5
+    - pos: -10.5,8.5
       parent: 1
       type: Transform
   - uid: 568
     components:
-    - pos: -11.5,7.5
-      parent: 1
-      type: Transform
-  - uid: 569
-    components:
-    - pos: -11.5,8.5
+    - pos: -10.5,7.5
       parent: 1
       type: Transform
   - uid: 570
     components:
-    - pos: -12.5,8.5
+    - pos: -10.5,6.5
       parent: 1
       type: Transform
   - uid: 990
@@ -3131,16 +3121,6 @@ entities:
   - uid: 110
     components:
     - pos: 8.5,1.5
-      parent: 1
-      type: Transform
-  - uid: 571
-    components:
-    - pos: -12.5,8.5
-      parent: 1
-      type: Transform
-  - uid: 573
-    components:
-    - pos: -11.5,8.5
       parent: 1
       type: Transform
   - uid: 574
@@ -3668,6 +3648,13 @@ entities:
   - uid: 1405
     components:
     - pos: 0.5,-1.5
+      parent: 1
+      type: Transform
+- proto: ComputerStationRecords
+  entities:
+  - uid: 569
+    components:
+    - pos: -12.5,8.5
       parent: 1
       type: Transform
 - proto: ConveyorBelt
@@ -7706,7 +7693,7 @@ entities:
   entities:
   - uid: 88
     components:
-    - pos: -12.5,8.5
+    - pos: -10.5,8.5
       parent: 1
       type: Transform
   - uid: 730
@@ -8680,7 +8667,7 @@ entities:
     - pos: 0.5,2.5
       parent: 1
       type: Transform
-    - location: RosebudMKII
+    - location: RosebudMKI
       type: WarpPoint
 - proto: WeaponCapacitorRecharger
   entities:

--- a/Resources/Maps/Shuttles/rosebudmkii.yml
+++ b/Resources/Maps/Shuttles/rosebudmkii.yml
@@ -11106,7 +11106,7 @@ entities:
   entities:
   - uid: 1087
     components:
-    - name: RosebudMKI
+    - name: RosebudMKII
       type: MetaData
     - pos: 0.5,2.5
       parent: 1

--- a/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
@@ -122,7 +122,7 @@
         - id: ClothingOuterHardsuitEngineering
         - id: ClothingMaskBreath
   - type: AccessReader
-    access: [["Engineering"]]
+    # access: [["Engineering"]]
 
 #Atmospherics hardsuit
 - type: entity
@@ -137,7 +137,7 @@
         - id: ClothingOuterHardsuitAtmos
         - id: ClothingMaskBreath
   - type: AccessReader
-    access: [["Atmospherics"]]
+    # access: [["Atmospherics"]]
 
 #Security hardsuit
 - type: entity
@@ -169,7 +169,7 @@
         - id: ClothingOuterHardsuitEngineeringWhite
         - id: ClothingMaskBreath
   - type: AccessReader
-    access: [["ChiefEngineer"]]
+    # access: [["ChiefEngineer"]]
 
 #CMO's hardsuit
 - type: entity
@@ -184,7 +184,7 @@
         - id: ClothingOuterHardsuitMedical
         - id: ClothingMaskBreathMedical
   - type: AccessReader
-    access: [ [ "ChiefMedicalOfficer" ] ]
+    # access: [ [ "ChiefMedicalOfficer" ] ]
 
 #RD's hardsuit
 - type: entity
@@ -199,7 +199,7 @@
         - id: ClothingOuterHardsuitRd
         - id: ClothingMaskBreath
   - type: AccessReader
-    access: [ [ "ResearchDirector" ] ]
+    # access: [ [ "ResearchDirector" ] ]
 
 #HOS's hardsuit
 - type: entity
@@ -245,7 +245,7 @@
         - id: ClothingOuterHardsuitCap
         - id: ClothingMaskGasCaptain
   - type: AccessReader
-    access: [["Captain"]]
+    # access: [["Captain"]]
 
 #Salvage hardsuit
 - type: entity
@@ -261,7 +261,7 @@
       - id: ClothingOuterHardsuitSpatio
       - id: ClothingMaskGasExplorer
   - type: AccessReader
-    access: [["Salvage"]]
+    # access: [["Salvage"]]
 
 #Blood-red hardsuit
 - type: entity

--- a/Resources/Prototypes/_NF/Shipyard/rosebudmki.yml
+++ b/Resources/Prototypes/_NF/Shipyard/rosebudmki.yml
@@ -2,7 +2,7 @@
   id: RosebudMKI
   name: NT Rosebud MKI
   description: A medium-sized luxury salvaging and mining vessel perfectly suited for a small crew.
-  price: 80000
+  price: 85000
   category: Medium
   group: Civilian
   shuttlePath: /Maps/Shuttles/rosebudmki.yml

--- a/Resources/Prototypes/_NF/Shipyard/svnugget.yml
+++ b/Resources/Prototypes/_NF/Shipyard/svnugget.yml
@@ -17,7 +17,7 @@
       stationProto: StandardFrontierVessel
       components:
         - type: StationNameSetup
-          mapNameTemplate: '{0} SV-Nugget {1}'
+          mapNameTemplate: 'SV14 Nugget {1}'
           nameGenerator:
             !type:NanotrasenNameGenerator
             prefixCreator: '14'

--- a/Resources/Prototypes/_NF/Shipyard/svnugget.yml
+++ b/Resources/Prototypes/_NF/Shipyard/svnugget.yml
@@ -1,6 +1,6 @@
 - type: vessel
   id: svnugget
-  name: SV-Nugget
+  name: SV Nugget
   description: A flying hunk of wood and metal disguised as a kitchen shuttle. Not FDA approved.
   price: 12250
   category: Small
@@ -9,7 +9,7 @@
 
 - type: gameMap
   id: svnugget
-  mapName: 'SV-Nugget'
+  mapName: 'SV Nugget'
   mapPath: /Maps/Shuttles/svnugget.yml
   minPlayers: 0
   stations:

--- a/Resources/Prototypes/_NF/Shipyard/svorange.yml
+++ b/Resources/Prototypes/_NF/Shipyard/svorange.yml
@@ -1,14 +1,15 @@
 - type: vessel
   id: svorange
-  name: SV-Orange
+  name: SV Orange
   description: A cargo slash salvage shuttle made from scavenged wrecks, comes with some damage.
   price: 16000 #Appraisal is 14500
   category: Small
   group: Civilian
   shuttlePath: /Maps/Shuttles/svorange.yml
+
 - type: gameMap
   id: svorange
-  mapName: 'SV-Orange'
+  mapName: 'SV Orange'
   mapPath: /Maps/Shuttles/svorange.yml
   minPlayers: 0
   stations:

--- a/Resources/Prototypes/_NF/Shipyard/svorange.yml
+++ b/Resources/Prototypes/_NF/Shipyard/svorange.yml
@@ -17,7 +17,7 @@
       stationProto: StandardFrontierVessel
       components:
         - type: StationNameSetup
-          mapNameTemplate: '{0} SV-Orange {1}'
+          mapNameTemplate: 'SV14 Orange {1}'
           nameGenerator:
             !type:NanotrasenNameGenerator
             prefixCreator: '14'

--- a/Resources/Prototypes/_NF/Shipyard/svtide.yml
+++ b/Resources/Prototypes/_NF/Shipyard/svtide.yml
@@ -1,6 +1,6 @@
 - type: vessel
   id: svtide
-  name: SV-Tide
+  name: SV Tide
   description: A cheaply made mass-produced shuttle made from salvaged wrecks. For the seasoned assistant.
   price: 9150
   category: Small

--- a/Resources/Prototypes/_NF/Shipyard/svtide.yml
+++ b/Resources/Prototypes/_NF/Shipyard/svtide.yml
@@ -17,7 +17,7 @@
       stationProto: StandardFrontierVessel
       components:
         - type: StationNameSetup
-          mapNameTemplate: '{0} SV Tide {1}'
+          mapNameTemplate: 'SV14 Tide {1}'
           nameGenerator:
             !type:NanotrasenNameGenerator
             prefixCreator: '14'


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Small changes resolving:
- #364: Fixed improperly-oriented defib cabinets
- #473: Added a Station Records console to the Rosebud MKI
- Raised the price of Rosebud MKI (80000 -> 85000) as appraisal was higher than old sell price (even without the console, how was this overlooked?)
- Minor internal (non-breaking) changes where the Rosebud MKI was referred to as the MKII, and vice versa
- SV ship names are no longer hyphenated on shipyard consoles, in line with all other ship names
- SV vessels now show with the SV14 prefix on IFF.
- Removed access on suit storage units (excluding Security)

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Minor tweaks resolving issues, as well as parity.
Suit storage units were previously locked unless you spawned as the requisite role or begged SR for clearance; e.g. a Helix captain previously could not open their CMO suit storage.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
YML changes.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://github.com/new-frontiers-14/frontier-station-14/assets/74548962/8fabb6a1-0bad-40c5-a604-5095cd4ffda1)
![image](https://github.com/new-frontiers-14/frontier-station-14/assets/74548962/7ddb6453-312a-439e-ab7d-bc10f76a0cbc)
![image](https://github.com/new-frontiers-14/frontier-station-14/assets/74548962/6239b101-d996-4072-a0ea-5f9c01fc6894)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
N/A

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: NT Rosebud MKI captains can now manage their crew. Rejoice!
- tweak: Adjusted NT Rosebud MKI's price for inflation.
- tweak: Tweaked the SV naming prefix on vessels.
- tweak: Suit storage lockers are now accessible to everyone.
- fix: Re-oriented NT Helix defibrillator cabinets to be internally accessible.
