### PR TITLE
Update vending_machines.yml

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -221,7 +221,7 @@
     energy: 1.3
     color: "#ffb0b0"
   - type: AccessReader
-    access: [["HeadOfPersonnel"]]
+    access: [["HeadOfPersonnel"], ["HeadOfSecurity"]] # Frontier - Added sheriff access
   - type: MarketModifier
     mod: 5
 
@@ -1637,8 +1637,8 @@
       shader: unshaded
     - state: panel
       map: ["enum.WiresVisualLayers.MaintenancePanel"]
-  - type: AccessReader
-    access: [["Service"]]
+#  - type: AccessReader # Frontier
+#    access: [["Service"]]
 
 - type: entity
   parent: VendingMachine


### PR DESCRIPTION
## About the PR
Updated AccessReader on ptech to allow sheriff to use it
Removed access lock from new machine.

## Why / Balance
Fix

## Technical details
.yml

## Media
- [X] this PR does not require an ingame showcase

## Breaking changes
N/A

**Changelog**
:cl: dvir01
- tweak: The sheriff can now use the Ptech vending,
