### PR TITLE
Balance For Servivel Box size

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/tin.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/tin.yml
@@ -37,7 +37,7 @@
   - type: Item
     sprite: Objects/Consumable/Food/snacks.rsi
     heldPrefix: packet
-    size: 2 # Frontier - 5 to 2 size
+    size: 2 # Frontier - 3 to 2 size
   - type: DamageOnLand
     damage:
       types:

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/tin.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/tin.yml
@@ -37,7 +37,7 @@
   - type: Item
     sprite: Objects/Consumable/Food/snacks.rsi
     heldPrefix: packet
-    size: 3
+    size: 2 # Frontier - 5 to 2 size
   - type: DamageOnLand
     damage:
       types:
@@ -66,7 +66,7 @@
   - type: Item
     sprite: Objects/Consumable/Food/snacks.rsi
     heldPrefix: packet
-    size: 3
+    size: 2 # Frontier - 3 to 2 size
   - type: Tag
     tags:
       - Trash

--- a/Resources/Prototypes/Entities/Objects/Devices/encryption_keys.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/encryption_keys.yml
@@ -8,6 +8,7 @@
   - type: EncryptionKey
   - type: Item
     sprite: Objects/Devices/encryption_keys.rsi
+    size: 2 # Frontier - 3 to 2 size
   - type: Sprite
     sprite: Objects/Devices/encryption_keys.rsi
   - type: StaticPrice

--- a/Resources/Prototypes/Entities/Objects/Devices/encryption_keys.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/encryption_keys.yml
@@ -8,7 +8,7 @@
   - type: EncryptionKey
   - type: Item
     sprite: Objects/Devices/encryption_keys.rsi
-    size: 2 # Frontier - 3 to 2 size
+    size: 2 # Frontier - 5 to 2 size
   - type: Sprite
     sprite: Objects/Devices/encryption_keys.rsi
   - type: StaticPrice


### PR DESCRIPTION
## About the PR
Lower tin can size 2>3
Lower encryption key size 2>5

## Why / Balance
Allow the items to fit into the card-box

## Technical details
.yml changes

## Media
- [X] this PR does not require an ingame showcase

## Breaking changes
N/A

**Changelog**
N/A