### PR TITLE
Lore-based Manufacturer Prefix Codes

### DIFF
--- a/Resources/Prototypes/_NF/Shipyard/anchor.yml
+++ b/Resources/Prototypes/_NF/Shipyard/anchor.yml
@@ -1,6 +1,6 @@
 - type: vessel
   id: Anchor
-  name: NT Anchor
+  name: KC Anchor
   description: A large luxury cruiser capable of long ranged travel acrossed the sector, expedition capable.
   price: 135020
   category: Large
@@ -9,7 +9,7 @@
   
 - type: gameMap
   id: Anchor
-  mapName: 'NT Anchor'
+  mapName: 'KC Anchor'
   mapPath: /Maps/Shuttles/anchor.yml
   minPlayers: 0
   stations: 
@@ -17,7 +17,7 @@
       stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
-          mapNameTemplate: '{0} Anchor {1}'
+          mapNameTemplate: 'KC14 Anchor {1}'
           nameGenerator:
             !type:NanotrasenNameGenerator
             prefixCreator: '14'

--- a/Resources/Prototypes/_NF/Shipyard/cleric.yml
+++ b/Resources/Prototypes/_NF/Shipyard/cleric.yml
@@ -1,6 +1,6 @@
 - type: vessel
   id: Cleric
-  name: NT Cleric
+  name: NSF Cleric
   description: Small support vessel used for emergency rescues and first aid.
   price: 10800 #Appraisal is 10500
   category: Small
@@ -9,7 +9,7 @@
 
 - type: gameMap
   id: Cleric
-  mapName: 'NT Cleric'
+  mapName: 'NSF Cleric'
   mapPath: /Maps/Shuttles/cleric.yml
   minPlayers: 0
   stations:
@@ -17,7 +17,7 @@
       stationProto: StandardFrontierSecurityVessel
       components:
         - type: StationNameSetup
-          mapNameTemplate: '{0} Cleric {1}'
+          mapNameTemplate: 'NSF14 Cleric {1}'
           nameGenerator:
             !type:NanotrasenNameGenerator
             prefixCreator: '14'

--- a/Resources/Prototypes/_NF/Shipyard/crescent.yml
+++ b/Resources/Prototypes/_NF/Shipyard/crescent.yml
@@ -1,6 +1,6 @@
 - type: vessel
   id: Crescent
-  name: NT Crescent
+  name: KC Crescent
   description: The Crescent, named for its exterior shape, is a vessel focused on providing service, medical aide, and scientific breakthroughs for smaller vessels.
   price: 208020
   category: Large
@@ -9,7 +9,7 @@
 
 - type: gameMap
   id: Crescent
-  mapName: 'NT Crescent'
+  mapName: 'KC Crescent'
   mapPath: /Maps/Shuttles/crescent.yml
   minPlayers: 0
   stations:
@@ -17,7 +17,7 @@
       stationProto: StandardFrontierVessel
       components:
         - type: StationNameSetup
-          mapNameTemplate: '{0} Crescent {1}'
+          mapNameTemplate: 'KC14 Crescent {1}'
           nameGenerator:
             !type:NanotrasenNameGenerator
             prefixCreator: '14'

--- a/Resources/Prototypes/_NF/Shipyard/empress.yml
+++ b/Resources/Prototypes/_NF/Shipyard/empress.yml
@@ -1,6 +1,6 @@
 - type: vessel
   id: Empress
-  name: NT Empress
+  name: NSF Empress
   description: A large patrol vessel capable of carrying up to 3 smaller faster attack ships. the flagship vessel of security.
   price: 170200
   category: Large
@@ -9,7 +9,7 @@
 
 - type: gameMap
   id: Empress
-  mapName: 'NT Empress'
+  mapName: 'NSF Empress'
   mapPath: /Maps/Shuttles/empress.yml
   minPlayers: 0
   stations:
@@ -17,7 +17,7 @@
       stationProto: StandardFrontierSecurityVessel
       components:
         - type: StationNameSetup
-          mapNameTemplate: '{0} Empress {1}'
+          mapNameTemplate: 'NSF14 Empress {1}'
           nameGenerator:
             !type:NanotrasenNameGenerator
             prefixCreator: '14'

--- a/Resources/Prototypes/_NF/Shipyard/fighter.yml
+++ b/Resources/Prototypes/_NF/Shipyard/fighter.yml
@@ -1,6 +1,6 @@
 - type: vessel
   id: Fighter
