### PR TITLE
Port carrying from Delta-v

### DIFF
--- a/Content.Server/Nyanotrasen/Carrying/CarryingSystem.cs
+++ b/Content.Server/Nyanotrasen/Carrying/CarryingSystem.cs
@@ -1,8 +1,11 @@
+using System.Threading;
+using Content.Server.DoAfter;
 using Content.Server.Body.Systems;
 using Content.Server.Hands.Systems;
 using Content.Server.Resist;
 using Content.Server.Popups;
 using Content.Server.Contests;
+using Content.Shared.Climbing; // Shared instead of Server
 using Content.Shared.Mobs;
 using Content.Shared.DoAfter;
 using Content.Shared.Buckle.Components;
@@ -11,6 +14,7 @@ using Content.Shared.Hands;
 using Content.Shared.Stunnable;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Verbs;
+using Content.Shared.Climbing.Events; // Added this.
 using Content.Shared.Carrying;
 using Content.Shared.Movement.Events;
 using Content.Shared.Movement.Systems;
@@ -18,7 +22,6 @@ using Content.Shared.Pulling;
 using Content.Shared.Pulling.Components;
 using Content.Shared.Standing;
 using Content.Shared.ActionBlocker;
-using Content.Shared.Climbing.Events;
 using Content.Shared.Throwing;
 using Content.Shared.Physics.Pull;
 using Content.Shared.Mobs.Systems;
@@ -30,7 +33,7 @@ namespace Content.Server.Carrying
     {
         [Dependency] private readonly HandVirtualItemSystem _virtualItemSystem = default!;
         [Dependency] private readonly CarryingSlowdownSystem _slowdown = default!;
-        [Dependency] private readonly SharedDoAfterSystem _doAfterSystem = default!;
+        [Dependency] private readonly DoAfterSystem _doAfterSystem = default!;
         [Dependency] private readonly StandingStateSystem _standingState = default!;
         [Dependency] private readonly ActionBlockerSystem _actionBlockerSystem = default!;
         [Dependency] private readonly SharedPullingSystem _pullingSystem = default!;
@@ -57,7 +60,7 @@ namespace Content.Server.Carrying
             SubscribeLocalEvent<BeingCarriedComponent, PullAttemptEvent>(OnPullAttempt);
             SubscribeLocalEvent<BeingCarriedComponent, StartClimbEvent>(OnStartClimb);
             SubscribeLocalEvent<BeingCarriedComponent, BuckleChangeEvent>(OnBuckleChange);
-            SubscribeLocalEvent<CarriableComponent, DoAfterEvent>(OnDoAfter);
+            SubscribeLocalEvent<CarriableComponent, CarryDoAfterEvent>(OnDoAfter);
         }
 
 
@@ -191,7 +194,7 @@ namespace Content.Server.Carrying
             DropCarried(component.Carrier, uid);
         }
 
-        private void OnDoAfter(EntityUid uid, CarriableComponent component, DoAfterEvent args)
+        private void OnDoAfter(EntityUid uid, CarriableComponent component, CarryDoAfterEvent args)
         {
             component.CancelToken = null;
             if (args.Handled || args.Cancelled)
@@ -205,14 +208,14 @@ namespace Content.Server.Carrying
         }
         private void StartCarryDoAfter(EntityUid carrier, EntityUid carried, CarriableComponent component)
         {
-            float length = 3f;
+            TimeSpan length = TimeSpan.FromSeconds(3);
 
             var mod = _contests.MassContest(carrier, carried);
 
             if (mod != 0)
                 length /= mod;
 
-            if (length >= 9)
+            if (length >= TimeSpan.FromSeconds(9))
             {
                 _popupSystem.PopupEntity(Loc.GetString("carry-too-heavy"), carried, carrier, Shared.Popups.PopupType.SmallCaution);
                 return;
@@ -221,7 +224,10 @@ namespace Content.Server.Carrying
             if (!HasComp<KnockedDownComponent>(carried))
                 length *= 2f;
 
-            var args = new DoAfterArgs(EntityManager, carrier, length, new CarryDoAfterEvent(), carried, target: carried)
+            component.CancelToken = new CancellationTokenSource();
+
+            var ev = new CarryDoAfterEvent();
+            var args = new DoAfterArgs(EntityManager, carrier, length, ev, carried, target: carried)
             {
                 BreakOnTargetMove = true,
                 BreakOnUserMove = true,
@@ -293,8 +299,8 @@ namespace Content.Server.Carrying
             if (HasComp<BeingCarriedComponent>(carrier) || HasComp<BeingCarriedComponent>(carried))
                 return false;
 
-            if (_respirator.IsReceivingCPR(carried))
-                return false;
+        //  if (_respirator.IsReceivingCPR(carried))
+            //  return false;
 
             if (!TryComp<HandsComponent>(carrier, out var hands))
                 return false;
@@ -304,8 +310,5 @@ namespace Content.Server.Carrying
 
             return true;
         }
-
-        private record struct CarryData()
-        {}
     }
 }

