### PR TITLE
PDA's in Ptech

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/cart.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/cart.yml
@@ -3,6 +3,22 @@
   startingInventory:
     PassengerPDA: 10
     ClearPDA: 10
+#    ClownPDA: 3
+#    MimePDA: 3
+#    ChaplainPDA: 3
+#    LawyerPDA: 3
+#    ReporterPDA: 3
+#    ZookeeperPDA: 3
+#    JanitorPDA: 3
+    MusicianPDA: 3
+#    PsychologistPDA: 3
+    MedicalPDA: 3
+#    ParamedicPDA: 3
+#    ChemistryPDA: 3
+#    CMOPDA: 3
+    SecurityPDA: 3
+    BrigmedicPDA: 3
+    WardenPDA: 3
     PassengerIDCard: 20
     ClothingHeadsetGrey: 10
     RubberStampCaptain: 10


### PR DESCRIPTION
## About the PR
Added more PDA to the Ptech at the SR office.

## Why / Balance
People keep asking for this.

## Technical details
.yml changes

## Media
![image](https://github.com/new-frontiers-14/frontier-station-14/assets/39403717/72d2eb13-feb2-41da-bee8-4ea9494856e6)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame,

## Breaking changes
Might need to create new entity for PDA without cards, nothing that will be an issue at the moment.

**Changelog**
:cl: dvir01
- add: SR has received a crate full of all kind of PDA, now available from the Ptech vend machine.  