### PR TITLE
TechBalance

### DIFF
--- a/Content.Client/Research/UI/DiskConsoleBoundUserInterface.cs
+++ b/Content.Client/Research/UI/DiskConsoleBoundUserInterface.cs
@@ -30,6 +30,10 @@ namespace Content.Client.Research.UI
             {
                 SendMessage(new DiskConsolePrintDiskMessage());
             };
+            _menu.OnPrintRareButtonPressed += () =>
+            {
+                SendMessage(new DiskConsolePrintRareDiskMessage());
+            };
         }
 
         protected override void Dispose(bool disposing)

--- a/Content.Client/Research/UI/DiskConsoleMenu.xaml
+++ b/Content.Client/Research/UI/DiskConsoleMenu.xaml
@@ -1,4 +1,4 @@
-﻿<controls:FancyWindow xmlns="https://spacestation14.io"
+<controls:FancyWindow xmlns="https://spacestation14.io"
                      xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
                      xmlns:graphics="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
                      Title="{Loc 'tech-disk-ui-name'}"
@@ -19,14 +19,18 @@
                 <Label Name="TotalLabel"
                        HorizontalAlignment="Center">
                 </Label>
-                <Label Name="CostLabel"
-                       HorizontalAlignment="Center">
-                </Label>
                 <BoxContainer MinHeight="20"></BoxContainer>
                 <Button
                     Name="PrintButton"
                     Text="{Loc 'tech-disk-ui-print-button'}"
-                    MaxWidth="120"
+                    MaxWidth="240"
+                    HorizontalAlignment="Center"
+                    VerticalExpand="False">
+                </Button>
+                <Button
+                    Name="PrintRareButton"
+                    Text="{Loc 'tech-disk-ui-print-rare-button'}"
+                    MaxWidth="240"
                     HorizontalAlignment="Center"
                     VerticalExpand="False">
                 </Button>

--- a/Content.Client/Research/UI/DiskConsoleMenu.xaml.cs
+++ b/Content.Client/Research/UI/DiskConsoleMenu.xaml.cs
@@ -10,6 +10,7 @@ public sealed partial class DiskConsoleMenu : FancyWindow
 {
     public event Action? OnServerButtonPressed;
     public event Action? OnPrintButtonPressed;
+    public event Action? OnPrintRareButtonPressed; // Frontier - Added for mass point use
 
     public DiskConsoleMenu()
     {
@@ -17,13 +18,17 @@ public sealed partial class DiskConsoleMenu : FancyWindow
 
         ServerButton.OnPressed += _ => OnServerButtonPressed?.Invoke();
         PrintButton.OnPressed += _ => OnPrintButtonPressed?.Invoke();
+        PrintRareButton.OnPressed += _ => OnPrintRareButtonPressed?.Invoke(); // Frontier - Added for mass point use
     }
 
     public void Update(DiskConsoleBoundUserInterfaceState state)
     {
         PrintButton.Disabled = !state.CanPrint;
+        PrintRareButton.Disabled = !state.CanPrintRare; // Frontier - Added for mass point use
         TotalLabel.Text = Loc.GetString("tech-disk-ui-total-label", ("amount", state.ServerPoints));
-        CostLabel.Text = Loc.GetString("tech-disk-ui-cost-label", ("amount", state.PointCost));
+        //CostLabel.Text = Loc.GetString("tech-disk-ui-cost-label", ("amount", state.PointCost));
+        PrintButton.Text = Loc.GetString("tech-disk-ui-print-button", ("amount", state.PointCost)); // Frontier
+        PrintRareButton.Text = Loc.GetString("tech-disk-ui-print-rare-button", ("amount", state.PointCostRare)); // Frontier
     }
 }
 

--- a/Content.Server/Research/TechnologyDisk/Components/DiskConsoleComponent.cs
+++ b/Content.Server/Research/TechnologyDisk/Components/DiskConsoleComponent.cs
@@ -1,4 +1,4 @@
-﻿using Robust.Shared.Audio;
+using Robust.Shared.Audio;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 
@@ -11,13 +11,25 @@ public sealed partial class DiskConsoleComponent : Component
     /// How much it costs to print a disk
     /// </summary>
     [DataField("pricePerDisk"), ViewVariables(VVAccess.ReadWrite)]
