### PR TITLE
Update emergency.yml

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
@@ -12,6 +12,7 @@
       - id: EmergencyMedipen
       - id: Flare
       - id: FoodTinMRE
+      - id: EncryptionKeyCommand
   - type: Sprite
     layers:
       - state: internals
@@ -31,6 +32,7 @@
       - id: EmergencyMedipen
       - id: Flare
       - id: FoodTinMRE
+      - id: EncryptionKeyCommand
   - type: Sprite
     layers:
       - state: internals
@@ -51,6 +53,7 @@
       - id: EmergencyMedipen
       - id: Flare
       - id: FoodTinMRE
+      - id: EncryptionKeyCommand
   - type: Sprite
     layers:
       - state: internals
@@ -71,6 +74,7 @@
       - id: EmergencyMedipen
       - id: EmergencyMedipen
       - id: FoodTinMRE
+      - id: EncryptionKeyCommand
   - type: Sprite
     layers:
       - state: internals
@@ -91,6 +95,7 @@
       - id: EmergencyMedipen
       - id: Flare
       - id: FoodTinMRE
+      - id: EncryptionKeyCommand
   - type: Sprite
     layers:
       - state: internals
@@ -116,6 +121,7 @@
       - id: EmergencyMedipen
       - id: Flare
       - id: FoodTinMRE
+      - id: EncryptionKeyCommand
   - type: Tag
     tags:
       - BoxHug
@@ -134,6 +140,7 @@
       - id: EmergencyMedipen
       - id: Flare
       - id: FoodTinMRE
+      - id: EncryptionKeyCommand
   - type: Sprite
     layers:
       - state: internals


### PR DESCRIPTION
## About the PR
Adds "EncryptionKeyCommand" to all survival boxs.

## Why / Balance
Allow start of round access to traffic radio.

## Technical details
.yml

## Media
- [X] this PR does not require an ingame showcase

## Breaking changes
N/A

**Changelog**
:cl: dvir01
- add: NT has provided everyone with a free space traffic control channel key in the survival box.