-  name: NT Fighter
+  name: NSF Fighter
   description: Small attack vessel used for boarding and transport of prisoners.
   price: 9000 #not sure how much mark up % to add but the appraisal is 8491$
   category: Small
@@ -9,7 +9,7 @@
 
 - type: gameMap
   id: Fighter
-  mapName: 'NT Fighter'
+  mapName: 'NSF Fighter'
   mapPath: /Maps/Shuttles/fighter.yml
   minPlayers: 0
   stations:
@@ -17,7 +17,7 @@
       stationProto: StandardFrontierSecurityVessel
       components:
         - type: StationNameSetup
-          mapNameTemplate: '{0} Fighter {1}'
+          mapNameTemplate: 'NSF14 Fighter {1}'
           nameGenerator:
             !type:NanotrasenNameGenerator
             prefixCreator: '14'

--- a/Resources/Prototypes/_NF/Shipyard/hospitaller.yml
+++ b/Resources/Prototypes/_NF/Shipyard/hospitaller.yml
@@ -1,6 +1,6 @@
 - type: vessel
   id: Hospitaller
-  name: NT Hospitaller
+  name: NSF Hospitaller
   description: A small security medical craft designed for emergency response and search and rescue operations.
   price: 23220
   category: Small
@@ -9,7 +9,7 @@
 
 - type: gameMap
   id: Hospitaller
-  mapName: 'NT Hospitaller'
+  mapName: 'NSF14 Hospitaller'
   mapPath: /Maps/Shuttles/hospitaller.yml
   minPlayers: 0
   stations:
@@ -17,7 +17,7 @@
       stationProto: StandardFrontierVessel
       components:
         - type: StationNameSetup
-          mapNameTemplate: '{0} Hospitaller {1}'
+          mapNameTemplate: 'NSF14 Hospitaller {1}'
           nameGenerator:
             !type:NanotrasenNameGenerator
             prefixCreator: '14'

--- a/Resources/Prototypes/_NF/Shipyard/interceptor.yml
+++ b/Resources/Prototypes/_NF/Shipyard/interceptor.yml
@@ -17,7 +17,7 @@
       stationProto: StandardFrontierSecurityVessel
       components:
         - type: StationNameSetup
-          mapNameTemplate: '{0} Interceptor {1}'
+          mapNameTemplate: 'NSF14 Interceptor {1}'
           nameGenerator:
             !type:NanotrasenNameGenerator
             prefixCreator: '14'

--- a/Resources/Prototypes/_NF/Shipyard/marauder.yml
+++ b/Resources/Prototypes/_NF/Shipyard/marauder.yml
@@ -1,6 +1,6 @@
 - type: vessel
   id: Marauder
-  name: NT Marauder
+  name: NSF Marauder
   description: A heavy corvette, the marauder class is a dedicated deep space patrol vessel outfitted with a reduced radar cross-section and heavily fortified against hostile assault.
   price: 100220
   category: Large
@@ -9,7 +9,7 @@
 
 - type: gameMap
   id: Marauder
-  mapName: 'NT Marauder'
+  mapName: 'NSF Marauder'
   mapPath: /Maps/Shuttles/marauder.yml
   minPlayers: 0
   stations:
@@ -17,7 +17,7 @@
       stationProto: StandardFrontierSecurityVessel
       components:
         - type: StationNameSetup
-          mapNameTemplate: '{0} Marauder {1}'
+          mapNameTemplate: 'NSF14 Marauder {1}'
           nameGenerator:
             !type:NanotrasenNameGenerator
             prefixCreator: '14'

--- a/Resources/Prototypes/_NF/Shipyard/pathfinder.yml
+++ b/Resources/Prototypes/_NF/Shipyard/pathfinder.yml
@@ -1,6 +1,6 @@
 - type: vessel
   id: Pathfinder
-  name: NT Pathfinder
+  name: KC Pathfinder
   description: Once a scout ship serving with the Nanotrasen Marine Expeditionary Forces, this now decommissioned expedition capable ship can be yours!
   price: 52920
   category: Small
@@ -9,7 +9,7 @@
   
 - type: gameMap
   id: Pathfinder
-  mapName: 'NT Pathfinder'
+  mapName: 'KC Pathfinder'
   mapPath: /Maps/Shuttles/pathfinder.yml
   minPlayers: 0
   stations: 
@@ -17,7 +17,7 @@
       stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
-          mapNameTemplate: '{0} Pathfinder {1}'
+          mapNameTemplate: 'KC14 Pathfinder {1}'
           nameGenerator:
             !type:NanotrasenNameGenerator
             prefixCreator: '14'