-    public int PricePerDisk = 1000;
+    public int PricePerDisk = 10000;
+
+    /// <summary>
+    /// How much it costs to print a rare disk
+    /// </summary>
+    [DataField("pricePerRareDisk"), ViewVariables(VVAccess.ReadWrite)]
+    public int PricePerRareDisk = 13000;
 
     /// <summary>
     /// The prototype of what's being printed
     /// </summary>
     [DataField("diskPrototype", customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>)), ViewVariables(VVAccess.ReadWrite)]
     public string DiskPrototype = "TechnologyDisk";
+
+    [DataField("diskPrototypeRare", customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>)), ViewVariables(VVAccess.ReadWrite)]
+    public string DiskPrototypeRare = "TechnologyDiskRare";
+
+    [DataField("diskRare"), ViewVariables(VVAccess.ReadWrite)]
+    public bool DiskRare = false;
 
     /// <summary>
     /// How long it takes to print <see cref="DiskPrototype"/>

--- a/Content.Server/Research/TechnologyDisk/Components/TechnologyDiskComponent.cs
+++ b/Content.Server/Research/TechnologyDisk/Components/TechnologyDiskComponent.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared.Random;
+using Content.Shared.Random;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 
 namespace Content.Server.Research.TechnologyDisk.Components;
@@ -13,8 +13,20 @@ public sealed partial class TechnologyDiskComponent : Component
     public List<string>? Recipes;
 
     /// <summary>
+    /// The recipe that will be added. If null, one will be randomly generated
+    /// </summary>
+    [DataField("recipesRare")]
+    public List<string>? RecipesRare;
+
+    /// <summary>
     /// A weighted random prototype for how rare each tier should be.
     /// </summary>
     [DataField("tierWeightPrototype", customTypeSerializer: typeof(PrototypeIdSerializer<WeightedRandomPrototype>))]
     public string TierWeightPrototype = "TechDiskTierWeights";
+
+    /// <summary>
+    /// A weighted random prototype for how rare each tier should be.
+    /// </summary>
+    [DataField("tierWeightPrototypeRare", customTypeSerializer: typeof(PrototypeIdSerializer<WeightedRandomPrototype>))]
+    public string TierWeightPrototypeRare = "RareTechDiskTierWeights";
 }

--- a/Content.Server/Research/TechnologyDisk/Systems/TechnologyDiskSystem.cs
+++ b/Content.Server/Research/TechnologyDisk/Systems/TechnologyDiskSystem.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using Content.Server.Popups;
 using Content.Server.Research.Systems;
 using Content.Server.Research.TechnologyDisk.Components;
@@ -88,5 +88,28 @@ public sealed class TechnologyDiskSystem : EntitySystem
         //pick one
         component.Recipes = new();
         component.Recipes.Add(_random.Pick(techs));
+
+        if (component.RecipesRare != null)
+            return;
+
+        var weightedRandomRare = _prototype.Index<WeightedRandomPrototype>(component.TierWeightPrototypeRare);
+        var tierRare = int.Parse(weightedRandomRare.Pick(_random));
+
+        var techsRare = new List<ProtoId<LatheRecipePrototype>>();
+        foreach (var techRare in _prototype.EnumeratePrototypes<TechnologyPrototype>())
+        {
+            if (techRare.Tier != tierRare)
+                continue;
+
+            techsRare.AddRange(techRare.RecipeUnlocks);
+        }
+        techsRare = techsRare.Distinct().ToList();
+
+        if (!techsRare.Any())
+            return;
+
+        //pick one
+        component.RecipesRare = new();
+        component.RecipesRare.Add(_random.Pick(techsRare));
     }
 }

--- a/Content.Shared/Research/SharedDiskConsole.cs
+++ b/Content.Shared/Research/SharedDiskConsole.cs
@@ -1,4 +1,4 @@
-﻿using Robust.Shared.Serialization;
+using Robust.Shared.Serialization;
 
 namespace Content.Shared.Research;
 