--- a/Content.Server/Resist/EscapeInventorySystem.cs
+++ b/Content.Server/Resist/EscapeInventorySystem.cs
@@ -106,13 +106,6 @@ public sealed class EscapeInventorySystem : EntitySystem
             return;
         } // End of carrying system of nyanotrasen.
 
-
-        if (TryComp<BeingCarriedComponent>(uid, out carried))
-        {
-            _carryingSystem.DropCarried(carried.Carrier, uid);
-            return;
-        }
-
         _containerSystem.AttachParentToContainerOrGrid((uid, Transform(uid)));
         args.Handled = true;
     }

--- a/Content.Server/Resist/EscapeInventorySystem.cs
+++ b/Content.Server/Resist/EscapeInventorySystem.cs
@@ -1,5 +1,9 @@
 using Content.Server.Contests;
 using Content.Server.Popups;
+using Content.Shared.Storage;
+using Content.Server.Carrying; // Carrying system from Nyanotrasen.
+using Content.Shared.Inventory;
+using Content.Shared.Hands.EntitySystems;
 using Content.Server.Storage.Components;
 using Content.Shared.ActionBlocker;
 using Content.Shared.DoAfter;
@@ -23,7 +27,7 @@ public sealed class EscapeInventorySystem : EntitySystem
     [Dependency] private readonly ActionBlockerSystem _actionBlockerSystem = default!;
     [Dependency] private readonly SharedHandsSystem _handsSystem = default!;
     [Dependency] private readonly ContestsSystem _contests = default!;
-    [Dependency] private readonly CarryingSystem _carryingSystem = default!;
+    [Dependency] private readonly CarryingSystem _carryingSystem = default!; // Carrying system from Nyanotrasen.
 
     /// <summary>
     /// You can't escape the hands of an entity this many times more massive than you.
@@ -67,7 +71,7 @@ public sealed class EscapeInventorySystem : EntitySystem
             AttemptEscape(uid, container.Owner, component);
     }
 