--- a/Resources/Prototypes/_NF/Shipyard/prowler.yml
+++ b/Resources/Prototypes/_NF/Shipyard/prowler.yml
@@ -1,6 +1,6 @@
 - type: vessel
   id: Prowler
-  name: NT Prowler
+  name: NSF Prowler
   description: A medium-sized patrol craft, the prowler class is a dedicated deep space reconnaissance and enforcement vessel outfitted with ECM technology to avoid detection.
   price: 49220
   category: Medium
@@ -9,7 +9,7 @@
 
 - type: gameMap
   id: Prowler
-  mapName: 'NT Prowler'
+  mapName: 'NSF Prowler'
   mapPath: /Maps/Shuttles/prowler.yml
   minPlayers: 0
   stations:
@@ -17,7 +17,7 @@
       stationProto: StandardFrontierSecurityVessel
       components:
         - type: StationNameSetup
-          mapNameTemplate: '{0} Prowler {1}'
+          mapNameTemplate: 'NSF14 Prowler {1}'
           nameGenerator:
             !type:NanotrasenNameGenerator
             prefixCreator: '14'

--- a/Resources/Prototypes/_NF/Shipyard/rogue.yml
+++ b/Resources/Prototypes/_NF/Shipyard/rogue.yml
@@ -1,6 +1,6 @@
 - type: vessel
   id: Rogue
-  name: NT Rogue
+  name: NSF Rogue
   description: Small assault vessel with a toggle for going dark in deep space.
   price: 8200 #the appraisal is 7941$
   category: Small
@@ -9,7 +9,7 @@
 
 - type: gameMap
   id: Rogue
-  mapName: 'NT Rogue'
+  mapName: 'NSF Rogue'
   mapPath: /Maps/Shuttles/rogue.yml
   minPlayers: 0
   stations:
@@ -17,7 +17,7 @@
       stationProto: StandardFrontierSecurityVessel
       components:
         - type: StationNameSetup
-          mapNameTemplate: '{0} Rogue {1}'
+          mapNameTemplate: 'NSF14 Rogue {1}'
           nameGenerator:
             !type:NanotrasenNameGenerator
             prefixCreator: '14'

--- a/Resources/Prototypes/_NF/Shipyard/sprinter.yml
+++ b/Resources/Prototypes/_NF/Shipyard/sprinter.yml
@@ -1,6 +1,6 @@
 - type: vessel
   id: Sprinter
-  name: NT Sprinter
+  name: KC Sprinter
   description: A light freighter often picked by bounty hunters due to its quick acceleration, expedition capable.
   price: 75020
   category: Medium
@@ -9,7 +9,7 @@
   
 - type: gameMap
   id: Sprinter
-  mapName: 'NT Sprinter'
+  mapName: 'KC Sprinter'
   mapPath: /Maps/Shuttles/sprinter.yml
   minPlayers: 0
   stations: 
@@ -17,7 +17,7 @@
       stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
-          mapNameTemplate: '{0} Sprinter {1}'
+          mapNameTemplate: 'KC14 Sprinter {1}'
           nameGenerator:
             !type:NanotrasenNameGenerator
             prefixCreator: '14'

--- a/Resources/Prototypes/_NF/Shipyard/templar.yml
+++ b/Resources/Prototypes/_NF/Shipyard/templar.yml
@@ -1,6 +1,6 @@
 - type: vessel
   id: Templar
-  name: NT Templar
+  name: NSF Templar
   description: A small security assault craft designed for combat interdiction operations.
   price: 21220
   category: Small
@@ -9,7 +9,7 @@
 
 - type: gameMap
   id: Templar
-  mapName: 'NT Templar'
+  mapName: 'NSF Templar'
   mapPath: /Maps/Shuttles/templar.yml
   minPlayers: 0
   stations:
@@ -17,7 +17,7 @@
       stationProto: StandardFrontierVessel
       components:
         - type: StationNameSetup
-          mapNameTemplate: '{0} Templar {1}'
+          mapNameTemplate: 'NSF14 Templar {1}'
           nameGenerator:
             !type:NanotrasenNameGenerator
             prefixCreator: '14'


### PR DESCRIPTION
## About the PR
Changes the KesCo civilian ships to use KC14 as the prefix code, denoting their manufacturer. Additionally, changes the NFSD ships to use the NSF14 prefix code.

## Why / Balance
moar lore moar better

**Changelog**
:cl:
- tweak: Changed KesCo ships to use a manufacturer prefix.
- tweak: Changed NFSD ships to use the NSF prefix.