@@ -12,19 +12,29 @@ public enum DiskConsoleUiKey : byte
 public sealed class DiskConsoleBoundUserInterfaceState : BoundUserInterfaceState
 {
     public bool CanPrint;
+    public bool CanPrintRare;
     public int PointCost;
+    public int PointCostRare;
     public int ServerPoints;
 
-    public DiskConsoleBoundUserInterfaceState(int serverPoints, int pointCost, bool canPrint)
+    public DiskConsoleBoundUserInterfaceState(int serverPoints, int pointCost, int pointCostRare, bool canPrint, bool canPrintRare)
     {
         CanPrint = canPrint;
+        CanPrintRare = canPrintRare;
         PointCost = pointCost;
+        PointCostRare = pointCostRare;
         ServerPoints = serverPoints;
     }
 }
 
 [Serializable, NetSerializable]
 public sealed class DiskConsolePrintDiskMessage : BoundUserInterfaceMessage
+{
+
+}
+
+[Serializable, NetSerializable]
+public sealed class DiskConsolePrintRareDiskMessage : BoundUserInterfaceMessage
 {
 
 }

--- a/Resources/Locale/en-US/research/components/technology-disk.ftl
+++ b/Resources/Locale/en-US/research/components/technology-disk.ftl
@@ -6,4 +6,5 @@ tech-disk-examine-more = There are more images printed, but they're too small to
 tech-disk-ui-name = technology disk terminal
 tech-disk-ui-total-label = There are {$amount} points on the selected server
 tech-disk-ui-cost-label = Each disk costs {$amount} points to print
-tech-disk-ui-print-button = Print Disk
+tech-disk-ui-print-button = Print Disk ({$amount})
+tech-disk-ui-print-rare-button = Print Rare Disk ({$amount})

--- a/Resources/Prototypes/Entities/Objects/Specific/Research/disk.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Research/disk.yml
@@ -21,7 +21,7 @@
   - type: ResearchDisk
     points: 5000
   - type: StaticPrice
-    price: 200 # Why was this worth nothing, NT want to buy this!
+    price: 1500 # Frontier - To be fair, its worth half a tech disk, but we still require tech to print it so its lower.
 
 - type: entity
   parent: ResearchDisk
@@ -32,7 +32,7 @@
   - type: ResearchDisk
     points: 10000
   - type: StaticPrice
-    price: 400 # Why was this worth nothing, NT want to buy this!
+    price: 3000 # Frontier - To be fair, its worth a tech disk, but we still require tech to print it so its lower.
 
 - type: entity
   parent: ResearchDisk

--- a/Resources/Prototypes/Entities/Objects/Specific/Research/disk.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Research/disk.yml
@@ -61,8 +61,9 @@
     - enum.DamageStateVisualLayers.Base:
         datadisk_base: Sixteen
   - type: TechnologyDisk
+    tierWeightPrototype: TechDiskTierWeights # Frontier
   - type: StaticPrice
-    price: 550 # It's still need to be worth it, but as it was stranding (1000) it was too much
+    price: 5000 # Frontier - Rebalance
 
 - type: entity
   parent: TechnologyDisk
@@ -70,5 +71,4 @@
   suffix: rare.
   components:
   - type: TechnologyDisk
-    tierWeightPrototype: RareTechDiskTierWeights
-    price: 750 # It's still need to be worth it, but as it was stranding (1000) it was too much
+    tierWeightPrototype: RareTechDiskTierWeights # Frontier


### PR DESCRIPTION
## About the PR
Changed how the tech disk printer working a tiny bit

It will print tier 1 disks for the price of 10k (worth 5k per disk)
And tier 2-3 disks for the price of 13k (worth 5k per disk)

Research disks worth more to much closer to tech disks

## Why / Balance
Allow printing for more points with a balance worth, to remove entity spam
Allow people to unlock tier 2/3 with less issues with a small extra price to points.

## Technical details
C#
Added new sub component to split the 2 disks pools to common and rare.
Added new button on the printer to allow printing rare disks
Updated the .yml for disks and .ftl for points amounts.

## Media
![image](https://github.com/new-frontiers-14/frontier-station-14/assets/39403717/41e72868-0568-4917-938a-8929e193adb0)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame,

## Breaking changes
Not as far as im aware

**Changelog**
:cl: dvir01
- tweak: The R&D disk printer can now print the disks for 10k for tier 1, and 13k for tier 2/3.
- tweak: Tech disks are worth 5000
- tweak: Research disks worth 3000/1500