-    public void AttemptEscape(EntityUid user, EntityUid container, CanEscapeInventoryComponent component, float multiplier = 1f)
+    public void AttemptEscape(EntityUid user, EntityUid container, CanEscapeInventoryComponent component, float multiplier = 1f) //private to public for carrying system.
     {
         if (component.IsEscaping)
             return;
@@ -96,7 +100,14 @@ public sealed class EscapeInventorySystem : EntitySystem
         if (args.Handled || args.Cancelled)
             return;
 
-        if (TryComp<BeingCarriedComponent>(uid, out var carried))
+        if (TryComp<BeingCarriedComponent>(uid, out var carried)) // Start of carrying system of nyanotrasen.
+        {
+            _carryingSystem.DropCarried(carried.Carrier, uid);
+            return;
+        } // End of carrying system of nyanotrasen.
+
+
+        if (TryComp<BeingCarriedComponent>(uid, out carried))
         {
             _carryingSystem.DropCarried(carried.Carrier, uid);
             return;

--- a/Content.Shared/Nyanotrasen/Carrying/CarryingDoAfterEvent.cs
+++ b/Content.Shared/Nyanotrasen/Carrying/CarryingDoAfterEvent.cs
@@ -1,0 +1,12 @@
+using Robust.Shared.Serialization;
+using Content.Shared.DoAfter;
+
+namespace Content.Shared.Carrying
+{
+}
+
+[Serializable, NetSerializable]
+public sealed partial class CarryDoAfterEvent : SimpleDoAfterEvent
+{
+}
+

--- a/Content.Shared/Nyanotrasen/Carrying/CarryingSlowdownComponent.cs
+++ b/Content.Shared/Nyanotrasen/Carrying/CarryingSlowdownComponent.cs
@@ -15,7 +15,7 @@ namespace Content.Shared.Carrying
     }
 
     [Serializable, NetSerializable]
-    public sealed partial class CarryingSlowdownComponentState : ComponentState
+    public sealed class CarryingSlowdownComponentState : ComponentState
     {
         public float WalkModifier;
         public float SprintModifier;

--- a/Content.Shared/Nyanotrasen/Carrying/CarryingSlowdownComponent.cs
+++ b/Content.Shared/Nyanotrasen/Carrying/CarryingSlowdownComponent.cs
@@ -15,7 +15,7 @@ namespace Content.Shared.Carrying
     }
 
     [Serializable, NetSerializable]
-    public sealed class CarryingSlowdownComponentState : ComponentState
+    public sealed partial class CarryingSlowdownComponentState : ComponentState
     {
         public float WalkModifier;
         public float SprintModifier;

--- a/Resources/Locale/en-US/nyanotrasen/carrying/carry.ftl
+++ b/Resources/Locale/en-US/nyanotrasen/carrying/carry.ftl
@@ -1,0 +1,3 @@
+carry-verb = Carry
+
+carry-too-heavy = You're not strong enough.

--- a/Resources/Prototypes/DeltaV/Entities/Mobs/Species/vulpkanin.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Mobs/Species/vulpkanin.yml
@@ -13,6 +13,7 @@
       types:
         Cold: 0.05
         Bloodloss: 0.1
+  - type: Carriable # Carrying system from nyanotrasen.
   - type: Thirst
     baseDecayRate: 0.0125
   - type: Icon
@@ -84,7 +85,6 @@
     damageContainer: Biological
     damageModifierSet: Vulps
   - type: Perishable
-  - type: Carriable
   - type: TemperatureProtection
     coefficient: 0.1
   - type: Temperature

--- a/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
@@ -16,6 +16,7 @@
       types:
         Cold: 0.1
         Bloodloss: 0.1
+  - type: Carriable # Carrying system from nyanotrasen.
   - type: Thirst
     baseDecayRate: 0.0125 # Read comment in hunger
   # Damage (Self)

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -214,6 +214,7 @@
   - type: MobPrice
     price: 1500 # Kidnapping a living person and selling them for cred is a good move.
     deathPenalty: 0.01 # However they really ought to be living and intact, otherwise they're worth 100x less.
+  - type: CanEscapeInventory # Carrying system from nyanotrasen.  
   - type: Tag
     tags:
     - CanPilot

--- a/Resources/Prototypes/Entities/Mobs/Species/diona.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/diona.yml
@@ -14,6 +14,7 @@
     baseDecayRate: 0.0083
   - type: Thirst
     baseDecayRate: 0.0083
+  - type: Carriable # Carrying system from nyanotrasen.  
   - type: Icon
     sprite: Mobs/Species/Diona/parts.rsi
     state: full

--- a/Resources/Prototypes/Entities/Mobs/Species/dwarf.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/dwarf.yml
@@ -11,6 +11,7 @@
         Cold: 0.1
         Bloodloss: 0.1
   - type: Thirst
+  - type: Carriable # Carrying system from nyanotrasen.
   - type: Icon
     sprite: Mobs/Species/Slime/parts.rsi # It was like this beforehand, no idea why.
     state: full

--- a/Resources/Prototypes/Entities/Mobs/Species/human.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/human.yml
@@ -14,6 +14,7 @@
     sprite: Mobs/Species/Human/parts.rsi
     state: full
   - type: Thirst
+  - type: Carriable # Carrying system from nyanotrasen.
   - type: Perishable
   - type: Butcherable
     butcheringType: Spike

--- a/Resources/Prototypes/Entities/Mobs/Species/moth.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/moth.yml
@@ -13,6 +13,7 @@
         Cold: 0.05
         Bloodloss: 0.1
   - type: Thirst
+  - type: Carriable # Carrying system from nyanotrasen.
   - type: Icon
     sprite: Mobs/Species/Moth/parts.rsi
     state: full

--- a/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
@@ -15,6 +15,7 @@
   - type: Puller
     needsHands: false
   - type: Thirst
+  - type: Carriable # Carrying system from nyanotrasen.
   - type: Icon
     sprite: Mobs/Species/Reptilian/parts.rsi
     state: full

--- a/Resources/Prototypes/Entities/Mobs/Species/skeleton.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/skeleton.yml
@@ -9,6 +9,7 @@
   components:
   - type: HumanoidAppearance
     species: Skeleton
+  - type: Carriable # Carrying system from nyanotrasen.  
   - type: Icon
     sprite: Mobs/Species/Skeleton/parts.rsi
     state: full

--- a/Resources/Prototypes/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/slime.yml
@@ -9,6 +9,7 @@
       types:
         Bloodloss: 0.1
   - type: Thirst
+  - type: Carriable # Carrying system from nyanotrasen.
   - type: Icon
     sprite: Mobs/Species/Slime/parts.rsi
     state: full


### PR DESCRIPTION
## About the PR
Adds the carrying system and gives the component to all available species. Carry the dead, carry the wounded, carry the people you want to throw, carry the prisoners, carry the felinids and launch them at mach 5 to the void of space where they belong when they spam meows.

## Why / Balance
Can be used by pirates to throw mates for boarding, sec for carrying prisoners, medics for carrying the wounded or just to throw away some people to space.

## Technical details

Most of the carrying code is already in this repository, this just takes the changes done on delta with some little changes so it could build, "it works on my machine" right now.

## Media


https://github.com/new-frontiers-14/frontier-station-14/assets/80334192/20c8f86e-5eac-48df-91f7-01a24eb376b4



- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


**Changelog**


:cl: Leander
- add: All species have learned how to carry people and throw them around.