### PR TITLE
NSF Inquisitor

### DIFF
--- a/Resources/Maps/Shuttles/inquisitor.yml
+++ b/Resources/Maps/Shuttles/inquisitor.yml
@@ -311,8 +311,13 @@ entities:
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 98
-      - 420
+      - 617
+      - 618
+      - 344
+      - 342
+      - 619
+      - 340
+      - 346
       address: AIR-07EE-EDC5
       transmitFrequency: 1621
       receiveFrequency: 1621
@@ -320,6 +325,13 @@ entities:
     - devices:
       - 98
       - 420
+      - 617
+      - 618
+      - 344
+      - 342
+      - 619
+      - 340
+      - 346
       type: DeviceList
     - containers:
         board: !type:Container
@@ -334,13 +346,14 @@ entities:
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 97
+      - 344
       address: AIR-1C93-2EB9
       transmitFrequency: 1621
       receiveFrequency: 1621
       type: DeviceNetwork
     - devices:
       - 97
+      - 344
       type: DeviceList
     - containers:
         board: !type:Container
@@ -356,13 +369,14 @@ entities:
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 96
+      - 342
       address: AIR-7F0A-41E3
       transmitFrequency: 1621
       receiveFrequency: 1621
       type: DeviceNetwork
     - devices:
       - 96
+      - 342
       type: DeviceList
     - containers:
         board: !type:Container
@@ -377,8 +391,7 @@ entities:
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 99
-      - 421
+      - 619
       address: AIR-0505-EB98
       transmitFrequency: 1621
       receiveFrequency: 1621
@@ -386,6 +399,7 @@ entities:
     - devices:
       - 99
       - 421
+      - 619
       type: DeviceList
     - containers:
         board: !type:Container
@@ -401,13 +415,14 @@ entities:
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 100
+      - 346
       address: AIR-0AFD-90EF
       transmitFrequency: 1621
       receiveFrequency: 1621
       type: DeviceNetwork
     - devices:
       - 100
+      - 346
       type: DeviceList
     - containers:
         board: !type:Container
@@ -422,13 +437,14 @@ entities:
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 95
+      - 340
       address: AIR-1775-A352
       transmitFrequency: 1621
       receiveFrequency: 1621
       type: DeviceNetwork
     - devices:
       - 95
+      - 340
       type: DeviceList
     - containers:
         board: !type:Container
@@ -639,9 +655,7 @@ entities:
     - pos: 9.5,-0.5
       parent: 1
       type: Transform
-    - ShutdownSubscribers:
-      - 78
-      address: SNS-560B-9584
+    - address: SNS-560B-9584
       transmitFrequency: 1621
       receiveFrequency: 1621
       type: DeviceNetwork
@@ -808,9 +822,7 @@ entities:
     - pos: 2.5,-6.5
       parent: 1
       type: Transform
-    - ShutdownSubscribers:
-      - 72
-      address: SNS-6277-ED41
+    - address: SNS-6277-ED41
       transmitFrequency: 1621
       receiveFrequency: 1621
       type: DeviceNetwork
@@ -979,9 +991,7 @@ entities:
     - pos: 2.5,5.5
       parent: 1
       type: Transform
-    - ShutdownSubscribers:
-      - 70
-      address: SNS-71A0-C8FD
+    - address: SNS-71A0-C8FD
       transmitFrequency: 1621
       receiveFrequency: 1621
       type: DeviceNetwork
@@ -1150,9 +1160,7 @@ entities:
     - pos: 3.5,-0.5
       parent: 1
       type: Transform
-    - ShutdownSubscribers:
-      - 68
-      address: SNS-6C67-0754
+    - address: SNS-6C67-0754
       transmitFrequency: 1621
       receiveFrequency: 1621
       type: DeviceNetwork
@@ -1321,9 +1329,7 @@ entities:
     - pos: 7.5,4.5
       parent: 1
       type: Transform
-    - ShutdownSubscribers:
-      - 74
-      address: SNS-6446-EABF
+    - address: SNS-6446-EABF
       transmitFrequency: 1621
       receiveFrequency: 1621
       type: DeviceNetwork
@@ -1493,9 +1499,7 @@ entities:
     - pos: 7.5,-5.5
       parent: 1
       type: Transform
-    - ShutdownSubscribers:
-      - 76
-      address: SNS-1310-25BB
+    - address: SNS-1310-25BB
       transmitFrequency: 1621
       receiveFrequency: 1621
       type: DeviceNetwork
@@ -3461,7 +3465,10 @@ entities:
           ents:
           - 341
       type: ContainerContainer
-    - address: 2A2F-32C5
+    - ShutdownSubscribers:
+      - 68
+      - 78
+      address: 2A2F-32C5
       receiveFrequency: 1621
       type: DeviceNetwork
   - uid: 342
@@ -3476,7 +3483,10 @@ entities:
           ents:
           - 343
       type: ContainerContainer
-    - address: 69E1-ED5D
+    - ShutdownSubscribers:
+      - 68
+      - 72
+      address: 69E1-ED5D
       receiveFrequency: 1621
       type: DeviceNetwork
   - uid: 344
@@ -3491,7 +3501,10 @@ entities:
           ents:
           - 345
       type: ContainerContainer
-    - address: 4EBA-47B3
+    - ShutdownSubscribers:
+      - 70
+      - 68
+      address: 4EBA-47B3
       receiveFrequency: 1621
       type: DeviceNetwork
   - uid: 346
@@ -3506,8 +3519,36 @@ entities:
           ents:
           - 347
       type: ContainerContainer
-    - address: 6D3F-5E6B
+    - ShutdownSubscribers:
+      - 68
+      - 76
+      address: 6D3F-5E6B
       receiveFrequency: 1621
+      type: DeviceNetwork
+  - uid: 617
+    components:
+    - pos: -1.5,1.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 68
+      type: DeviceNetwork
+  - uid: 618
+    components:
+    - pos: -1.5,-2.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 68
+      type: DeviceNetwork
+  - uid: 619
+    components:
+    - pos: 6.5,2.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 68
+      - 74
       type: DeviceNetwork
 - proto: FlashlightLantern
   entities:
@@ -4865,9 +4906,7 @@ entities:
       pos: 5.5,-0.5
       parent: 1
       type: Transform
-    - ShutdownSubscribers:
-      - 68
-      address: SCR-5EC7-51F9
+    - address: SCR-5EC7-51F9
       transmitFrequency: 1621
       receiveFrequency: 1621
       type: DeviceNetwork
@@ -5039,9 +5078,7 @@ entities:
       pos: 10.5,5.5
       parent: 1
       type: Transform
-    - ShutdownSubscribers:
-      - 74
-      address: SCR-598A-AED4
+    - address: SCR-598A-AED4
       transmitFrequency: 1621
       receiveFrequency: 1621
       type: DeviceNetwork
@@ -6450,36 +6487,36 @@ entities:
         321:
         - Pressed: Toggle
       type: DeviceLinkSource
-  - uid: 615
+  - uid: 491
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,-4.5
       parent: 1
       type: Transform
     - linkedPorts:
-        614:
+        615:
         - Pressed: DoorBolt
       type: DeviceLinkSource
-  - uid: 616
+  - uid: 492
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,3.5
       parent: 1
       type: Transform
     - linkedPorts:
-        613:
+        614:
         - Pressed: DoorBolt
       type: DeviceLinkSource
     - type: ItemCooldown
 - proto: SignBridge
   entities:
-  - uid: 491
+  - uid: 493
     components:
     - rot: 3.141592653589793 rad
       pos: 7.5,-1.5
       parent: 1
       type: Transform
-  - uid: 492
+  - uid: 494
     components:
     - rot: 3.141592653589793 rad
       pos: 7.5,0.5
@@ -6487,7 +6524,7 @@ entities:
       type: Transform
 - proto: SignConspiracyBoard
   entities:
-  - uid: 493
+  - uid: 495
     components:
     - rot: 3.141592653589793 rad
       pos: 8.5,-7.5
@@ -6495,26 +6532,26 @@ entities:
       type: Transform
 - proto: SignDirectionalBrig
   entities:
-  - uid: 494
+  - uid: 496
     components:
     - rot: 3.141592653589793 rad
       pos: 1.5,1.5
       parent: 1
       type: Transform
-  - uid: 495
+  - uid: 497
     components:
     - pos: 1.5,-2.5
       parent: 1
       type: Transform
 - proto: SignEngineering
   entities:
-  - uid: 496
+  - uid: 498
     components:
     - rot: 3.141592653589793 rad
       pos: 5.5,2.5
       parent: 1
       type: Transform
-  - uid: 497
+  - uid: 499
     components:
     - rot: 3.141592653589793 rad
       pos: 7.5,2.5
@@ -6522,27 +6559,27 @@ entities:
       type: Transform
 - proto: SignFlammableMed
   entities:
-  - uid: 498
+  - uid: 500
     components:
     - pos: 7.5,6.5
       parent: 1
       type: Transform
 - proto: SignGravity
   entities:
-  - uid: 499
+  - uid: 501
     components:
     - pos: 11.5,5.5
       parent: 1
       type: Transform
 - proto: SignSec
   entities:
-  - uid: 500
+  - uid: 502
     components:
     - rot: 3.141592653589793 rad
       pos: 7.5,-3.5
       parent: 1
       type: Transform
-  - uid: 501
+  - uid: 503
     components:
     - rot: 3.141592653589793 rad
       pos: 5.5,-3.5
@@ -6550,13 +6587,13 @@ entities:
       type: Transform
 - proto: SignShipDock
   entities:
-  - uid: 502
+  - uid: 504
     components:
     - rot: 3.141592653589793 rad
       pos: -3.5,-1.5
       parent: 1
       type: Transform
-  - uid: 503
+  - uid: 505
     components:
     - rot: 3.141592653589793 rad
       pos: -3.5,0.5
@@ -6564,35 +6601,35 @@ entities:
       type: Transform
 - proto: SMESBasic
   entities:
-  - uid: 504
+  - uid: 506
     components:
     - pos: 10.5,5.5
       parent: 1
       type: Transform
 - proto: SpawnPointDetective
   entities:
-  - uid: 505
+  - uid: 507
     components:
     - pos: 9.5,-5.5
       parent: 1
       type: Transform
 - proto: SpawnPointLatejoin
   entities:
-  - uid: 506
+  - uid: 508
     components:
     - pos: 2.5,-0.5
       parent: 1
       type: Transform
 - proto: SpawnPointSecurityOfficer
   entities:
-  - uid: 507
+  - uid: 509
     components:
     - pos: 7.5,4.5
       parent: 1
       type: Transform
 - proto: SpawnPointWarden
   entities:
-  - uid: 508
+  - uid: 510
     components:
     - pos: 1.5,-0.5
       parent: 1
@@ -6609,14 +6646,14 @@ entities:
       type: Physics
 - proto: SubstationBasic
   entities:
-  - uid: 509
+  - uid: 511
     components:
     - pos: 10.5,4.5
       parent: 1
       type: Transform
 - proto: SuitStorageSec
   entities:
-  - uid: 510
+  - uid: 512
     components:
     - pos: 9.5,-1.5
       parent: 1
@@ -6639,7 +6676,7 @@ entities:
         - 0
         - 0
       type: EntityStorage
-  - uid: 511
+  - uid: 513
     components:
     - pos: 10.5,-5.5
       parent: 1
@@ -6664,7 +6701,7 @@ entities:
       type: EntityStorage
 - proto: SuitStorageWarden
   entities:
-  - uid: 512
+  - uid: 514
     components:
     - pos: 0.5,-0.5
       parent: 1
@@ -6699,17 +6736,17 @@ entities:
       type: Physics
 - proto: TableWood
   entities:
-  - uid: 513
+  - uid: 515
     components:
     - pos: 9.5,0.5
       parent: 1
       type: Transform
-  - uid: 514
+  - uid: 516
     components:
     - pos: 9.5,-6.5
       parent: 1
       type: Transform
-  - uid: 515
+  - uid: 517
     components:
     - pos: 8.5,-6.5
       parent: 1
@@ -6992,539 +7029,539 @@ entities:
       type: ContainerContainer
 - proto: WallShuttle
   entities:
-  - uid: 516
+  - uid: 518
     components:
     - pos: 5.5,-5.5
       parent: 1
       type: Transform
-  - uid: 517
+  - uid: 519
     components:
     - rot: 1.5707963267948966 rad
       pos: 11.5,1.5
       parent: 1
       type: Transform
-  - uid: 518
+  - uid: 520
     components:
     - rot: -1.5707963267948966 rad
       pos: -1.5,0.5
       parent: 1
       type: Transform
-  - uid: 519
+  - uid: 521
     components:
     - rot: -1.5707963267948966 rad
       pos: -2.5,0.5
       parent: 1
       type: Transform
-  - uid: 520
+  - uid: 522
     components:
     - rot: -1.5707963267948966 rad
       pos: 1.5,-7.5
       parent: 1
       type: Transform
-  - uid: 521
+  - uid: 523
     components:
     - pos: 4.5,1.5
       parent: 1
       type: Transform
-  - uid: 522
+  - uid: 524
     components:
     - rot: 3.141592653589793 rad
       pos: 5.5,2.5
       parent: 1
       type: Transform
-  - uid: 523
+  - uid: 525
     components:
     - rot: 3.141592653589793 rad
       pos: 5.5,3.5
       parent: 1
       type: Transform
-  - uid: 524
+  - uid: 526
     components:
     - rot: -1.5707963267948966 rad
       pos: 7.5,2.5
       parent: 1
       type: Transform
-  - uid: 525
+  - uid: 527
     components:
     - pos: 7.5,1.5
       parent: 1
       type: Transform
-  - uid: 526
+  - uid: 528
     components:
     - pos: 8.5,1.5
       parent: 1
       type: Transform
-  - uid: 527
+  - uid: 529
     components:
     - pos: 9.5,1.5
       parent: 1
       type: Transform
-  - uid: 528
-    components:
-    - pos: 10.5,1.5
-      parent: 1
-      type: Transform
-  - uid: 529
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 11.5,-2.5
-      parent: 1
-      type: Transform
   - uid: 530
     components:
-    - rot: 1.5707963267948966 rad
-      pos: 10.5,-2.5
+    - pos: 10.5,1.5
       parent: 1
       type: Transform
   - uid: 531
     components:
     - rot: 1.5707963267948966 rad
-      pos: 9.5,-2.5
+      pos: 11.5,-2.5
       parent: 1
       type: Transform
   - uid: 532
     components:
     - rot: 1.5707963267948966 rad
-      pos: 8.5,-2.5
+      pos: 10.5,-2.5
       parent: 1
       type: Transform
   - uid: 533
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 6.5,6.5
+    - rot: 1.5707963267948966 rad
+      pos: 9.5,-2.5
       parent: 1
       type: Transform
   - uid: 534
     components:
     - rot: 1.5707963267948966 rad
-      pos: 7.5,-2.5
+      pos: 8.5,-2.5
       parent: 1
       type: Transform
   - uid: 535
     components:
     - rot: -1.5707963267948966 rad
-      pos: 7.5,-3.5
+      pos: 6.5,6.5
       parent: 1
       type: Transform
   - uid: 536
     components:
-    - pos: 5.5,-4.5
+    - rot: 1.5707963267948966 rad
+      pos: 7.5,-2.5
       parent: 1
       type: Transform
   - uid: 537
     components:
     - rot: -1.5707963267948966 rad
-      pos: 9.5,-4.5
+      pos: 7.5,-3.5
       parent: 1
       type: Transform
   - uid: 538
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 8.5,-4.5
+    - pos: 5.5,-4.5
       parent: 1
       type: Transform
   - uid: 539
     components:
     - rot: -1.5707963267948966 rad
-      pos: 10.5,-4.5
+      pos: 9.5,-4.5
       parent: 1
       type: Transform
   - uid: 540
     components:
     - rot: -1.5707963267948966 rad
-      pos: 11.5,-4.5
+      pos: 8.5,-4.5
       parent: 1
       type: Transform
   - uid: 541
     components:
     - rot: -1.5707963267948966 rad
-      pos: 7.5,6.5
+      pos: 10.5,-4.5
       parent: 1
       type: Transform
   - uid: 542
     components:
     - rot: -1.5707963267948966 rad
-      pos: 8.5,6.5
+      pos: 11.5,-4.5
       parent: 1
       type: Transform
   - uid: 543
     components:
     - rot: -1.5707963267948966 rad
-      pos: 9.5,6.5
+      pos: 7.5,6.5
       parent: 1
       type: Transform
   - uid: 544
     components:
     - rot: -1.5707963267948966 rad
-      pos: 10.5,6.5
+      pos: 8.5,6.5
       parent: 1
       type: Transform
   - uid: 545
     components:
     - rot: -1.5707963267948966 rad
-      pos: 11.5,6.5
+      pos: 9.5,6.5
       parent: 1
       type: Transform
   - uid: 546
     components:
-    - rot: 1.5707963267948966 rad
-      pos: 5.5,-3.5
+    - rot: -1.5707963267948966 rad
+      pos: 10.5,6.5
       parent: 1
       type: Transform
   - uid: 547
     components:
     - rot: -1.5707963267948966 rad
-      pos: 4.5,-2.5
+      pos: 11.5,6.5
       parent: 1
       type: Transform
   - uid: 548
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 2.5,-7.5
+    - rot: 1.5707963267948966 rad
+      pos: 5.5,-3.5
       parent: 1
       type: Transform
   - uid: 549
     components:
     - rot: -1.5707963267948966 rad
-      pos: 3.5,-7.5
+      pos: 4.5,-2.5
       parent: 1
       type: Transform
   - uid: 550
     components:
     - rot: -1.5707963267948966 rad
-      pos: -3.5,0.5
+      pos: 2.5,-7.5
       parent: 1
       type: Transform
   - uid: 551
     components:
     - rot: -1.5707963267948966 rad
-      pos: -0.5,2.5
+      pos: 3.5,-7.5
       parent: 1
       type: Transform
   - uid: 552
     components:
-    - pos: 8.5,3.5
+    - rot: -1.5707963267948966 rad
+      pos: -3.5,0.5
       parent: 1
       type: Transform
   - uid: 553
     components:
-    - pos: 9.5,3.5
+    - rot: -1.5707963267948966 rad
+      pos: -0.5,2.5
       parent: 1
       type: Transform
   - uid: 554
     components:
-    - pos: 10.5,3.5
+    - pos: 8.5,3.5
       parent: 1
       type: Transform
   - uid: 555
     components:
-    - pos: 11.5,3.5
+    - pos: 9.5,3.5
       parent: 1
       type: Transform
   - uid: 556
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 9.5,-7.5
+    - pos: 10.5,3.5
       parent: 1
       type: Transform
   - uid: 557
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 10.5,-7.5
+    - pos: 11.5,3.5
       parent: 1
       type: Transform
   - uid: 558
     components:
     - rot: -1.5707963267948966 rad
-      pos: 11.5,-7.5
+      pos: 9.5,-7.5
       parent: 1
       type: Transform
   - uid: 559
     components:
     - rot: -1.5707963267948966 rad
-      pos: 11.5,5.5
+      pos: 10.5,-7.5
       parent: 1
       type: Transform
   - uid: 560
     components:
     - rot: -1.5707963267948966 rad
-      pos: 11.5,4.5
+      pos: 11.5,-7.5
       parent: 1
       type: Transform
   - uid: 561
     components:
     - rot: -1.5707963267948966 rad
-      pos: 6.5,5.5
+      pos: 11.5,5.5
       parent: 1
       type: Transform
   - uid: 562
     components:
     - rot: -1.5707963267948966 rad
-      pos: 8.5,-7.5
+      pos: 11.5,4.5
       parent: 1
       type: Transform
   - uid: 563
     components:
     - rot: -1.5707963267948966 rad
-      pos: 7.5,-7.5
+      pos: 6.5,5.5
       parent: 1
       type: Transform
   - uid: 564
     components:
     - rot: -1.5707963267948966 rad
-      pos: 6.5,-7.5
+      pos: 8.5,-7.5
       parent: 1
       type: Transform
   - uid: 565
     components:
     - rot: -1.5707963267948966 rad
-      pos: 6.5,-6.5
+      pos: 7.5,-7.5
       parent: 1
       type: Transform
   - uid: 566
     components:
     - rot: -1.5707963267948966 rad
-      pos: -1.5,2.5
+      pos: 6.5,-7.5
       parent: 1
       type: Transform
   - uid: 567
     components:
     - rot: -1.5707963267948966 rad
-      pos: -4.5,0.5
+      pos: 6.5,-6.5
       parent: 1
       type: Transform
   - uid: 568
     components:
     - rot: -1.5707963267948966 rad
-      pos: -4.5,2.5
+      pos: -1.5,2.5
       parent: 1
       type: Transform
   - uid: 569
     components:
-    - rot: 3.141592653589793 rad
-      pos: 0.5,2.5
+    - rot: -1.5707963267948966 rad
+      pos: -4.5,0.5
       parent: 1
       type: Transform
   - uid: 570
     components:
     - rot: -1.5707963267948966 rad
-      pos: -0.5,-0.5
+      pos: -4.5,2.5
       parent: 1
       type: Transform
   - uid: 571
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 572
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -0.5,-0.5
+      parent: 1
+      type: Transform
+  - uid: 573
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,-3.5
       parent: 1
       type: Transform
-  - uid: 572
+  - uid: 574
     components:
     - rot: 3.141592653589793 rad
       pos: 3.5,6.5
       parent: 1
       type: Transform
-  - uid: 573
+  - uid: 575
     components:
     - rot: 3.141592653589793 rad
       pos: 3.5,1.5
       parent: 1
       type: Transform
-  - uid: 574
+  - uid: 576
     components:
     - rot: 3.141592653589793 rad
       pos: 3.5,2.5
       parent: 1
       type: Transform
-  - uid: 575
+  - uid: 577
     components:
     - rot: 3.141592653589793 rad
       pos: 1.5,-4.5
       parent: 1
       type: Transform
-  - uid: 576
+  - uid: 578
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,-2.5
       parent: 1
       type: Transform
-  - uid: 577
+  - uid: 579
     components:
     - rot: -1.5707963267948966 rad
       pos: 1.5,-3.5
       parent: 1
       type: Transform
-  - uid: 578
-    components:
-    - pos: 1.5,-2.5
-      parent: 1
-      type: Transform
-  - uid: 579
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 0.5,-7.5
-      parent: 1
-      type: Transform
   - uid: 580
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 0.5,-5.5
+    - pos: 1.5,-2.5
       parent: 1
       type: Transform
   - uid: 581
     components:
     - rot: -1.5707963267948966 rad
-      pos: 1.5,1.5
+      pos: 0.5,-7.5
       parent: 1
       type: Transform
   - uid: 582
     components:
     - rot: -1.5707963267948966 rad
-      pos: -1.5,-3.5
+      pos: 0.5,-5.5
       parent: 1
       type: Transform
   - uid: 583
     components:
     - rot: -1.5707963267948966 rad
-      pos: -0.5,-3.5
+      pos: 1.5,1.5
       parent: 1
       type: Transform
   - uid: 584
     components:
-    - rot: 3.141592653589793 rad
-      pos: 0.5,-3.5
+    - rot: -1.5707963267948966 rad
+      pos: -1.5,-3.5
       parent: 1
       type: Transform
   - uid: 585
     components:
     - rot: -1.5707963267948966 rad
-      pos: -3.5,-1.5
+      pos: -0.5,-3.5
       parent: 1
       type: Transform
   - uid: 586
     components:
-    - rot: -1.5707963267948966 rad
-      pos: -1.5,-1.5
+    - rot: 3.141592653589793 rad
+      pos: 0.5,-3.5
       parent: 1
       type: Transform
   - uid: 587
     components:
     - rot: -1.5707963267948966 rad
-      pos: -2.5,-1.5
+      pos: -3.5,-1.5
       parent: 1
       type: Transform
   - uid: 588
     components:
     - rot: -1.5707963267948966 rad
-      pos: -4.5,-1.5
+      pos: -1.5,-1.5
       parent: 1
       type: Transform
   - uid: 589
     components:
     - rot: -1.5707963267948966 rad
-      pos: -4.5,-3.5
+      pos: -2.5,-1.5
       parent: 1
       type: Transform
   - uid: 590
     components:
-    - rot: 3.141592653589793 rad
-      pos: 1.5,6.5
+    - rot: -1.5707963267948966 rad
+      pos: -4.5,-1.5
       parent: 1
       type: Transform
   - uid: 591
     components:
-    - rot: 3.141592653589793 rad
-      pos: 2.5,6.5
+    - rot: -1.5707963267948966 rad
+      pos: -4.5,-3.5
       parent: 1
       type: Transform
   - uid: 592
     components:
     - rot: 3.141592653589793 rad
-      pos: 0.5,6.5
+      pos: 1.5,6.5
       parent: 1
       type: Transform
   - uid: 593
     components:
     - rot: 3.141592653589793 rad
-      pos: 0.5,4.5
+      pos: 2.5,6.5
       parent: 1
       type: Transform
   - uid: 594
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 595
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 596
     components:
     - rot: -1.5707963267948966 rad
       pos: 1.5,3.5
       parent: 1
       type: Transform
-  - uid: 595
+  - uid: 597
     components:
     - rot: -1.5707963267948966 rad
       pos: 1.5,2.5
       parent: 1
       type: Transform
-  - uid: 596
+  - uid: 598
     components:
     - pos: 5.5,5.5
       parent: 1
       type: Transform
-  - uid: 597
+  - uid: 599
     components:
     - pos: 5.5,4.5
       parent: 1
       type: Transform
-  - uid: 598
+  - uid: 600
     components:
     - pos: 5.5,-6.5
       parent: 1
       type: Transform
 - proto: WallShuttleDiagonal
   entities:
-  - uid: 599
+  - uid: 601
     components:
     - rot: 3.141592653589793 rad
       pos: 5.5,1.5
       parent: 1
       type: Transform
-  - uid: 600
+  - uid: 602
     components:
     - rot: 1.5707963267948966 rad
       pos: 7.5,-3.5
       parent: 1
       type: Transform
-  - uid: 601
+  - uid: 603
     components:
     - rot: -1.5707963267948966 rad
       pos: 5.5,-2.5
       parent: 1
       type: Transform
-  - uid: 602
+  - uid: 604
     components:
     - pos: 7.5,3.5
       parent: 1
       type: Transform
-  - uid: 603
+  - uid: 605
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,-1.5
       parent: 1
       type: Transform
-  - uid: 604
+  - uid: 606
     components:
     - rot: 3.141592653589793 rad
       pos: 1.5,-5.5
       parent: 1
       type: Transform
-  - uid: 605
+  - uid: 607
     components:
     - rot: -1.5707963267948966 rad
       pos: -0.5,0.5
       parent: 1
       type: Transform
-  - uid: 606
+  - uid: 608
     components:
     - rot: 1.5707963267948966 rad
       pos: 7.5,-4.5
       parent: 1
       type: Transform
-  - uid: 607
+  - uid: 609
     components:
     - rot: -1.5707963267948966 rad
       pos: 1.5,4.5
@@ -7532,7 +7569,7 @@ entities:
       type: Transform
 - proto: WallWeaponCapacitorRecharger
   entities:
-  - uid: 608
+  - uid: 610
     components:
     - pos: -0.5,-0.5
       parent: 1
@@ -7541,7 +7578,7 @@ entities:
       type: Charger
     - powerLoad: 0
       type: ApcPowerReceiver
-  - uid: 609
+  - uid: 611
     components:
     - pos: 8.5,1.5
       parent: 1
@@ -7550,7 +7587,7 @@ entities:
       type: Charger
     - powerLoad: 0
       type: ApcPowerReceiver
-  - uid: 610
+  - uid: 612
     components:
     - pos: 8.5,-2.5
       parent: 1
@@ -7561,7 +7598,7 @@ entities:
       type: ApcPowerReceiver
 - proto: WarpPointShip
   entities:
-  - uid: 611
+  - uid: 613
     components:
     - pos: 4.5,-0.5
       parent: 1
@@ -7618,27 +7655,27 @@ entities:
     - type: InsideEntityStorage
 - proto: WindoorSecure
   entities:
-  - uid: 613
+  - uid: 614
     components:
     - pos: 2.5,4.5
       parent: 1
       type: Transform
     - invokeCounter: 2
       links:
-      - 616
+      - 492
       type: DeviceLinkSink
-  - uid: 614
+  - uid: 615
     components:
     - rot: 3.141592653589793 rad
       pos: 2.5,-5.5
       parent: 1
       type: Transform
     - links:
-      - 615
+      - 491
       type: DeviceLinkSink
 - proto: Wrench
   entities:
-  - uid: 612
+  - uid: 616
     components:
     - pos: 7.533099,4.573193
       parent: 1

--- a/Resources/Maps/Shuttles/inquisitor.yml
+++ b/Resources/Maps/Shuttles/inquisitor.yml
@@ -1,0 +1,7629 @@
+meta:
+  format: 6
+  postmapinit: false
+tilemap:
+  0: Space
+  27: FloorDark
+  30: FloorDarkHerringbone
+  31: FloorDarkMini
+  32: FloorDarkMono
+  97: FloorTechMaint2
+  112: Lattice
+  113: Plating
+entities:
+- proto: ""
+  entities:
+  - uid: 1
+    components:
+    - name: grid
+      type: MetaData
+    - pos: 1.6817646,-5.3364935
+      parent: invalid
+      type: Transform
+    - chunks:
+        0,0:
+          ind: 0,0
+          tiles: GwAAAAABGwAAAAADGwAAAAAAGwAAAAAAGwAAAAACGwAAAAAAGwAAAAAAGwAAAAAAHgAAAAAAHgAAAAAAHgAAAAAAGwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGwAAAAAAGwAAAAAAYQAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGwAAAAAAGwAAAAAAHwAAAAAAGwAAAAAAcAAAAAAAGwAAAAAAYQAAAAAAGwAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAGwAAAAAAHwAAAAAAGwAAAAAAcAAAAAAAGwAAAAAAcQAAAAAAcQAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGwAAAAAAHwAAAAAAHwAAAAAAGwAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAGwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGwAAAAAAHwAAAAAAHwAAAAAAGwAAAAAAAAAAAAAAcQAAAAAAGwAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAGwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAAAAAAAAAAAAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          version: 6
+        0,-1:
+          ind: 0,-1
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAAAAAAAAAAAAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGwAAAAAAHwAAAAAAHwAAAAAAGwAAAAAAAAAAAAAAcQAAAAAAGwAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAGwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGwAAAAAAHwAAAAAAHwAAAAAAGwAAAAAAAAAAAAAAcQAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAGwAAAAABGwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAGwAAAAAAHwAAAAAAGwAAAAAAcAAAAAAAGwAAAAAAIAAAAAAAIAAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGwAAAAAAGwAAAAAAHwAAAAAAGwAAAAAAcAAAAAAAGwAAAAAAYQAAAAAAGwAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGwAAAAABGwAAAAAAYQAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGwAAAAACGwAAAAABGwAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAHgAAAAAAHgAAAAAAHgAAAAAAGwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGwAAAAACGwAAAAABGwAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAYQAAAAAAHgAAAAAAHgAAAAAAHgAAAAAAGwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          version: 6
+        -1,-1:
+          ind: -1,-1
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYQAAAAAAGwAAAAADGwAAAAAAGwAAAAACGwAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAGwAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAGwAAAAAA
+          version: 6
+        -1,0:
+          ind: -1,0
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAGwAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYQAAAAAAGwAAAAAAGwAAAAAAGwAAAAADGwAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          version: 6
+      type: MapGrid
+    - type: Broadphase
+    - bodyStatus: InAir
+      angularDamping: 0.05
+      linearDamping: 0.05
+      fixedRotation: False
+      bodyType: Dynamic
+      type: Physics
+    - fixtures: {}
+      type: Fixtures
+    - type: OccluderTree
+    - updateAccumulator: 0.58426464
+      type: SpreaderGrid
+    - type: Shuttle
+    - type: GridPathfinding
+    - gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+      type: Gravity
+    - chunkCollection:
+        version: 2
+        nodes:
+        - node:
+            color: '#FFFFFFFF'
+            id: Caution
+          decals:
+            17: 2,0
+        - node:
+            angle: 3.141592653589793 rad
+            color: '#FFFFFFFF'
+            id: Caution
+          decals:
+            16: 2,-2
+        - node:
+            color: '#FFFFFFFF'
+            id: CautionGreyscale
+          decals:
+            18: 6,1
+        - node:
+            angle: 3.141592653589793 rad
+            color: '#FFFFFFFF'
+            id: CautionGreyscale
+          decals:
+            19: 6,-3
+        - node:
+            angle: -3.141592653589793 rad
+            color: '#FFFFFFFF'
+            id: Dirt
+          decals:
+            5: 1,-7
+            6: 2,-7
+        - node:
+            angle: -1.5707963267948966 rad
+            color: '#FFFFFFFF'
+            id: Dirt
+          decals:
+            4: 2,-6
+        - node:
+            color: '#FFFFFFFF'
+            id: Dirt
+          decals:
+            3: 2,-5
+            7: 2,2
+            12: 1,-6
+            15: 2,4
+        - node:
+            angle: 1.5707963267948966 rad
+            color: '#FFFFFFFF'
+            id: Dirt
+          decals:
+            2: 2,-4
+            8: 2,3
+        - node:
+            angle: 4.71238898038469 rad
+            color: '#FFFFFFFF'
+            id: Dirt
+          decals:
+            9: 2,5
+            10: 1,5
+        - node:
+            angle: 6.283185307179586 rad
+            color: '#FFFFFFFF'
+            id: Dirt
+          decals:
+            11: 1,4
+        - node:
+            angle: 1.5707963267948966 rad
+            color: '#FFFFFFFF'
+            id: LoadingAreaGreyscale
+          decals:
+            0: -4,-3
+            1: -4,1
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnLineW
+          decals:
+            13: 2,0
+        - node:
+            angle: 3.141592653589793 rad
+            color: '#FFFFFFFF'
+            id: WarnLineW
+          decals:
+            14: 2,-2
+      type: DecalGrid
+    - version: 2
+      data:
+        tiles:
+          0,0:
+            0: 65535
+          0,-1:
+            0: 65535
+          -1,-1:
+            0: 65535
+          -1,0:
+            0: 4095
+          0,1:
+            0: 4095
+          1,0:
+            0: 65535
+          1,1:
+            0: 3310
+          2,0:
+            0: 61951
+          2,1:
+            0: 4095
+          0,-2:
+            0: 65535
+          1,-2:
+            0: 65260
+          1,-1:
+            0: 65535
+          2,-2:
+            0: 65535
+          2,-1:
+            0: 65521
+          -2,-1:
+            0: 34952
+          -2,0:
+            0: 2184
+        uniqueMixes:
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 21.824879
+          - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        chunkSize: 4
+      type: GridAtmosphere
+    - type: GasTileOverlay
+    - id: Inquisitor
+      type: BecomesStation
+    - type: RadiationGridResistance
+    - shakeTimes: 10
+      type: GravityShake
+- proto: ActionToggleLight
+  entities:
+  - uid: 3
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 2
+      type: Transform
+    - container: 2
+      type: InstantAction
+  - uid: 4
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 2
+      type: Transform
+    - container: 2
+      type: InstantAction
+  - uid: 9
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 8
+      type: Transform
+    - container: 8
+      type: InstantAction
+  - uid: 10
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 8
+      type: Transform
+    - container: 8
+      type: InstantAction
+  - uid: 25
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 24
+      type: Transform
+    - container: 24
+      type: InstantAction
+  - uid: 26
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 24
+      type: Transform
+    - container: 24
+      type: InstantAction
+  - uid: 35
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 34
+      type: Transform
+    - container: 34
+      type: InstantAction
+  - uid: 42
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 41
+      type: Transform
+    - container: 41
+      type: InstantAction
+- proto: ActionToggleSuitPiece
+  entities:
+  - uid: 18
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 17
+      type: Transform
+    - container: 17
+      entIcon: 19
+      type: InstantAction
+  - uid: 48
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 47
+      type: Transform
+    - container: 47
+      entIcon: 49
+      type: InstantAction
+- proto: ActionVendingThrow
+  entities:
+  - uid: 65
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 64
+      type: Transform
+    - container: 64
+      type: InstantAction
+  - uid: 67
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 66
+      type: Transform
+    - container: 66
+      type: InstantAction
+- proto: AirAlarm
+  entities:
+  - uid: 68
+    components:
+    - pos: 3.5,1.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 98
+      - 420
+      address: AIR-07EE-EDC5
+      transmitFrequency: 1621
+      receiveFrequency: 1621
+      type: DeviceNetwork
+    - devices:
+      - 98
+      - 420
+      type: DeviceList
+    - containers:
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 69
+      type: ContainerContainer
+  - uid: 70
+    components:
+    - pos: 2.5,6.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 97
+      address: AIR-1C93-2EB9
+      transmitFrequency: 1621
+      receiveFrequency: 1621
+      type: DeviceNetwork
+    - devices:
+      - 97
+      type: DeviceList
+    - containers:
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 71
+      type: ContainerContainer
+  - uid: 72
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 2.5,-7.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 96
+      address: AIR-7F0A-41E3
+      transmitFrequency: 1621
+      receiveFrequency: 1621
+      type: DeviceNetwork
+    - devices:
+      - 96
+      type: DeviceList
+    - containers:
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 73
+      type: ContainerContainer
+  - uid: 74
+    components:
+    - pos: 10.5,6.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 99
+      - 421
+      address: AIR-0505-EB98
+      transmitFrequency: 1621
+      receiveFrequency: 1621
+      type: DeviceNetwork
+    - devices:
+      - 99
+      - 421
+      type: DeviceList
+    - containers:
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 75
+      type: ContainerContainer
+  - uid: 76
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 10.5,-7.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 100
+      address: AIR-0AFD-90EF
+      transmitFrequency: 1621
+      receiveFrequency: 1621
+      type: DeviceNetwork
+    - devices:
+      - 100
+      type: DeviceList
+    - containers:
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 77
+      type: ContainerContainer
+  - uid: 78
+    components:
+    - pos: 9.5,1.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 95
+      address: AIR-1775-A352
+      transmitFrequency: 1621
+      receiveFrequency: 1621
+      type: DeviceNetwork
+    - devices:
+      - 95
+      type: DeviceList
+    - containers:
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 79
+      type: ContainerContainer
+- proto: AirAlarmElectronics
+  entities:
+  - uid: 69
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 68
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 71
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 70
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 73
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 72
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 75
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 74
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 77
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 76
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 79
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 78
+      type: Transform
+    - canCollide: False
+      type: Physics
+- proto: AirCanister
+  entities:
+  - uid: 80
+    components:
+    - pos: 8.5,4.5
+      parent: 1
+      type: Transform
+- proto: AirlockCommandGlass
+  entities:
+  - uid: 81
+    components:
+    - pos: 7.5,-0.5
+      parent: 1
+      type: Transform
+    - wiresAccessible: False
+      examine: wires-panel-component-on-examine-security-level2
+      type: WiresPanelSecurity
+    - node: medSecurity
+      type: Construction
+    - containers:
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 82
+      type: ContainerContainer
+    - address: 15BA-7CDD
+      receiveFrequency: 1280
+      type: DeviceNetwork
+- proto: AirlockEngineeringGlass
+  entities:
+  - uid: 83
+    components:
+    - pos: 6.5,2.5
+      parent: 1
+      type: Transform
+    - containers:
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 84
+      type: ContainerContainer
+    - address: 43F1-6C63
+      receiveFrequency: 1280
+      type: DeviceNetwork
+- proto: AirlockGlass
+  entities:
+  - uid: 85
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 2.5,-2.5
+      parent: 1
+      type: Transform
+    - containers:
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 86
+      type: ContainerContainer
+    - address: 3497-4A2F
+      receiveFrequency: 1280
+      type: DeviceNetwork
+    - links:
+      - 487
+      type: DeviceLinkSink
+  - uid: 87
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 2.5,1.5
+      parent: 1
+      type: Transform
+    - containers:
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 88
+      type: ContainerContainer
+    - address: 4413-8EE1
+      receiveFrequency: 1280
+      type: DeviceNetwork
+    - links:
+      - 488
+      type: DeviceLinkSink
+- proto: AirlockGlassShuttle
+  entities:
+  - uid: 89
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -4.5,-2.5
+      parent: 1
+      type: Transform
+    - containers:
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 90
+      type: ContainerContainer
+    - address: 2960-D1C2
+      receiveFrequency: 1280
+      type: DeviceNetwork
+  - uid: 91
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -4.5,1.5
+      parent: 1
+      type: Transform
+    - containers:
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 92
+      type: ContainerContainer
+    - address: 6C41-C2AE
+      receiveFrequency: 1280
+      type: DeviceNetwork
+    - dnas: []
+      fibers:
+      - black insulative fibers
+      fingerprints: []
+      type: Forensics
+- proto: AirlockSecurityGlass
+  entities:
+  - uid: 93
+    components:
+    - pos: 6.5,-3.5
+      parent: 1
+      type: Transform
+    - containers:
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 94
+      type: ContainerContainer
+    - address: 3C12-27EA
+      receiveFrequency: 1280
+      type: DeviceNetwork
+    - links:
+      - 490
+      type: DeviceLinkSink
+- proto: AirSensor
+  entities:
+  - uid: 95
+    components:
+    - pos: 9.5,-0.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 78
+      address: SNS-560B-9584
+      transmitFrequency: 1621
+      receiveFrequency: 1621
+      type: DeviceNetwork
+    - registeredDevices:
+      - AIR-1775-A352
+      gasThresholds:
+        Oxygen:
+          lowerWarnAround:
+            threshold: 1.5
+            enabled: True
+          upperWarnAround:
+            threshold: 0
+            enabled: False
+          lowerBound:
+            threshold: 0.1
+            enabled: True
+          upperBound:
+            threshold: 0
+            enabled: False
+          ignore: False
+        Nitrogen:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0
+            enabled: False
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0
+            enabled: False
+          ignore: True
+        CarbonDioxide:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0.5
+            enabled: True
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.0025
+            enabled: True
+          ignore: False
+        Plasma:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0
+            enabled: False
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.0001
+            enabled: True
+          ignore: False
+        Tritium:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0
+            enabled: False
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.0001
+            enabled: True
+          ignore: False
+        WaterVapor:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0.5
+            enabled: True
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 1.5
+            enabled: True
+          ignore: False
+        Miasma:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0.5
+            enabled: True
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.05
+            enabled: True
+          ignore: False
+        NitrousOxide:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0.5
+            enabled: True
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.01
+            enabled: True
+          ignore: False
+        Frezon:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0
+            enabled: False
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.0001
+            enabled: True
+          ignore: False
+      pressureThreshold:
+        lowerWarnAround:
+          threshold: 2.5
+          enabled: True
+        upperWarnAround:
+          threshold: 0.7
+          enabled: True
+        lowerBound:
+          threshold: 20
+          enabled: True
+        upperBound:
+          threshold: 550
+          enabled: True
+        ignore: False
+      temperatureThreshold:
+        lowerWarnAround:
+          threshold: 1.1
+          enabled: True
+        upperWarnAround:
+          threshold: 0.8
+          enabled: True
+        lowerBound:
+          threshold: 193.15
+          enabled: True
+        upperBound:
+          threshold: 393.15
+          enabled: True
+        ignore: False
+      type: AtmosMonitor
+  - uid: 96
+    components:
+    - pos: 2.5,-6.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 72
+      address: SNS-6277-ED41
+      transmitFrequency: 1621
+      receiveFrequency: 1621
+      type: DeviceNetwork
+    - registeredDevices:
+      - AIR-7F0A-41E3
+      trippedThresholds:
+      - Pressure
+      gasThresholds:
+        Oxygen:
+          lowerWarnAround:
+            threshold: 1.5
+            enabled: True
+          upperWarnAround:
+            threshold: 0
+            enabled: False
+          lowerBound:
+            threshold: 0.1
+            enabled: True
+          upperBound:
+            threshold: 0
+            enabled: False
+          ignore: False
+        Nitrogen:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0
+            enabled: False
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0
+            enabled: False
+          ignore: True
+        CarbonDioxide:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0.5
+            enabled: True
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.0025
+            enabled: True
+          ignore: False
+        Plasma:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0
+            enabled: False
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.0001
+            enabled: True
+          ignore: False
+        Tritium:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0
+            enabled: False
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.0001
+            enabled: True
+          ignore: False
+        WaterVapor:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0.5
+            enabled: True
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 1.5
+            enabled: True
+          ignore: False
+        Miasma:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0.5
+            enabled: True
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.05
+            enabled: True
+          ignore: False
+        NitrousOxide:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0.5
+            enabled: True
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.01
+            enabled: True
+          ignore: False
+        Frezon:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0
+            enabled: False
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.0001
+            enabled: True
+          ignore: False
+      pressureThreshold:
+        lowerWarnAround:
+          threshold: 2.5
+          enabled: True
+        upperWarnAround:
+          threshold: 0.7
+          enabled: True
+        lowerBound:
+          threshold: 20
+          enabled: True
+        upperBound:
+          threshold: 550
+          enabled: True
+        ignore: False
+      temperatureThreshold:
+        lowerWarnAround:
+          threshold: 1.1
+          enabled: True
+        upperWarnAround:
+          threshold: 0.8
+          enabled: True
+        lowerBound:
+          threshold: 193.15
+          enabled: True
+        upperBound:
+          threshold: 393.15
+          enabled: True
+        ignore: False
+      type: AtmosMonitor
+  - uid: 97
+    components:
+    - pos: 2.5,5.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 70
+      address: SNS-71A0-C8FD
+      transmitFrequency: 1621
+      receiveFrequency: 1621
+      type: DeviceNetwork
+    - registeredDevices:
+      - AIR-1C93-2EB9
+      trippedThresholds:
+      - Pressure
+      gasThresholds:
+        Oxygen:
+          lowerWarnAround:
+            threshold: 1.5
+            enabled: True
+          upperWarnAround:
+            threshold: 0
+            enabled: False
+          lowerBound:
+            threshold: 0.1
+            enabled: True
+          upperBound:
+            threshold: 0
+            enabled: False
+          ignore: False
+        Nitrogen:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0
+            enabled: False
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0
+            enabled: False
+          ignore: True
+        CarbonDioxide:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0.5
+            enabled: True
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.0025
+            enabled: True
+          ignore: False
+        Plasma:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0
+            enabled: False
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.0001
+            enabled: True
+          ignore: False
+        Tritium:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0
+            enabled: False
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.0001
+            enabled: True
+          ignore: False
+        WaterVapor:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0.5
+            enabled: True
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 1.5
+            enabled: True
+          ignore: False
+        Miasma:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0.5
+            enabled: True
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.05
+            enabled: True
+          ignore: False
+        NitrousOxide:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0.5
+            enabled: True
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.01
+            enabled: True
+          ignore: False
+        Frezon:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0
+            enabled: False
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.0001
+            enabled: True
+          ignore: False
+      pressureThreshold:
+        lowerWarnAround:
+          threshold: 2.5
+          enabled: True
+        upperWarnAround:
+          threshold: 0.7
+          enabled: True
+        lowerBound:
+          threshold: 20
+          enabled: True
+        upperBound:
+          threshold: 550
+          enabled: True
+        ignore: False
+      temperatureThreshold:
+        lowerWarnAround:
+          threshold: 1.1
+          enabled: True
+        upperWarnAround:
+          threshold: 0.8
+          enabled: True
+        lowerBound:
+          threshold: 193.15
+          enabled: True
+        upperBound:
+          threshold: 393.15
+          enabled: True
+        ignore: False
+      type: AtmosMonitor
+  - uid: 98
+    components:
+    - pos: 3.5,-0.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 68
+      address: SNS-6C67-0754
+      transmitFrequency: 1621
+      receiveFrequency: 1621
+      type: DeviceNetwork
+    - registeredDevices:
+      - AIR-07EE-EDC5
+      trippedThresholds:
+      - Temperature
+      gasThresholds:
+        Oxygen:
+          lowerWarnAround:
+            threshold: 1.5
+            enabled: True
+          upperWarnAround:
+            threshold: 0
+            enabled: False
+          lowerBound:
+            threshold: 0.1
+            enabled: True
+          upperBound:
+            threshold: 0
+            enabled: False
+          ignore: False
+        Nitrogen:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0
+            enabled: False
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0
+            enabled: False
+          ignore: True
+        CarbonDioxide:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0.5
+            enabled: True
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.0025
+            enabled: True
+          ignore: False
+        Plasma:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0
+            enabled: False
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.0001
+            enabled: True
+          ignore: False
+        Tritium:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0
+            enabled: False
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.0001
+            enabled: True
+          ignore: False
+        WaterVapor:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0.5
+            enabled: True
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 1.5
+            enabled: True
+          ignore: False
+        Miasma:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0.5
+            enabled: True
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.05
+            enabled: True
+          ignore: False
+        NitrousOxide:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0.5
+            enabled: True
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.01
+            enabled: True
+          ignore: False
+        Frezon:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0
+            enabled: False
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.0001
+            enabled: True
+          ignore: False
+      pressureThreshold:
+        lowerWarnAround:
+          threshold: 2.5
+          enabled: True
+        upperWarnAround:
+          threshold: 0.7
+          enabled: True
+        lowerBound:
+          threshold: 20
+          enabled: True
+        upperBound:
+          threshold: 550
+          enabled: True
+        ignore: False
+      temperatureThreshold:
+        lowerWarnAround:
+          threshold: 1.1
+          enabled: True
+        upperWarnAround:
+          threshold: 0.8
+          enabled: True
+        lowerBound:
+          threshold: 193.15
+          enabled: True
+        upperBound:
+          threshold: 393.15
+          enabled: True
+        ignore: False
+      type: AtmosMonitor
+  - uid: 99
+    components:
+    - pos: 7.5,4.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 74
+      address: SNS-6446-EABF
+      transmitFrequency: 1621
+      receiveFrequency: 1621
+      type: DeviceNetwork
+    - registeredDevices:
+      - AIR-0505-EB98
+      trippedThresholds:
+      - Gas
+      lastAlarmState: Warning
+      gasThresholds:
+        Oxygen:
+          lowerWarnAround:
+            threshold: 1.5
+            enabled: True
+          upperWarnAround:
+            threshold: 0
+            enabled: False
+          lowerBound:
+            threshold: 0.1
+            enabled: True
+          upperBound:
+            threshold: 0
+            enabled: False
+          ignore: False
+        Nitrogen:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0
+            enabled: False
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0
+            enabled: False
+          ignore: True
+        CarbonDioxide:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0.5
+            enabled: True
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.0025
+            enabled: True
+          ignore: False
+        Plasma:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0
+            enabled: False
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.0001
+            enabled: True
+          ignore: False
+        Tritium:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0
+            enabled: False
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.0001
+            enabled: True
+          ignore: False
+        WaterVapor:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0.5
+            enabled: True
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 1.5
+            enabled: True
+          ignore: False
+        Miasma:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0.5
+            enabled: True
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.05
+            enabled: True
+          ignore: False
+        NitrousOxide:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0.5
+            enabled: True
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.01
+            enabled: True
+          ignore: False
+        Frezon:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0
+            enabled: False
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.0001
+            enabled: True
+          ignore: False
+      pressureThreshold:
+        lowerWarnAround:
+          threshold: 2.5
+          enabled: True
+        upperWarnAround:
+          threshold: 0.7
+          enabled: True
+        lowerBound:
+          threshold: 20
+          enabled: True
+        upperBound:
+          threshold: 550
+          enabled: True
+        ignore: False
+      temperatureThreshold:
+        lowerWarnAround:
+          threshold: 1.1
+          enabled: True
+        upperWarnAround:
+          threshold: 0.8
+          enabled: True
+        lowerBound:
+          threshold: 193.15
+          enabled: True
+        upperBound:
+          threshold: 393.15
+          enabled: True
+        ignore: False
+      type: AtmosMonitor
+  - uid: 100
+    components:
+    - pos: 7.5,-5.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 76
+      address: SNS-1310-25BB
+      transmitFrequency: 1621
+      receiveFrequency: 1621
+      type: DeviceNetwork
+    - registeredDevices:
+      - AIR-0AFD-90EF
+      gasThresholds:
+        Oxygen:
+          lowerWarnAround:
+            threshold: 1.5
+            enabled: True
+          upperWarnAround:
+            threshold: 0
+            enabled: False
+          lowerBound:
+            threshold: 0.1
+            enabled: True
+          upperBound:
+            threshold: 0
+            enabled: False
+          ignore: False
+        Nitrogen:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0
+            enabled: False
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0
+            enabled: False
+          ignore: True
+        CarbonDioxide:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0.5
+            enabled: True
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.0025
+            enabled: True
+          ignore: False
+        Plasma:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0
+            enabled: False
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.0001
+            enabled: True
+          ignore: False
+        Tritium:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0
+            enabled: False
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.0001
+            enabled: True
+          ignore: False
+        WaterVapor:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0.5
+            enabled: True
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 1.5
+            enabled: True
+          ignore: False
+        Miasma:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0.5
+            enabled: True
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.05
+            enabled: True
+          ignore: False
+        NitrousOxide:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0.5
+            enabled: True
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.01
+            enabled: True
+          ignore: False
+        Frezon:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0
+            enabled: False
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.0001
+            enabled: True
+          ignore: False
+      pressureThreshold:
+        lowerWarnAround:
+          threshold: 2.5
+          enabled: True
+        upperWarnAround:
+          threshold: 0.7
+          enabled: True
+        lowerBound:
+          threshold: 20
+          enabled: True
+        upperBound:
+          threshold: 550
+          enabled: True
+        ignore: False
+      temperatureThreshold:
+        lowerWarnAround:
+          threshold: 1.1
+          enabled: True
+        upperWarnAround:
+          threshold: 0.8
+          enabled: True
+        lowerBound:
+          threshold: 193.15
+          enabled: True
+        upperBound:
+          threshold: 393.15
+          enabled: True
+        ignore: False
+      type: AtmosMonitor
+- proto: APCBasic
+  entities:
+  - uid: 101
+    components:
+    - pos: 9.5,6.5
+      parent: 1
+      type: Transform
+    - startingCharge: 0
+      type: Battery
+    - hasAccess: True
+      lastChargeState: Charging
+      type: Apc
+  - uid: 102
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 9.5,-2.5
+      parent: 1
+      type: Transform
+    - startingCharge: 0
+      type: Battery
+    - hasAccess: True
+      lastChargeState: Full
+      type: Apc
+  - uid: 103
+    components:
+    - pos: 4.5,1.5
+      parent: 1
+      type: Transform
+    - startingCharge: 0
+      type: Battery
+    - hasAccess: True
+      type: Apc
+- proto: AtmosDeviceFanTiny
+  entities:
+  - uid: 104
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -4.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 105
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -4.5,-2.5
+      parent: 1
+      type: Transform
+- proto: BarSign
+  entities:
+  - uid: 106
+    components:
+    - desc: Anteriormente ubicado en Spessmerica.
+      name: Zocalo
+      type: MetaData
+    - pos: 9.5,-4.5
+      parent: 1
+      type: Transform
+    - current: Zocalo
+      type: BarSign
+- proto: Bed
+  entities:
+  - uid: 107
+    components:
+    - pos: 1.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 108
+    components:
+    - pos: 1.5,-6.5
+      parent: 1
+      type: Transform
+- proto: BedsheetBlack
+  entities:
+  - uid: 109
+    components:
+    - pos: 1.5,5.5
+      parent: 1
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 110
+    components:
+    - pos: 1.5,-6.5
+      parent: 1
+      type: Transform
+    - canCollide: False
+      type: Physics
+- proto: CableApcExtension
+  entities:
+  - uid: 111
+    components:
+    - pos: -3.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 112
+    components:
+    - pos: -4.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 113
+    components:
+    - pos: -2.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 114
+    components:
+    - pos: -4.5,-2.5
+      parent: 1
+      type: Transform
+  - uid: 115
+    components:
+    - pos: -2.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 116
+    components:
+    - pos: -1.5,1.5
+      parent: 1
+      type: Transform
+    - dnas: []
+      fibers:
+      - black insulative fibers
+      fingerprints: []
+      type: Forensics
+  - uid: 117
+    components:
+    - pos: 1.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 118
+    components:
+    - pos: 0.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 119
+    components:
+    - pos: -0.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 120
+    components:
+    - pos: 0.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 121
+    components:
+    - pos: 2.5,-5.5
+      parent: 1
+      type: Transform
+  - uid: 122
+    components:
+    - pos: 9.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 123
+    components:
+    - pos: 9.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 124
+    components:
+    - pos: 9.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 125
+    components:
+    - pos: 8.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 126
+    components:
+    - pos: 7.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 127
+    components:
+    - pos: 6.5,-2.5
+      parent: 1
+      type: Transform
+  - uid: 128
+    components:
+    - pos: 4.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 129
+    components:
+    - pos: 4.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 130
+    components:
+    - pos: 3.5,-0.5
+      parent: 1
+      type: Transform
+  - uid: 131
+    components:
+    - pos: 2.5,-0.5
+      parent: 1
+      type: Transform
+  - uid: 132
+    components:
+    - pos: 0.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 133
+    components:
+    - pos: 1.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 134
+    components:
+    - pos: -0.5,-2.5
+      parent: 1
+      type: Transform
+  - uid: 135
+    components:
+    - pos: 0.5,-2.5
+      parent: 1
+      type: Transform
+  - uid: 136
+    components:
+    - pos: -1.5,-2.5
+      parent: 1
+      type: Transform
+  - uid: 137
+    components:
+    - pos: -2.5,-2.5
+      parent: 1
+      type: Transform
+  - uid: 138
+    components:
+    - pos: -1.5,-2.5
+      parent: 1
+      type: Transform
+  - uid: 139
+    components:
+    - pos: -2.5,-2.5
+      parent: 1
+      type: Transform
+  - uid: 140
+    components:
+    - pos: -3.5,-2.5
+      parent: 1
+      type: Transform
+  - uid: 141
+    components:
+    - pos: 4.5,-0.5
+      parent: 1
+      type: Transform
+  - uid: 142
+    components:
+    - pos: 7.5,-0.5
+      parent: 1
+      type: Transform
+  - uid: 143
+    components:
+    - pos: 6.5,-0.5
+      parent: 1
+      type: Transform
+  - uid: 144
+    components:
+    - pos: 6.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 145
+    components:
+    - pos: 8.5,-0.5
+      parent: 1
+      type: Transform
+  - uid: 146
+    components:
+    - pos: 6.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 147
+    components:
+    - pos: 7.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 148
+    components:
+    - pos: 7.5,-5.5
+      parent: 1
+      type: Transform
+  - uid: 149
+    components:
+    - pos: 8.5,-5.5
+      parent: 1
+      type: Transform
+  - uid: 150
+    components:
+    - pos: 9.5,-2.5
+      parent: 1
+      type: Transform
+  - uid: 151
+    components:
+    - pos: 9.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 152
+    components:
+    - pos: 9.5,-0.5
+      parent: 1
+      type: Transform
+  - uid: 153
+    components:
+    - pos: 9.5,-5.5
+      parent: 1
+      type: Transform
+  - uid: 154
+    components:
+    - pos: 10.5,-5.5
+      parent: 1
+      type: Transform
+  - uid: 155
+    components:
+    - pos: 2.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 156
+    components:
+    - pos: 2.5,-2.5
+      parent: 1
+      type: Transform
+  - uid: 157
+    components:
+    - pos: 2.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 158
+    components:
+    - pos: 2.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 159
+    components:
+    - pos: 2.5,-6.5
+      parent: 1
+      type: Transform
+  - uid: 160
+    components:
+    - pos: 2.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 161
+    components:
+    - pos: 2.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 162
+    components:
+    - pos: 2.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 163
+    components:
+    - pos: 2.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 164
+    components:
+    - pos: 2.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 165
+    components:
+    - pos: 2.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 166
+    components:
+    - pos: 2.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 167
+    components:
+    - pos: 6.5,-1.5
+      parent: 1
+      type: Transform
+- proto: CableApcStack1
+  entities:
+  - uid: 169
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 168
+      type: Transform
+    - count: 5
+      type: Stack
+    - size: 5
+      type: Item
+    - canCollide: False
+      type: Physics
+- proto: CableHV
+  entities:
+  - uid: 173
+    components:
+    - pos: 8.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 174
+    components:
+    - pos: 8.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 175
+    components:
+    - pos: 9.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 176
+    components:
+    - pos: 10.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 177
+    components:
+    - pos: 10.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 178
+    components:
+    - pos: 7.5,5.5
+      parent: 1
+      type: Transform
+- proto: CableHVStack1
+  entities:
+  - uid: 180
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 179
+      type: Transform
+    - count: 5
+      type: Stack
+    - size: 5
+      type: Item
+    - canCollide: False
+      type: Physics
+  - uid: 184
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 183
+      type: Transform
+    - count: 5
+      type: Stack
+    - size: 5
+      type: Item
+    - canCollide: False
+      type: Physics
+- proto: CableMV
+  entities:
+  - uid: 187
+    components:
+    - pos: 10.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 188
+    components:
+    - pos: 9.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 189
+    components:
+    - pos: 9.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 190
+    components:
+    - pos: 9.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 191
+    components:
+    - pos: 9.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 192
+    components:
+    - pos: 10.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 193
+    components:
+    - pos: 9.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 194
+    components:
+    - pos: 8.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 195
+    components:
+    - pos: 7.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 196
+    components:
+    - pos: 7.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 197
+    components:
+    - pos: 6.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 198
+    components:
+    - pos: 6.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 199
+    components:
+    - pos: 6.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 200
+    components:
+    - pos: 6.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 201
+    components:
+    - pos: 4.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 202
+    components:
+    - pos: 6.5,-0.5
+      parent: 1
+      type: Transform
+  - uid: 203
+    components:
+    - pos: 7.5,-0.5
+      parent: 1
+      type: Transform
+  - uid: 204
+    components:
+    - pos: 8.5,-0.5
+      parent: 1
+      type: Transform
+  - uid: 205
+    components:
+    - pos: 9.5,-0.5
+      parent: 1
+      type: Transform
+  - uid: 206
+    components:
+    - pos: 9.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 207
+    components:
+    - pos: 9.5,-2.5
+      parent: 1
+      type: Transform
+  - uid: 208
+    components:
+    - pos: 4.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 209
+    components:
+    - pos: 5.5,0.5
+      parent: 1
+      type: Transform
+- proto: CableMVStack1
+  entities:
+  - uid: 211
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 210
+      type: Transform
+    - count: 5
+      type: Stack
+    - size: 5
+      type: Item
+    - canCollide: False
+      type: Physics
+- proto: CapacitorStockPart
+  entities:
+  - uid: 170
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 168
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 171
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 168
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 181
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 179
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 185
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 183
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 212
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 210
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 213
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 210
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 216
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 215
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 222
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 221
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 223
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 221
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 224
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 221
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 225
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 221
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 229
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 228
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 230
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 228
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 231
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 228
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 232
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 228
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 236
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 235
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 237
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 235
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 238
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 235
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 239
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 235
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 243
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 242
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 244
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 242
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 245
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 242
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 246
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 242
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 250
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 249
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 251
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 249
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 252
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 249
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 253
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 249
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 257
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 256
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 258
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 256
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 259
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 256
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 260
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 256
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 264
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 263
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 265
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 263
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 266
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 263
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 267
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 263
+      type: Transform
+    - canCollide: False
+      type: Physics
+- proto: Catwalk
+  entities:
+  - uid: 270
+    components:
+    - pos: 7.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 271
+    components:
+    - pos: 9.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 272
+    components:
+    - pos: 9.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 273
+    components:
+    - pos: 10.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 274
+    components:
+    - pos: 8.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 275
+    components:
+    - pos: 7.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 276
+    components:
+    - pos: 10.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 277
+    components:
+    - pos: 7.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 278
+    components:
+    - pos: 6.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 279
+    components:
+    - pos: 8.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 280
+    components:
+    - pos: 6.5,4.5
+      parent: 1
+      type: Transform
+- proto: CellRechargerCircuitboard
+  entities:
+  - uid: 172
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 168
+      type: Transform
+    - canCollide: False
+      type: Physics
+- proto: ClosetBase
+  entities:
+  - uid: 281
+    components:
+    - pos: 2.5,5.5
+      parent: 1
+      type: Transform
+    - air:
+        volume: 200
+        immutable: False
+        temperature: 293.14963
+        moles:
+        - 1.8641987
+        - 7.012938
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+      type: EntityStorage
+    - containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 285
+          - 282
+          - 283
+          - 288
+          - 284
+          - 294
+          - 287
+          - 286
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+      type: ContainerContainer
+  - uid: 295
+    components:
+    - pos: 2.5,-6.5
+      parent: 1
+      type: Transform
+    - air:
+        volume: 200
+        immutable: False
+        temperature: 293.14963
+        moles:
+        - 1.7456715
+        - 6.56705
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+      type: EntityStorage
+    - containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 300
+          - 303
+          - 299
+          - 298
+          - 296
+          - 297
+          - 302
+          - 301
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+      type: ContainerContainer
+- proto: ClosetWallEmergencyFilledRandom
+  entities:
+  - uid: 6
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -0.5,-3.5
+      parent: 1
+      type: Transform
+    - containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 17
+          - 20
+          - 7
+          - 22
+          - 21
+      type: ContainerContainer
+  - uid: 46
+    components:
+    - pos: -0.5,2.5
+      parent: 1
+      type: Transform
+    - air:
+        volume: 200
+        immutable: False
+        temperature: 293.14963
+        moles:
+        - 1.7458104
+        - 6.567589
+        - 3.8282697E-06
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+      type: EntityStorage
+    - containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 47
+          - 50
+          - 51
+          - 63
+      type: ContainerContainer
+    - dnas: []
+      fibers:
+      - black insulative fibers
+      fingerprints: []
+      type: Forensics
+- proto: ClosetWallFireFilledRandom
+  entities:
+  - uid: 23
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 6.5,5.5
+      parent: 1
+      type: Transform
+    - containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 29
+          - 24
+          - 28
+          - 31
+          - 30
+      type: ContainerContainer
+- proto: ClosetWallOrange
+  entities:
+  - uid: 309
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 1.5,3.5
+      parent: 1
+      type: Transform
+    - air:
+        volume: 200
+        immutable: False
+        temperature: 293.1496
+        moles:
+        - 1.8641734
+        - 7.0128436
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+      type: EntityStorage
+  - uid: 310
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 1.5,-4.5
+      parent: 1
+      type: Transform
+    - air:
+        volume: 200
+        immutable: False
+        temperature: 293.14957
+        moles:
+        - 1.7692513
+        - 6.655794
+        - 1.0433227E-05
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+      type: EntityStorage
+- proto: ClothingHandsTacticalMaidGloves
+  entities:
+  - uid: 311
+    components:
+    - pos: 6.4730835,4.565351
+      parent: 1
+      type: Transform
+- proto: ClothingHeadHatCatEars
+  entities:
+  - uid: 312
+    components:
+    - pos: 6.5147495,4.620907
+      parent: 1
+      type: Transform
+- proto: ClothingHeadHatTacticalMaidHeadband
+  entities:
+  - uid: 313
+    components:
+    - pos: 6.4939165,4.6486845
+      parent: 1
+      type: Transform
+- proto: ClothingHeadHelmetEVALarge
+  entities:
+  - uid: 19
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 17
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - AttachedUid: 17
+      type: AttachedClothing
+  - uid: 49
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 47
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - AttachedUid: 47
+      type: AttachedClothing
+- proto: ClothingHeadHelmetFire
+  entities:
+  - uid: 24
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 23
+      type: Transform
+    - selfToggleActionEntity: 26
+      toggleActionEntity: 25
+      type: HandheldLight
+    - containers:
+        cell_slot: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: 27
+        actions: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 25
+          - 26
+      type: ContainerContainer
+    - canCollide: False
+      type: Physics
+    - type: ActionsContainer
+    - actions:
+      - 26
+      type: Actions
+    - type: InsideEntityStorage
+- proto: ClothingMaskBreath
+  entities:
+  - uid: 12
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 7
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 13
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 7
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 20
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 6
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 50
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 46
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: ClothingMaskBreathMedical
+  entities:
+  - uid: 52
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 51
+      type: Transform
+    - canCollide: False
+      type: Physics
+- proto: ClothingMaskGas
+  entities:
+  - uid: 28
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 23
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: ClothingOuterHardsuitEVAPrisoner
+  entities:
+  - uid: 36
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 32
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 43
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 39
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: ClothingOuterSuitEmergency
+  entities:
+  - uid: 17
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 6
+      type: Transform
+    - clothingUid: 19
+      actionEntity: 18
+      type: ToggleableClothing
+    - containers:
+        toggleable-clothing: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: 19
+        actions: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 18
+      type: ContainerContainer
+    - canCollide: False
+      type: Physics
+    - type: ActionsContainer
+    - type: InsideEntityStorage
+  - uid: 47
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 46
+      type: Transform
+    - clothingUid: 49
+      actionEntity: 48
+      type: ToggleableClothing
+    - containers:
+        toggleable-clothing: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: 49
+        actions: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 48
+      type: ContainerContainer
+    - canCollide: False
+      type: Physics
+    - type: ActionsContainer
+    - type: InsideEntityStorage
+- proto: ClothingOuterSuitFire
+  entities:
+  - uid: 29
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 23
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: ClothingUniformJumpskirtPrisoner
+  entities:
+  - uid: 37
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 32
+      type: Transform
+    - address: 20C7-2C7A
+      transmitFrequency: 1262
+      type: DeviceNetwork
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 44
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 39
+      type: Transform
+    - address: 0BF0-6E75
+      transmitFrequency: 1262
+      type: DeviceNetwork
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: ClothingUniformJumpskirtTacticalMaid
+  entities:
+  - uid: 314
+    components:
+    - pos: 6.5564165,4.5861845
+      parent: 1
+      type: Transform
+- proto: ClothingUniformJumpsuitPrisoner
+  entities:
+  - uid: 38
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 32
+      type: Transform
+    - address: 0F77-CE54
+      transmitFrequency: 1262
+      type: DeviceNetwork
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 45
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 39
+      type: Transform
+    - address: 6F23-4F6E
+      transmitFrequency: 1262
+      type: DeviceNetwork
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: ComputerCrewMonitoring
+  entities:
+  - uid: 315
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 10.5,-1.5
+      parent: 1
+      type: Transform
+    - address: 5D96-2B9F
+      receiveFrequency: 1261
+      type: DeviceNetwork
+    - containers:
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 316
+      type: ContainerContainer
+    - dnas: []
+      fibers:
+      - black insulative fibers
+      fingerprints: []
+      type: Forensics
+- proto: ComputerShuttle
+  entities:
+  - uid: 317
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 10.5,-0.5
+      parent: 1
+      type: Transform
+    - containers:
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 318
+      type: ContainerContainer
+    - dnas: []
+      fibers:
+      - black insulative fibers
+      fingerprints: []
+      type: Forensics
+- proto: ComputerStationRecords
+  entities:
+  - uid: 319
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 10.5,0.5
+      parent: 1
+      type: Transform
+    - containers:
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 320
+      type: ContainerContainer
+    - dnas: []
+      fibers:
+      - black insulative fibers
+      fingerprints: []
+      type: Forensics
+- proto: CrewMonitoringComputerCircuitboard
+  entities:
+  - uid: 316
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 315
+      type: Transform
+    - canCollide: False
+      type: Physics
+- proto: CrowbarRed
+  entities:
+  - uid: 14
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 7
+      type: Transform
+    - canCollide: False
+      type: Physics
+- proto: DoorElectronics
+  entities:
+  - uid: 82
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 81
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 84
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 83
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 86
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 85
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 88
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 87
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 90
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 89
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 92
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 91
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 94
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 93
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 322
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 321
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 324
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 323
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 326
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 325
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 328
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 327
+      type: Transform
+    - canCollide: False
+      type: Physics
+- proto: EmergencyLight
+  entities:
+  - uid: 329
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 2.5,-6.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: PointLight
+    - startingCharge: 10198.422
+      type: Battery
+    - type: ActiveEmergencyLight
+  - uid: 330
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 9.5,-6.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: PointLight
+    - startingCharge: 5770.106
+      type: Battery
+    - type: ActiveEmergencyLight
+  - uid: 331
+    components:
+    - pos: -2.5,-2.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: PointLight
+    - startingCharge: 9827.992
+      type: Battery
+    - type: ActiveEmergencyLight
+  - uid: 332
+    components:
+    - pos: 2.5,5.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: PointLight
+    - startingCharge: 10316.518
+      type: Battery
+    - type: ActiveEmergencyLight
+  - uid: 333
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -2.5,1.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: PointLight
+    - startingCharge: 9749.828
+      type: Battery
+    - type: ActiveEmergencyLight
+  - uid: 334
+    components:
+    - pos: 9.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 335
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 6.5,1.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: PointLight
+    - startingCharge: 6116.946
+      type: Battery
+    - type: ActiveEmergencyLight
+  - uid: 336
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 9.5,-1.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: PointLight
+    - startingCharge: 5948.6265
+      type: Battery
+    - type: ActiveEmergencyLight
+  - uid: 337
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 6.5,-2.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: PointLight
+    - startingCharge: 6078.6914
+      type: Battery
+    - type: ActiveEmergencyLight
+- proto: EmergencyMedipen
+  entities:
+  - uid: 53
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 51
+      type: Transform
+    - canCollide: False
+      type: Physics
+- proto: EmergencyOxygenTankFilled
+  entities:
+  - uid: 21
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 6
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 54
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 51
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 63
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 46
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: EuphoniumInstrument
+  entities:
+  - uid: 296
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 295
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: FaxMachineShip
+  entities:
+  - uid: 338
+    components:
+    - pos: 9.5,0.5
+      parent: 1
+      type: Transform
+    - destinationAddress: 2BAF-50B3
+      type: FaxMachine
+    - address: 4EF3-2C0C
+      transmitFrequency: 2640
+      receiveFrequency: 2640
+      type: DeviceNetwork
+- proto: filingCabinetRandom
+  entities:
+  - uid: 339
+    components:
+    - pos: 10.5,-6.5
+      parent: 1
+      type: Transform
+- proto: FireExtinguisher
+  entities:
+  - uid: 30
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 23
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: FirelockElectronics
+  entities:
+  - uid: 341
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 340
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 343
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 342
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 345
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 344
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 347
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 346
+      type: Transform
+    - canCollide: False
+      type: Physics
+- proto: FirelockGlass
+  entities:
+  - uid: 340
+    components:
+    - pos: 7.5,-0.5
+      parent: 1
+      type: Transform
+    - containers:
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 341
+      type: ContainerContainer
+    - address: 2A2F-32C5
+      receiveFrequency: 1621
+      type: DeviceNetwork
+  - uid: 342
+    components:
+    - pos: 2.5,-2.5
+      parent: 1
+      type: Transform
+    - containers:
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 343
+      type: ContainerContainer
+    - address: 69E1-ED5D
+      receiveFrequency: 1621
+      type: DeviceNetwork
+  - uid: 344
+    components:
+    - pos: 2.5,1.5
+      parent: 1
+      type: Transform
+    - containers:
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 345
+      type: ContainerContainer
+    - address: 4EBA-47B3
+      receiveFrequency: 1621
+      type: DeviceNetwork
+  - uid: 346
+    components:
+    - pos: 6.5,-3.5
+      parent: 1
+      type: Transform
+    - containers:
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 347
+      type: ContainerContainer
+    - address: 6D3F-5E6B
+      receiveFrequency: 1621
+      type: DeviceNetwork
+- proto: FlashlightLantern
+  entities:
+  - uid: 8
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 7
+      type: Transform
+    - selfToggleActionEntity: 10
+      toggleActionEntity: 9
+      type: HandheldLight
+    - containers:
+        cell_slot: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: 11
+        actions: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 9
+          - 10
+      type: ContainerContainer
+    - canCollide: False
+      type: Physics
+    - type: ActionsContainer
+    - actions:
+      - 10
+      type: Actions
+- proto: FoodSnackChocolate
+  entities:
+  - uid: 15
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 7
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 16
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 7
+      type: Transform
+    - canCollide: False
+      type: Physics
+- proto: FoodSnackSus
+  entities:
+  - uid: 282
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 281
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 283
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 281
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 284
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 281
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 285
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 281
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 286
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 281
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 297
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 295
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 298
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 295
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 299
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 295
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 300
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 295
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 301
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 295
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: GasPassiveVent
+  entities:
+  - uid: 348
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -4.5,-0.5
+      parent: 1
+      type: Transform
+    - color: '#80FF00FF'
+      type: AtmosPipeColor
+  - uid: 416
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 2.5,-0.5
+      parent: 1
+      type: Transform
+    - color: '#FF00EEFF'
+      type: AtmosPipeColor
+- proto: GasPipeBend
+  entities:
+  - uid: 349
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,-2.5
+      parent: 1
+      type: Transform
+    - color: '#80FF00FF'
+      type: AtmosPipeColor
+  - uid: 350
+    components:
+    - pos: 2.5,5.5
+      parent: 1
+      type: Transform
+    - color: '#FF00EEFF'
+      type: AtmosPipeColor
+  - uid: 351
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 5.5,1.5
+      parent: 1
+      type: Transform
+    - color: '#80FF00FF'
+      type: AtmosPipeColor
+  - uid: 352
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 2.5,-6.5
+      parent: 1
+      type: Transform
+    - color: '#FF00EEFF'
+      type: AtmosPipeColor
+  - uid: 353
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 4.5,1.5
+      parent: 1
+      type: Transform
+    - color: '#80FF00FF'
+      type: AtmosPipeColor
+  - uid: 354
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 4.5,-2.5
+      parent: 1
+      type: Transform
+    - color: '#80FF00FF'
+      type: AtmosPipeColor
+  - uid: 355
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 2.5,0.5
+      parent: 1
+      type: Transform
+    - color: '#FF00EEFF'
+      type: AtmosPipeColor
+  - uid: 356
+    components:
+    - pos: 0.5,-0.5
+      parent: 1
+      type: Transform
+    - color: '#80FF00FF'
+      type: AtmosPipeColor
+  - uid: 357
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 6.5,4.5
+      parent: 1
+      type: Transform
+    - color: '#FF00EEFF'
+      type: AtmosPipeColor
+  - uid: 358
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 6.5,-5.5
+      parent: 1
+      type: Transform
+    - color: '#FF00EEFF'
+      type: AtmosPipeColor
+  - uid: 359
+    components:
+    - pos: 8.5,-5.5
+      parent: 1
+      type: Transform
+    - color: '#FF00EEFF'
+      type: AtmosPipeColor
+  - uid: 360
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 2.5,-1.5
+      parent: 1
+      type: Transform
+    - color: '#FF00EEFF'
+      type: AtmosPipeColor
+  - uid: 361
+    components:
+    - pos: 9.5,-0.5
+      parent: 1
+      type: Transform
+    - color: '#FF00EEFF'
+      type: AtmosPipeColor
+  - uid: 362
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 8.5,-6.5
+      parent: 1
+      type: Transform
+    - color: '#FF00EEFF'
+      type: AtmosPipeColor
+  - uid: 363
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 8.5,-6.5
+      parent: 1
+      type: Transform
+    - color: '#FF00EEFF'
+      type: AtmosPipeColor
+  - uid: 364
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 5.5,5.5
+      parent: 1
+      type: Transform
+    - color: '#80FF00FF'
+      type: AtmosPipeColor
+- proto: GasPipeStraight
+  entities:
+  - uid: 365
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -2.5,-0.5
+      parent: 1
+      type: Transform
+    - color: '#80FF00FF'
+      type: AtmosPipeColor
+  - uid: 366
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 6.5,5.5
+      parent: 1
+      type: Transform
+    - color: '#80FF00FF'
+      type: AtmosPipeColor
+  - uid: 367
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 5.5,0.5
+      parent: 1
+      type: Transform
+    - color: '#FF00EEFF'
+      type: AtmosPipeColor
+  - uid: 368
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 2.5,2.5
+      parent: 1
+      type: Transform
+    - color: '#FF00EEFF'
+      type: AtmosPipeColor
+  - uid: 369
+    components:
+    - pos: 6.5,-4.5
+      parent: 1
+      type: Transform
+    - color: '#FF00EEFF'
+      type: AtmosPipeColor
+  - uid: 370
+    components:
+    - pos: 4.5,-1.5
+      parent: 1
+      type: Transform
+    - color: '#80FF00FF'
+      type: AtmosPipeColor
+  - uid: 371
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 2.5,-2.5
+      parent: 1
+      type: Transform
+    - color: '#80FF00FF'
+      type: AtmosPipeColor
+  - uid: 372
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 2.5,4.5
+      parent: 1
+      type: Transform
+    - color: '#FF00EEFF'
+      type: AtmosPipeColor
+  - uid: 373
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 8.5,5.5
+      parent: 1
+      type: Transform
+    - color: '#80FF00FF'
+      type: AtmosPipeColor
+  - uid: 374
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 5.5,-1.5
+      parent: 1
+      type: Transform
+    - color: '#FF00EEFF'
+      type: AtmosPipeColor
+  - uid: 375
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 1.5,-2.5
+      parent: 1
+      type: Transform
+    - color: '#80FF00FF'
+      type: AtmosPipeColor
+  - uid: 376
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 3.5,-2.5
+      parent: 1
+      type: Transform
+    - color: '#80FF00FF'
+      type: AtmosPipeColor
+  - uid: 377
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 2.5,1.5
+      parent: 1
+      type: Transform
+    - color: '#FF00EEFF'
+      type: AtmosPipeColor
+  - uid: 378
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 4.5,0.5
+      parent: 1
+      type: Transform
+    - color: '#FF00EEFF'
+      type: AtmosPipeColor
+  - uid: 379
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 4.5,-1.5
+      parent: 1
+      type: Transform
+    - color: '#FF00EEFF'
+      type: AtmosPipeColor
+  - uid: 380
+    components:
+    - pos: 2.5,-2.5
+      parent: 1
+      type: Transform
+    - color: '#FF00EEFF'
+      type: AtmosPipeColor
+  - uid: 381
+    components:
+    - pos: 2.5,-5.5
+      parent: 1
+      type: Transform
+    - color: '#FF00EEFF'
+      type: AtmosPipeColor
+  - uid: 382
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 7.5,5.5
+      parent: 1
+      type: Transform
+    - color: '#80FF00FF'
+      type: AtmosPipeColor
+  - uid: 383
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 7.5,-5.5
+      parent: 1
+      type: Transform
+    - color: '#FF00EEFF'
+      type: AtmosPipeColor
+  - uid: 384
+    components:
+    - pos: 6.5,-3.5
+      parent: 1
+      type: Transform
+    - color: '#FF00EEFF'
+      type: AtmosPipeColor
+  - uid: 385
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 7.5,-0.5
+      parent: 1
+      type: Transform
+    - color: '#FF00EEFF'
+      type: AtmosPipeColor
+  - uid: 386
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 9.5,-6.5
+      parent: 1
+      type: Transform
+    - color: '#FF00EEFF'
+      type: AtmosPipeColor
+  - uid: 387
+    components:
+    - pos: 6.5,1.5
+      parent: 1
+      type: Transform
+    - color: '#FF00EEFF'
+      type: AtmosPipeColor
+  - uid: 388
+    components:
+    - pos: 6.5,3.5
+      parent: 1
+      type: Transform
+    - color: '#FF00EEFF'
+      type: AtmosPipeColor
+  - uid: 389
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 9.5,5.5
+      parent: 1
+      type: Transform
+    - color: '#80FF00FF'
+      type: AtmosPipeColor
+  - uid: 390
+    components:
+    - pos: 0.5,-1.5
+      parent: 1
+      type: Transform
+    - color: '#80FF00FF'
+      type: AtmosPipeColor
+  - uid: 391
+    components:
+    - pos: 5.5,2.5
+      parent: 1
+      type: Transform
+    - color: '#80FF00FF'
+      type: AtmosPipeColor
+  - uid: 392
+    components:
+    - pos: 5.5,3.5
+      parent: 1
+      type: Transform
+    - color: '#80FF00FF'
+      type: AtmosPipeColor
+  - uid: 393
+    components:
+    - pos: 2.5,-3.5
+      parent: 1
+      type: Transform
+    - color: '#FF00EEFF'
+      type: AtmosPipeColor
+  - uid: 394
+    components:
+    - pos: 2.5,-4.5
+      parent: 1
+      type: Transform
+    - color: '#FF00EEFF'
+      type: AtmosPipeColor
+  - uid: 395
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 2.5,3.5
+      parent: 1
+      type: Transform
+    - color: '#FF00EEFF'
+      type: AtmosPipeColor
+  - uid: 396
+    components:
+    - pos: 6.5,-2.5
+      parent: 1
+      type: Transform
+    - color: '#FF00EEFF'
+      type: AtmosPipeColor
+  - uid: 397
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 8.5,-0.5
+      parent: 1
+      type: Transform
+    - color: '#FF00EEFF'
+      type: AtmosPipeColor
+  - uid: 398
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 9.5,4.5
+      parent: 1
+      type: Transform
+    - color: '#FF00EEFF'
+      type: AtmosPipeColor
+  - uid: 399
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 8.5,4.5
+      parent: 1
+      type: Transform
+    - color: '#FF00EEFF'
+      type: AtmosPipeColor
+  - uid: 400
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -3.5,-0.5
+      parent: 1
+      type: Transform
+    - color: '#80FF00FF'
+      type: AtmosPipeColor
+  - uid: 401
+    components:
+    - pos: 5.5,4.5
+      parent: 1
+      type: Transform
+    - color: '#80FF00FF'
+      type: AtmosPipeColor
+  - uid: 402
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -1.5,-0.5
+      parent: 1
+      type: Transform
+    - color: '#80FF00FF'
+      type: AtmosPipeColor
+  - uid: 403
+    components:
+    - pos: 6.5,2.5
+      parent: 1
+      type: Transform
+    - color: '#FF00EEFF'
+      type: AtmosPipeColor
+  - uid: 404
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -0.5,-0.5
+      parent: 1
+      type: Transform
+    - color: '#80FF00FF'
+      type: AtmosPipeColor
+  - uid: 405
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 7.5,4.5
+      parent: 1
+      type: Transform
+    - color: '#FF00EEFF'
+      type: AtmosPipeColor
+  - uid: 406
+    components:
+    - pos: 4.5,0.5
+      parent: 1
+      type: Transform
+    - color: '#80FF00FF'
+      type: AtmosPipeColor
+- proto: GasPipeTJunction
+  entities:
+  - uid: 407
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 6.5,-1.5
+      parent: 1
+      type: Transform
+    - color: '#FF00EEFF'
+      type: AtmosPipeColor
+  - uid: 408
+    components:
+    - pos: 3.5,0.5
+      parent: 1
+      type: Transform
+    - color: '#FF00EEFF'
+      type: AtmosPipeColor
+  - uid: 409
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 4.5,-0.5
+      parent: 1
+      type: Transform
+    - color: '#80FF00FF'
+      type: AtmosPipeColor
+  - uid: 410
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 6.5,0.5
+      parent: 1
+      type: Transform
+    - color: '#FF00EEFF'
+      type: AtmosPipeColor
+  - uid: 411
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 6.5,-0.5
+      parent: 1
+      type: Transform
+    - color: '#FF00EEFF'
+      type: AtmosPipeColor
+  - uid: 412
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 3.5,-0.5
+      parent: 1
+      type: Transform
+    - color: '#FF00EEFF'
+      type: AtmosPipeColor
+  - uid: 413
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 3.5,-1.5
+      parent: 1
+      type: Transform
+    - color: '#FF00EEFF'
+      type: AtmosPipeColor
+- proto: GasVentPump
+  entities:
+  - uid: 414
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 10.5,-6.5
+      parent: 1
+      type: Transform
+    - color: '#FF00EEFF'
+      type: AtmosPipeColor
+  - uid: 415
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 10.5,4.5
+      parent: 1
+      type: Transform
+    - address: VNT-69E9-2D7C
+      transmitFrequency: 1621
+      receiveFrequency: 1621
+      type: DeviceNetwork
+    - gasThresholds:
+        Oxygen:
+          lowerWarnAround:
+            threshold: 1.5
+            enabled: True
+          upperWarnAround:
+            threshold: 0
+            enabled: False
+          lowerBound:
+            threshold: 0.1
+            enabled: True
+          upperBound:
+            threshold: 0
+            enabled: False
+          ignore: False
+        Nitrogen:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0
+            enabled: False
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0
+            enabled: False
+          ignore: True
+        CarbonDioxide:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0.5
+            enabled: True
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.0025
+            enabled: True
+          ignore: False
+        Plasma:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0
+            enabled: False
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.0001
+            enabled: True
+          ignore: False
+        Tritium:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0
+            enabled: False
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.0001
+            enabled: True
+          ignore: False
+        WaterVapor:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0.5
+            enabled: True
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 1.5
+            enabled: True
+          ignore: False
+        Miasma:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0.5
+            enabled: True
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.05
+            enabled: True
+          ignore: False
+        NitrousOxide:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0.5
+            enabled: True
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.01
+            enabled: True
+          ignore: False
+        Frezon:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0
+            enabled: False
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.0001
+            enabled: True
+          ignore: False
+      pressureThreshold:
+        lowerWarnAround:
+          threshold: 2.5
+          enabled: True
+        upperWarnAround:
+          threshold: 0.7
+          enabled: True
+        lowerBound:
+          threshold: 20
+          enabled: True
+        upperBound:
+          threshold: 550
+          enabled: True
+        ignore: False
+      temperatureThreshold:
+        lowerWarnAround:
+          threshold: 1.1
+          enabled: True
+        upperWarnAround:
+          threshold: 0.8
+          enabled: True
+        lowerBound:
+          threshold: 193.15
+          enabled: True
+        upperBound:
+          threshold: 393.15
+          enabled: True
+        ignore: False
+      type: AtmosMonitor
+    - color: '#FF00EEFF'
+      type: AtmosPipeColor
+  - uid: 417
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 1.5,5.5
+      parent: 1
+      type: Transform
+    - address: VNT-581C-5F83
+      transmitFrequency: 1621
+      receiveFrequency: 1621
+      type: DeviceNetwork
+    - trippedThresholds:
+      - Pressure
+      gasThresholds:
+        Oxygen:
+          lowerWarnAround:
+            threshold: 1.5
+            enabled: True
+          upperWarnAround:
+            threshold: 0
+            enabled: False
+          lowerBound:
+            threshold: 0.1
+            enabled: True
+          upperBound:
+            threshold: 0
+            enabled: False
+          ignore: False
+        Nitrogen:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0
+            enabled: False
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0
+            enabled: False
+          ignore: True
+        CarbonDioxide:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0.5
+            enabled: True
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.0025
+            enabled: True
+          ignore: False
+        Plasma:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0
+            enabled: False
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.0001
+            enabled: True
+          ignore: False
+        Tritium:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0
+            enabled: False
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.0001
+            enabled: True
+          ignore: False
+        WaterVapor:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0.5
+            enabled: True
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 1.5
+            enabled: True
+          ignore: False
+        Miasma:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0.5
+            enabled: True
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.05
+            enabled: True
+          ignore: False
+        NitrousOxide:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0.5
+            enabled: True
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.01
+            enabled: True
+          ignore: False
+        Frezon:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0
+            enabled: False
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.0001
+            enabled: True
+          ignore: False
+      pressureThreshold:
+        lowerWarnAround:
+          threshold: 2.5
+          enabled: True
+        upperWarnAround:
+          threshold: 0.7
+          enabled: True
+        lowerBound:
+          threshold: 20
+          enabled: True
+        upperBound:
+          threshold: 550
+          enabled: True
+        ignore: False
+      temperatureThreshold:
+        lowerWarnAround:
+          threshold: 1.1
+          enabled: True
+        upperWarnAround:
+          threshold: 0.8
+          enabled: True
+        lowerBound:
+          threshold: 193.15
+          enabled: True
+        upperBound:
+          threshold: 393.15
+          enabled: True
+        ignore: False
+      type: AtmosMonitor
+    - color: '#FF00EEFF'
+      type: AtmosPipeColor
+  - uid: 418
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 1.5,-6.5
+      parent: 1
+      type: Transform
+    - address: VNT-3184-5791
+      transmitFrequency: 1621
+      receiveFrequency: 1621
+      type: DeviceNetwork
+    - trippedThresholds:
+      - Pressure
+      gasThresholds:
+        Oxygen:
+          lowerWarnAround:
+            threshold: 1.5
+            enabled: True
+          upperWarnAround:
+            threshold: 0
+            enabled: False
+          lowerBound:
+            threshold: 0.1
+            enabled: True
+          upperBound:
+            threshold: 0
+            enabled: False
+          ignore: False
+        Nitrogen:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0
+            enabled: False
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0
+            enabled: False
+          ignore: True
+        CarbonDioxide:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0.5
+            enabled: True
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.0025
+            enabled: True
+          ignore: False
+        Plasma:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0
+            enabled: False
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.0001
+            enabled: True
+          ignore: False
+        Tritium:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0
+            enabled: False
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.0001
+            enabled: True
+          ignore: False
+        WaterVapor:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0.5
+            enabled: True
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 1.5
+            enabled: True
+          ignore: False
+        Miasma:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0.5
+            enabled: True
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.05
+            enabled: True
+          ignore: False
+        NitrousOxide:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0.5
+            enabled: True
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.01
+            enabled: True
+          ignore: False
+        Frezon:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0
+            enabled: False
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.0001
+            enabled: True
+          ignore: False
+      pressureThreshold:
+        lowerWarnAround:
+          threshold: 2.5
+          enabled: True
+        upperWarnAround:
+          threshold: 0.7
+          enabled: True
+        lowerBound:
+          threshold: 20
+          enabled: True
+        upperBound:
+          threshold: 550
+          enabled: True
+        ignore: False
+      temperatureThreshold:
+        lowerWarnAround:
+          threshold: 1.1
+          enabled: True
+        upperWarnAround:
+          threshold: 0.8
+          enabled: True
+        lowerBound:
+          threshold: 193.15
+          enabled: True
+        upperBound:
+          threshold: 393.15
+          enabled: True
+        ignore: False
+      type: AtmosMonitor
+    - color: '#FF00EEFF'
+      type: AtmosPipeColor
+  - uid: 419
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 9.5,-1.5
+      parent: 1
+      type: Transform
+    - address: VNT-7448-1915
+      transmitFrequency: 1621
+      receiveFrequency: 1621
+      type: DeviceNetwork
+    - gasThresholds:
+        Oxygen:
+          lowerWarnAround:
+            threshold: 1.5
+            enabled: True
+          upperWarnAround:
+            threshold: 0
+            enabled: False
+          lowerBound:
+            threshold: 0.1
+            enabled: True
+          upperBound:
+            threshold: 0
+            enabled: False
+          ignore: False
+        Nitrogen:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0
+            enabled: False
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0
+            enabled: False
+          ignore: True
+        CarbonDioxide:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0.5
+            enabled: True
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.0025
+            enabled: True
+          ignore: False
+        Plasma:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0
+            enabled: False
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.0001
+            enabled: True
+          ignore: False
+        Tritium:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0
+            enabled: False
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.0001
+            enabled: True
+          ignore: False
+        WaterVapor:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0.5
+            enabled: True
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 1.5
+            enabled: True
+          ignore: False
+        Miasma:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0.5
+            enabled: True
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.05
+            enabled: True
+          ignore: False
+        NitrousOxide:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0.5
+            enabled: True
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.01
+            enabled: True
+          ignore: False
+        Frezon:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0
+            enabled: False
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.0001
+            enabled: True
+          ignore: False
+      pressureThreshold:
+        lowerWarnAround:
+          threshold: 2.5
+          enabled: True
+        upperWarnAround:
+          threshold: 0.7
+          enabled: True
+        lowerBound:
+          threshold: 20
+          enabled: True
+        upperBound:
+          threshold: 550
+          enabled: True
+        ignore: False
+      temperatureThreshold:
+        lowerWarnAround:
+          threshold: 1.1
+          enabled: True
+        upperWarnAround:
+          threshold: 0.8
+          enabled: True
+        lowerBound:
+          threshold: 193.15
+          enabled: True
+        upperBound:
+          threshold: 393.15
+          enabled: True
+        ignore: False
+      type: AtmosMonitor
+    - color: '#FF00EEFF'
+      type: AtmosPipeColor
+- proto: GasVentScrubber
+  entities:
+  - uid: 420
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 5.5,-0.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 68
+      address: SCR-5EC7-51F9
+      transmitFrequency: 1621
+      receiveFrequency: 1621
+      type: DeviceNetwork
+    - registeredDevices:
+      - AIR-07EE-EDC5
+      trippedThresholds:
+      - Temperature
+      gasThresholds:
+        Oxygen:
+          lowerWarnAround:
+            threshold: 1.5
+            enabled: True
+          upperWarnAround:
+            threshold: 0
+            enabled: False
+          lowerBound:
+            threshold: 0.1
+            enabled: True
+          upperBound:
+            threshold: 0
+            enabled: False
+          ignore: False
+        Nitrogen:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0
+            enabled: False
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0
+            enabled: False
+          ignore: True
+        CarbonDioxide:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0.5
+            enabled: True
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.0025
+            enabled: True
+          ignore: False
+        Plasma:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0
+            enabled: False
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.0001
+            enabled: True
+          ignore: False
+        Tritium:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0
+            enabled: False
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.0001
+            enabled: True
+          ignore: False
+        WaterVapor:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0.5
+            enabled: True
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 1.5
+            enabled: True
+          ignore: False
+        Miasma:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0.5
+            enabled: True
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.05
+            enabled: True
+          ignore: False
+        NitrousOxide:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0.5
+            enabled: True
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.01
+            enabled: True
+          ignore: False
+        Frezon:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0
+            enabled: False
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.0001
+            enabled: True
+          ignore: False
+      pressureThreshold:
+        lowerWarnAround:
+          threshold: 2.5
+          enabled: True
+        upperWarnAround:
+          threshold: 0.7
+          enabled: True
+        lowerBound:
+          threshold: 20
+          enabled: True
+        upperBound:
+          threshold: 550
+          enabled: True
+        ignore: False
+      temperatureThreshold:
+        lowerWarnAround:
+          threshold: 1.1
+          enabled: True
+        upperWarnAround:
+          threshold: 0.8
+          enabled: True
+        lowerBound:
+          threshold: 193.15
+          enabled: True
+        upperBound:
+          threshold: 393.15
+          enabled: True
+        ignore: False
+      type: AtmosMonitor
+    - color: '#80FF00FF'
+      type: AtmosPipeColor
+  - uid: 421
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 10.5,5.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 74
+      address: SCR-598A-AED4
+      transmitFrequency: 1621
+      receiveFrequency: 1621
+      type: DeviceNetwork
+    - registeredDevices:
+      - AIR-0505-EB98
+      gasThresholds:
+        Oxygen:
+          lowerWarnAround:
+            threshold: 1.5
+            enabled: True
+          upperWarnAround:
+            threshold: 0
+            enabled: False
+          lowerBound:
+            threshold: 0.1
+            enabled: True
+          upperBound:
+            threshold: 0
+            enabled: False
+          ignore: False
+        Nitrogen:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0
+            enabled: False
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0
+            enabled: False
+          ignore: True
+        CarbonDioxide:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0.5
+            enabled: True
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.0025
+            enabled: True
+          ignore: False
+        Plasma:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0
+            enabled: False
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.0001
+            enabled: True
+          ignore: False
+        Tritium:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0
+            enabled: False
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.0001
+            enabled: True
+          ignore: False
+        WaterVapor:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0.5
+            enabled: True
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 1.5
+            enabled: True
+          ignore: False
+        Miasma:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0.5
+            enabled: True
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.05
+            enabled: True
+          ignore: False
+        NitrousOxide:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0.5
+            enabled: True
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.01
+            enabled: True
+          ignore: False
+        Frezon:
+          lowerWarnAround:
+            threshold: 0
+            enabled: False
+          upperWarnAround:
+            threshold: 0
+            enabled: False
+          lowerBound:
+            threshold: 0
+            enabled: False
+          upperBound:
+            threshold: 0.0001
+            enabled: True
+          ignore: False
+      pressureThreshold:
+        lowerWarnAround:
+          threshold: 2.5
+          enabled: True
+        upperWarnAround:
+          threshold: 0.7
+          enabled: True
+        lowerBound:
+          threshold: 20
+          enabled: True
+        upperBound:
+          threshold: 550
+          enabled: True
+        ignore: False
+      temperatureThreshold:
+        lowerWarnAround:
+          threshold: 1.1
+          enabled: True
+        upperWarnAround:
+          threshold: 0.8
+          enabled: True
+        lowerBound:
+          threshold: 193.15
+          enabled: True
+        upperBound:
+          threshold: 393.15
+          enabled: True
+        ignore: False
+      type: AtmosMonitor
+    - color: '#80FF00FF'
+      type: AtmosPipeColor
+- proto: GravityGeneratorMini
+  entities:
+  - uid: 422
+    components:
+    - pos: 9.5,5.5
+      parent: 1
+      type: Transform
+- proto: Grille
+  entities:
+  - uid: 423
+    components:
+    - pos: 11.5,-6.5
+      parent: 1
+      type: Transform
+  - uid: 424
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 0.5,-6.5
+      parent: 1
+      type: Transform
+  - uid: 425
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -2.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 426
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 3.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 427
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 3.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 428
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 11.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 429
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -3.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 430
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 7.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 431
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 7.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 432
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 3.5,-5.5
+      parent: 1
+      type: Transform
+  - uid: 433
+    components:
+    - pos: 11.5,-5.5
+      parent: 1
+      type: Transform
+  - uid: 434
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 11.5,-0.5
+      parent: 1
+      type: Transform
+  - uid: 435
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 0.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 436
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -3.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 437
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 3.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 438
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -2.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 439
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 3.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 440
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 3.5,-6.5
+      parent: 1
+      type: Transform
+  - uid: 441
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 11.5,-1.5
+      parent: 1
+      type: Transform
+- proto: Gyroscope
+  entities:
+  - uid: 215
+    components:
+    - pos: 9.5,4.5
+      parent: 1
+      type: Transform
+    - containers:
+        machine_board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 217
+        machine_parts: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 218
+          - 219
+          - 216
+          - 220
+      type: ContainerContainer
+- proto: GyroscopeMachineCircuitboard
+  entities:
+  - uid: 217
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 215
+      type: Transform
+    - canCollide: False
+      type: Physics
+- proto: Joint
+  entities:
+  - uid: 287
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 281
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 302
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 295
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: LampGold
+  entities:
+  - uid: 2
+    components:
+    - pos: 8.945301,-6.166047
+      parent: 1
+      type: Transform
+    - selfToggleActionEntity: 4
+      toggleActionEntity: 3
+      type: HandheldLight
+    - containers:
+        cell_slot: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: 5
+        actions: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 3
+          - 4
+      type: ContainerContainer
+    - type: ActionsContainer
+    - actions:
+      - 4
+      type: Actions
+- proto: LightImplant
+  entities:
+  - uid: 34
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 33
+      type: Transform
+    - toggleActionEntity: 35
+      type: UnpoweredFlashlight
+    - canCollide: False
+      type: Physics
+    - type: ActionsContainer
+    - containers:
+        actions: !type:Container
+          ents:
+          - 35
+      type: ContainerContainer
+  - uid: 41
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 40
+      type: Transform
+    - toggleActionEntity: 42
+      type: UnpoweredFlashlight
+    - canCollide: False
+      type: Physics
+    - type: ActionsContainer
+    - containers:
+        actions: !type:Container
+          ents:
+          - 42
+      type: ContainerContainer
+- proto: LightImplanter
+  entities:
+  - uid: 33
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 32
+      type: Transform
+    - implantData:
+        light implant: This implant emits light from the user's skin on activation.
+      type: Implanter
+    - containers:
+        implanter_slot: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: 34
+      type: ContainerContainer
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 40
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 39
+      type: Transform
+    - implantData:
+        light implant: This implant emits light from the user's skin on activation.
+      type: Implanter
+    - containers:
+        implanter_slot: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: 41
+      type: ContainerContainer
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: LockerDetectiveFilled
+  entities:
+  - uid: 442
+    components:
+    - pos: 7.5,-6.5
+      parent: 1
+      type: Transform
+    - air:
+        volume: 200
+        immutable: False
+        temperature: 293.1496
+        moles:
+        - 1.8863183
+        - 7.09615
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+      type: EntityStorage
+- proto: LockerEvidence
+  entities:
+  - uid: 32
+    components:
+    - pos: 3.5,0.5
+      parent: 1
+      type: Transform
+    - air:
+        volume: 200
+        immutable: False
+        temperature: 292.97778
+        moles:
+        - 1.7497417
+        - 6.5843496
+        - 0.00045677694
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+      type: EntityStorage
+    - containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 33
+          - 38
+          - 37
+          - 36
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+      type: ContainerContainer
+  - uid: 39
+    components:
+    - pos: 3.5,-1.5
+      parent: 1
+      type: Transform
+    - air:
+        volume: 200
+        immutable: False
+        temperature: 293.08878
+        moles:
+        - 1.7463328
+        - 6.570048
+        - 0.000129352
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+      type: EntityStorage
+    - containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 45
+          - 43
+          - 44
+          - 40
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+      type: ContainerContainer
+- proto: LockerSecurityFilled
+  entities:
+  - uid: 443
+    components:
+    - pos: 8.5,0.5
+      parent: 1
+      type: Transform
+- proto: LockerWardenFilled
+  entities:
+  - uid: 444
+    components:
+    - pos: 8.5,-1.5
+      parent: 1
+      type: Transform
+- proto: Matchbox
+  entities:
+  - uid: 288
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 281
+      type: Transform
+    - storageUsed: 5
+      type: Storage
+    - containers:
+        storagebase: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 289
+          - 290
+          - 291
+          - 292
+          - 293
+      type: ContainerContainer
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 303
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 295
+      type: Transform
+    - storageUsed: 5
+      type: Storage
+    - containers:
+        storagebase: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 304
+          - 305
+          - 306
+          - 307
+          - 308
+      type: ContainerContainer
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: Matchstick
+  entities:
+  - uid: 289
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 288
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 290
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 288
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 291
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 288
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 292
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 288
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 293
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 288
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 304
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 303
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 305
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 303
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 306
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 303
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 307
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 303
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 308
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 303
+      type: Transform
+    - canCollide: False
+      type: Physics
+- proto: MedkitOxygenFilled
+  entities:
+  - uid: 51
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 46
+      type: Transform
+    - storageUsed: 28
+      type: Storage
+    - containers:
+        storagebase: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 52
+          - 54
+          - 53
+          - 62
+          - 55
+          - 56
+          - 57
+          - 58
+          - 59
+          - 60
+          - 61
+      type: ContainerContainer
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: MicroManipulatorStockPart
+  entities:
+  - uid: 218
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 215
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 219
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 215
+      type: Transform
+    - canCollide: False
+      type: Physics
+- proto: PillDexalin
+  entities:
+  - uid: 55
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 51
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 56
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 51
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 57
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 51
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 58
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 51
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 59
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 51
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 60
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 51
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 61
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 51
+      type: Transform
+    - canCollide: False
+      type: Physics
+- proto: PortableGeneratorPacman
+  entities:
+  - uid: 179
+    components:
+    - pos: 8.5,5.5
+      parent: 1
+      type: Transform
+    - storage:
+        Plasma: 3000
+      type: MaterialStorage
+    - supplyRate: 15000
+      type: PowerSupplier
+    - containers:
+        machine_board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 182
+        machine_parts: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 181
+          - 180
+      type: ContainerContainer
+    - type: ItemCooldown
+  - uid: 183
+    components:
+    - pos: 7.5,5.5
+      parent: 1
+      type: Transform
+    - storage:
+        Plasma: 3000
+      type: MaterialStorage
+    - supplyRate: 15000
+      type: PowerSupplier
+    - containers:
+        machine_board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 186
+        machine_parts: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 185
+          - 184
+      type: ContainerContainer
+    - type: ItemCooldown
+- proto: PortableGeneratorPacmanMachineCircuitboard
+  entities:
+  - uid: 182
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 179
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 186
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 183
+      type: Transform
+    - canCollide: False
+      type: Physics
+- proto: PosterContrabandBorgFancy
+  entities:
+  - uid: 445
+    components:
+    - pos: -1.5,-3.5
+      parent: 1
+      type: Transform
+- proto: PosterContrabandDonutCorp
+  entities:
+  - uid: 446
+    components:
+    - pos: 3.5,-3.5
+      parent: 1
+      type: Transform
+- proto: PosterContrabandKosmicheskayaStantsiya
+  entities:
+  - uid: 447
+    components:
+    - pos: 4.5,-2.5
+      parent: 1
+      type: Transform
+- proto: PosterContrabandNuclearDeviceInformational
+  entities:
+  - uid: 448
+    components:
+    - pos: 1.5,-7.5
+      parent: 1
+      type: Transform
+- proto: PosterContrabandWehWatches
+  entities:
+  - uid: 449
+    components:
+    - pos: 1.5,6.5
+      parent: 1
+      type: Transform
+- proto: PosterLegit12Gauge
+  entities:
+  - uid: 450
+    components:
+    - pos: -1.5,2.5
+      parent: 1
+      type: Transform
+- proto: PosterLegitCarbonDioxide
+  entities:
+  - uid: 451
+    components:
+    - pos: 10.5,1.5
+      parent: 1
+      type: Transform
+- proto: PosterLegitEnlist
+  entities:
+  - uid: 452
+    components:
+    - pos: 8.5,3.5
+      parent: 1
+      type: Transform
+- proto: PosterLegitFruitBowl
+  entities:
+  - uid: 453
+    components:
+    - pos: 7.5,-7.5
+      parent: 1
+      type: Transform
+- proto: PosterLegitGetYourLEGS
+  entities:
+  - uid: 454
+    components:
+    - pos: 3.5,2.5
+      parent: 1
+      type: Transform
+- proto: PosterLegitLoveIan
+  entities:
+  - uid: 455
+    components:
+    - pos: 1.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 456
+    components:
+    - pos: 6.5,-6.5
+      parent: 1
+      type: Transform
+- proto: PosterLegitPeriodicTable
+  entities:
+  - uid: 457
+    components:
+    - pos: 10.5,-2.5
+      parent: 1
+      type: Transform
+- proto: PosterLegitThereIsNoGasGiant
+  entities:
+  - uid: 458
+    components:
+    - pos: 1.5,2.5
+      parent: 1
+      type: Transform
+- proto: PowerCellMedium
+  entities:
+  - uid: 11
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 8
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 27
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 24
+      type: Transform
+    - canCollide: False
+      type: Physics
+- proto: PowerCellRecharger
+  entities:
+  - uid: 168
+    components:
+    - pos: 9.5,-6.5
+      parent: 1
+      type: Transform
+    - containers:
+        charger_slot: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+        machine_board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 172
+        machine_parts: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 170
+          - 171
+          - 169
+      type: ContainerContainer
+    - powerLoad: 0
+      type: ApcPowerReceiver
+- proto: PowerCellSmall
+  entities:
+  - uid: 5
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 2
+      type: Transform
+    - startingCharge: 356.87933
+      type: Battery
+    - canCollide: False
+      type: Physics
+- proto: Poweredlight
+  entities:
+  - uid: 459
+    components:
+    - pos: 3.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 460
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -3.5,-2.5
+      parent: 1
+      type: Transform
+  - uid: 461
+    components:
+    - pos: 8.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 462
+    components:
+    - pos: -3.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 463
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 3.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 464
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 10.5,4.5
+      parent: 1
+      type: Transform
+- proto: PoweredlightColoredRed
+  entities:
+  - uid: 465
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 10.5,-5.5
+      parent: 1
+      type: Transform
+- proto: SheetGlass1
+  entities:
+  - uid: 220
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 215
+      type: Transform
+    - count: 2
+      type: Stack
+    - size: 2
+      type: Item
+    - canCollide: False
+      type: Physics
+- proto: SheetPlasma
+  entities:
+  - uid: 466
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 7.50222,4.459353
+      parent: 1
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 467
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 7.517845,4.537478
+      parent: 1
+      type: Transform
+    - canCollide: False
+      type: Physics
+- proto: SheetSteel1
+  entities:
+  - uid: 226
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 221
+      type: Transform
+    - size: 5
+      type: Item
+    - count: 5
+      type: Stack
+    - canCollide: False
+      type: Physics
+  - uid: 233
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 228
+      type: Transform
+    - size: 5
+      type: Item
+    - count: 5
+      type: Stack
+    - canCollide: False
+      type: Physics
+  - uid: 240
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 235
+      type: Transform
+    - size: 5
+      type: Item
+    - count: 5
+      type: Stack
+    - canCollide: False
+      type: Physics
+  - uid: 247
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 242
+      type: Transform
+    - size: 5
+      type: Item
+    - count: 5
+      type: Stack
+    - canCollide: False
+      type: Physics
+  - uid: 254
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 249
+      type: Transform
+    - size: 5
+      type: Item
+    - count: 5
+      type: Stack
+    - canCollide: False
+      type: Physics
+  - uid: 261
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 256
+      type: Transform
+    - size: 5
+      type: Item
+    - count: 5
+      type: Stack
+    - canCollide: False
+      type: Physics
+  - uid: 268
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 263
+      type: Transform
+    - size: 5
+      type: Item
+    - count: 5
+      type: Stack
+    - canCollide: False
+      type: Physics
+- proto: ShuttersNormalOpen
+  entities:
+  - uid: 321
+    components:
+    - pos: 6.5,-3.5
+      parent: 1
+      type: Transform
+    - containers:
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 322
+      type: ContainerContainer
+    - address: 4AA5-F3B3
+      receiveFrequency: 1280
+      type: DeviceNetwork
+    - links:
+      - 490
+      type: DeviceLinkSink
+  - uid: 323
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 11.5,-1.5
+      parent: 1
+      type: Transform
+    - containers:
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 324
+      type: ContainerContainer
+    - address: 4967-8FDB
+      receiveFrequency: 1280
+      type: DeviceNetwork
+    - links:
+      - 489
+      type: DeviceLinkSink
+  - uid: 325
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 11.5,0.5
+      parent: 1
+      type: Transform
+    - containers:
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 326
+      type: ContainerContainer
+    - address: 7927-5FE5
+      receiveFrequency: 1280
+      type: DeviceNetwork
+    - links:
+      - 489
+      type: DeviceLinkSink
+  - uid: 327
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 11.5,-0.5
+      parent: 1
+      type: Transform
+    - containers:
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 328
+      type: ContainerContainer
+    - address: 2F67-D620
+      receiveFrequency: 1280
+      type: DeviceNetwork
+    - links:
+      - 489
+      type: DeviceLinkSink
+- proto: ShuttleConsoleCircuitboard
+  entities:
+  - uid: 318
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 317
+      type: Transform
+    - canCollide: False
+      type: Physics
+- proto: ShuttleWindow
+  entities:
+  - uid: 468
+    components:
+    - pos: 11.5,-6.5
+      parent: 1
+      type: Transform
+  - uid: 469
+    components:
+    - pos: -3.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 470
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 7.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 471
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 7.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 472
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 11.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 473
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 11.5,-0.5
+      parent: 1
+      type: Transform
+  - uid: 474
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 11.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 475
+    components:
+    - pos: 11.5,-5.5
+      parent: 1
+      type: Transform
+  - uid: 476
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 3.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 477
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 3.5,-5.5
+      parent: 1
+      type: Transform
+  - uid: 478
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 3.5,-6.5
+      parent: 1
+      type: Transform
+  - uid: 479
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 3.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 480
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 0.5,-6.5
+      parent: 1
+      type: Transform
+  - uid: 481
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 3.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 482
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 0.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 483
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -3.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 484
+    components:
+    - pos: -2.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 485
+    components:
+    - pos: -2.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 486
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 3.5,4.5
+      parent: 1
+      type: Transform
+- proto: SignalButton
+  entities:
+  - uid: 487
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 1.5,-2.5
+      parent: 1
+      type: Transform
+    - linkedPorts:
+        85:
+        - Pressed: DoorBolt
+      type: DeviceLinkSource
+  - uid: 488
+    components:
+    - pos: 1.5,1.5
+      parent: 1
+      type: Transform
+    - linkedPorts:
+        87:
+        - Pressed: DoorBolt
+      type: DeviceLinkSource
+  - uid: 489
+    components:
+    - pos: 9.5,1.5
+      parent: 1
+      type: Transform
+    - linkedPorts:
+        325:
+        - Pressed: Toggle
+        327:
+        - Pressed: Toggle
+        323:
+        - Pressed: Toggle
+      type: DeviceLinkSource
+  - uid: 490
+    components:
+    - pos: 8.5,-4.5
+      parent: 1
+      type: Transform
+    - linkedPorts:
+        93:
+        - Pressed: DoorBolt
+        321:
+        - Pressed: Toggle
+      type: DeviceLinkSource
+- proto: SignBridge
+  entities:
+  - uid: 491
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 7.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 492
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 7.5,0.5
+      parent: 1
+      type: Transform
+- proto: SignConspiracyBoard
+  entities:
+  - uid: 493
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 8.5,-7.5
+      parent: 1
+      type: Transform
+- proto: SignDirectionalBrig
+  entities:
+  - uid: 494
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 1.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 495
+    components:
+    - pos: 1.5,-2.5
+      parent: 1
+      type: Transform
+- proto: SignEngineering
+  entities:
+  - uid: 496
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 5.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 497
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 7.5,2.5
+      parent: 1
+      type: Transform
+- proto: SignFlammableMed
+  entities:
+  - uid: 498
+    components:
+    - pos: 7.5,6.5
+      parent: 1
+      type: Transform
+- proto: SignGravity
+  entities:
+  - uid: 499
+    components:
+    - pos: 11.5,5.5
+      parent: 1
+      type: Transform
+- proto: SignSec
+  entities:
+  - uid: 500
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 7.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 501
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 5.5,-3.5
+      parent: 1
+      type: Transform
+- proto: SignShipDock
+  entities:
+  - uid: 502
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -3.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 503
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -3.5,0.5
+      parent: 1
+      type: Transform
+- proto: SMESBasic
+  entities:
+  - uid: 504
+    components:
+    - pos: 10.5,5.5
+      parent: 1
+      type: Transform
+- proto: SpawnPointDetective
+  entities:
+  - uid: 505
+    components:
+    - pos: 9.5,-5.5
+      parent: 1
+      type: Transform
+- proto: SpawnPointLatejoin
+  entities:
+  - uid: 506
+    components:
+    - pos: 2.5,-0.5
+      parent: 1
+      type: Transform
+- proto: SpawnPointSecurityOfficer
+  entities:
+  - uid: 507
+    components:
+    - pos: 7.5,4.5
+      parent: 1
+      type: Transform
+- proto: SpawnPointWarden
+  entities:
+  - uid: 508
+    components:
+    - pos: 1.5,-0.5
+      parent: 1
+      type: Transform
+- proto: StationRecordsComputerCircuitboard
+  entities:
+  - uid: 320
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 319
+      type: Transform
+    - canCollide: False
+      type: Physics
+- proto: SubstationBasic
+  entities:
+  - uid: 509
+    components:
+    - pos: 10.5,4.5
+      parent: 1
+      type: Transform
+- proto: SuitStorageSec
+  entities:
+  - uid: 510
+    components:
+    - pos: 9.5,-1.5
+      parent: 1
+      type: Transform
+    - air:
+        volume: 200
+        immutable: False
+        temperature: 293.14502
+        moles:
+        - 1.8849107
+        - 7.0908566
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+      type: EntityStorage
+  - uid: 511
+    components:
+    - pos: 10.5,-5.5
+      parent: 1
+      type: Transform
+    - air:
+        volume: 200
+        immutable: False
+        temperature: 293.1496
+        moles:
+        - 1.8852007
+        - 7.091946
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+      type: EntityStorage
+- proto: SuitStorageWarden
+  entities:
+  - uid: 512
+    components:
+    - pos: 0.5,-0.5
+      parent: 1
+      type: Transform
+    - air:
+        volume: 200
+        immutable: False
+        temperature: 292.91797
+        moles:
+        - 1.8809017
+        - 7.077882
+        - 0.00055792386
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+      type: EntityStorage
+- proto: SyringeInaprovaline
+  entities:
+  - uid: 62
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 51
+      type: Transform
+    - canCollide: False
+      type: Physics
+- proto: TableWood
+  entities:
+  - uid: 513
+    components:
+    - pos: 9.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 514
+    components:
+    - pos: 9.5,-6.5
+      parent: 1
+      type: Transform
+  - uid: 515
+    components:
+    - pos: 8.5,-6.5
+      parent: 1
+      type: Transform
+- proto: Thruster
+  entities:
+  - uid: 221
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -1.5,-0.5
+      parent: 1
+      type: Transform
+    - containers:
+        machine_board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 227
+        machine_parts: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 222
+          - 223
+          - 224
+          - 225
+          - 226
+      type: ContainerContainer
+  - uid: 228
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 0.5,-4.5
+      parent: 1
+      type: Transform
+    - containers:
+        machine_board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 234
+        machine_parts: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 229
+          - 230
+          - 231
+          - 232
+          - 233
+      type: ContainerContainer
+  - uid: 235
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 0.5,3.5
+      parent: 1
+      type: Transform
+    - containers:
+        machine_board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 241
+        machine_parts: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 236
+          - 237
+          - 238
+          - 239
+          - 240
+      type: ContainerContainer
+  - uid: 242
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 4.5,-3.5
+      parent: 1
+      type: Transform
+    - containers:
+        machine_board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 248
+        machine_parts: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 243
+          - 244
+          - 245
+          - 246
+          - 247
+      type: ContainerContainer
+  - uid: 249
+    components:
+    - pos: 4.5,2.5
+      parent: 1
+      type: Transform
+    - containers:
+        machine_board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 255
+        machine_parts: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 250
+          - 251
+          - 252
+          - 253
+          - 254
+      type: ContainerContainer
+  - uid: 256
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 8.5,-3.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: Thruster
+    - containers:
+        machine_board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 262
+        machine_parts: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 257
+          - 258
+          - 259
+          - 260
+          - 261
+      type: ContainerContainer
+  - uid: 263
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 8.5,2.5
+      parent: 1
+      type: Transform
+    - containers:
+        machine_board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 269
+        machine_parts: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 264
+          - 265
+          - 266
+          - 267
+          - 268
+      type: ContainerContainer
+- proto: ThrusterMachineCircuitboard
+  entities:
+  - uid: 227
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 221
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 234
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 228
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 241
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 235
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 248
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 242
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 255
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 249
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 262
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 256
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 269
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 263
+      type: Transform
+    - canCollide: False
+      type: Physics
+- proto: ToolboxEmergencyFilled
+  entities:
+  - uid: 7
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 6
+      type: Transform
+    - storageUsed: 31
+      type: Storage
+    - containers:
+        storagebase: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 14
+          - 12
+          - 13
+          - 15
+          - 8
+          - 16
+      type: ContainerContainer
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: VendingMachineBooze
+  entities:
+  - uid: 64
+    components:
+    - pos: 4.5,0.5
+      parent: 1
+      type: Transform
+    - actionEntity: 65
+      type: VendingMachine
+    - actions:
+      - 65
+      type: Actions
+    - type: ActionsContainer
+    - containers:
+        actions: !type:Container
+          ents:
+          - 65
+      type: ContainerContainer
+- proto: VendingMachineCigs
+  entities:
+  - uid: 66
+    components:
+    - pos: 4.5,-1.5
+      parent: 1
+      type: Transform
+    - actionEntity: 67
+      type: VendingMachine
+    - actions:
+      - 67
+      type: Actions
+    - type: ActionsContainer
+    - containers:
+        actions: !type:Container
+          ents:
+          - 67
+      type: ContainerContainer
+- proto: WallShuttle
+  entities:
+  - uid: 516
+    components:
+    - pos: 5.5,-5.5
+      parent: 1
+      type: Transform
+  - uid: 517
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 11.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 518
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -1.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 519
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -2.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 520
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 1.5,-7.5
+      parent: 1
+      type: Transform
+  - uid: 521
+    components:
+    - pos: 4.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 522
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 5.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 523
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 5.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 524
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 7.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 525
+    components:
+    - pos: 7.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 526
+    components:
+    - pos: 8.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 527
+    components:
+    - pos: 9.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 528
+    components:
+    - pos: 10.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 529
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 11.5,-2.5
+      parent: 1
+      type: Transform
+  - uid: 530
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 10.5,-2.5
+      parent: 1
+      type: Transform
+  - uid: 531
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 9.5,-2.5
+      parent: 1
+      type: Transform
+  - uid: 532
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 8.5,-2.5
+      parent: 1
+      type: Transform
+  - uid: 533
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 6.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 534
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 7.5,-2.5
+      parent: 1
+      type: Transform
+  - uid: 535
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 7.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 536
+    components:
+    - pos: 5.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 537
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 9.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 538
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 8.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 539
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 10.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 540
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 11.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 541
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 7.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 542
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 8.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 543
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 9.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 544
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 10.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 545
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 11.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 546
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 5.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 547
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 4.5,-2.5
+      parent: 1
+      type: Transform
+  - uid: 548
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 2.5,-7.5
+      parent: 1
+      type: Transform
+  - uid: 549
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 3.5,-7.5
+      parent: 1
+      type: Transform
+  - uid: 550
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -3.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 551
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -0.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 552
+    components:
+    - pos: 8.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 553
+    components:
+    - pos: 9.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 554
+    components:
+    - pos: 10.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 555
+    components:
+    - pos: 11.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 556
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 9.5,-7.5
+      parent: 1
+      type: Transform
+  - uid: 557
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 10.5,-7.5
+      parent: 1
+      type: Transform
+  - uid: 558
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 11.5,-7.5
+      parent: 1
+      type: Transform
+  - uid: 559
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 11.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 560
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 11.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 561
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 6.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 562
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 8.5,-7.5
+      parent: 1
+      type: Transform
+  - uid: 563
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 7.5,-7.5
+      parent: 1
+      type: Transform
+  - uid: 564
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 6.5,-7.5
+      parent: 1
+      type: Transform
+  - uid: 565
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 6.5,-6.5
+      parent: 1
+      type: Transform
+  - uid: 566
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -1.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 567
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -4.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 568
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -4.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 569
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 570
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -0.5,-0.5
+      parent: 1
+      type: Transform
+  - uid: 571
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 3.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 572
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 3.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 573
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 3.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 574
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 3.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 575
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 1.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 576
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 3.5,-2.5
+      parent: 1
+      type: Transform
+  - uid: 577
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 1.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 578
+    components:
+    - pos: 1.5,-2.5
+      parent: 1
+      type: Transform
+  - uid: 579
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 0.5,-7.5
+      parent: 1
+      type: Transform
+  - uid: 580
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 0.5,-5.5
+      parent: 1
+      type: Transform
+  - uid: 581
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 1.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 582
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -1.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 583
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -0.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 584
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 585
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -3.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 586
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -1.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 587
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -2.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 588
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -4.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 589
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -4.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 590
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 1.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 591
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 2.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 592
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 593
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 594
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 1.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 595
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 1.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 596
+    components:
+    - pos: 5.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 597
+    components:
+    - pos: 5.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 598
+    components:
+    - pos: 5.5,-6.5
+      parent: 1
+      type: Transform
+- proto: WallShuttleDiagonal
+  entities:
+  - uid: 599
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 5.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 600
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 7.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 601
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 5.5,-2.5
+      parent: 1
+      type: Transform
+  - uid: 602
+    components:
+    - pos: 7.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 603
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -0.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 604
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 1.5,-5.5
+      parent: 1
+      type: Transform
+  - uid: 605
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -0.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 606
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 7.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 607
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 1.5,4.5
+      parent: 1
+      type: Transform
+- proto: WallWeaponCapacitorRecharger
+  entities:
+  - uid: 608
+    components:
+    - pos: -0.5,-0.5
+      parent: 1
+      type: Transform
+    - chargeRate: 13.333334
+      type: Charger
+    - powerLoad: 0
+      type: ApcPowerReceiver
+  - uid: 609
+    components:
+    - pos: 8.5,1.5
+      parent: 1
+      type: Transform
+    - chargeRate: 13.333334
+      type: Charger
+    - powerLoad: 0
+      type: ApcPowerReceiver
+  - uid: 610
+    components:
+    - pos: 8.5,-2.5
+      parent: 1
+      type: Transform
+    - chargeRate: 13.333334
+      type: Charger
+    - powerLoad: 0
+      type: ApcPowerReceiver
+- proto: WarpPointShip
+  entities:
+  - uid: 611
+    components:
+    - pos: 4.5,-0.5
+      parent: 1
+      type: Transform
+- proto: WeaponCapacitorRecharger
+  entities:
+  - uid: 210
+    components:
+    - pos: 8.5,-6.5
+      parent: 1
+      type: Transform
+    - containers:
+        charger_slot: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+        machine_board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 214
+        machine_parts: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 212
+          - 213
+          - 211
+      type: ContainerContainer
+    - powerLoad: 0
+      type: ApcPowerReceiver
+- proto: WeaponCapacitorRechargerCircuitboard
+  entities:
+  - uid: 214
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 210
+      type: Transform
+    - canCollide: False
+      type: Physics
+- proto: WeaponFlareGun
+  entities:
+  - uid: 22
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 6
+      type: Transform
+    - unspawnedCount: 1
+      type: BallisticAmmoProvider
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: Wrench
+  entities:
+  - uid: 612
+    components:
+    - pos: 7.533099,4.573193
+      parent: 1
+      type: Transform
+    - canCollide: False
+      type: Physics
+- proto: XylophoneInstrument
+  entities:
+  - uid: 294
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 281
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: YellowOxygenTankFilled
+  entities:
+  - uid: 31
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 23
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+...

--- a/Resources/Maps/Shuttles/inquisitor.yml
+++ b/Resources/Maps/Shuttles/inquisitor.yml
@@ -260,62 +260,153 @@ entities:
     - container: 17
       entIcon: 19
       type: InstantAction
-  - uid: 42
+  - uid: 34
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 41
+    - parent: 33
       type: Transform
-    - container: 41
-      entIcon: 43
+    - container: 33
+      entIcon: 35
       type: InstantAction
 - proto: ActionVendingThrow
   entities:
-  - uid: 59
+  - uid: 51
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 58
+    - parent: 50
       type: Transform
-    - container: 58
+    - container: 50
       type: InstantAction
-  - uid: 61
+  - uid: 53
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 60
+    - parent: 52
       type: Transform
-    - container: 60
+    - container: 52
       type: InstantAction
 - proto: AirAlarm
   entities:
-  - uid: 62
+  - uid: 54
     components:
     - pos: 3.5,1.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 342
-      - 343
-      - 338
-      - 336
-      - 344
-      - 334
-      - 340
+      - 300
+      - 301
+      - 296
+      - 294
+      - 302
+      - 292
+      - 298
       address: AIR-07EE-EDC5
       transmitFrequency: 1621
       receiveFrequency: 1621
       type: DeviceNetwork
     - devices:
-      - 92
-      - 416
-      - 342
-      - 343
-      - 338
-      - 336
-      - 344
-      - 334
-      - 340
+      - 84
+      - 374
+      - 300
+      - 301
+      - 296
+      - 294
+      - 302
+      - 292
+      - 298
+      type: DeviceList
+    - containers:
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 55
+      type: ContainerContainer
+  - uid: 56
+    components:
+    - pos: 2.5,6.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 296
+      address: AIR-1C93-2EB9
+      transmitFrequency: 1621
+      receiveFrequency: 1621
+      type: DeviceNetwork
+    - devices:
+      - 83
+      - 296
+      type: DeviceList
+    - containers:
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 57
+      type: ContainerContainer
+  - uid: 58
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 2.5,-7.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 294
+      address: AIR-7F0A-41E3
+      transmitFrequency: 1621
+      receiveFrequency: 1621
+      type: DeviceNetwork
+    - devices:
+      - 82
+      - 294
+      type: DeviceList
+    - containers:
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 59
+      type: ContainerContainer
+  - uid: 60
+    components:
+    - pos: 10.5,6.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 302
+      address: AIR-0505-EB98
+      transmitFrequency: 1621
+      receiveFrequency: 1621
+      type: DeviceNetwork
+    - devices:
+      - 85
+      - 375
+      - 302
+      type: DeviceList
+    - containers:
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 61
+      type: ContainerContainer
+  - uid: 62
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 10.5,-7.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 298
+      address: AIR-0AFD-90EF
+      transmitFrequency: 1621
+      receiveFrequency: 1621
+      type: DeviceNetwork
+    - devices:
+      - 86
+      - 298
       type: DeviceList
     - containers:
         board: !type:Container
@@ -326,18 +417,18 @@ entities:
       type: ContainerContainer
   - uid: 64
     components:
-    - pos: 2.5,6.5
+    - pos: 9.5,1.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 338
-      address: AIR-1C93-2EB9
+      - 292
+      address: AIR-1775-A352
       transmitFrequency: 1621
       receiveFrequency: 1621
       type: DeviceNetwork
     - devices:
-      - 91
-      - 338
+      - 81
+      - 292
       type: DeviceList
     - containers:
         board: !type:Container
@@ -346,99 +437,40 @@ entities:
           ents:
           - 65
       type: ContainerContainer
-  - uid: 66
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 2.5,-7.5
-      parent: 1
-      type: Transform
-    - ShutdownSubscribers:
-      - 336
-      address: AIR-7F0A-41E3
-      transmitFrequency: 1621
-      receiveFrequency: 1621
-      type: DeviceNetwork
-    - devices:
-      - 90
-      - 336
-      type: DeviceList
-    - containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 67
-      type: ContainerContainer
-  - uid: 68
-    components:
-    - pos: 10.5,6.5
-      parent: 1
-      type: Transform
-    - ShutdownSubscribers:
-      - 344
-      address: AIR-0505-EB98
-      transmitFrequency: 1621
-      receiveFrequency: 1621
-      type: DeviceNetwork
-    - devices:
-      - 93
-      - 417
-      - 344
-      type: DeviceList
-    - containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 69
-      type: ContainerContainer
-  - uid: 70
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 10.5,-7.5
-      parent: 1
-      type: Transform
-    - ShutdownSubscribers:
-      - 340
-      address: AIR-0AFD-90EF
-      transmitFrequency: 1621
-      receiveFrequency: 1621
-      type: DeviceNetwork
-    - devices:
-      - 94
-      - 340
-      type: DeviceList
-    - containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 71
-      type: ContainerContainer
-  - uid: 72
-    components:
-    - pos: 9.5,1.5
-      parent: 1
-      type: Transform
-    - ShutdownSubscribers:
-      - 334
-      address: AIR-1775-A352
-      transmitFrequency: 1621
-      receiveFrequency: 1621
-      type: DeviceNetwork
-    - devices:
-      - 89
-      - 334
-      type: DeviceList
-    - containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 73
-      type: ContainerContainer
 - proto: AirAlarmElectronics
   entities:
+  - uid: 55
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 54
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 57
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 56
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 59
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 58
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 61
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 60
+      type: Transform
+    - canCollide: False
+      type: Physics
   - uid: 63
     components:
     - flags: InContainer
@@ -455,48 +487,16 @@ entities:
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 67
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 66
-      type: Transform
-    - canCollide: False
-      type: Physics
-  - uid: 69
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 68
-      type: Transform
-    - canCollide: False
-      type: Physics
-  - uid: 71
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 70
-      type: Transform
-    - canCollide: False
-      type: Physics
-  - uid: 73
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 72
-      type: Transform
-    - canCollide: False
-      type: Physics
 - proto: AirCanister
   entities:
-  - uid: 74
+  - uid: 66
     components:
     - pos: 8.5,4.5
       parent: 1
       type: Transform
 - proto: AirlockCommandGlass
   entities:
-  - uid: 75
+  - uid: 67
     components:
     - pos: 7.5,-0.5
       parent: 1
@@ -511,14 +511,14 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 76
+          - 68
       type: ContainerContainer
     - address: 15BA-7CDD
       receiveFrequency: 1280
       type: DeviceNetwork
 - proto: AirlockEngineeringGlass
   entities:
-  - uid: 77
+  - uid: 69
     components:
     - pos: 6.5,2.5
       parent: 1
@@ -528,14 +528,14 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 78
+          - 70
       type: ContainerContainer
     - address: 43F1-6C63
       receiveFrequency: 1280
       type: DeviceNetwork
 - proto: AirlockGlass
   entities:
-  - uid: 79
+  - uid: 71
     components:
     - rot: -1.5707963267948966 rad
       pos: 2.5,-2.5
@@ -546,15 +546,15 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 80
+          - 72
       type: ContainerContainer
     - address: 3497-4A2F
       receiveFrequency: 1280
       type: DeviceNetwork
     - links:
-      - 483
+      - 443
       type: DeviceLinkSink
-  - uid: 81
+  - uid: 73
     components:
     - rot: -1.5707963267948966 rad
       pos: 2.5,1.5
@@ -565,17 +565,17 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 82
+          - 74
       type: ContainerContainer
     - address: 4413-8EE1
       receiveFrequency: 1280
       type: DeviceNetwork
     - links:
-      - 484
+      - 444
       type: DeviceLinkSink
 - proto: AirlockGlassShuttle
   entities:
-  - uid: 83
+  - uid: 75
     components:
     - rot: -1.5707963267948966 rad
       pos: -4.5,-2.5
@@ -586,12 +586,12 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 84
+          - 76
       type: ContainerContainer
     - address: 2960-D1C2
       receiveFrequency: 1280
       type: DeviceNetwork
-  - uid: 85
+  - uid: 77
     components:
     - rot: -1.5707963267948966 rad
       pos: -4.5,1.5
@@ -602,7 +602,7 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 86
+          - 78
       type: ContainerContainer
     - address: 6C41-C2AE
       receiveFrequency: 1280
@@ -614,7 +614,7 @@ entities:
       type: Forensics
 - proto: AirlockSecurityGlass
   entities:
-  - uid: 87
+  - uid: 79
     components:
     - pos: 6.5,-3.5
       parent: 1
@@ -624,17 +624,17 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 88
+          - 80
       type: ContainerContainer
     - address: 3C12-27EA
       receiveFrequency: 1280
       type: DeviceNetwork
     - links:
-      - 486
+      - 446
       type: DeviceLinkSink
 - proto: AirSensor
   entities:
-  - uid: 89
+  - uid: 81
     components:
     - pos: 9.5,-0.5
       parent: 1
@@ -801,7 +801,7 @@ entities:
           enabled: True
         ignore: False
       type: AtmosMonitor
-  - uid: 90
+  - uid: 82
     components:
     - pos: 2.5,-6.5
       parent: 1
@@ -970,7 +970,7 @@ entities:
           enabled: True
         ignore: False
       type: AtmosMonitor
-  - uid: 91
+  - uid: 83
     components:
     - pos: 2.5,5.5
       parent: 1
@@ -1139,7 +1139,7 @@ entities:
           enabled: True
         ignore: False
       type: AtmosMonitor
-  - uid: 92
+  - uid: 84
     components:
     - pos: 3.5,-0.5
       parent: 1
@@ -1308,7 +1308,7 @@ entities:
           enabled: True
         ignore: False
       type: AtmosMonitor
-  - uid: 93
+  - uid: 85
     components:
     - pos: 7.5,4.5
       parent: 1
@@ -1478,7 +1478,7 @@ entities:
           enabled: True
         ignore: False
       type: AtmosMonitor
-  - uid: 94
+  - uid: 86
     components:
     - pos: 7.5,-5.5
       parent: 1
@@ -1647,7 +1647,7 @@ entities:
       type: AtmosMonitor
 - proto: APCBasic
   entities:
-  - uid: 95
+  - uid: 87
     components:
     - pos: 9.5,6.5
       parent: 1
@@ -1657,7 +1657,7 @@ entities:
     - hasAccess: True
       lastChargeState: Charging
       type: Apc
-  - uid: 96
+  - uid: 88
     components:
     - rot: 3.141592653589793 rad
       pos: 9.5,-2.5
@@ -1668,7 +1668,7 @@ entities:
     - hasAccess: True
       lastChargeState: Full
       type: Apc
-  - uid: 97
+  - uid: 89
     components:
     - pos: 4.5,1.5
       parent: 1
@@ -1679,13 +1679,13 @@ entities:
       type: Apc
 - proto: AtmosDeviceFanTiny
   entities:
-  - uid: 98
+  - uid: 90
     components:
     - rot: 1.5707963267948966 rad
       pos: -4.5,1.5
       parent: 1
       type: Transform
-  - uid: 99
+  - uid: 91
     components:
     - rot: 1.5707963267948966 rad
       pos: -4.5,-2.5
@@ -1693,7 +1693,7 @@ entities:
       type: Transform
 - proto: BarSign
   entities:
-  - uid: 100
+  - uid: 92
     components:
     - desc: Anteriormente ubicado en Spessmerica.
       name: Zocalo
@@ -1705,26 +1705,26 @@ entities:
       type: BarSign
 - proto: Bed
   entities:
-  - uid: 101
+  - uid: 93
     components:
     - pos: 1.5,5.5
       parent: 1
       type: Transform
-  - uid: 102
+  - uid: 94
     components:
     - pos: 1.5,-6.5
       parent: 1
       type: Transform
 - proto: BedsheetBlack
   entities:
-  - uid: 103
+  - uid: 95
     components:
     - pos: 1.5,5.5
       parent: 1
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 104
+  - uid: 96
     components:
     - pos: 1.5,-6.5
       parent: 1
@@ -1733,32 +1733,32 @@ entities:
       type: Physics
 - proto: CableApcExtension
   entities:
-  - uid: 105
+  - uid: 97
     components:
     - pos: -3.5,1.5
       parent: 1
       type: Transform
-  - uid: 106
+  - uid: 98
     components:
     - pos: -4.5,1.5
       parent: 1
       type: Transform
-  - uid: 107
+  - uid: 99
     components:
     - pos: -2.5,1.5
       parent: 1
       type: Transform
-  - uid: 108
+  - uid: 100
     components:
     - pos: -4.5,-2.5
       parent: 1
       type: Transform
-  - uid: 109
+  - uid: 101
     components:
     - pos: -2.5,1.5
       parent: 1
       type: Transform
-  - uid: 110
+  - uid: 102
     components:
     - pos: -1.5,1.5
       parent: 1
@@ -1768,268 +1768,268 @@ entities:
       - black insulative fibers
       fingerprints: []
       type: Forensics
-  - uid: 111
+  - uid: 103
     components:
     - pos: 1.5,0.5
       parent: 1
       type: Transform
-  - uid: 112
+  - uid: 104
     components:
     - pos: 0.5,1.5
       parent: 1
       type: Transform
-  - uid: 113
+  - uid: 105
     components:
     - pos: -0.5,1.5
       parent: 1
       type: Transform
-  - uid: 114
+  - uid: 106
     components:
     - pos: 0.5,0.5
       parent: 1
       type: Transform
-  - uid: 115
+  - uid: 107
     components:
     - pos: 2.5,-5.5
       parent: 1
       type: Transform
-  - uid: 116
+  - uid: 108
     components:
     - pos: 9.5,6.5
       parent: 1
       type: Transform
-  - uid: 117
+  - uid: 109
     components:
     - pos: 9.5,5.5
       parent: 1
       type: Transform
-  - uid: 118
+  - uid: 110
     components:
     - pos: 9.5,4.5
       parent: 1
       type: Transform
-  - uid: 119
+  - uid: 111
     components:
     - pos: 8.5,4.5
       parent: 1
       type: Transform
-  - uid: 120
+  - uid: 112
     components:
     - pos: 7.5,4.5
       parent: 1
       type: Transform
-  - uid: 121
+  - uid: 113
     components:
     - pos: 6.5,-2.5
       parent: 1
       type: Transform
-  - uid: 122
+  - uid: 114
     components:
     - pos: 4.5,1.5
       parent: 1
       type: Transform
-  - uid: 123
+  - uid: 115
     components:
     - pos: 4.5,0.5
       parent: 1
       type: Transform
-  - uid: 124
+  - uid: 116
     components:
     - pos: 3.5,-0.5
       parent: 1
       type: Transform
-  - uid: 125
+  - uid: 117
     components:
     - pos: 2.5,-0.5
       parent: 1
       type: Transform
-  - uid: 126
+  - uid: 118
     components:
     - pos: 0.5,-1.5
       parent: 1
       type: Transform
-  - uid: 127
+  - uid: 119
     components:
     - pos: 1.5,-1.5
       parent: 1
       type: Transform
-  - uid: 128
+  - uid: 120
     components:
     - pos: -0.5,-2.5
       parent: 1
       type: Transform
-  - uid: 129
+  - uid: 121
     components:
     - pos: 0.5,-2.5
       parent: 1
       type: Transform
-  - uid: 130
+  - uid: 122
     components:
     - pos: -1.5,-2.5
       parent: 1
       type: Transform
-  - uid: 131
+  - uid: 123
     components:
     - pos: -2.5,-2.5
       parent: 1
       type: Transform
-  - uid: 132
+  - uid: 124
     components:
     - pos: -1.5,-2.5
       parent: 1
       type: Transform
-  - uid: 133
+  - uid: 125
     components:
     - pos: -2.5,-2.5
       parent: 1
       type: Transform
-  - uid: 134
+  - uid: 126
     components:
     - pos: -3.5,-2.5
       parent: 1
       type: Transform
-  - uid: 135
+  - uid: 127
     components:
     - pos: 4.5,-0.5
       parent: 1
       type: Transform
-  - uid: 136
+  - uid: 128
     components:
     - pos: 7.5,-0.5
       parent: 1
       type: Transform
-  - uid: 137
+  - uid: 129
     components:
     - pos: 6.5,-0.5
       parent: 1
       type: Transform
-  - uid: 138
+  - uid: 130
     components:
     - pos: 6.5,-3.5
       parent: 1
       type: Transform
-  - uid: 139
+  - uid: 131
     components:
     - pos: 8.5,-0.5
       parent: 1
       type: Transform
-  - uid: 140
+  - uid: 132
     components:
     - pos: 6.5,-4.5
       parent: 1
       type: Transform
-  - uid: 141
+  - uid: 133
     components:
     - pos: 7.5,-4.5
       parent: 1
       type: Transform
-  - uid: 142
+  - uid: 134
     components:
     - pos: 7.5,-5.5
       parent: 1
       type: Transform
-  - uid: 143
+  - uid: 135
     components:
     - pos: 8.5,-5.5
       parent: 1
       type: Transform
-  - uid: 144
+  - uid: 136
     components:
     - pos: 9.5,-2.5
       parent: 1
       type: Transform
-  - uid: 145
+  - uid: 137
     components:
     - pos: 9.5,-1.5
       parent: 1
       type: Transform
-  - uid: 146
+  - uid: 138
     components:
     - pos: 9.5,-0.5
       parent: 1
       type: Transform
-  - uid: 147
+  - uid: 139
     components:
     - pos: 9.5,-5.5
       parent: 1
       type: Transform
-  - uid: 148
+  - uid: 140
     components:
     - pos: 10.5,-5.5
       parent: 1
       type: Transform
-  - uid: 149
+  - uid: 141
     components:
     - pos: 2.5,-1.5
       parent: 1
       type: Transform
-  - uid: 150
+  - uid: 142
     components:
     - pos: 2.5,-2.5
       parent: 1
       type: Transform
-  - uid: 151
+  - uid: 143
     components:
     - pos: 2.5,-3.5
       parent: 1
       type: Transform
-  - uid: 152
+  - uid: 144
     components:
     - pos: 2.5,-4.5
       parent: 1
       type: Transform
-  - uid: 153
+  - uid: 145
     components:
     - pos: 2.5,-6.5
       parent: 1
       type: Transform
-  - uid: 154
+  - uid: 146
     components:
     - pos: 2.5,0.5
       parent: 1
       type: Transform
-  - uid: 155
+  - uid: 147
     components:
     - pos: 2.5,1.5
       parent: 1
       type: Transform
-  - uid: 156
+  - uid: 148
     components:
     - pos: 2.5,2.5
       parent: 1
       type: Transform
-  - uid: 157
+  - uid: 149
     components:
     - pos: 2.5,3.5
       parent: 1
       type: Transform
-  - uid: 158
+  - uid: 150
     components:
     - pos: 2.5,3.5
       parent: 1
       type: Transform
-  - uid: 159
+  - uid: 151
     components:
     - pos: 2.5,4.5
       parent: 1
       type: Transform
-  - uid: 160
+  - uid: 152
     components:
     - pos: 2.5,5.5
       parent: 1
       type: Transform
-  - uid: 161
+  - uid: 153
     components:
     - pos: 6.5,-1.5
       parent: 1
       type: Transform
 - proto: CableApcStack1
   entities:
-  - uid: 163
+  - uid: 155
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 162
+    - parent: 154
       type: Transform
     - count: 5
       type: Stack
@@ -2039,43 +2039,43 @@ entities:
       type: Physics
 - proto: CableHV
   entities:
-  - uid: 167
+  - uid: 159
     components:
     - pos: 8.5,5.5
       parent: 1
       type: Transform
-  - uid: 168
+  - uid: 160
     components:
     - pos: 8.5,4.5
       parent: 1
       type: Transform
-  - uid: 169
+  - uid: 161
     components:
     - pos: 9.5,4.5
       parent: 1
       type: Transform
-  - uid: 170
+  - uid: 162
     components:
     - pos: 10.5,4.5
       parent: 1
       type: Transform
-  - uid: 171
+  - uid: 163
     components:
     - pos: 10.5,5.5
       parent: 1
       type: Transform
-  - uid: 172
+  - uid: 164
     components:
     - pos: 7.5,5.5
       parent: 1
       type: Transform
 - proto: CableHVStack1
   entities:
-  - uid: 174
+  - uid: 166
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 173
+    - parent: 165
       type: Transform
     - count: 5
       type: Stack
@@ -2083,11 +2083,11 @@ entities:
       type: Item
     - canCollide: False
       type: Physics
-  - uid: 178
+  - uid: 170
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 177
+    - parent: 169
       type: Transform
     - count: 5
       type: Stack
@@ -2097,128 +2097,128 @@ entities:
       type: Physics
 - proto: CableMV
   entities:
-  - uid: 181
+  - uid: 173
     components:
     - pos: 10.5,4.5
       parent: 1
       type: Transform
-  - uid: 182
+  - uid: 174
     components:
     - pos: 9.5,4.5
       parent: 1
       type: Transform
-  - uid: 183
+  - uid: 175
     components:
     - pos: 9.5,5.5
       parent: 1
       type: Transform
-  - uid: 184
+  - uid: 176
     components:
     - pos: 9.5,6.5
       parent: 1
       type: Transform
-  - uid: 185
+  - uid: 177
     components:
     - pos: 9.5,4.5
       parent: 1
       type: Transform
-  - uid: 186
+  - uid: 178
     components:
     - pos: 10.5,4.5
       parent: 1
       type: Transform
-  - uid: 187
+  - uid: 179
     components:
     - pos: 9.5,4.5
       parent: 1
       type: Transform
-  - uid: 188
+  - uid: 180
     components:
     - pos: 8.5,4.5
       parent: 1
       type: Transform
-  - uid: 189
+  - uid: 181
     components:
     - pos: 7.5,4.5
       parent: 1
       type: Transform
-  - uid: 190
+  - uid: 182
     components:
     - pos: 7.5,3.5
       parent: 1
       type: Transform
-  - uid: 191
+  - uid: 183
     components:
     - pos: 6.5,3.5
       parent: 1
       type: Transform
-  - uid: 192
+  - uid: 184
     components:
     - pos: 6.5,2.5
       parent: 1
       type: Transform
-  - uid: 193
+  - uid: 185
     components:
     - pos: 6.5,1.5
       parent: 1
       type: Transform
-  - uid: 194
+  - uid: 186
     components:
     - pos: 6.5,0.5
       parent: 1
       type: Transform
-  - uid: 195
+  - uid: 187
     components:
     - pos: 4.5,0.5
       parent: 1
       type: Transform
-  - uid: 196
+  - uid: 188
     components:
     - pos: 6.5,-0.5
       parent: 1
       type: Transform
-  - uid: 197
+  - uid: 189
     components:
     - pos: 7.5,-0.5
       parent: 1
       type: Transform
-  - uid: 198
+  - uid: 190
     components:
     - pos: 8.5,-0.5
       parent: 1
       type: Transform
-  - uid: 199
+  - uid: 191
     components:
     - pos: 9.5,-0.5
       parent: 1
       type: Transform
-  - uid: 200
+  - uid: 192
     components:
     - pos: 9.5,-1.5
       parent: 1
       type: Transform
-  - uid: 201
+  - uid: 193
     components:
     - pos: 9.5,-2.5
       parent: 1
       type: Transform
-  - uid: 202
+  - uid: 194
     components:
     - pos: 4.5,1.5
       parent: 1
       type: Transform
-  - uid: 203
+  - uid: 195
     components:
     - pos: 5.5,0.5
       parent: 1
       type: Transform
 - proto: CableMVStack1
   entities:
-  - uid: 205
+  - uid: 197
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 204
+    - parent: 196
       type: Transform
     - count: 5
       type: Stack
@@ -2228,356 +2228,132 @@ entities:
       type: Physics
 - proto: CapacitorStockPart
   entities:
-  - uid: 164
+  - uid: 156
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 162
+    - parent: 154
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 165
+  - uid: 157
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 162
+    - parent: 154
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 175
+  - uid: 167
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 173
+    - parent: 165
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 179
+  - uid: 171
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 177
+    - parent: 169
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 206
+  - uid: 198
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 204
+    - parent: 196
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 207
+  - uid: 199
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 204
+    - parent: 196
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 210
+  - uid: 202
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 209
-      type: Transform
-    - canCollide: False
-      type: Physics
-  - uid: 216
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 215
-      type: Transform
-    - canCollide: False
-      type: Physics
-  - uid: 217
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 215
-      type: Transform
-    - canCollide: False
-      type: Physics
-  - uid: 218
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 215
-      type: Transform
-    - canCollide: False
-      type: Physics
-  - uid: 219
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 215
-      type: Transform
-    - canCollide: False
-      type: Physics
-  - uid: 223
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 222
-      type: Transform
-    - canCollide: False
-      type: Physics
-  - uid: 224
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 222
-      type: Transform
-    - canCollide: False
-      type: Physics
-  - uid: 225
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 222
-      type: Transform
-    - canCollide: False
-      type: Physics
-  - uid: 226
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 222
-      type: Transform
-    - canCollide: False
-      type: Physics
-  - uid: 230
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 229
-      type: Transform
-    - canCollide: False
-      type: Physics
-  - uid: 231
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 229
-      type: Transform
-    - canCollide: False
-      type: Physics
-  - uid: 232
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 229
-      type: Transform
-    - canCollide: False
-      type: Physics
-  - uid: 233
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 229
-      type: Transform
-    - canCollide: False
-      type: Physics
-  - uid: 237
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 236
-      type: Transform
-    - canCollide: False
-      type: Physics
-  - uid: 238
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 236
-      type: Transform
-    - canCollide: False
-      type: Physics
-  - uid: 239
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 236
-      type: Transform
-    - canCollide: False
-      type: Physics
-  - uid: 240
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 236
-      type: Transform
-    - canCollide: False
-      type: Physics
-  - uid: 244
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 243
-      type: Transform
-    - canCollide: False
-      type: Physics
-  - uid: 245
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 243
-      type: Transform
-    - canCollide: False
-      type: Physics
-  - uid: 246
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 243
-      type: Transform
-    - canCollide: False
-      type: Physics
-  - uid: 247
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 243
-      type: Transform
-    - canCollide: False
-      type: Physics
-  - uid: 251
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 250
-      type: Transform
-    - canCollide: False
-      type: Physics
-  - uid: 252
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 250
-      type: Transform
-    - canCollide: False
-      type: Physics
-  - uid: 253
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 250
-      type: Transform
-    - canCollide: False
-      type: Physics
-  - uid: 254
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 250
-      type: Transform
-    - canCollide: False
-      type: Physics
-  - uid: 258
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 257
-      type: Transform
-    - canCollide: False
-      type: Physics
-  - uid: 259
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 257
-      type: Transform
-    - canCollide: False
-      type: Physics
-  - uid: 260
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 257
-      type: Transform
-    - canCollide: False
-      type: Physics
-  - uid: 261
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 257
+    - parent: 201
       type: Transform
     - canCollide: False
       type: Physics
 - proto: Catwalk
   entities:
-  - uid: 264
+  - uid: 214
     components:
     - pos: 7.5,5.5
       parent: 1
       type: Transform
-  - uid: 265
+  - uid: 215
     components:
     - pos: 9.5,4.5
       parent: 1
       type: Transform
-  - uid: 266
+  - uid: 216
     components:
     - pos: 9.5,5.5
       parent: 1
       type: Transform
-  - uid: 267
+  - uid: 217
     components:
     - pos: 10.5,5.5
       parent: 1
       type: Transform
-  - uid: 268
+  - uid: 218
     components:
     - pos: 8.5,5.5
       parent: 1
       type: Transform
-  - uid: 269
+  - uid: 219
     components:
     - pos: 7.5,4.5
       parent: 1
       type: Transform
-  - uid: 270
+  - uid: 220
     components:
     - pos: 10.5,4.5
       parent: 1
       type: Transform
-  - uid: 271
+  - uid: 221
     components:
     - pos: 7.5,3.5
       parent: 1
       type: Transform
-  - uid: 272
+  - uid: 222
     components:
     - pos: 6.5,3.5
       parent: 1
       type: Transform
-  - uid: 273
+  - uid: 223
     components:
     - pos: 8.5,4.5
       parent: 1
       type: Transform
-  - uid: 274
+  - uid: 224
     components:
     - pos: 6.5,4.5
       parent: 1
       type: Transform
 - proto: CellRechargerCircuitboard
   entities:
-  - uid: 166
+  - uid: 158
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 162
+    - parent: 154
       type: Transform
     - canCollide: False
       type: Physics
 - proto: ClosetBase
   entities:
-  - uid: 275
+  - uid: 225
     components:
     - pos: 2.5,5.5
       parent: 1
@@ -2605,20 +2381,20 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 279
-          - 276
-          - 277
-          - 282
-          - 278
-          - 288
-          - 281
-          - 280
+          - 229
+          - 226
+          - 227
+          - 232
+          - 228
+          - 238
+          - 231
+          - 230
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
           ent: null
       type: ContainerContainer
-  - uid: 289
+  - uid: 239
     components:
     - pos: 2.5,-6.5
       parent: 1
@@ -2646,14 +2422,14 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 294
-          - 297
-          - 293
-          - 292
-          - 290
-          - 291
-          - 296
-          - 295
+          - 244
+          - 247
+          - 243
+          - 242
+          - 240
+          - 241
+          - 246
+          - 245
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -2678,7 +2454,7 @@ entities:
           - 22
           - 21
       type: ContainerContainer
-  - uid: 40
+  - uid: 32
     components:
     - pos: -0.5,2.5
       parent: 1
@@ -2706,10 +2482,10 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 41
-          - 44
-          - 45
-          - 57
+          - 33
+          - 36
+          - 37
+          - 49
       type: ContainerContainer
     - dnas: []
       fibers:
@@ -2737,7 +2513,7 @@ entities:
       type: ContainerContainer
 - proto: ClosetWallOrange
   entities:
-  - uid: 303
+  - uid: 253
     components:
     - rot: 1.5707963267948966 rad
       pos: 1.5,3.5
@@ -2761,7 +2537,7 @@ entities:
         - 0
         - 0
       type: EntityStorage
-  - uid: 304
+  - uid: 254
     components:
     - rot: 1.5707963267948966 rad
       pos: 1.5,-4.5
@@ -2787,21 +2563,21 @@ entities:
       type: EntityStorage
 - proto: ClothingHandsTacticalMaidGloves
   entities:
-  - uid: 305
+  - uid: 255
     components:
     - pos: 6.4730835,4.565351
       parent: 1
       type: Transform
 - proto: ClothingHeadHatCatEars
   entities:
-  - uid: 306
+  - uid: 256
     components:
     - pos: 6.5147495,4.620907
       parent: 1
       type: Transform
 - proto: ClothingHeadHatTacticalMaidHeadband
   entities:
-  - uid: 307
+  - uid: 257
     components:
     - pos: 6.4939165,4.6486845
       parent: 1
@@ -2818,15 +2594,15 @@ entities:
       type: Physics
     - AttachedUid: 17
       type: AttachedClothing
-  - uid: 43
+  - uid: 35
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 41
+    - parent: 33
       type: Transform
     - canCollide: False
       type: Physics
-    - AttachedUid: 41
+    - AttachedUid: 33
       type: AttachedClothing
 - proto: ClothingHeadHelmetFire
   entities:
@@ -2885,22 +2661,22 @@ entities:
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 44
+  - uid: 36
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 40
+    - parent: 32
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: ClothingMaskBreathMedical
   entities:
-  - uid: 46
+  - uid: 38
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 45
+    - parent: 37
       type: Transform
     - canCollide: False
       type: Physics
@@ -2917,20 +2693,20 @@ entities:
     - type: InsideEntityStorage
 - proto: ClothingOuterHardsuitEVAPrisoner
   entities:
-  - uid: 33
+  - uid: 259
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 32
+    - parent: 258
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 39
+  - uid: 263
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 36
+    - parent: 262
       type: Transform
     - canCollide: False
       type: Physics
@@ -2961,25 +2737,25 @@ entities:
       type: Physics
     - type: ActionsContainer
     - type: InsideEntityStorage
-  - uid: 41
+  - uid: 33
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 40
+    - parent: 32
       type: Transform
-    - clothingUid: 43
-      actionEntity: 42
+    - clothingUid: 35
+      actionEntity: 34
       type: ToggleableClothing
     - containers:
         toggleable-clothing: !type:ContainerSlot
           showEnts: False
           occludes: True
-          ent: 43
+          ent: 35
         actions: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 42
+          - 34
       type: ContainerContainer
     - canCollide: False
       type: Physics
@@ -2998,11 +2774,11 @@ entities:
     - type: InsideEntityStorage
 - proto: ClothingUniformJumpskirtPrisoner
   entities:
-  - uid: 34
+  - uid: 260
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 32
+    - parent: 258
       type: Transform
     - address: 20C7-2C7A
       transmitFrequency: 1262
@@ -3010,11 +2786,11 @@ entities:
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 37
+  - uid: 264
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 36
+    - parent: 262
       type: Transform
     - address: 0BF0-6E75
       transmitFrequency: 1262
@@ -3024,18 +2800,18 @@ entities:
     - type: InsideEntityStorage
 - proto: ClothingUniformJumpskirtTacticalMaid
   entities:
-  - uid: 308
+  - uid: 266
     components:
     - pos: 6.5564165,4.5861845
       parent: 1
       type: Transform
 - proto: ClothingUniformJumpsuitPrisoner
   entities:
-  - uid: 35
+  - uid: 261
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 32
+    - parent: 258
       type: Transform
     - address: 0F77-CE54
       transmitFrequency: 1262
@@ -3043,11 +2819,11 @@ entities:
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 38
+  - uid: 265
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 36
+    - parent: 262
       type: Transform
     - address: 6F23-4F6E
       transmitFrequency: 1262
@@ -3057,7 +2833,7 @@ entities:
     - type: InsideEntityStorage
 - proto: ComputerCrewMonitoring
   entities:
-  - uid: 309
+  - uid: 267
     components:
     - rot: -1.5707963267948966 rad
       pos: 10.5,-1.5
@@ -3071,7 +2847,7 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 310
+          - 268
       type: ContainerContainer
     - dnas: []
       fibers:
@@ -3080,7 +2856,7 @@ entities:
       type: Forensics
 - proto: ComputerShuttle
   entities:
-  - uid: 311
+  - uid: 269
     components:
     - rot: -1.5707963267948966 rad
       pos: 10.5,-0.5
@@ -3091,7 +2867,7 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 312
+          - 270
       type: ContainerContainer
     - dnas: []
       fibers:
@@ -3100,7 +2876,7 @@ entities:
       type: Forensics
 - proto: ComputerStationRecords
   entities:
-  - uid: 313
+  - uid: 271
     components:
     - rot: -1.5707963267948966 rad
       pos: 10.5,0.5
@@ -3111,7 +2887,7 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 314
+          - 272
       type: ContainerContainer
     - dnas: []
       fibers:
@@ -3120,11 +2896,11 @@ entities:
       type: Forensics
 - proto: CrewMonitoringComputerCircuitboard
   entities:
-  - uid: 310
+  - uid: 268
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 309
+    - parent: 267
       type: Transform
     - canCollide: False
       type: Physics
@@ -3140,6 +2916,38 @@ entities:
       type: Physics
 - proto: DoorElectronics
   entities:
+  - uid: 68
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 67
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 70
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 69
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 72
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 71
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 74
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 73
+      type: Transform
+    - canCollide: False
+      type: Physics
   - uid: 76
     components:
     - flags: InContainer
@@ -3164,73 +2972,41 @@ entities:
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 82
+  - uid: 274
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 81
+    - parent: 273
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 84
+  - uid: 276
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 83
+    - parent: 275
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 86
+  - uid: 278
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 85
+    - parent: 277
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 88
+  - uid: 280
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 87
-      type: Transform
-    - canCollide: False
-      type: Physics
-  - uid: 316
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 315
-      type: Transform
-    - canCollide: False
-      type: Physics
-  - uid: 318
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 317
-      type: Transform
-    - canCollide: False
-      type: Physics
-  - uid: 320
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 319
-      type: Transform
-    - canCollide: False
-      type: Physics
-  - uid: 322
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 321
+    - parent: 279
       type: Transform
     - canCollide: False
       type: Physics
 - proto: EmergencyLight
   entities:
-  - uid: 323
+  - uid: 281
     components:
     - rot: 3.141592653589793 rad
       pos: 2.5,-6.5
@@ -3241,7 +3017,7 @@ entities:
     - startingCharge: 10198.422
       type: Battery
     - type: ActiveEmergencyLight
-  - uid: 324
+  - uid: 282
     components:
     - rot: 3.141592653589793 rad
       pos: 9.5,-6.5
@@ -3252,7 +3028,7 @@ entities:
     - startingCharge: 5770.106
       type: Battery
     - type: ActiveEmergencyLight
-  - uid: 325
+  - uid: 283
     components:
     - pos: -2.5,-2.5
       parent: 1
@@ -3262,7 +3038,7 @@ entities:
     - startingCharge: 9827.992
       type: Battery
     - type: ActiveEmergencyLight
-  - uid: 326
+  - uid: 284
     components:
     - pos: 2.5,5.5
       parent: 1
@@ -3272,7 +3048,7 @@ entities:
     - startingCharge: 10316.518
       type: Battery
     - type: ActiveEmergencyLight
-  - uid: 327
+  - uid: 285
     components:
     - rot: 3.141592653589793 rad
       pos: -2.5,1.5
@@ -3283,12 +3059,12 @@ entities:
     - startingCharge: 9749.828
       type: Battery
     - type: ActiveEmergencyLight
-  - uid: 328
+  - uid: 286
     components:
     - pos: 9.5,5.5
       parent: 1
       type: Transform
-  - uid: 329
+  - uid: 287
     components:
     - rot: -1.5707963267948966 rad
       pos: 6.5,1.5
@@ -3299,7 +3075,7 @@ entities:
     - startingCharge: 6116.946
       type: Battery
     - type: ActiveEmergencyLight
-  - uid: 330
+  - uid: 288
     components:
     - rot: 3.141592653589793 rad
       pos: 9.5,-1.5
@@ -3310,7 +3086,7 @@ entities:
     - startingCharge: 5948.6265
       type: Battery
     - type: ActiveEmergencyLight
-  - uid: 331
+  - uid: 289
     components:
     - rot: -1.5707963267948966 rad
       pos: 6.5,-2.5
@@ -3323,11 +3099,11 @@ entities:
     - type: ActiveEmergencyLight
 - proto: EmergencyMedipen
   entities:
-  - uid: 47
+  - uid: 39
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 45
+    - parent: 37
       type: Transform
     - canCollide: False
       type: Physics
@@ -3342,37 +3118,37 @@ entities:
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 48
+  - uid: 40
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 45
+    - parent: 37
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 57
+  - uid: 49
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 40
+    - parent: 32
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: EuphoniumInstrument
   entities:
-  - uid: 290
+  - uid: 240
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 289
+    - parent: 239
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: FaxMachineShip
   entities:
-  - uid: 332
+  - uid: 290
     components:
     - pos: 9.5,0.5
       parent: 1
@@ -3385,7 +3161,7 @@ entities:
       type: DeviceNetwork
 - proto: filingCabinetRandom
   entities:
-  - uid: 333
+  - uid: 291
     components:
     - pos: 10.5,-6.5
       parent: 1
@@ -3403,41 +3179,41 @@ entities:
     - type: InsideEntityStorage
 - proto: FirelockElectronics
   entities:
-  - uid: 335
+  - uid: 293
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 334
+    - parent: 292
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 337
+  - uid: 295
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 336
+    - parent: 294
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 339
+  - uid: 297
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 338
+    - parent: 296
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 341
+  - uid: 299
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 340
+    - parent: 298
       type: Transform
     - canCollide: False
       type: Physics
 - proto: FirelockGlass
   entities:
-  - uid: 334
+  - uid: 292
     components:
     - pos: 7.5,-0.5
       parent: 1
@@ -3447,15 +3223,15 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 335
+          - 293
       type: ContainerContainer
     - ShutdownSubscribers:
-      - 62
-      - 72
+      - 54
+      - 64
       address: 2A2F-32C5
       receiveFrequency: 1621
       type: DeviceNetwork
-  - uid: 336
+  - uid: 294
     components:
     - pos: 2.5,-2.5
       parent: 1
@@ -3465,15 +3241,15 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 337
+          - 295
       type: ContainerContainer
     - ShutdownSubscribers:
-      - 62
-      - 66
+      - 54
+      - 58
       address: 69E1-ED5D
       receiveFrequency: 1621
       type: DeviceNetwork
-  - uid: 338
+  - uid: 296
     components:
     - pos: 2.5,1.5
       parent: 1
@@ -3483,15 +3259,15 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 339
+          - 297
       type: ContainerContainer
     - ShutdownSubscribers:
-      - 64
-      - 62
+      - 56
+      - 54
       address: 4EBA-47B3
       receiveFrequency: 1621
       type: DeviceNetwork
-  - uid: 340
+  - uid: 298
     components:
     - pos: 6.5,-3.5
       parent: 1
@@ -3501,38 +3277,38 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 341
+          - 299
       type: ContainerContainer
     - ShutdownSubscribers:
+      - 54
       - 62
-      - 70
       address: 6D3F-5E6B
       receiveFrequency: 1621
       type: DeviceNetwork
-  - uid: 342
+  - uid: 300
     components:
     - pos: -1.5,1.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 62
+      - 54
       type: DeviceNetwork
-  - uid: 343
+  - uid: 301
     components:
     - pos: -1.5,-2.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 62
+      - 54
       type: DeviceNetwork
-  - uid: 344
+  - uid: 302
     components:
     - pos: 6.5,2.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 62
-      - 68
+      - 54
+      - 60
       type: DeviceNetwork
 - proto: FlashlightLantern
   entities:
@@ -3583,99 +3359,99 @@ entities:
       type: Physics
 - proto: FoodSnackSus
   entities:
-  - uid: 276
+  - uid: 226
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 275
+    - parent: 225
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 277
+  - uid: 227
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 275
+    - parent: 225
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 278
+  - uid: 228
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 275
+    - parent: 225
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 279
+  - uid: 229
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 275
+    - parent: 225
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 280
+  - uid: 230
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 275
+    - parent: 225
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 291
+  - uid: 241
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 289
+    - parent: 239
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 292
+  - uid: 242
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 289
+    - parent: 239
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 293
+  - uid: 243
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 289
+    - parent: 239
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 294
+  - uid: 244
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 289
+    - parent: 239
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 295
+  - uid: 245
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 289
+    - parent: 239
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: GasPassiveVent
   entities:
-  - uid: 345
+  - uid: 303
     components:
     - rot: 1.5707963267948966 rad
       pos: -4.5,-0.5
@@ -3685,7 +3461,7 @@ entities:
       type: AtmosPipeColor
 - proto: GasPipeBend
   entities:
-  - uid: 346
+  - uid: 304
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,-2.5
@@ -3693,14 +3469,14 @@ entities:
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 347
+  - uid: 305
     components:
     - pos: 2.5,5.5
       parent: 1
       type: Transform
     - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 348
+  - uid: 306
     components:
     - rot: -1.5707963267948966 rad
       pos: 5.5,1.5
@@ -3708,7 +3484,7 @@ entities:
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 349
+  - uid: 307
     components:
     - rot: -1.5707963267948966 rad
       pos: 2.5,-6.5
@@ -3716,7 +3492,7 @@ entities:
       type: Transform
     - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 350
+  - uid: 308
     components:
     - rot: 1.5707963267948966 rad
       pos: 4.5,1.5
@@ -3724,7 +3500,7 @@ entities:
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 351
+  - uid: 309
     components:
     - rot: -1.5707963267948966 rad
       pos: 4.5,-2.5
@@ -3732,7 +3508,7 @@ entities:
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 352
+  - uid: 310
     components:
     - rot: 3.141592653589793 rad
       pos: 2.5,0.5
@@ -3740,14 +3516,14 @@ entities:
       type: Transform
     - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 353
+  - uid: 311
     components:
     - pos: 0.5,-0.5
       parent: 1
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 354
+  - uid: 312
     components:
     - rot: 1.5707963267948966 rad
       pos: 6.5,4.5
@@ -3755,7 +3531,7 @@ entities:
       type: Transform
     - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 355
+  - uid: 313
     components:
     - rot: 3.141592653589793 rad
       pos: 6.5,-5.5
@@ -3763,14 +3539,14 @@ entities:
       type: Transform
     - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 356
+  - uid: 314
     components:
     - pos: 8.5,-5.5
       parent: 1
       type: Transform
     - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 357
+  - uid: 315
     components:
     - rot: 1.5707963267948966 rad
       pos: 2.5,-1.5
@@ -3778,14 +3554,14 @@ entities:
       type: Transform
     - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 358
+  - uid: 316
     components:
     - pos: 9.5,-0.5
       parent: 1
       type: Transform
     - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 359
+  - uid: 317
     components:
     - rot: 3.141592653589793 rad
       pos: 8.5,-6.5
@@ -3793,7 +3569,7 @@ entities:
       type: Transform
     - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 360
+  - uid: 318
     components:
     - rot: 3.141592653589793 rad
       pos: 8.5,-6.5
@@ -3801,7 +3577,7 @@ entities:
       type: Transform
     - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 361
+  - uid: 319
     components:
     - rot: 1.5707963267948966 rad
       pos: 5.5,5.5
@@ -3811,7 +3587,7 @@ entities:
       type: AtmosPipeColor
 - proto: GasPipeStraight
   entities:
-  - uid: 362
+  - uid: 320
     components:
     - rot: -1.5707963267948966 rad
       pos: -2.5,-0.5
@@ -3819,7 +3595,7 @@ entities:
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 363
+  - uid: 321
     components:
     - rot: -1.5707963267948966 rad
       pos: 6.5,5.5
@@ -3827,7 +3603,7 @@ entities:
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 364
+  - uid: 322
     components:
     - rot: -1.5707963267948966 rad
       pos: 5.5,0.5
@@ -3835,7 +3611,7 @@ entities:
       type: Transform
     - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 365
+  - uid: 323
     components:
     - rot: 3.141592653589793 rad
       pos: 2.5,2.5
@@ -3843,21 +3619,21 @@ entities:
       type: Transform
     - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 366
+  - uid: 324
     components:
     - pos: 6.5,-4.5
       parent: 1
       type: Transform
     - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 367
+  - uid: 325
     components:
     - pos: 4.5,-1.5
       parent: 1
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 368
+  - uid: 326
     components:
     - rot: 1.5707963267948966 rad
       pos: 2.5,-2.5
@@ -3865,7 +3641,7 @@ entities:
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 369
+  - uid: 327
     components:
     - rot: 3.141592653589793 rad
       pos: 2.5,4.5
@@ -3873,7 +3649,7 @@ entities:
       type: Transform
     - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 370
+  - uid: 328
     components:
     - rot: -1.5707963267948966 rad
       pos: 8.5,5.5
@@ -3881,7 +3657,7 @@ entities:
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 371
+  - uid: 329
     components:
     - rot: -1.5707963267948966 rad
       pos: 5.5,-1.5
@@ -3889,7 +3665,7 @@ entities:
       type: Transform
     - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 372
+  - uid: 330
     components:
     - rot: 1.5707963267948966 rad
       pos: 1.5,-2.5
@@ -3897,7 +3673,7 @@ entities:
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 373
+  - uid: 331
     components:
     - rot: 1.5707963267948966 rad
       pos: 3.5,-2.5
@@ -3905,7 +3681,7 @@ entities:
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 374
+  - uid: 332
     components:
     - rot: 3.141592653589793 rad
       pos: 2.5,1.5
@@ -3913,7 +3689,7 @@ entities:
       type: Transform
     - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 375
+  - uid: 333
     components:
     - rot: -1.5707963267948966 rad
       pos: 4.5,0.5
@@ -3921,7 +3697,7 @@ entities:
       type: Transform
     - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 376
+  - uid: 334
     components:
     - rot: -1.5707963267948966 rad
       pos: 4.5,-1.5
@@ -3929,21 +3705,21 @@ entities:
       type: Transform
     - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 377
+  - uid: 335
     components:
     - pos: 2.5,-2.5
       parent: 1
       type: Transform
     - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 378
+  - uid: 336
     components:
     - pos: 2.5,-5.5
       parent: 1
       type: Transform
     - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 379
+  - uid: 337
     components:
     - rot: -1.5707963267948966 rad
       pos: 7.5,5.5
@@ -3951,7 +3727,7 @@ entities:
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 380
+  - uid: 338
     components:
     - rot: 1.5707963267948966 rad
       pos: 7.5,-5.5
@@ -3959,14 +3735,14 @@ entities:
       type: Transform
     - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 381
+  - uid: 339
     components:
     - pos: 6.5,-3.5
       parent: 1
       type: Transform
     - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 382
+  - uid: 340
     components:
     - rot: -1.5707963267948966 rad
       pos: 7.5,-0.5
@@ -3974,7 +3750,7 @@ entities:
       type: Transform
     - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 383
+  - uid: 341
     components:
     - rot: 1.5707963267948966 rad
       pos: 9.5,-6.5
@@ -3982,21 +3758,21 @@ entities:
       type: Transform
     - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 384
+  - uid: 342
     components:
     - pos: 6.5,1.5
       parent: 1
       type: Transform
     - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 385
+  - uid: 343
     components:
     - pos: 6.5,3.5
       parent: 1
       type: Transform
     - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 386
+  - uid: 344
     components:
     - rot: -1.5707963267948966 rad
       pos: 9.5,5.5
@@ -4004,42 +3780,42 @@ entities:
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 387
+  - uid: 345
     components:
     - pos: 0.5,-1.5
       parent: 1
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 388
+  - uid: 346
     components:
     - pos: 5.5,2.5
       parent: 1
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 389
+  - uid: 347
     components:
     - pos: 5.5,3.5
       parent: 1
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 390
+  - uid: 348
     components:
     - pos: 2.5,-3.5
       parent: 1
       type: Transform
     - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 391
+  - uid: 349
     components:
     - pos: 2.5,-4.5
       parent: 1
       type: Transform
     - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 392
+  - uid: 350
     components:
     - rot: 3.141592653589793 rad
       pos: 2.5,3.5
@@ -4047,14 +3823,14 @@ entities:
       type: Transform
     - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 393
+  - uid: 351
     components:
     - pos: 6.5,-2.5
       parent: 1
       type: Transform
     - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 394
+  - uid: 352
     components:
     - rot: -1.5707963267948966 rad
       pos: 8.5,-0.5
@@ -4062,7 +3838,7 @@ entities:
       type: Transform
     - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 395
+  - uid: 353
     components:
     - rot: -1.5707963267948966 rad
       pos: -3.5,-0.5
@@ -4070,14 +3846,14 @@ entities:
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 396
+  - uid: 354
     components:
     - pos: 5.5,4.5
       parent: 1
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 397
+  - uid: 355
     components:
     - rot: -1.5707963267948966 rad
       pos: -1.5,-0.5
@@ -4085,14 +3861,14 @@ entities:
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 398
+  - uid: 356
     components:
     - pos: 6.5,2.5
       parent: 1
       type: Transform
     - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 399
+  - uid: 357
     components:
     - rot: -1.5707963267948966 rad
       pos: -0.5,-0.5
@@ -4100,7 +3876,7 @@ entities:
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 400
+  - uid: 358
     components:
     - pos: 4.5,0.5
       parent: 1
@@ -4109,7 +3885,7 @@ entities:
       type: AtmosPipeColor
 - proto: GasPipeTJunction
   entities:
-  - uid: 401
+  - uid: 359
     components:
     - rot: 3.141592653589793 rad
       pos: 7.5,4.5
@@ -4117,7 +3893,7 @@ entities:
       type: Transform
     - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 402
+  - uid: 360
     components:
     - rot: -1.5707963267948966 rad
       pos: 6.5,-1.5
@@ -4125,14 +3901,14 @@ entities:
       type: Transform
     - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 403
+  - uid: 361
     components:
     - pos: 3.5,0.5
       parent: 1
       type: Transform
     - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 404
+  - uid: 362
     components:
     - rot: 1.5707963267948966 rad
       pos: 4.5,-0.5
@@ -4140,7 +3916,7 @@ entities:
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 405
+  - uid: 363
     components:
     - rot: -1.5707963267948966 rad
       pos: 6.5,0.5
@@ -4148,7 +3924,7 @@ entities:
       type: Transform
     - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 406
+  - uid: 364
     components:
     - rot: 1.5707963267948966 rad
       pos: 6.5,-0.5
@@ -4156,7 +3932,7 @@ entities:
       type: Transform
     - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 407
+  - uid: 365
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,-0.5
@@ -4164,7 +3940,7 @@ entities:
       type: Transform
     - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 408
+  - uid: 366
     components:
     - rot: 3.141592653589793 rad
       pos: 3.5,-1.5
@@ -4174,7 +3950,7 @@ entities:
       type: AtmosPipeColor
 - proto: GasPort
   entities:
-  - uid: 409
+  - uid: 367
     components:
     - rot: -1.5707963267948966 rad
       pos: 8.5,4.5
@@ -4184,7 +3960,7 @@ entities:
       type: AtmosPipeColor
 - proto: GasVentPump
   entities:
-  - uid: 410
+  - uid: 368
     components:
     - rot: 1.5707963267948966 rad
       pos: 2.5,-0.5
@@ -4192,14 +3968,14 @@ entities:
       type: Transform
     - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 411
+  - uid: 369
     components:
     - pos: 7.5,5.5
       parent: 1
       type: Transform
     - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 412
+  - uid: 370
     components:
     - rot: -1.5707963267948966 rad
       pos: 10.5,-6.5
@@ -4207,7 +3983,7 @@ entities:
       type: Transform
     - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 413
+  - uid: 371
     components:
     - rot: 1.5707963267948966 rad
       pos: 1.5,5.5
@@ -4377,7 +4153,7 @@ entities:
       type: AtmosMonitor
     - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 414
+  - uid: 372
     components:
     - rot: 1.5707963267948966 rad
       pos: 1.5,-6.5
@@ -4547,7 +4323,7 @@ entities:
       type: AtmosMonitor
     - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 415
+  - uid: 373
     components:
     - rot: 3.141592653589793 rad
       pos: 9.5,-1.5
@@ -4717,7 +4493,7 @@ entities:
       type: AtmosPipeColor
 - proto: GasVentScrubber
   entities:
-  - uid: 416
+  - uid: 374
     components:
     - rot: -1.5707963267948966 rad
       pos: 5.5,-0.5
@@ -4889,7 +4665,7 @@ entities:
       type: AtmosMonitor
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 417
+  - uid: 375
     components:
     - rot: -1.5707963267948966 rad
       pos: 10.5,5.5
@@ -5061,120 +4837,120 @@ entities:
       type: AtmosPipeColor
 - proto: GravityGeneratorMini
   entities:
-  - uid: 418
+  - uid: 376
     components:
     - pos: 9.5,5.5
       parent: 1
       type: Transform
 - proto: Grille
   entities:
-  - uid: 419
+  - uid: 377
     components:
     - pos: 11.5,-6.5
       parent: 1
       type: Transform
-  - uid: 420
+  - uid: 378
     components:
     - rot: -1.5707963267948966 rad
       pos: 0.5,-6.5
       parent: 1
       type: Transform
-  - uid: 421
+  - uid: 379
     components:
     - rot: -1.5707963267948966 rad
       pos: -2.5,-3.5
       parent: 1
       type: Transform
-  - uid: 422
+  - uid: 380
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,5.5
       parent: 1
       type: Transform
-  - uid: 423
+  - uid: 381
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,-4.5
       parent: 1
       type: Transform
-  - uid: 424
+  - uid: 382
     components:
     - rot: -1.5707963267948966 rad
       pos: 11.5,0.5
       parent: 1
       type: Transform
-  - uid: 425
+  - uid: 383
     components:
     - rot: -1.5707963267948966 rad
       pos: -3.5,-3.5
       parent: 1
       type: Transform
-  - uid: 426
+  - uid: 384
     components:
     - rot: 3.141592653589793 rad
       pos: 7.5,-1.5
       parent: 1
       type: Transform
-  - uid: 427
+  - uid: 385
     components:
     - rot: 3.141592653589793 rad
       pos: 7.5,0.5
       parent: 1
       type: Transform
-  - uid: 428
+  - uid: 386
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,-5.5
       parent: 1
       type: Transform
-  - uid: 429
+  - uid: 387
     components:
     - pos: 11.5,-5.5
       parent: 1
       type: Transform
-  - uid: 430
+  - uid: 388
     components:
     - rot: -1.5707963267948966 rad
       pos: 11.5,-0.5
       parent: 1
       type: Transform
-  - uid: 431
+  - uid: 389
     components:
     - rot: -1.5707963267948966 rad
       pos: 0.5,5.5
       parent: 1
       type: Transform
-  - uid: 432
+  - uid: 390
     components:
     - rot: -1.5707963267948966 rad
       pos: -3.5,2.5
       parent: 1
       type: Transform
-  - uid: 433
+  - uid: 391
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,3.5
       parent: 1
       type: Transform
-  - uid: 434
+  - uid: 392
     components:
     - rot: -1.5707963267948966 rad
       pos: -2.5,2.5
       parent: 1
       type: Transform
-  - uid: 435
+  - uid: 393
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,4.5
       parent: 1
       type: Transform
-  - uid: 436
+  - uid: 394
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,-6.5
       parent: 1
       type: Transform
-  - uid: 437
+  - uid: 395
     components:
     - rot: -1.5707963267948966 rad
       pos: 11.5,-1.5
@@ -5182,7 +4958,7 @@ entities:
       type: Transform
 - proto: Gyroscope
   entities:
-  - uid: 209
+  - uid: 201
     components:
     - pos: 9.5,4.5
       parent: 1
@@ -5192,42 +4968,42 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 211
+          - 203
         machine_parts: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 212
-          - 213
-          - 210
-          - 214
+          - 204
+          - 205
+          - 202
+          - 206
       type: ContainerContainer
 - proto: GyroscopeMachineCircuitboard
   entities:
-  - uid: 211
+  - uid: 203
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 209
+    - parent: 201
       type: Transform
     - canCollide: False
       type: Physics
 - proto: Joint
   entities:
-  - uid: 281
+  - uid: 231
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 275
+    - parent: 225
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 296
+  - uid: 246
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 289
+    - parent: 239
       type: Transform
     - canCollide: False
       type: Physics
@@ -5260,7 +5036,7 @@ entities:
       type: Actions
 - proto: LockerDetectiveFilled
   entities:
-  - uid: 438
+  - uid: 396
     components:
     - pos: 7.5,-6.5
       parent: 1
@@ -5285,7 +5061,7 @@ entities:
       type: EntityStorage
 - proto: LockerEvidence
   entities:
-  - uid: 32
+  - uid: 258
     components:
     - pos: 3.5,0.5
       parent: 1
@@ -5313,15 +5089,15 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 33
-          - 34
-          - 35
+          - 259
+          - 260
+          - 261
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
           ent: null
       type: ContainerContainer
-  - uid: 36
+  - uid: 262
     components:
     - pos: 3.5,-1.5
       parent: 1
@@ -5349,9 +5125,9 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 37
-          - 39
-          - 38
+          - 264
+          - 263
+          - 265
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -5359,25 +5135,25 @@ entities:
       type: ContainerContainer
 - proto: LockerSecurityFilled
   entities:
-  - uid: 439
+  - uid: 397
     components:
     - pos: 8.5,0.5
       parent: 1
       type: Transform
 - proto: LockerWardenFilled
   entities:
-  - uid: 440
+  - uid: 398
     components:
     - pos: 8.5,-1.5
       parent: 1
       type: Transform
 - proto: Matchbox
   entities:
-  - uid: 282
+  - uid: 232
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 275
+    - parent: 225
       type: Transform
     - storageUsed: 5
       type: Storage
@@ -5386,20 +5162,20 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 283
-          - 284
-          - 285
-          - 286
-          - 287
+          - 233
+          - 234
+          - 235
+          - 236
+          - 237
       type: ContainerContainer
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 297
+  - uid: 247
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 289
+    - parent: 239
       type: Transform
     - storageUsed: 5
       type: Storage
@@ -5408,104 +5184,104 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 298
-          - 299
-          - 300
-          - 301
-          - 302
+          - 248
+          - 249
+          - 250
+          - 251
+          - 252
       type: ContainerContainer
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: Matchstick
   entities:
-  - uid: 283
+  - uid: 233
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 282
+    - parent: 232
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 284
+  - uid: 234
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 282
+    - parent: 232
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 285
+  - uid: 235
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 282
+    - parent: 232
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 286
+  - uid: 236
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 282
+    - parent: 232
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 287
+  - uid: 237
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 282
+    - parent: 232
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 298
+  - uid: 248
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 297
+    - parent: 247
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 299
+  - uid: 249
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 297
+    - parent: 247
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 300
+  - uid: 250
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 297
+    - parent: 247
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 301
+  - uid: 251
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 297
+    - parent: 247
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 302
+  - uid: 252
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 297
+    - parent: 247
       type: Transform
     - canCollide: False
       type: Physics
 - proto: MedkitOxygenFilled
   entities:
-  - uid: 45
+  - uid: 37
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 40
+    - parent: 32
       type: Transform
     - storageUsed: 28
       type: Storage
@@ -5514,100 +5290,100 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 46
+          - 38
+          - 40
+          - 39
           - 48
+          - 41
+          - 42
+          - 43
+          - 44
+          - 45
+          - 46
           - 47
-          - 56
-          - 49
-          - 50
-          - 51
-          - 52
-          - 53
-          - 54
-          - 55
       type: ContainerContainer
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: MicroManipulatorStockPart
   entities:
-  - uid: 212
+  - uid: 204
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 209
+    - parent: 201
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 213
+  - uid: 205
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 209
+    - parent: 201
       type: Transform
     - canCollide: False
       type: Physics
 - proto: PillDexalin
   entities:
-  - uid: 49
+  - uid: 41
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 45
+    - parent: 37
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 50
+  - uid: 42
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 45
+    - parent: 37
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 51
+  - uid: 43
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 45
+    - parent: 37
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 52
+  - uid: 44
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 45
+    - parent: 37
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 53
+  - uid: 45
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 45
+    - parent: 37
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 54
+  - uid: 46
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 45
+    - parent: 37
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 55
+  - uid: 47
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 45
+    - parent: 37
       type: Transform
     - canCollide: False
       type: Physics
 - proto: PortableGeneratorPacman
   entities:
-  - uid: 173
+  - uid: 165
     components:
     - pos: 8.5,5.5
       parent: 1
@@ -5622,16 +5398,16 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 176
+          - 168
         machine_parts: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 175
-          - 174
+          - 167
+          - 166
       type: ContainerContainer
     - type: ItemCooldown
-  - uid: 177
+  - uid: 169
     components:
     - pos: 7.5,5.5
       parent: 1
@@ -5646,125 +5422,125 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 180
+          - 172
         machine_parts: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 179
-          - 178
+          - 171
+          - 170
       type: ContainerContainer
     - type: ItemCooldown
 - proto: PortableGeneratorPacmanMachineCircuitboard
   entities:
-  - uid: 176
+  - uid: 168
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 173
+    - parent: 165
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 180
+  - uid: 172
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 177
+    - parent: 169
       type: Transform
     - canCollide: False
       type: Physics
 - proto: PosterContrabandBorgFancy
   entities:
-  - uid: 441
+  - uid: 399
     components:
     - pos: -1.5,-3.5
       parent: 1
       type: Transform
 - proto: PosterContrabandDonutCorp
   entities:
-  - uid: 442
+  - uid: 400
     components:
     - pos: 3.5,-3.5
       parent: 1
       type: Transform
 - proto: PosterContrabandKosmicheskayaStantsiya
   entities:
-  - uid: 443
+  - uid: 401
     components:
     - pos: 4.5,-2.5
       parent: 1
       type: Transform
 - proto: PosterContrabandNuclearDeviceInformational
   entities:
-  - uid: 444
+  - uid: 402
     components:
     - pos: 1.5,-7.5
       parent: 1
       type: Transform
 - proto: PosterContrabandWehWatches
   entities:
-  - uid: 445
+  - uid: 403
     components:
     - pos: 1.5,6.5
       parent: 1
       type: Transform
 - proto: PosterLegit12Gauge
   entities:
-  - uid: 446
+  - uid: 404
     components:
     - pos: -1.5,2.5
       parent: 1
       type: Transform
 - proto: PosterLegitCarbonDioxide
   entities:
-  - uid: 447
+  - uid: 405
     components:
     - pos: 10.5,1.5
       parent: 1
       type: Transform
 - proto: PosterLegitEnlist
   entities:
-  - uid: 448
+  - uid: 406
     components:
     - pos: 8.5,3.5
       parent: 1
       type: Transform
 - proto: PosterLegitFruitBowl
   entities:
-  - uid: 449
+  - uid: 407
     components:
     - pos: 7.5,-7.5
       parent: 1
       type: Transform
 - proto: PosterLegitGetYourLEGS
   entities:
-  - uid: 450
+  - uid: 408
     components:
     - pos: 3.5,2.5
       parent: 1
       type: Transform
 - proto: PosterLegitLoveIan
   entities:
-  - uid: 451
+  - uid: 409
     components:
     - pos: 1.5,-3.5
       parent: 1
       type: Transform
-  - uid: 452
+  - uid: 410
     components:
     - pos: 6.5,-6.5
       parent: 1
       type: Transform
 - proto: PosterLegitPeriodicTable
   entities:
-  - uid: 453
+  - uid: 411
     components:
     - pos: 10.5,-2.5
       parent: 1
       type: Transform
 - proto: PosterLegitThereIsNoGasGiant
   entities:
-  - uid: 454
+  - uid: 412
     components:
     - pos: 1.5,2.5
       parent: 1
@@ -5789,7 +5565,7 @@ entities:
       type: Physics
 - proto: PowerCellRecharger
   entities:
-  - uid: 162
+  - uid: 154
     components:
     - pos: 9.5,-6.5
       parent: 1
@@ -5803,14 +5579,14 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 166
+          - 158
         machine_parts: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 164
-          - 165
-          - 163
+          - 156
+          - 157
+          - 155
       type: ContainerContainer
     - powerLoad: 0
       type: ApcPowerReceiver
@@ -5828,34 +5604,34 @@ entities:
       type: Physics
 - proto: Poweredlight
   entities:
-  - uid: 455
+  - uid: 413
     components:
     - pos: 3.5,0.5
       parent: 1
       type: Transform
-  - uid: 456
+  - uid: 414
     components:
     - rot: 3.141592653589793 rad
       pos: -3.5,-2.5
       parent: 1
       type: Transform
-  - uid: 457
+  - uid: 415
     components:
     - pos: 8.5,0.5
       parent: 1
       type: Transform
-  - uid: 458
+  - uid: 416
     components:
     - pos: -3.5,1.5
       parent: 1
       type: Transform
-  - uid: 459
+  - uid: 417
     components:
     - rot: 3.141592653589793 rad
       pos: 3.5,-1.5
       parent: 1
       type: Transform
-  - uid: 460
+  - uid: 418
     components:
     - rot: -1.5707963267948966 rad
       pos: 10.5,4.5
@@ -5863,7 +5639,7 @@ entities:
       type: Transform
 - proto: PoweredlightColoredRed
   entities:
-  - uid: 461
+  - uid: 419
     components:
     - rot: -1.5707963267948966 rad
       pos: 10.5,-5.5
@@ -5871,13 +5647,13 @@ entities:
       type: Transform
 - proto: PoweredlightLED
   entities:
-  - uid: 613
+  - uid: 420
     components:
     - rot: -1.5707963267948966 rad
       pos: 2.5,3.5
       parent: 1
       type: Transform
-  - uid: 614
+  - uid: 421
     components:
     - rot: -1.5707963267948966 rad
       pos: 2.5,-4.5
@@ -5885,11 +5661,11 @@ entities:
       type: Transform
 - proto: SheetGlass1
   entities:
-  - uid: 214
+  - uid: 206
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 209
+    - parent: 201
       type: Transform
     - count: 2
       type: Stack
@@ -5899,7 +5675,7 @@ entities:
       type: Physics
 - proto: SheetPlasma
   entities:
-  - uid: 462
+  - uid: 422
     components:
     - rot: 3.141592653589793 rad
       pos: 7.50222,4.459353
@@ -5907,7 +5683,7 @@ entities:
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 463
+  - uid: 423
     components:
     - rot: 3.141592653589793 rad
       pos: 7.517845,4.537478
@@ -5915,95 +5691,9 @@ entities:
       type: Transform
     - canCollide: False
       type: Physics
-- proto: SheetSteel1
-  entities:
-  - uid: 220
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 215
-      type: Transform
-    - size: 5
-      type: Item
-    - count: 5
-      type: Stack
-    - canCollide: False
-      type: Physics
-  - uid: 227
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 222
-      type: Transform
-    - size: 5
-      type: Item
-    - count: 5
-      type: Stack
-    - canCollide: False
-      type: Physics
-  - uid: 234
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 229
-      type: Transform
-    - size: 5
-      type: Item
-    - count: 5
-      type: Stack
-    - canCollide: False
-      type: Physics
-  - uid: 241
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 236
-      type: Transform
-    - size: 5
-      type: Item
-    - count: 5
-      type: Stack
-    - canCollide: False
-      type: Physics
-  - uid: 248
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 243
-      type: Transform
-    - size: 5
-      type: Item
-    - count: 5
-      type: Stack
-    - canCollide: False
-      type: Physics
-  - uid: 255
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 250
-      type: Transform
-    - size: 5
-      type: Item
-    - count: 5
-      type: Stack
-    - canCollide: False
-      type: Physics
-  - uid: 262
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 257
-      type: Transform
-    - size: 5
-      type: Item
-    - count: 5
-      type: Stack
-    - canCollide: False
-      type: Physics
 - proto: ShuttersNormalOpen
   entities:
-  - uid: 315
+  - uid: 273
     components:
     - pos: 6.5,-3.5
       parent: 1
@@ -6013,15 +5703,15 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 316
+          - 274
       type: ContainerContainer
     - address: 4AA5-F3B3
       receiveFrequency: 1280
       type: DeviceNetwork
     - links:
-      - 486
+      - 446
       type: DeviceLinkSink
-  - uid: 317
+  - uid: 275
     components:
     - rot: -1.5707963267948966 rad
       pos: 11.5,-1.5
@@ -6032,15 +5722,15 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 318
+          - 276
       type: ContainerContainer
     - address: 4967-8FDB
       receiveFrequency: 1280
       type: DeviceNetwork
     - links:
-      - 485
+      - 445
       type: DeviceLinkSink
-  - uid: 319
+  - uid: 277
     components:
     - rot: -1.5707963267948966 rad
       pos: 11.5,0.5
@@ -6051,15 +5741,15 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 320
+          - 278
       type: ContainerContainer
     - address: 7927-5FE5
       receiveFrequency: 1280
       type: DeviceNetwork
     - links:
-      - 485
+      - 445
       type: DeviceLinkSink
-  - uid: 321
+  - uid: 279
     components:
     - rot: -1.5707963267948966 rad
       pos: 11.5,-0.5
@@ -6070,130 +5760,130 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 322
+          - 280
       type: ContainerContainer
     - address: 2F67-D620
       receiveFrequency: 1280
       type: DeviceNetwork
     - links:
-      - 485
+      - 445
       type: DeviceLinkSink
 - proto: ShuttleConsoleCircuitboard
   entities:
-  - uid: 312
+  - uid: 270
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 311
+    - parent: 269
       type: Transform
     - canCollide: False
       type: Physics
 - proto: ShuttleWindow
   entities:
-  - uid: 464
+  - uid: 424
     components:
     - pos: 11.5,-6.5
       parent: 1
       type: Transform
-  - uid: 465
+  - uid: 425
     components:
     - pos: -3.5,2.5
       parent: 1
       type: Transform
-  - uid: 466
+  - uid: 426
     components:
     - rot: 3.141592653589793 rad
       pos: 7.5,0.5
       parent: 1
       type: Transform
-  - uid: 467
+  - uid: 427
     components:
     - rot: 3.141592653589793 rad
       pos: 7.5,-1.5
       parent: 1
       type: Transform
-  - uid: 468
+  - uid: 428
     components:
     - rot: -1.5707963267948966 rad
       pos: 11.5,0.5
       parent: 1
       type: Transform
-  - uid: 469
+  - uid: 429
     components:
     - rot: -1.5707963267948966 rad
       pos: 11.5,-0.5
       parent: 1
       type: Transform
-  - uid: 470
+  - uid: 430
     components:
     - rot: -1.5707963267948966 rad
       pos: 11.5,-1.5
       parent: 1
       type: Transform
-  - uid: 471
+  - uid: 431
     components:
     - pos: 11.5,-5.5
       parent: 1
       type: Transform
-  - uid: 472
+  - uid: 432
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,-4.5
       parent: 1
       type: Transform
-  - uid: 473
+  - uid: 433
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,-5.5
       parent: 1
       type: Transform
-  - uid: 474
+  - uid: 434
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,-6.5
       parent: 1
       type: Transform
-  - uid: 475
+  - uid: 435
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,3.5
       parent: 1
       type: Transform
-  - uid: 476
+  - uid: 436
     components:
     - rot: -1.5707963267948966 rad
       pos: 0.5,-6.5
       parent: 1
       type: Transform
-  - uid: 477
+  - uid: 437
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,5.5
       parent: 1
       type: Transform
-  - uid: 478
+  - uid: 438
     components:
     - rot: -1.5707963267948966 rad
       pos: 0.5,5.5
       parent: 1
       type: Transform
-  - uid: 479
+  - uid: 439
     components:
     - rot: -1.5707963267948966 rad
       pos: -3.5,-3.5
       parent: 1
       type: Transform
-  - uid: 480
+  - uid: 440
     components:
     - pos: -2.5,-3.5
       parent: 1
       type: Transform
-  - uid: 481
+  - uid: 441
     components:
     - pos: -2.5,2.5
       parent: 1
       type: Transform
-  - uid: 482
+  - uid: 442
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,4.5
@@ -6201,80 +5891,80 @@ entities:
       type: Transform
 - proto: SignalButton
   entities:
-  - uid: 483
+  - uid: 443
     components:
     - rot: 3.141592653589793 rad
       pos: 1.5,-2.5
       parent: 1
       type: Transform
     - linkedPorts:
-        79:
+        71:
         - Pressed: DoorBolt
       type: DeviceLinkSource
-  - uid: 484
+  - uid: 444
     components:
     - pos: 1.5,1.5
       parent: 1
       type: Transform
     - linkedPorts:
-        81:
+        73:
         - Pressed: DoorBolt
       type: DeviceLinkSource
-  - uid: 485
+  - uid: 445
     components:
     - rot: 1.5707963267948966 rad
       pos: 7.5,0.5
       parent: 1
       type: Transform
     - linkedPorts:
-        319:
+        277:
         - Pressed: Toggle
-        321:
+        279:
         - Pressed: Toggle
-        317:
+        275:
         - Pressed: Toggle
       type: DeviceLinkSource
-  - uid: 486
+  - uid: 446
     components:
     - pos: 8.5,-4.5
       parent: 1
       type: Transform
     - linkedPorts:
-        87:
+        79:
         - Pressed: DoorBolt
-        315:
+        273:
         - Pressed: Toggle
       type: DeviceLinkSource
-  - uid: 487
+  - uid: 447
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,-4.5
       parent: 1
       type: Transform
     - linkedPorts:
-        611:
+        571:
         - Pressed: DoorBolt
       type: DeviceLinkSource
-  - uid: 488
+  - uid: 448
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,3.5
       parent: 1
       type: Transform
     - linkedPorts:
-        610:
+        570:
         - Pressed: DoorBolt
       type: DeviceLinkSource
     - type: ItemCooldown
 - proto: SignBridge
   entities:
-  - uid: 489
+  - uid: 449
     components:
     - rot: 3.141592653589793 rad
       pos: 7.5,-1.5
       parent: 1
       type: Transform
-  - uid: 490
+  - uid: 450
     components:
     - rot: 3.141592653589793 rad
       pos: 7.5,0.5
@@ -6282,7 +5972,7 @@ entities:
       type: Transform
 - proto: SignConspiracyBoard
   entities:
-  - uid: 491
+  - uid: 451
     components:
     - rot: 3.141592653589793 rad
       pos: 8.5,-7.5
@@ -6290,26 +5980,26 @@ entities:
       type: Transform
 - proto: SignDirectionalBrig
   entities:
-  - uid: 492
+  - uid: 452
     components:
     - rot: 3.141592653589793 rad
       pos: 1.5,1.5
       parent: 1
       type: Transform
-  - uid: 493
+  - uid: 453
     components:
     - pos: 1.5,-2.5
       parent: 1
       type: Transform
 - proto: SignEngineering
   entities:
-  - uid: 494
+  - uid: 454
     components:
     - rot: 3.141592653589793 rad
       pos: 5.5,2.5
       parent: 1
       type: Transform
-  - uid: 495
+  - uid: 455
     components:
     - rot: 3.141592653589793 rad
       pos: 7.5,2.5
@@ -6317,27 +6007,27 @@ entities:
       type: Transform
 - proto: SignFlammableMed
   entities:
-  - uid: 496
+  - uid: 456
     components:
     - pos: 7.5,6.5
       parent: 1
       type: Transform
 - proto: SignGravity
   entities:
-  - uid: 497
+  - uid: 457
     components:
     - pos: 11.5,5.5
       parent: 1
       type: Transform
 - proto: SignSec
   entities:
-  - uid: 498
+  - uid: 458
     components:
     - rot: 3.141592653589793 rad
       pos: 7.5,-3.5
       parent: 1
       type: Transform
-  - uid: 499
+  - uid: 459
     components:
     - rot: 3.141592653589793 rad
       pos: 5.5,-3.5
@@ -6345,13 +6035,13 @@ entities:
       type: Transform
 - proto: SignShipDock
   entities:
-  - uid: 500
+  - uid: 460
     components:
     - rot: 3.141592653589793 rad
       pos: -3.5,-1.5
       parent: 1
       type: Transform
-  - uid: 501
+  - uid: 461
     components:
     - rot: 3.141592653589793 rad
       pos: -3.5,0.5
@@ -6359,59 +6049,59 @@ entities:
       type: Transform
 - proto: SMESBasic
   entities:
-  - uid: 502
+  - uid: 462
     components:
     - pos: 10.5,5.5
       parent: 1
       type: Transform
 - proto: SpawnPointDetective
   entities:
-  - uid: 503
+  - uid: 463
     components:
     - pos: 9.5,-5.5
       parent: 1
       type: Transform
 - proto: SpawnPointLatejoin
   entities:
-  - uid: 504
+  - uid: 464
     components:
     - pos: 2.5,-0.5
       parent: 1
       type: Transform
 - proto: SpawnPointSecurityOfficer
   entities:
-  - uid: 505
+  - uid: 465
     components:
     - pos: 7.5,4.5
       parent: 1
       type: Transform
 - proto: SpawnPointWarden
   entities:
-  - uid: 506
+  - uid: 466
     components:
     - pos: 1.5,-0.5
       parent: 1
       type: Transform
 - proto: StationRecordsComputerCircuitboard
   entities:
-  - uid: 314
+  - uid: 272
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 313
+    - parent: 271
       type: Transform
     - canCollide: False
       type: Physics
 - proto: SubstationBasic
   entities:
-  - uid: 507
+  - uid: 467
     components:
     - pos: 10.5,4.5
       parent: 1
       type: Transform
 - proto: SuitStorageSec
   entities:
-  - uid: 508
+  - uid: 468
     components:
     - pos: 9.5,-1.5
       parent: 1
@@ -6434,7 +6124,7 @@ entities:
         - 0
         - 0
       type: EntityStorage
-  - uid: 509
+  - uid: 469
     components:
     - pos: 10.5,-5.5
       parent: 1
@@ -6459,7 +6149,7 @@ entities:
       type: EntityStorage
 - proto: SuitStorageWarden
   entities:
-  - uid: 510
+  - uid: 470
     components:
     - pos: 0.5,-0.5
       parent: 1
@@ -6484,248 +6174,74 @@ entities:
       type: EntityStorage
 - proto: SyringeInaprovaline
   entities:
-  - uid: 56
+  - uid: 48
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 45
+    - parent: 37
       type: Transform
     - canCollide: False
       type: Physics
 - proto: TableWood
   entities:
-  - uid: 511
+  - uid: 471
     components:
     - pos: 9.5,0.5
       parent: 1
       type: Transform
-  - uid: 512
+  - uid: 472
     components:
     - pos: 9.5,-6.5
       parent: 1
       type: Transform
-  - uid: 513
+  - uid: 473
     components:
     - pos: 8.5,-6.5
       parent: 1
       type: Transform
 - proto: Thruster
   entities:
-  - uid: 215
+  - uid: 207
     components:
     - rot: 1.5707963267948966 rad
       pos: -1.5,-0.5
       parent: 1
       type: Transform
-    - containers:
-        machine_board: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 221
-        machine_parts: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 216
-          - 217
-          - 218
-          - 219
-          - 220
-      type: ContainerContainer
-  - uid: 222
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 0.5,-4.5
-      parent: 1
-      type: Transform
-    - containers:
-        machine_board: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 228
-        machine_parts: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 223
-          - 224
-          - 225
-          - 226
-          - 227
-      type: ContainerContainer
-  - uid: 229
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 0.5,3.5
-      parent: 1
-      type: Transform
-    - containers:
-        machine_board: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 235
-        machine_parts: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 230
-          - 231
-          - 232
-          - 233
-          - 234
-      type: ContainerContainer
-  - uid: 236
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 4.5,-3.5
-      parent: 1
-      type: Transform
-    - containers:
-        machine_board: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 242
-        machine_parts: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 237
-          - 238
-          - 239
-          - 240
-          - 241
-      type: ContainerContainer
-  - uid: 243
-    components:
-    - pos: 4.5,2.5
-      parent: 1
-      type: Transform
-    - containers:
-        machine_board: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 249
-        machine_parts: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 244
-          - 245
-          - 246
-          - 247
-          - 248
-      type: ContainerContainer
-  - uid: 250
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 8.5,-3.5
-      parent: 1
-      type: Transform
-    - enabled: False
-      type: Thruster
-    - containers:
-        machine_board: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 256
-        machine_parts: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 251
-          - 252
-          - 253
-          - 254
-          - 255
-      type: ContainerContainer
-  - uid: 257
+  - uid: 208
     components:
     - rot: -1.5707963267948966 rad
       pos: 8.5,2.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: Thruster
-    - containers:
-        machine_board: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 263
-        machine_parts: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 258
-          - 259
-          - 260
-          - 261
-          - 262
-      type: ContainerContainer
-- proto: ThrusterMachineCircuitboard
-  entities:
-  - uid: 221
+  - uid: 209
     components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 215
+    - rot: -1.5707963267948966 rad
+      pos: 8.5,-3.5
+      parent: 1
       type: Transform
-    - canCollide: False
-      type: Physics
-  - uid: 228
+  - uid: 210
     components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 222
+    - rot: 1.5707963267948966 rad
+      pos: 0.5,-4.5
+      parent: 1
       type: Transform
-    - canCollide: False
-      type: Physics
-  - uid: 235
+  - uid: 211
     components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 229
+    - rot: 3.141592653589793 rad
+      pos: 4.5,-3.5
+      parent: 1
       type: Transform
-    - canCollide: False
-      type: Physics
-  - uid: 242
+  - uid: 212
     components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 236
+    - rot: 1.5707963267948966 rad
+      pos: 0.5,3.5
+      parent: 1
       type: Transform
-    - canCollide: False
-      type: Physics
-  - uid: 249
+  - uid: 213
     components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 243
+    - pos: 4.5,2.5
+      parent: 1
       type: Transform
-    - canCollide: False
-      type: Physics
-  - uid: 256
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 250
-      type: Transform
-    - canCollide: False
-      type: Physics
-  - uid: 263
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 257
-      type: Transform
-    - canCollide: False
-      type: Physics
 - proto: ToolboxEmergencyFilled
   entities:
   - uid: 7
@@ -6753,575 +6269,575 @@ entities:
     - type: InsideEntityStorage
 - proto: VendingMachineBooze
   entities:
-  - uid: 58
+  - uid: 50
     components:
     - pos: 4.5,0.5
       parent: 1
       type: Transform
-    - actionEntity: 59
+    - actionEntity: 51
       type: VendingMachine
     - actions:
-      - 59
+      - 51
       type: Actions
     - type: ActionsContainer
     - containers:
         actions: !type:Container
           ents:
-          - 59
+          - 51
       type: ContainerContainer
 - proto: VendingMachineCigs
   entities:
-  - uid: 60
+  - uid: 52
     components:
     - pos: 4.5,-1.5
       parent: 1
       type: Transform
-    - actionEntity: 61
+    - actionEntity: 53
       type: VendingMachine
     - actions:
-      - 61
+      - 53
       type: Actions
     - type: ActionsContainer
     - containers:
         actions: !type:Container
           ents:
-          - 61
+          - 53
       type: ContainerContainer
 - proto: WallShuttle
   entities:
-  - uid: 514
+  - uid: 474
     components:
     - pos: 5.5,-5.5
       parent: 1
       type: Transform
-  - uid: 515
+  - uid: 475
     components:
     - rot: 1.5707963267948966 rad
       pos: 11.5,1.5
       parent: 1
       type: Transform
-  - uid: 516
+  - uid: 476
     components:
     - rot: -1.5707963267948966 rad
       pos: -1.5,0.5
       parent: 1
       type: Transform
-  - uid: 517
+  - uid: 477
     components:
     - rot: -1.5707963267948966 rad
       pos: -2.5,0.5
       parent: 1
       type: Transform
-  - uid: 518
+  - uid: 478
     components:
     - rot: -1.5707963267948966 rad
       pos: 1.5,-7.5
       parent: 1
       type: Transform
-  - uid: 519
+  - uid: 479
     components:
     - pos: 4.5,1.5
       parent: 1
       type: Transform
-  - uid: 520
+  - uid: 480
     components:
     - rot: 3.141592653589793 rad
       pos: 5.5,2.5
       parent: 1
       type: Transform
-  - uid: 521
+  - uid: 481
     components:
     - rot: 3.141592653589793 rad
       pos: 5.5,3.5
       parent: 1
       type: Transform
-  - uid: 522
+  - uid: 482
     components:
     - rot: -1.5707963267948966 rad
       pos: 7.5,2.5
       parent: 1
       type: Transform
-  - uid: 523
+  - uid: 483
     components:
     - pos: 7.5,1.5
       parent: 1
       type: Transform
-  - uid: 524
+  - uid: 484
     components:
     - pos: 8.5,1.5
       parent: 1
       type: Transform
-  - uid: 525
+  - uid: 485
     components:
     - pos: 9.5,1.5
       parent: 1
       type: Transform
-  - uid: 526
+  - uid: 486
     components:
     - pos: 10.5,1.5
       parent: 1
       type: Transform
-  - uid: 527
+  - uid: 487
     components:
     - rot: 1.5707963267948966 rad
       pos: 11.5,-2.5
       parent: 1
       type: Transform
-  - uid: 528
+  - uid: 488
     components:
     - rot: 1.5707963267948966 rad
       pos: 10.5,-2.5
       parent: 1
       type: Transform
-  - uid: 529
+  - uid: 489
     components:
     - rot: 1.5707963267948966 rad
       pos: 9.5,-2.5
       parent: 1
       type: Transform
-  - uid: 530
+  - uid: 490
     components:
     - rot: 1.5707963267948966 rad
       pos: 8.5,-2.5
       parent: 1
       type: Transform
-  - uid: 531
+  - uid: 491
     components:
     - rot: -1.5707963267948966 rad
       pos: 6.5,6.5
       parent: 1
       type: Transform
-  - uid: 532
+  - uid: 492
     components:
     - rot: 1.5707963267948966 rad
       pos: 7.5,-2.5
       parent: 1
       type: Transform
-  - uid: 533
+  - uid: 493
     components:
     - rot: -1.5707963267948966 rad
       pos: 7.5,-3.5
       parent: 1
       type: Transform
-  - uid: 534
+  - uid: 494
     components:
     - pos: 5.5,-4.5
       parent: 1
       type: Transform
-  - uid: 535
+  - uid: 495
     components:
     - rot: -1.5707963267948966 rad
       pos: 9.5,-4.5
       parent: 1
       type: Transform
-  - uid: 536
+  - uid: 496
     components:
     - rot: -1.5707963267948966 rad
       pos: 8.5,-4.5
       parent: 1
       type: Transform
-  - uid: 537
+  - uid: 497
     components:
     - rot: -1.5707963267948966 rad
       pos: 10.5,-4.5
       parent: 1
       type: Transform
-  - uid: 538
+  - uid: 498
     components:
     - rot: -1.5707963267948966 rad
       pos: 11.5,-4.5
       parent: 1
       type: Transform
-  - uid: 539
+  - uid: 499
     components:
     - rot: -1.5707963267948966 rad
       pos: 7.5,6.5
       parent: 1
       type: Transform
-  - uid: 540
+  - uid: 500
     components:
     - rot: -1.5707963267948966 rad
       pos: 8.5,6.5
       parent: 1
       type: Transform
-  - uid: 541
+  - uid: 501
     components:
     - rot: -1.5707963267948966 rad
       pos: 9.5,6.5
       parent: 1
       type: Transform
-  - uid: 542
+  - uid: 502
     components:
     - rot: -1.5707963267948966 rad
       pos: 10.5,6.5
       parent: 1
       type: Transform
-  - uid: 543
+  - uid: 503
     components:
     - rot: -1.5707963267948966 rad
       pos: 11.5,6.5
       parent: 1
       type: Transform
-  - uid: 544
+  - uid: 504
     components:
     - rot: 1.5707963267948966 rad
       pos: 5.5,-3.5
       parent: 1
       type: Transform
-  - uid: 545
+  - uid: 505
     components:
     - rot: -1.5707963267948966 rad
       pos: 4.5,-2.5
       parent: 1
       type: Transform
-  - uid: 546
+  - uid: 506
     components:
     - rot: -1.5707963267948966 rad
       pos: 2.5,-7.5
       parent: 1
       type: Transform
-  - uid: 547
+  - uid: 507
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,-7.5
       parent: 1
       type: Transform
-  - uid: 548
+  - uid: 508
     components:
     - rot: -1.5707963267948966 rad
       pos: -3.5,0.5
       parent: 1
       type: Transform
-  - uid: 549
+  - uid: 509
     components:
     - rot: -1.5707963267948966 rad
       pos: -0.5,2.5
       parent: 1
       type: Transform
-  - uid: 550
+  - uid: 510
     components:
     - pos: 8.5,3.5
       parent: 1
       type: Transform
-  - uid: 551
+  - uid: 511
     components:
     - pos: 9.5,3.5
       parent: 1
       type: Transform
-  - uid: 552
+  - uid: 512
     components:
     - pos: 10.5,3.5
       parent: 1
       type: Transform
-  - uid: 553
+  - uid: 513
     components:
     - pos: 11.5,3.5
       parent: 1
       type: Transform
-  - uid: 554
+  - uid: 514
     components:
     - rot: -1.5707963267948966 rad
       pos: 9.5,-7.5
       parent: 1
       type: Transform
-  - uid: 555
+  - uid: 515
     components:
     - rot: -1.5707963267948966 rad
       pos: 10.5,-7.5
       parent: 1
       type: Transform
-  - uid: 556
+  - uid: 516
     components:
     - rot: -1.5707963267948966 rad
       pos: 11.5,-7.5
       parent: 1
       type: Transform
-  - uid: 557
+  - uid: 517
     components:
     - rot: -1.5707963267948966 rad
       pos: 11.5,5.5
       parent: 1
       type: Transform
-  - uid: 558
+  - uid: 518
     components:
     - rot: -1.5707963267948966 rad
       pos: 11.5,4.5
       parent: 1
       type: Transform
-  - uid: 559
+  - uid: 519
     components:
     - rot: -1.5707963267948966 rad
       pos: 6.5,5.5
       parent: 1
       type: Transform
-  - uid: 560
+  - uid: 520
     components:
     - rot: -1.5707963267948966 rad
       pos: 8.5,-7.5
       parent: 1
       type: Transform
-  - uid: 561
+  - uid: 521
     components:
     - rot: -1.5707963267948966 rad
       pos: 7.5,-7.5
       parent: 1
       type: Transform
-  - uid: 562
+  - uid: 522
     components:
     - rot: -1.5707963267948966 rad
       pos: 6.5,-7.5
       parent: 1
       type: Transform
-  - uid: 563
+  - uid: 523
     components:
     - rot: -1.5707963267948966 rad
       pos: 6.5,-6.5
       parent: 1
       type: Transform
-  - uid: 564
+  - uid: 524
     components:
     - rot: -1.5707963267948966 rad
       pos: -1.5,2.5
       parent: 1
       type: Transform
-  - uid: 565
+  - uid: 525
     components:
     - rot: -1.5707963267948966 rad
       pos: -4.5,0.5
       parent: 1
       type: Transform
-  - uid: 566
+  - uid: 526
     components:
     - rot: -1.5707963267948966 rad
       pos: -4.5,2.5
       parent: 1
       type: Transform
-  - uid: 567
+  - uid: 527
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,2.5
       parent: 1
       type: Transform
-  - uid: 568
+  - uid: 528
     components:
     - rot: -1.5707963267948966 rad
       pos: -0.5,-0.5
       parent: 1
       type: Transform
-  - uid: 569
+  - uid: 529
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,-3.5
       parent: 1
       type: Transform
-  - uid: 570
+  - uid: 530
     components:
     - rot: 3.141592653589793 rad
       pos: 3.5,6.5
       parent: 1
       type: Transform
-  - uid: 571
+  - uid: 531
     components:
     - rot: 3.141592653589793 rad
       pos: 3.5,1.5
       parent: 1
       type: Transform
-  - uid: 572
+  - uid: 532
     components:
     - rot: 3.141592653589793 rad
       pos: 3.5,2.5
       parent: 1
       type: Transform
-  - uid: 573
+  - uid: 533
     components:
     - rot: 3.141592653589793 rad
       pos: 1.5,-4.5
       parent: 1
       type: Transform
-  - uid: 574
+  - uid: 534
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,-2.5
       parent: 1
       type: Transform
-  - uid: 575
+  - uid: 535
     components:
     - rot: -1.5707963267948966 rad
       pos: 1.5,-3.5
       parent: 1
       type: Transform
-  - uid: 576
+  - uid: 536
     components:
     - pos: 1.5,-2.5
       parent: 1
       type: Transform
-  - uid: 577
+  - uid: 537
     components:
     - rot: -1.5707963267948966 rad
       pos: 0.5,-7.5
       parent: 1
       type: Transform
-  - uid: 578
+  - uid: 538
     components:
     - rot: -1.5707963267948966 rad
       pos: 0.5,-5.5
       parent: 1
       type: Transform
-  - uid: 579
+  - uid: 539
     components:
     - rot: -1.5707963267948966 rad
       pos: 1.5,1.5
       parent: 1
       type: Transform
-  - uid: 580
+  - uid: 540
     components:
     - rot: -1.5707963267948966 rad
       pos: -1.5,-3.5
       parent: 1
       type: Transform
-  - uid: 581
+  - uid: 541
     components:
     - rot: -1.5707963267948966 rad
       pos: -0.5,-3.5
       parent: 1
       type: Transform
-  - uid: 582
+  - uid: 542
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,-3.5
       parent: 1
       type: Transform
-  - uid: 583
+  - uid: 543
     components:
     - rot: -1.5707963267948966 rad
       pos: -3.5,-1.5
       parent: 1
       type: Transform
-  - uid: 584
+  - uid: 544
     components:
     - rot: -1.5707963267948966 rad
       pos: -1.5,-1.5
       parent: 1
       type: Transform
-  - uid: 585
+  - uid: 545
     components:
     - rot: -1.5707963267948966 rad
       pos: -2.5,-1.5
       parent: 1
       type: Transform
-  - uid: 586
+  - uid: 546
     components:
     - rot: -1.5707963267948966 rad
       pos: -4.5,-1.5
       parent: 1
       type: Transform
-  - uid: 587
+  - uid: 547
     components:
     - rot: -1.5707963267948966 rad
       pos: -4.5,-3.5
       parent: 1
       type: Transform
-  - uid: 588
+  - uid: 548
     components:
     - rot: 3.141592653589793 rad
       pos: 1.5,6.5
       parent: 1
       type: Transform
-  - uid: 589
+  - uid: 549
     components:
     - rot: 3.141592653589793 rad
       pos: 2.5,6.5
       parent: 1
       type: Transform
-  - uid: 590
+  - uid: 550
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,6.5
       parent: 1
       type: Transform
-  - uid: 591
+  - uid: 551
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,4.5
       parent: 1
       type: Transform
-  - uid: 592
+  - uid: 552
     components:
     - rot: -1.5707963267948966 rad
       pos: 1.5,3.5
       parent: 1
       type: Transform
-  - uid: 593
+  - uid: 553
     components:
     - rot: -1.5707963267948966 rad
       pos: 1.5,2.5
       parent: 1
       type: Transform
-  - uid: 594
+  - uid: 554
     components:
     - pos: 5.5,5.5
       parent: 1
       type: Transform
-  - uid: 595
+  - uid: 555
     components:
     - pos: 5.5,4.5
       parent: 1
       type: Transform
-  - uid: 596
+  - uid: 556
     components:
     - pos: 5.5,-6.5
       parent: 1
       type: Transform
 - proto: WallShuttleDiagonal
   entities:
-  - uid: 597
+  - uid: 557
     components:
     - rot: 3.141592653589793 rad
       pos: 5.5,1.5
       parent: 1
       type: Transform
-  - uid: 598
+  - uid: 558
     components:
     - rot: 1.5707963267948966 rad
       pos: 7.5,-3.5
       parent: 1
       type: Transform
-  - uid: 599
+  - uid: 559
     components:
     - rot: -1.5707963267948966 rad
       pos: 5.5,-2.5
       parent: 1
       type: Transform
-  - uid: 600
+  - uid: 560
     components:
     - pos: 7.5,3.5
       parent: 1
       type: Transform
-  - uid: 601
+  - uid: 561
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,-1.5
       parent: 1
       type: Transform
-  - uid: 602
+  - uid: 562
     components:
     - rot: 3.141592653589793 rad
       pos: 1.5,-5.5
       parent: 1
       type: Transform
-  - uid: 603
+  - uid: 563
     components:
     - rot: -1.5707963267948966 rad
       pos: -0.5,0.5
       parent: 1
       type: Transform
-  - uid: 604
+  - uid: 564
     components:
     - rot: 1.5707963267948966 rad
       pos: 7.5,-4.5
       parent: 1
       type: Transform
-  - uid: 605
+  - uid: 565
     components:
     - rot: -1.5707963267948966 rad
       pos: 1.5,4.5
@@ -7329,7 +6845,7 @@ entities:
       type: Transform
 - proto: WallWeaponCapacitorRecharger
   entities:
-  - uid: 606
+  - uid: 566
     components:
     - pos: -0.5,-0.5
       parent: 1
@@ -7338,7 +6854,7 @@ entities:
       type: Charger
     - powerLoad: 0
       type: ApcPowerReceiver
-  - uid: 607
+  - uid: 567
     components:
     - pos: 8.5,1.5
       parent: 1
@@ -7347,7 +6863,7 @@ entities:
       type: Charger
     - powerLoad: 0
       type: ApcPowerReceiver
-  - uid: 608
+  - uid: 568
     components:
     - pos: 8.5,-2.5
       parent: 1
@@ -7358,14 +6874,14 @@ entities:
       type: ApcPowerReceiver
 - proto: WarpPointShip
   entities:
-  - uid: 609
+  - uid: 569
     components:
     - pos: 4.5,-0.5
       parent: 1
       type: Transform
 - proto: WeaponCapacitorRecharger
   entities:
-  - uid: 204
+  - uid: 196
     components:
     - pos: 8.5,-6.5
       parent: 1
@@ -7379,24 +6895,24 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 208
+          - 200
         machine_parts: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 206
-          - 207
-          - 205
+          - 198
+          - 199
+          - 197
       type: ContainerContainer
     - powerLoad: 0
       type: ApcPowerReceiver
 - proto: WeaponCapacitorRechargerCircuitboard
   entities:
-  - uid: 208
+  - uid: 200
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 204
+    - parent: 196
       type: Transform
     - canCollide: False
       type: Physics
@@ -7415,27 +6931,27 @@ entities:
     - type: InsideEntityStorage
 - proto: WindoorSecure
   entities:
-  - uid: 610
+  - uid: 570
     components:
     - pos: 2.5,4.5
       parent: 1
       type: Transform
     - invokeCounter: 2
       links:
-      - 488
+      - 448
       type: DeviceLinkSink
-  - uid: 611
+  - uid: 571
     components:
     - rot: 3.141592653589793 rad
       pos: 2.5,-5.5
       parent: 1
       type: Transform
     - links:
-      - 487
+      - 447
       type: DeviceLinkSink
 - proto: Wrench
   entities:
-  - uid: 612
+  - uid: 572
     components:
     - pos: 7.533099,4.573193
       parent: 1
@@ -7444,11 +6960,11 @@ entities:
       type: Physics
 - proto: XylophoneInstrument
   entities:
-  - uid: 288
+  - uid: 238
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 275
+    - parent: 225
       type: Transform
     - canCollide: False
       type: Physics

--- a/Resources/Maps/Shuttles/inquisitor.yml
+++ b/Resources/Maps/Shuttles/inquisitor.yml
@@ -3658,7 +3658,7 @@ entities:
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 416
+  - uid: 349
     components:
     - rot: 1.5707963267948966 rad
       pos: 2.5,-0.5
@@ -3668,7 +3668,7 @@ entities:
       type: AtmosPipeColor
 - proto: GasPipeBend
   entities:
-  - uid: 349
+  - uid: 350
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,-2.5
@@ -3676,14 +3676,14 @@ entities:
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 350
+  - uid: 351
     components:
     - pos: 2.5,5.5
       parent: 1
       type: Transform
     - color: '#FF00EEFF'
       type: AtmosPipeColor
-  - uid: 351
+  - uid: 352
     components:
     - rot: -1.5707963267948966 rad
       pos: 5.5,1.5
@@ -3691,7 +3691,7 @@ entities:
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 352
+  - uid: 353
     components:
     - rot: -1.5707963267948966 rad
       pos: 2.5,-6.5
@@ -3699,7 +3699,7 @@ entities:
       type: Transform
     - color: '#FF00EEFF'
       type: AtmosPipeColor
-  - uid: 353
+  - uid: 354
     components:
     - rot: 1.5707963267948966 rad
       pos: 4.5,1.5
@@ -3707,7 +3707,7 @@ entities:
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 354
+  - uid: 355
     components:
     - rot: -1.5707963267948966 rad
       pos: 4.5,-2.5
@@ -3715,7 +3715,7 @@ entities:
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 355
+  - uid: 356
     components:
     - rot: 3.141592653589793 rad
       pos: 2.5,0.5
@@ -3723,14 +3723,14 @@ entities:
       type: Transform
     - color: '#FF00EEFF'
       type: AtmosPipeColor
-  - uid: 356
+  - uid: 357
     components:
     - pos: 0.5,-0.5
       parent: 1
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 357
+  - uid: 358
     components:
     - rot: 1.5707963267948966 rad
       pos: 6.5,4.5
@@ -3738,7 +3738,7 @@ entities:
       type: Transform
     - color: '#FF00EEFF'
       type: AtmosPipeColor
-  - uid: 358
+  - uid: 359
     components:
     - rot: 3.141592653589793 rad
       pos: 6.5,-5.5
@@ -3746,14 +3746,14 @@ entities:
       type: Transform
     - color: '#FF00EEFF'
       type: AtmosPipeColor
-  - uid: 359
+  - uid: 360
     components:
     - pos: 8.5,-5.5
       parent: 1
       type: Transform
     - color: '#FF00EEFF'
       type: AtmosPipeColor
-  - uid: 360
+  - uid: 361
     components:
     - rot: 1.5707963267948966 rad
       pos: 2.5,-1.5
@@ -3761,17 +3761,9 @@ entities:
       type: Transform
     - color: '#FF00EEFF'
       type: AtmosPipeColor
-  - uid: 361
-    components:
-    - pos: 9.5,-0.5
-      parent: 1
-      type: Transform
-    - color: '#FF00EEFF'
-      type: AtmosPipeColor
   - uid: 362
     components:
-    - rot: 3.141592653589793 rad
-      pos: 8.5,-6.5
+    - pos: 9.5,-0.5
       parent: 1
       type: Transform
     - color: '#FF00EEFF'
@@ -3786,6 +3778,14 @@ entities:
       type: AtmosPipeColor
   - uid: 364
     components:
+    - rot: 3.141592653589793 rad
+      pos: 8.5,-6.5
+      parent: 1
+      type: Transform
+    - color: '#FF00EEFF'
+      type: AtmosPipeColor
+  - uid: 365
+    components:
     - rot: 1.5707963267948966 rad
       pos: 5.5,5.5
       parent: 1
@@ -3794,7 +3794,7 @@ entities:
       type: AtmosPipeColor
 - proto: GasPipeStraight
   entities:
-  - uid: 365
+  - uid: 366
     components:
     - rot: -1.5707963267948966 rad
       pos: -2.5,-0.5
@@ -3802,7 +3802,7 @@ entities:
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 366
+  - uid: 367
     components:
     - rot: -1.5707963267948966 rad
       pos: 6.5,5.5
@@ -3810,7 +3810,7 @@ entities:
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 367
+  - uid: 368
     components:
     - rot: -1.5707963267948966 rad
       pos: 5.5,0.5
@@ -3818,7 +3818,7 @@ entities:
       type: Transform
     - color: '#FF00EEFF'
       type: AtmosPipeColor
-  - uid: 368
+  - uid: 369
     components:
     - rot: 3.141592653589793 rad
       pos: 2.5,2.5
@@ -3826,21 +3826,21 @@ entities:
       type: Transform
     - color: '#FF00EEFF'
       type: AtmosPipeColor
-  - uid: 369
+  - uid: 370
     components:
     - pos: 6.5,-4.5
       parent: 1
       type: Transform
     - color: '#FF00EEFF'
       type: AtmosPipeColor
-  - uid: 370
+  - uid: 371
     components:
     - pos: 4.5,-1.5
       parent: 1
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 371
+  - uid: 372
     components:
     - rot: 1.5707963267948966 rad
       pos: 2.5,-2.5
@@ -3848,7 +3848,7 @@ entities:
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 372
+  - uid: 373
     components:
     - rot: 3.141592653589793 rad
       pos: 2.5,4.5
@@ -3856,7 +3856,7 @@ entities:
       type: Transform
     - color: '#FF00EEFF'
       type: AtmosPipeColor
-  - uid: 373
+  - uid: 374
     components:
     - rot: -1.5707963267948966 rad
       pos: 8.5,5.5
@@ -3864,7 +3864,7 @@ entities:
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 374
+  - uid: 375
     components:
     - rot: -1.5707963267948966 rad
       pos: 5.5,-1.5
@@ -3872,7 +3872,7 @@ entities:
       type: Transform
     - color: '#FF00EEFF'
       type: AtmosPipeColor
-  - uid: 375
+  - uid: 376
     components:
     - rot: 1.5707963267948966 rad
       pos: 1.5,-2.5
@@ -3880,7 +3880,7 @@ entities:
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 376
+  - uid: 377
     components:
     - rot: 1.5707963267948966 rad
       pos: 3.5,-2.5
@@ -3888,7 +3888,7 @@ entities:
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 377
+  - uid: 378
     components:
     - rot: 3.141592653589793 rad
       pos: 2.5,1.5
@@ -3896,7 +3896,7 @@ entities:
       type: Transform
     - color: '#FF00EEFF'
       type: AtmosPipeColor
-  - uid: 378
+  - uid: 379
     components:
     - rot: -1.5707963267948966 rad
       pos: 4.5,0.5
@@ -3904,7 +3904,7 @@ entities:
       type: Transform
     - color: '#FF00EEFF'
       type: AtmosPipeColor
-  - uid: 379
+  - uid: 380
     components:
     - rot: -1.5707963267948966 rad
       pos: 4.5,-1.5
@@ -3912,21 +3912,21 @@ entities:
       type: Transform
     - color: '#FF00EEFF'
       type: AtmosPipeColor
-  - uid: 380
+  - uid: 381
     components:
     - pos: 2.5,-2.5
       parent: 1
       type: Transform
     - color: '#FF00EEFF'
       type: AtmosPipeColor
-  - uid: 381
+  - uid: 382
     components:
     - pos: 2.5,-5.5
       parent: 1
       type: Transform
     - color: '#FF00EEFF'
       type: AtmosPipeColor
-  - uid: 382
+  - uid: 383
     components:
     - rot: -1.5707963267948966 rad
       pos: 7.5,5.5
@@ -3934,7 +3934,7 @@ entities:
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 383
+  - uid: 384
     components:
     - rot: 1.5707963267948966 rad
       pos: 7.5,-5.5
@@ -3942,14 +3942,14 @@ entities:
       type: Transform
     - color: '#FF00EEFF'
       type: AtmosPipeColor
-  - uid: 384
+  - uid: 385
     components:
     - pos: 6.5,-3.5
       parent: 1
       type: Transform
     - color: '#FF00EEFF'
       type: AtmosPipeColor
-  - uid: 385
+  - uid: 386
     components:
     - rot: -1.5707963267948966 rad
       pos: 7.5,-0.5
@@ -3957,7 +3957,7 @@ entities:
       type: Transform
     - color: '#FF00EEFF'
       type: AtmosPipeColor
-  - uid: 386
+  - uid: 387
     components:
     - rot: 1.5707963267948966 rad
       pos: 9.5,-6.5
@@ -3965,21 +3965,21 @@ entities:
       type: Transform
     - color: '#FF00EEFF'
       type: AtmosPipeColor
-  - uid: 387
+  - uid: 388
     components:
     - pos: 6.5,1.5
       parent: 1
       type: Transform
     - color: '#FF00EEFF'
       type: AtmosPipeColor
-  - uid: 388
+  - uid: 389
     components:
     - pos: 6.5,3.5
       parent: 1
       type: Transform
     - color: '#FF00EEFF'
       type: AtmosPipeColor
-  - uid: 389
+  - uid: 390
     components:
     - rot: -1.5707963267948966 rad
       pos: 9.5,5.5
@@ -3987,42 +3987,42 @@ entities:
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 390
+  - uid: 391
     components:
     - pos: 0.5,-1.5
       parent: 1
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 391
+  - uid: 392
     components:
     - pos: 5.5,2.5
       parent: 1
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 392
+  - uid: 393
     components:
     - pos: 5.5,3.5
       parent: 1
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 393
+  - uid: 394
     components:
     - pos: 2.5,-3.5
       parent: 1
       type: Transform
     - color: '#FF00EEFF'
       type: AtmosPipeColor
-  - uid: 394
+  - uid: 395
     components:
     - pos: 2.5,-4.5
       parent: 1
       type: Transform
     - color: '#FF00EEFF'
       type: AtmosPipeColor
-  - uid: 395
+  - uid: 396
     components:
     - rot: 3.141592653589793 rad
       pos: 2.5,3.5
@@ -4030,17 +4030,9 @@ entities:
       type: Transform
     - color: '#FF00EEFF'
       type: AtmosPipeColor
-  - uid: 396
-    components:
-    - pos: 6.5,-2.5
-      parent: 1
-      type: Transform
-    - color: '#FF00EEFF'
-      type: AtmosPipeColor
   - uid: 397
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 8.5,-0.5
+    - pos: 6.5,-2.5
       parent: 1
       type: Transform
     - color: '#FF00EEFF'
@@ -4048,7 +4040,7 @@ entities:
   - uid: 398
     components:
     - rot: -1.5707963267948966 rad
-      pos: 9.5,4.5
+      pos: 8.5,-0.5
       parent: 1
       type: Transform
     - color: '#FF00EEFF'
@@ -4056,7 +4048,7 @@ entities:
   - uid: 399
     components:
     - rot: -1.5707963267948966 rad
-      pos: 8.5,4.5
+      pos: 9.5,4.5
       parent: 1
       type: Transform
     - color: '#FF00EEFF'
@@ -4064,19 +4056,27 @@ entities:
   - uid: 400
     components:
     - rot: -1.5707963267948966 rad
+      pos: 8.5,4.5
+      parent: 1
+      type: Transform
+    - color: '#FF00EEFF'
+      type: AtmosPipeColor
+  - uid: 401
+    components:
+    - rot: -1.5707963267948966 rad
       pos: -3.5,-0.5
       parent: 1
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 401
+  - uid: 402
     components:
     - pos: 5.5,4.5
       parent: 1
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 402
+  - uid: 403
     components:
     - rot: -1.5707963267948966 rad
       pos: -1.5,-0.5
@@ -4084,14 +4084,14 @@ entities:
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 403
+  - uid: 404
     components:
     - pos: 6.5,2.5
       parent: 1
       type: Transform
     - color: '#FF00EEFF'
       type: AtmosPipeColor
-  - uid: 404
+  - uid: 405
     components:
     - rot: -1.5707963267948966 rad
       pos: -0.5,-0.5
@@ -4099,7 +4099,7 @@ entities:
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 405
+  - uid: 406
     components:
     - rot: -1.5707963267948966 rad
       pos: 7.5,4.5
@@ -4107,7 +4107,7 @@ entities:
       type: Transform
     - color: '#FF00EEFF'
       type: AtmosPipeColor
-  - uid: 406
+  - uid: 407
     components:
     - pos: 4.5,0.5
       parent: 1
@@ -4116,7 +4116,7 @@ entities:
       type: AtmosPipeColor
 - proto: GasPipeTJunction
   entities:
-  - uid: 407
+  - uid: 408
     components:
     - rot: -1.5707963267948966 rad
       pos: 6.5,-1.5
@@ -4124,14 +4124,14 @@ entities:
       type: Transform
     - color: '#FF00EEFF'
       type: AtmosPipeColor
-  - uid: 408
+  - uid: 409
     components:
     - pos: 3.5,0.5
       parent: 1
       type: Transform
     - color: '#FF00EEFF'
       type: AtmosPipeColor
-  - uid: 409
+  - uid: 410
     components:
     - rot: 1.5707963267948966 rad
       pos: 4.5,-0.5
@@ -4139,7 +4139,7 @@ entities:
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 410
+  - uid: 411
     components:
     - rot: -1.5707963267948966 rad
       pos: 6.5,0.5
@@ -4147,7 +4147,7 @@ entities:
       type: Transform
     - color: '#FF00EEFF'
       type: AtmosPipeColor
-  - uid: 411
+  - uid: 412
     components:
     - rot: 1.5707963267948966 rad
       pos: 6.5,-0.5
@@ -4155,7 +4155,7 @@ entities:
       type: Transform
     - color: '#FF00EEFF'
       type: AtmosPipeColor
-  - uid: 412
+  - uid: 413
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,-0.5
@@ -4163,7 +4163,7 @@ entities:
       type: Transform
     - color: '#FF00EEFF'
       type: AtmosPipeColor
-  - uid: 413
+  - uid: 414
     components:
     - rot: 3.141592653589793 rad
       pos: 3.5,-1.5
@@ -4173,7 +4173,7 @@ entities:
       type: AtmosPipeColor
 - proto: GasVentPump
   entities:
-  - uid: 414
+  - uid: 415
     components:
     - rot: -1.5707963267948966 rad
       pos: 10.5,-6.5
@@ -4181,7 +4181,7 @@ entities:
       type: Transform
     - color: '#FF00EEFF'
       type: AtmosPipeColor
-  - uid: 415
+  - uid: 416
     components:
     - rot: -1.5707963267948966 rad
       pos: 10.5,4.5
@@ -6450,6 +6450,27 @@ entities:
         321:
         - Pressed: Toggle
       type: DeviceLinkSource
+  - uid: 615
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 3.5,-4.5
+      parent: 1
+      type: Transform
+    - linkedPorts:
+        614:
+        - Pressed: DoorBolt
+      type: DeviceLinkSource
+  - uid: 616
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 3.5,3.5
+      parent: 1
+      type: Transform
+    - linkedPorts:
+        613:
+        - Pressed: DoorBolt
+      type: DeviceLinkSource
+    - type: ItemCooldown
 - proto: SignBridge
   entities:
   - uid: 491
@@ -7595,6 +7616,26 @@ entities:
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
+- proto: WindoorSecure
+  entities:
+  - uid: 613
+    components:
+    - pos: 2.5,4.5
+      parent: 1
+      type: Transform
+    - invokeCounter: 2
+      links:
+      - 616
+      type: DeviceLinkSink
+  - uid: 614
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 2.5,-5.5
+      parent: 1
+      type: Transform
+    - links:
+      - 615
+      type: DeviceLinkSink
 - proto: Wrench
   entities:
   - uid: 612

--- a/Resources/Maps/Shuttles/inquisitor.yml
+++ b/Resources/Maps/Shuttles/inquisitor.yml
@@ -249,22 +249,6 @@ entities:
       type: Transform
     - container: 24
       type: InstantAction
-  - uid: 35
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 34
-      type: Transform
-    - container: 34
-      type: InstantAction
-  - uid: 42
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 41
-      type: Transform
-    - container: 41
-      type: InstantAction
 - proto: ActionToggleSuitPiece
   entities:
   - uid: 18
@@ -276,62 +260,130 @@ entities:
     - container: 17
       entIcon: 19
       type: InstantAction
-  - uid: 48
+  - uid: 42
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 47
+    - parent: 41
       type: Transform
-    - container: 47
-      entIcon: 49
+    - container: 41
+      entIcon: 43
       type: InstantAction
 - proto: ActionVendingThrow
   entities:
-  - uid: 65
+  - uid: 59
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 64
+    - parent: 58
       type: Transform
-    - container: 64
+    - container: 58
       type: InstantAction
-  - uid: 67
+  - uid: 61
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 66
+    - parent: 60
       type: Transform
-    - container: 66
+    - container: 60
       type: InstantAction
 - proto: AirAlarm
   entities:
-  - uid: 68
+  - uid: 62
     components:
     - pos: 3.5,1.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 617
-      - 618
-      - 344
       - 342
-      - 619
+      - 343
+      - 338
+      - 336
+      - 344
+      - 334
       - 340
-      - 346
       address: AIR-07EE-EDC5
       transmitFrequency: 1621
       receiveFrequency: 1621
       type: DeviceNetwork
     - devices:
-      - 98
-      - 420
-      - 617
-      - 618
-      - 344
+      - 92
+      - 416
       - 342
-      - 619
+      - 343
+      - 338
+      - 336
+      - 344
+      - 334
       - 340
-      - 346
+      type: DeviceList
+    - containers:
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 63
+      type: ContainerContainer
+  - uid: 64
+    components:
+    - pos: 2.5,6.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 338
+      address: AIR-1C93-2EB9
+      transmitFrequency: 1621
+      receiveFrequency: 1621
+      type: DeviceNetwork
+    - devices:
+      - 91
+      - 338
+      type: DeviceList
+    - containers:
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 65
+      type: ContainerContainer
+  - uid: 66
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 2.5,-7.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 336
+      address: AIR-7F0A-41E3
+      transmitFrequency: 1621
+      receiveFrequency: 1621
+      type: DeviceNetwork
+    - devices:
+      - 90
+      - 336
+      type: DeviceList
+    - containers:
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 67
+      type: ContainerContainer
+  - uid: 68
+    components:
+    - pos: 10.5,6.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 344
+      address: AIR-0505-EB98
+      transmitFrequency: 1621
+      receiveFrequency: 1621
+      type: DeviceNetwork
+    - devices:
+      - 93
+      - 417
+      - 344
       type: DeviceList
     - containers:
         board: !type:Container
@@ -342,18 +394,19 @@ entities:
       type: ContainerContainer
   - uid: 70
     components:
-    - pos: 2.5,6.5
+    - rot: 3.141592653589793 rad
+      pos: 10.5,-7.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 344
-      address: AIR-1C93-2EB9
+      - 340
+      address: AIR-0AFD-90EF
       transmitFrequency: 1621
       receiveFrequency: 1621
       type: DeviceNetwork
     - devices:
-      - 97
-      - 344
+      - 94
+      - 340
       type: DeviceList
     - containers:
         board: !type:Container
@@ -364,19 +417,18 @@ entities:
       type: ContainerContainer
   - uid: 72
     components:
-    - rot: 3.141592653589793 rad
-      pos: 2.5,-7.5
+    - pos: 9.5,1.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 342
-      address: AIR-7F0A-41E3
+      - 334
+      address: AIR-1775-A352
       transmitFrequency: 1621
       receiveFrequency: 1621
       type: DeviceNetwork
     - devices:
-      - 96
-      - 342
+      - 89
+      - 334
       type: DeviceList
     - containers:
         board: !type:Container
@@ -385,76 +437,32 @@ entities:
           ents:
           - 73
       type: ContainerContainer
-  - uid: 74
-    components:
-    - pos: 10.5,6.5
-      parent: 1
-      type: Transform
-    - ShutdownSubscribers:
-      - 619
-      address: AIR-0505-EB98
-      transmitFrequency: 1621
-      receiveFrequency: 1621
-      type: DeviceNetwork
-    - devices:
-      - 99
-      - 421
-      - 619
-      type: DeviceList
-    - containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 75
-      type: ContainerContainer
-  - uid: 76
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 10.5,-7.5
-      parent: 1
-      type: Transform
-    - ShutdownSubscribers:
-      - 346
-      address: AIR-0AFD-90EF
-      transmitFrequency: 1621
-      receiveFrequency: 1621
-      type: DeviceNetwork
-    - devices:
-      - 100
-      - 346
-      type: DeviceList
-    - containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 77
-      type: ContainerContainer
-  - uid: 78
-    components:
-    - pos: 9.5,1.5
-      parent: 1
-      type: Transform
-    - ShutdownSubscribers:
-      - 340
-      address: AIR-1775-A352
-      transmitFrequency: 1621
-      receiveFrequency: 1621
-      type: DeviceNetwork
-    - devices:
-      - 95
-      - 340
-      type: DeviceList
-    - containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 79
-      type: ContainerContainer
 - proto: AirAlarmElectronics
   entities:
+  - uid: 63
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 62
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 65
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 64
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 67
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 66
+      type: Transform
+    - canCollide: False
+      type: Physics
   - uid: 69
     components:
     - flags: InContainer
@@ -479,40 +487,16 @@ entities:
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 75
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 74
-      type: Transform
-    - canCollide: False
-      type: Physics
-  - uid: 77
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 76
-      type: Transform
-    - canCollide: False
-      type: Physics
-  - uid: 79
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 78
-      type: Transform
-    - canCollide: False
-      type: Physics
 - proto: AirCanister
   entities:
-  - uid: 80
+  - uid: 74
     components:
     - pos: 8.5,4.5
       parent: 1
       type: Transform
 - proto: AirlockCommandGlass
   entities:
-  - uid: 81
+  - uid: 75
     components:
     - pos: 7.5,-0.5
       parent: 1
@@ -527,14 +511,14 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 82
+          - 76
       type: ContainerContainer
     - address: 15BA-7CDD
       receiveFrequency: 1280
       type: DeviceNetwork
 - proto: AirlockEngineeringGlass
   entities:
-  - uid: 83
+  - uid: 77
     components:
     - pos: 6.5,2.5
       parent: 1
@@ -544,14 +528,14 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 84
+          - 78
       type: ContainerContainer
     - address: 43F1-6C63
       receiveFrequency: 1280
       type: DeviceNetwork
 - proto: AirlockGlass
   entities:
-  - uid: 85
+  - uid: 79
     components:
     - rot: -1.5707963267948966 rad
       pos: 2.5,-2.5
@@ -562,15 +546,15 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 86
+          - 80
       type: ContainerContainer
     - address: 3497-4A2F
       receiveFrequency: 1280
       type: DeviceNetwork
     - links:
-      - 487
+      - 483
       type: DeviceLinkSink
-  - uid: 87
+  - uid: 81
     components:
     - rot: -1.5707963267948966 rad
       pos: 2.5,1.5
@@ -581,17 +565,17 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 88
+          - 82
       type: ContainerContainer
     - address: 4413-8EE1
       receiveFrequency: 1280
       type: DeviceNetwork
     - links:
-      - 488
+      - 484
       type: DeviceLinkSink
 - proto: AirlockGlassShuttle
   entities:
-  - uid: 89
+  - uid: 83
     components:
     - rot: -1.5707963267948966 rad
       pos: -4.5,-2.5
@@ -602,12 +586,12 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 90
+          - 84
       type: ContainerContainer
     - address: 2960-D1C2
       receiveFrequency: 1280
       type: DeviceNetwork
-  - uid: 91
+  - uid: 85
     components:
     - rot: -1.5707963267948966 rad
       pos: -4.5,1.5
@@ -618,7 +602,7 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 92
+          - 86
       type: ContainerContainer
     - address: 6C41-C2AE
       receiveFrequency: 1280
@@ -630,7 +614,7 @@ entities:
       type: Forensics
 - proto: AirlockSecurityGlass
   entities:
-  - uid: 93
+  - uid: 87
     components:
     - pos: 6.5,-3.5
       parent: 1
@@ -640,17 +624,17 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 94
+          - 88
       type: ContainerContainer
     - address: 3C12-27EA
       receiveFrequency: 1280
       type: DeviceNetwork
     - links:
-      - 490
+      - 486
       type: DeviceLinkSink
 - proto: AirSensor
   entities:
-  - uid: 95
+  - uid: 89
     components:
     - pos: 9.5,-0.5
       parent: 1
@@ -817,7 +801,7 @@ entities:
           enabled: True
         ignore: False
       type: AtmosMonitor
-  - uid: 96
+  - uid: 90
     components:
     - pos: 2.5,-6.5
       parent: 1
@@ -986,7 +970,7 @@ entities:
           enabled: True
         ignore: False
       type: AtmosMonitor
-  - uid: 97
+  - uid: 91
     components:
     - pos: 2.5,5.5
       parent: 1
@@ -1155,7 +1139,7 @@ entities:
           enabled: True
         ignore: False
       type: AtmosMonitor
-  - uid: 98
+  - uid: 92
     components:
     - pos: 3.5,-0.5
       parent: 1
@@ -1324,7 +1308,7 @@ entities:
           enabled: True
         ignore: False
       type: AtmosMonitor
-  - uid: 99
+  - uid: 93
     components:
     - pos: 7.5,4.5
       parent: 1
@@ -1494,7 +1478,7 @@ entities:
           enabled: True
         ignore: False
       type: AtmosMonitor
-  - uid: 100
+  - uid: 94
     components:
     - pos: 7.5,-5.5
       parent: 1
@@ -1663,7 +1647,7 @@ entities:
       type: AtmosMonitor
 - proto: APCBasic
   entities:
-  - uid: 101
+  - uid: 95
     components:
     - pos: 9.5,6.5
       parent: 1
@@ -1673,7 +1657,7 @@ entities:
     - hasAccess: True
       lastChargeState: Charging
       type: Apc
-  - uid: 102
+  - uid: 96
     components:
     - rot: 3.141592653589793 rad
       pos: 9.5,-2.5
@@ -1684,7 +1668,7 @@ entities:
     - hasAccess: True
       lastChargeState: Full
       type: Apc
-  - uid: 103
+  - uid: 97
     components:
     - pos: 4.5,1.5
       parent: 1
@@ -1695,13 +1679,13 @@ entities:
       type: Apc
 - proto: AtmosDeviceFanTiny
   entities:
-  - uid: 104
+  - uid: 98
     components:
     - rot: 1.5707963267948966 rad
       pos: -4.5,1.5
       parent: 1
       type: Transform
-  - uid: 105
+  - uid: 99
     components:
     - rot: 1.5707963267948966 rad
       pos: -4.5,-2.5
@@ -1709,7 +1693,7 @@ entities:
       type: Transform
 - proto: BarSign
   entities:
-  - uid: 106
+  - uid: 100
     components:
     - desc: Anteriormente ubicado en Spessmerica.
       name: Zocalo
@@ -1721,26 +1705,26 @@ entities:
       type: BarSign
 - proto: Bed
   entities:
-  - uid: 107
+  - uid: 101
     components:
     - pos: 1.5,5.5
       parent: 1
       type: Transform
-  - uid: 108
+  - uid: 102
     components:
     - pos: 1.5,-6.5
       parent: 1
       type: Transform
 - proto: BedsheetBlack
   entities:
-  - uid: 109
+  - uid: 103
     components:
     - pos: 1.5,5.5
       parent: 1
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 110
+  - uid: 104
     components:
     - pos: 1.5,-6.5
       parent: 1
@@ -1749,32 +1733,32 @@ entities:
       type: Physics
 - proto: CableApcExtension
   entities:
-  - uid: 111
+  - uid: 105
     components:
     - pos: -3.5,1.5
       parent: 1
       type: Transform
-  - uid: 112
+  - uid: 106
     components:
     - pos: -4.5,1.5
       parent: 1
       type: Transform
-  - uid: 113
+  - uid: 107
     components:
     - pos: -2.5,1.5
       parent: 1
       type: Transform
-  - uid: 114
+  - uid: 108
     components:
     - pos: -4.5,-2.5
       parent: 1
       type: Transform
-  - uid: 115
+  - uid: 109
     components:
     - pos: -2.5,1.5
       parent: 1
       type: Transform
-  - uid: 116
+  - uid: 110
     components:
     - pos: -1.5,1.5
       parent: 1
@@ -1784,268 +1768,268 @@ entities:
       - black insulative fibers
       fingerprints: []
       type: Forensics
-  - uid: 117
+  - uid: 111
     components:
     - pos: 1.5,0.5
       parent: 1
       type: Transform
-  - uid: 118
+  - uid: 112
     components:
     - pos: 0.5,1.5
       parent: 1
       type: Transform
-  - uid: 119
+  - uid: 113
     components:
     - pos: -0.5,1.5
       parent: 1
       type: Transform
-  - uid: 120
+  - uid: 114
     components:
     - pos: 0.5,0.5
       parent: 1
       type: Transform
-  - uid: 121
+  - uid: 115
     components:
     - pos: 2.5,-5.5
       parent: 1
       type: Transform
-  - uid: 122
+  - uid: 116
     components:
     - pos: 9.5,6.5
       parent: 1
       type: Transform
-  - uid: 123
+  - uid: 117
     components:
     - pos: 9.5,5.5
       parent: 1
       type: Transform
-  - uid: 124
+  - uid: 118
     components:
     - pos: 9.5,4.5
       parent: 1
       type: Transform
-  - uid: 125
+  - uid: 119
     components:
     - pos: 8.5,4.5
       parent: 1
       type: Transform
-  - uid: 126
+  - uid: 120
     components:
     - pos: 7.5,4.5
       parent: 1
       type: Transform
-  - uid: 127
+  - uid: 121
     components:
     - pos: 6.5,-2.5
       parent: 1
       type: Transform
-  - uid: 128
+  - uid: 122
     components:
     - pos: 4.5,1.5
       parent: 1
       type: Transform
-  - uid: 129
+  - uid: 123
     components:
     - pos: 4.5,0.5
       parent: 1
       type: Transform
-  - uid: 130
+  - uid: 124
     components:
     - pos: 3.5,-0.5
       parent: 1
       type: Transform
-  - uid: 131
+  - uid: 125
     components:
     - pos: 2.5,-0.5
       parent: 1
       type: Transform
-  - uid: 132
+  - uid: 126
     components:
     - pos: 0.5,-1.5
       parent: 1
       type: Transform
-  - uid: 133
+  - uid: 127
     components:
     - pos: 1.5,-1.5
       parent: 1
       type: Transform
-  - uid: 134
+  - uid: 128
     components:
     - pos: -0.5,-2.5
       parent: 1
       type: Transform
-  - uid: 135
+  - uid: 129
     components:
     - pos: 0.5,-2.5
       parent: 1
       type: Transform
-  - uid: 136
+  - uid: 130
     components:
     - pos: -1.5,-2.5
       parent: 1
       type: Transform
-  - uid: 137
+  - uid: 131
     components:
     - pos: -2.5,-2.5
       parent: 1
       type: Transform
-  - uid: 138
+  - uid: 132
     components:
     - pos: -1.5,-2.5
       parent: 1
       type: Transform
-  - uid: 139
+  - uid: 133
     components:
     - pos: -2.5,-2.5
       parent: 1
       type: Transform
-  - uid: 140
+  - uid: 134
     components:
     - pos: -3.5,-2.5
       parent: 1
       type: Transform
-  - uid: 141
+  - uid: 135
     components:
     - pos: 4.5,-0.5
       parent: 1
       type: Transform
-  - uid: 142
+  - uid: 136
     components:
     - pos: 7.5,-0.5
       parent: 1
       type: Transform
-  - uid: 143
+  - uid: 137
     components:
     - pos: 6.5,-0.5
       parent: 1
       type: Transform
-  - uid: 144
+  - uid: 138
     components:
     - pos: 6.5,-3.5
       parent: 1
       type: Transform
-  - uid: 145
+  - uid: 139
     components:
     - pos: 8.5,-0.5
       parent: 1
       type: Transform
-  - uid: 146
+  - uid: 140
     components:
     - pos: 6.5,-4.5
       parent: 1
       type: Transform
-  - uid: 147
+  - uid: 141
     components:
     - pos: 7.5,-4.5
       parent: 1
       type: Transform
-  - uid: 148
+  - uid: 142
     components:
     - pos: 7.5,-5.5
       parent: 1
       type: Transform
-  - uid: 149
+  - uid: 143
     components:
     - pos: 8.5,-5.5
       parent: 1
       type: Transform
-  - uid: 150
+  - uid: 144
     components:
     - pos: 9.5,-2.5
       parent: 1
       type: Transform
-  - uid: 151
+  - uid: 145
     components:
     - pos: 9.5,-1.5
       parent: 1
       type: Transform
-  - uid: 152
+  - uid: 146
     components:
     - pos: 9.5,-0.5
       parent: 1
       type: Transform
-  - uid: 153
+  - uid: 147
     components:
     - pos: 9.5,-5.5
       parent: 1
       type: Transform
-  - uid: 154
+  - uid: 148
     components:
     - pos: 10.5,-5.5
       parent: 1
       type: Transform
-  - uid: 155
+  - uid: 149
     components:
     - pos: 2.5,-1.5
       parent: 1
       type: Transform
-  - uid: 156
+  - uid: 150
     components:
     - pos: 2.5,-2.5
       parent: 1
       type: Transform
-  - uid: 157
+  - uid: 151
     components:
     - pos: 2.5,-3.5
       parent: 1
       type: Transform
-  - uid: 158
+  - uid: 152
     components:
     - pos: 2.5,-4.5
       parent: 1
       type: Transform
-  - uid: 159
+  - uid: 153
     components:
     - pos: 2.5,-6.5
       parent: 1
       type: Transform
-  - uid: 160
+  - uid: 154
     components:
     - pos: 2.5,0.5
       parent: 1
       type: Transform
-  - uid: 161
+  - uid: 155
     components:
     - pos: 2.5,1.5
       parent: 1
       type: Transform
-  - uid: 162
+  - uid: 156
     components:
     - pos: 2.5,2.5
       parent: 1
       type: Transform
-  - uid: 163
+  - uid: 157
     components:
     - pos: 2.5,3.5
       parent: 1
       type: Transform
-  - uid: 164
+  - uid: 158
     components:
     - pos: 2.5,3.5
       parent: 1
       type: Transform
-  - uid: 165
+  - uid: 159
     components:
     - pos: 2.5,4.5
       parent: 1
       type: Transform
-  - uid: 166
+  - uid: 160
     components:
     - pos: 2.5,5.5
       parent: 1
       type: Transform
-  - uid: 167
+  - uid: 161
     components:
     - pos: 6.5,-1.5
       parent: 1
       type: Transform
 - proto: CableApcStack1
   entities:
-  - uid: 169
+  - uid: 163
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 168
+    - parent: 162
       type: Transform
     - count: 5
       type: Stack
@@ -2055,43 +2039,43 @@ entities:
       type: Physics
 - proto: CableHV
   entities:
-  - uid: 173
+  - uid: 167
     components:
     - pos: 8.5,5.5
       parent: 1
       type: Transform
-  - uid: 174
+  - uid: 168
     components:
     - pos: 8.5,4.5
       parent: 1
       type: Transform
-  - uid: 175
+  - uid: 169
     components:
     - pos: 9.5,4.5
       parent: 1
       type: Transform
-  - uid: 176
+  - uid: 170
     components:
     - pos: 10.5,4.5
       parent: 1
       type: Transform
-  - uid: 177
+  - uid: 171
     components:
     - pos: 10.5,5.5
       parent: 1
       type: Transform
-  - uid: 178
+  - uid: 172
     components:
     - pos: 7.5,5.5
       parent: 1
       type: Transform
 - proto: CableHVStack1
   entities:
-  - uid: 180
+  - uid: 174
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 179
+    - parent: 173
       type: Transform
     - count: 5
       type: Stack
@@ -2099,11 +2083,11 @@ entities:
       type: Item
     - canCollide: False
       type: Physics
-  - uid: 184
+  - uid: 178
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 183
+    - parent: 177
       type: Transform
     - count: 5
       type: Stack
@@ -2113,128 +2097,128 @@ entities:
       type: Physics
 - proto: CableMV
   entities:
-  - uid: 187
+  - uid: 181
     components:
     - pos: 10.5,4.5
       parent: 1
       type: Transform
-  - uid: 188
+  - uid: 182
     components:
     - pos: 9.5,4.5
       parent: 1
       type: Transform
-  - uid: 189
+  - uid: 183
     components:
     - pos: 9.5,5.5
       parent: 1
       type: Transform
-  - uid: 190
+  - uid: 184
     components:
     - pos: 9.5,6.5
       parent: 1
       type: Transform
-  - uid: 191
+  - uid: 185
     components:
     - pos: 9.5,4.5
       parent: 1
       type: Transform
-  - uid: 192
+  - uid: 186
     components:
     - pos: 10.5,4.5
       parent: 1
       type: Transform
-  - uid: 193
+  - uid: 187
     components:
     - pos: 9.5,4.5
       parent: 1
       type: Transform
-  - uid: 194
+  - uid: 188
     components:
     - pos: 8.5,4.5
       parent: 1
       type: Transform
-  - uid: 195
+  - uid: 189
     components:
     - pos: 7.5,4.5
       parent: 1
       type: Transform
-  - uid: 196
+  - uid: 190
     components:
     - pos: 7.5,3.5
       parent: 1
       type: Transform
-  - uid: 197
+  - uid: 191
     components:
     - pos: 6.5,3.5
       parent: 1
       type: Transform
-  - uid: 198
+  - uid: 192
     components:
     - pos: 6.5,2.5
       parent: 1
       type: Transform
-  - uid: 199
+  - uid: 193
     components:
     - pos: 6.5,1.5
       parent: 1
       type: Transform
-  - uid: 200
+  - uid: 194
     components:
     - pos: 6.5,0.5
       parent: 1
       type: Transform
-  - uid: 201
+  - uid: 195
     components:
     - pos: 4.5,0.5
       parent: 1
       type: Transform
-  - uid: 202
+  - uid: 196
     components:
     - pos: 6.5,-0.5
       parent: 1
       type: Transform
-  - uid: 203
+  - uid: 197
     components:
     - pos: 7.5,-0.5
       parent: 1
       type: Transform
-  - uid: 204
+  - uid: 198
     components:
     - pos: 8.5,-0.5
       parent: 1
       type: Transform
-  - uid: 205
+  - uid: 199
     components:
     - pos: 9.5,-0.5
       parent: 1
       type: Transform
-  - uid: 206
+  - uid: 200
     components:
     - pos: 9.5,-1.5
       parent: 1
       type: Transform
-  - uid: 207
+  - uid: 201
     components:
     - pos: 9.5,-2.5
       parent: 1
       type: Transform
-  - uid: 208
+  - uid: 202
     components:
     - pos: 4.5,1.5
       parent: 1
       type: Transform
-  - uid: 209
+  - uid: 203
     components:
     - pos: 5.5,0.5
       parent: 1
       type: Transform
 - proto: CableMVStack1
   entities:
-  - uid: 211
+  - uid: 205
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 210
+    - parent: 204
       type: Transform
     - count: 5
       type: Stack
@@ -2244,51 +2228,59 @@ entities:
       type: Physics
 - proto: CapacitorStockPart
   entities:
-  - uid: 170
+  - uid: 164
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 168
+    - parent: 162
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 171
+  - uid: 165
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 168
+    - parent: 162
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 181
+  - uid: 175
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 179
+    - parent: 173
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 185
+  - uid: 179
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 183
+    - parent: 177
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 212
+  - uid: 206
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 210
+    - parent: 204
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 213
+  - uid: 207
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 210
+    - parent: 204
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 210
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 209
       type: Transform
     - canCollide: False
       type: Physics
@@ -2300,11 +2292,27 @@ entities:
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 222
+  - uid: 217
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 221
+    - parent: 215
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 218
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 215
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 219
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 215
       type: Transform
     - canCollide: False
       type: Physics
@@ -2312,7 +2320,7 @@ entities:
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 221
+    - parent: 222
       type: Transform
     - canCollide: False
       type: Physics
@@ -2320,7 +2328,7 @@ entities:
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 221
+    - parent: 222
       type: Transform
     - canCollide: False
       type: Physics
@@ -2328,15 +2336,15 @@ entities:
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 221
+    - parent: 222
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 229
+  - uid: 226
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 228
+    - parent: 222
       type: Transform
     - canCollide: False
       type: Physics
@@ -2344,7 +2352,7 @@ entities:
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 228
+    - parent: 229
       type: Transform
     - canCollide: False
       type: Physics
@@ -2352,7 +2360,7 @@ entities:
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 228
+    - parent: 229
       type: Transform
     - canCollide: False
       type: Physics
@@ -2360,15 +2368,15 @@ entities:
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 228
+    - parent: 229
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 236
+  - uid: 233
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 235
+    - parent: 229
       type: Transform
     - canCollide: False
       type: Physics
@@ -2376,7 +2384,7 @@ entities:
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 235
+    - parent: 236
       type: Transform
     - canCollide: False
       type: Physics
@@ -2384,7 +2392,7 @@ entities:
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 235
+    - parent: 236
       type: Transform
     - canCollide: False
       type: Physics
@@ -2392,15 +2400,15 @@ entities:
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 235
+    - parent: 236
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 243
+  - uid: 240
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 242
+    - parent: 236
       type: Transform
     - canCollide: False
       type: Physics
@@ -2408,7 +2416,7 @@ entities:
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 242
+    - parent: 243
       type: Transform
     - canCollide: False
       type: Physics
@@ -2416,7 +2424,7 @@ entities:
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 242
+    - parent: 243
       type: Transform
     - canCollide: False
       type: Physics
@@ -2424,15 +2432,15 @@ entities:
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 242
+    - parent: 243
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 250
+  - uid: 247
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 249
+    - parent: 243
       type: Transform
     - canCollide: False
       type: Physics
@@ -2440,7 +2448,7 @@ entities:
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 249
+    - parent: 250
       type: Transform
     - canCollide: False
       type: Physics
@@ -2448,7 +2456,7 @@ entities:
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 249
+    - parent: 250
       type: Transform
     - canCollide: False
       type: Physics
@@ -2456,15 +2464,15 @@ entities:
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 249
+    - parent: 250
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 257
+  - uid: 254
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 256
+    - parent: 250
       type: Transform
     - canCollide: False
       type: Physics
@@ -2472,7 +2480,7 @@ entities:
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 256
+    - parent: 257
       type: Transform
     - canCollide: False
       type: Physics
@@ -2480,7 +2488,7 @@ entities:
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 256
+    - parent: 257
       type: Transform
     - canCollide: False
       type: Physics
@@ -2488,112 +2496,88 @@ entities:
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 256
+    - parent: 257
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 264
+  - uid: 261
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 263
-      type: Transform
-    - canCollide: False
-      type: Physics
-  - uid: 265
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 263
-      type: Transform
-    - canCollide: False
-      type: Physics
-  - uid: 266
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 263
-      type: Transform
-    - canCollide: False
-      type: Physics
-  - uid: 267
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 263
+    - parent: 257
       type: Transform
     - canCollide: False
       type: Physics
 - proto: Catwalk
   entities:
-  - uid: 270
+  - uid: 264
     components:
     - pos: 7.5,5.5
       parent: 1
       type: Transform
-  - uid: 271
+  - uid: 265
     components:
     - pos: 9.5,4.5
       parent: 1
       type: Transform
-  - uid: 272
+  - uid: 266
     components:
     - pos: 9.5,5.5
       parent: 1
       type: Transform
-  - uid: 273
+  - uid: 267
     components:
     - pos: 10.5,5.5
       parent: 1
       type: Transform
-  - uid: 274
+  - uid: 268
     components:
     - pos: 8.5,5.5
       parent: 1
       type: Transform
-  - uid: 275
+  - uid: 269
     components:
     - pos: 7.5,4.5
       parent: 1
       type: Transform
-  - uid: 276
+  - uid: 270
     components:
     - pos: 10.5,4.5
       parent: 1
       type: Transform
-  - uid: 277
+  - uid: 271
     components:
     - pos: 7.5,3.5
       parent: 1
       type: Transform
-  - uid: 278
+  - uid: 272
     components:
     - pos: 6.5,3.5
       parent: 1
       type: Transform
-  - uid: 279
+  - uid: 273
     components:
     - pos: 8.5,4.5
       parent: 1
       type: Transform
-  - uid: 280
+  - uid: 274
     components:
     - pos: 6.5,4.5
       parent: 1
       type: Transform
 - proto: CellRechargerCircuitboard
   entities:
-  - uid: 172
+  - uid: 166
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 168
+    - parent: 162
       type: Transform
     - canCollide: False
       type: Physics
 - proto: ClosetBase
   entities:
-  - uid: 281
+  - uid: 275
     components:
     - pos: 2.5,5.5
       parent: 1
@@ -2621,20 +2605,20 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 285
+          - 279
+          - 276
+          - 277
           - 282
-          - 283
+          - 278
           - 288
-          - 284
-          - 294
-          - 287
-          - 286
+          - 281
+          - 280
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
           ent: null
       type: ContainerContainer
-  - uid: 295
+  - uid: 289
     components:
     - pos: 2.5,-6.5
       parent: 1
@@ -2662,14 +2646,14 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 300
-          - 303
-          - 299
-          - 298
-          - 296
+          - 294
           - 297
-          - 302
-          - 301
+          - 293
+          - 292
+          - 290
+          - 291
+          - 296
+          - 295
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -2694,7 +2678,7 @@ entities:
           - 22
           - 21
       type: ContainerContainer
-  - uid: 46
+  - uid: 40
     components:
     - pos: -0.5,2.5
       parent: 1
@@ -2722,10 +2706,10 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 47
-          - 50
-          - 51
-          - 63
+          - 41
+          - 44
+          - 45
+          - 57
       type: ContainerContainer
     - dnas: []
       fibers:
@@ -2753,7 +2737,7 @@ entities:
       type: ContainerContainer
 - proto: ClosetWallOrange
   entities:
-  - uid: 309
+  - uid: 303
     components:
     - rot: 1.5707963267948966 rad
       pos: 1.5,3.5
@@ -2777,7 +2761,7 @@ entities:
         - 0
         - 0
       type: EntityStorage
-  - uid: 310
+  - uid: 304
     components:
     - rot: 1.5707963267948966 rad
       pos: 1.5,-4.5
@@ -2803,21 +2787,21 @@ entities:
       type: EntityStorage
 - proto: ClothingHandsTacticalMaidGloves
   entities:
-  - uid: 311
+  - uid: 305
     components:
     - pos: 6.4730835,4.565351
       parent: 1
       type: Transform
 - proto: ClothingHeadHatCatEars
   entities:
-  - uid: 312
+  - uid: 306
     components:
     - pos: 6.5147495,4.620907
       parent: 1
       type: Transform
 - proto: ClothingHeadHatTacticalMaidHeadband
   entities:
-  - uid: 313
+  - uid: 307
     components:
     - pos: 6.4939165,4.6486845
       parent: 1
@@ -2834,15 +2818,15 @@ entities:
       type: Physics
     - AttachedUid: 17
       type: AttachedClothing
-  - uid: 49
+  - uid: 43
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 47
+    - parent: 41
       type: Transform
     - canCollide: False
       type: Physics
-    - AttachedUid: 47
+    - AttachedUid: 41
       type: AttachedClothing
 - proto: ClothingHeadHelmetFire
   entities:
@@ -2901,22 +2885,22 @@ entities:
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 50
+  - uid: 44
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 46
+    - parent: 40
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: ClothingMaskBreathMedical
   entities:
-  - uid: 52
+  - uid: 46
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 51
+    - parent: 45
       type: Transform
     - canCollide: False
       type: Physics
@@ -2933,7 +2917,7 @@ entities:
     - type: InsideEntityStorage
 - proto: ClothingOuterHardsuitEVAPrisoner
   entities:
-  - uid: 36
+  - uid: 33
     components:
     - flags: InContainer
       type: MetaData
@@ -2942,11 +2926,11 @@ entities:
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 43
+  - uid: 39
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 39
+    - parent: 36
       type: Transform
     - canCollide: False
       type: Physics
@@ -2977,25 +2961,25 @@ entities:
       type: Physics
     - type: ActionsContainer
     - type: InsideEntityStorage
-  - uid: 47
+  - uid: 41
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 46
+    - parent: 40
       type: Transform
-    - clothingUid: 49
-      actionEntity: 48
+    - clothingUid: 43
+      actionEntity: 42
       type: ToggleableClothing
     - containers:
         toggleable-clothing: !type:ContainerSlot
           showEnts: False
           occludes: True
-          ent: 49
+          ent: 43
         actions: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 48
+          - 42
       type: ContainerContainer
     - canCollide: False
       type: Physics
@@ -3014,7 +2998,7 @@ entities:
     - type: InsideEntityStorage
 - proto: ClothingUniformJumpskirtPrisoner
   entities:
-  - uid: 37
+  - uid: 34
     components:
     - flags: InContainer
       type: MetaData
@@ -3026,11 +3010,11 @@ entities:
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 44
+  - uid: 37
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 39
+    - parent: 36
       type: Transform
     - address: 0BF0-6E75
       transmitFrequency: 1262
@@ -3040,14 +3024,14 @@ entities:
     - type: InsideEntityStorage
 - proto: ClothingUniformJumpskirtTacticalMaid
   entities:
-  - uid: 314
+  - uid: 308
     components:
     - pos: 6.5564165,4.5861845
       parent: 1
       type: Transform
 - proto: ClothingUniformJumpsuitPrisoner
   entities:
-  - uid: 38
+  - uid: 35
     components:
     - flags: InContainer
       type: MetaData
@@ -3059,11 +3043,11 @@ entities:
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 45
+  - uid: 38
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 39
+    - parent: 36
       type: Transform
     - address: 6F23-4F6E
       transmitFrequency: 1262
@@ -3073,7 +3057,7 @@ entities:
     - type: InsideEntityStorage
 - proto: ComputerCrewMonitoring
   entities:
-  - uid: 315
+  - uid: 309
     components:
     - rot: -1.5707963267948966 rad
       pos: 10.5,-1.5
@@ -3087,7 +3071,7 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 316
+          - 310
       type: ContainerContainer
     - dnas: []
       fibers:
@@ -3096,7 +3080,7 @@ entities:
       type: Forensics
 - proto: ComputerShuttle
   entities:
-  - uid: 317
+  - uid: 311
     components:
     - rot: -1.5707963267948966 rad
       pos: 10.5,-0.5
@@ -3107,7 +3091,7 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 318
+          - 312
       type: ContainerContainer
     - dnas: []
       fibers:
@@ -3116,7 +3100,7 @@ entities:
       type: Forensics
 - proto: ComputerStationRecords
   entities:
-  - uid: 319
+  - uid: 313
     components:
     - rot: -1.5707963267948966 rad
       pos: 10.5,0.5
@@ -3127,7 +3111,7 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 320
+          - 314
       type: ContainerContainer
     - dnas: []
       fibers:
@@ -3136,11 +3120,11 @@ entities:
       type: Forensics
 - proto: CrewMonitoringComputerCircuitboard
   entities:
-  - uid: 316
+  - uid: 310
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 315
+    - parent: 309
       type: Transform
     - canCollide: False
       type: Physics
@@ -3156,6 +3140,30 @@ entities:
       type: Physics
 - proto: DoorElectronics
   entities:
+  - uid: 76
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 75
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 78
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 77
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 80
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 79
+      type: Transform
+    - canCollide: False
+      type: Physics
   - uid: 82
     components:
     - flags: InContainer
@@ -3188,27 +3196,27 @@ entities:
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 90
+  - uid: 316
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 89
+    - parent: 315
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 92
+  - uid: 318
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 91
+    - parent: 317
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 94
+  - uid: 320
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 93
+    - parent: 319
       type: Transform
     - canCollide: False
       type: Physics
@@ -3220,33 +3228,9 @@ entities:
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 324
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 323
-      type: Transform
-    - canCollide: False
-      type: Physics
-  - uid: 326
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 325
-      type: Transform
-    - canCollide: False
-      type: Physics
-  - uid: 328
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 327
-      type: Transform
-    - canCollide: False
-      type: Physics
 - proto: EmergencyLight
   entities:
-  - uid: 329
+  - uid: 323
     components:
     - rot: 3.141592653589793 rad
       pos: 2.5,-6.5
@@ -3257,7 +3241,7 @@ entities:
     - startingCharge: 10198.422
       type: Battery
     - type: ActiveEmergencyLight
-  - uid: 330
+  - uid: 324
     components:
     - rot: 3.141592653589793 rad
       pos: 9.5,-6.5
@@ -3268,7 +3252,7 @@ entities:
     - startingCharge: 5770.106
       type: Battery
     - type: ActiveEmergencyLight
-  - uid: 331
+  - uid: 325
     components:
     - pos: -2.5,-2.5
       parent: 1
@@ -3278,7 +3262,7 @@ entities:
     - startingCharge: 9827.992
       type: Battery
     - type: ActiveEmergencyLight
-  - uid: 332
+  - uid: 326
     components:
     - pos: 2.5,5.5
       parent: 1
@@ -3288,7 +3272,7 @@ entities:
     - startingCharge: 10316.518
       type: Battery
     - type: ActiveEmergencyLight
-  - uid: 333
+  - uid: 327
     components:
     - rot: 3.141592653589793 rad
       pos: -2.5,1.5
@@ -3299,12 +3283,12 @@ entities:
     - startingCharge: 9749.828
       type: Battery
     - type: ActiveEmergencyLight
-  - uid: 334
+  - uid: 328
     components:
     - pos: 9.5,5.5
       parent: 1
       type: Transform
-  - uid: 335
+  - uid: 329
     components:
     - rot: -1.5707963267948966 rad
       pos: 6.5,1.5
@@ -3315,7 +3299,7 @@ entities:
     - startingCharge: 6116.946
       type: Battery
     - type: ActiveEmergencyLight
-  - uid: 336
+  - uid: 330
     components:
     - rot: 3.141592653589793 rad
       pos: 9.5,-1.5
@@ -3326,7 +3310,7 @@ entities:
     - startingCharge: 5948.6265
       type: Battery
     - type: ActiveEmergencyLight
-  - uid: 337
+  - uid: 331
     components:
     - rot: -1.5707963267948966 rad
       pos: 6.5,-2.5
@@ -3339,11 +3323,11 @@ entities:
     - type: ActiveEmergencyLight
 - proto: EmergencyMedipen
   entities:
-  - uid: 53
+  - uid: 47
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 51
+    - parent: 45
       type: Transform
     - canCollide: False
       type: Physics
@@ -3358,37 +3342,37 @@ entities:
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 54
+  - uid: 48
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 51
+    - parent: 45
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 63
+  - uid: 57
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 46
+    - parent: 40
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: EuphoniumInstrument
   entities:
-  - uid: 296
+  - uid: 290
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 295
+    - parent: 289
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: FaxMachineShip
   entities:
-  - uid: 338
+  - uid: 332
     components:
     - pos: 9.5,0.5
       parent: 1
@@ -3401,7 +3385,7 @@ entities:
       type: DeviceNetwork
 - proto: filingCabinetRandom
   entities:
-  - uid: 339
+  - uid: 333
     components:
     - pos: 10.5,-6.5
       parent: 1
@@ -3419,6 +3403,30 @@ entities:
     - type: InsideEntityStorage
 - proto: FirelockElectronics
   entities:
+  - uid: 335
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 334
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 337
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 336
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 339
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 338
+      type: Transform
+    - canCollide: False
+      type: Physics
   - uid: 341
     components:
     - flags: InContainer
@@ -3427,35 +3435,65 @@ entities:
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 343
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 342
-      type: Transform
-    - canCollide: False
-      type: Physics
-  - uid: 345
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 344
-      type: Transform
-    - canCollide: False
-      type: Physics
-  - uid: 347
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 346
-      type: Transform
-    - canCollide: False
-      type: Physics
 - proto: FirelockGlass
   entities:
-  - uid: 340
+  - uid: 334
     components:
     - pos: 7.5,-0.5
+      parent: 1
+      type: Transform
+    - containers:
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 335
+      type: ContainerContainer
+    - ShutdownSubscribers:
+      - 62
+      - 72
+      address: 2A2F-32C5
+      receiveFrequency: 1621
+      type: DeviceNetwork
+  - uid: 336
+    components:
+    - pos: 2.5,-2.5
+      parent: 1
+      type: Transform
+    - containers:
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 337
+      type: ContainerContainer
+    - ShutdownSubscribers:
+      - 62
+      - 66
+      address: 69E1-ED5D
+      receiveFrequency: 1621
+      type: DeviceNetwork
+  - uid: 338
+    components:
+    - pos: 2.5,1.5
+      parent: 1
+      type: Transform
+    - containers:
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 339
+      type: ContainerContainer
+    - ShutdownSubscribers:
+      - 64
+      - 62
+      address: 4EBA-47B3
+      receiveFrequency: 1621
+      type: DeviceNetwork
+  - uid: 340
+    components:
+    - pos: 6.5,-3.5
       parent: 1
       type: Transform
     - containers:
@@ -3466,89 +3504,35 @@ entities:
           - 341
       type: ContainerContainer
     - ShutdownSubscribers:
-      - 68
-      - 78
-      address: 2A2F-32C5
-      receiveFrequency: 1621
-      type: DeviceNetwork
-  - uid: 342
-    components:
-    - pos: 2.5,-2.5
-      parent: 1
-      type: Transform
-    - containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 343
-      type: ContainerContainer
-    - ShutdownSubscribers:
-      - 68
-      - 72
-      address: 69E1-ED5D
-      receiveFrequency: 1621
-      type: DeviceNetwork
-  - uid: 344
-    components:
-    - pos: 2.5,1.5
-      parent: 1
-      type: Transform
-    - containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 345
-      type: ContainerContainer
-    - ShutdownSubscribers:
+      - 62
       - 70
-      - 68
-      address: 4EBA-47B3
-      receiveFrequency: 1621
-      type: DeviceNetwork
-  - uid: 346
-    components:
-    - pos: 6.5,-3.5
-      parent: 1
-      type: Transform
-    - containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 347
-      type: ContainerContainer
-    - ShutdownSubscribers:
-      - 68
-      - 76
       address: 6D3F-5E6B
       receiveFrequency: 1621
       type: DeviceNetwork
-  - uid: 617
+  - uid: 342
     components:
     - pos: -1.5,1.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 68
+      - 62
       type: DeviceNetwork
-  - uid: 618
+  - uid: 343
     components:
     - pos: -1.5,-2.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 68
+      - 62
       type: DeviceNetwork
-  - uid: 619
+  - uid: 344
     components:
     - pos: 6.5,2.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
+      - 62
       - 68
-      - 74
       type: DeviceNetwork
 - proto: FlashlightLantern
   entities:
@@ -3599,99 +3583,99 @@ entities:
       type: Physics
 - proto: FoodSnackSus
   entities:
-  - uid: 282
+  - uid: 276
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 281
+    - parent: 275
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 283
+  - uid: 277
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 281
+    - parent: 275
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 284
+  - uid: 278
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 281
+    - parent: 275
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 285
+  - uid: 279
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 281
+    - parent: 275
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 286
+  - uid: 280
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 281
+    - parent: 275
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 297
+  - uid: 291
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 295
+    - parent: 289
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 298
+  - uid: 292
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 295
+    - parent: 289
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 299
+  - uid: 293
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 295
+    - parent: 289
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 300
+  - uid: 294
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 295
+    - parent: 289
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 301
+  - uid: 295
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 295
+    - parent: 289
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: GasPassiveVent
   entities:
-  - uid: 348
+  - uid: 345
     components:
     - rot: 1.5707963267948966 rad
       pos: -4.5,-0.5
@@ -3699,17 +3683,9 @@ entities:
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 349
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 2.5,-0.5
-      parent: 1
-      type: Transform
-    - color: '#FF00EEFF'
-      type: AtmosPipeColor
 - proto: GasPipeBend
   entities:
-  - uid: 350
+  - uid: 346
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,-2.5
@@ -3717,14 +3693,14 @@ entities:
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 351
+  - uid: 347
     components:
     - pos: 2.5,5.5
       parent: 1
       type: Transform
-    - color: '#FF00EEFF'
+    - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 352
+  - uid: 348
     components:
     - rot: -1.5707963267948966 rad
       pos: 5.5,1.5
@@ -3732,15 +3708,15 @@ entities:
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 353
+  - uid: 349
     components:
     - rot: -1.5707963267948966 rad
       pos: 2.5,-6.5
       parent: 1
       type: Transform
-    - color: '#FF00EEFF'
+    - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 354
+  - uid: 350
     components:
     - rot: 1.5707963267948966 rad
       pos: 4.5,1.5
@@ -3748,7 +3724,7 @@ entities:
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 355
+  - uid: 351
     components:
     - rot: -1.5707963267948966 rad
       pos: 4.5,-2.5
@@ -3756,76 +3732,76 @@ entities:
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 356
+  - uid: 352
     components:
     - rot: 3.141592653589793 rad
       pos: 2.5,0.5
       parent: 1
       type: Transform
-    - color: '#FF00EEFF'
+    - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 357
+  - uid: 353
     components:
     - pos: 0.5,-0.5
       parent: 1
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 358
+  - uid: 354
     components:
     - rot: 1.5707963267948966 rad
       pos: 6.5,4.5
       parent: 1
       type: Transform
-    - color: '#FF00EEFF'
+    - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 359
+  - uid: 355
     components:
     - rot: 3.141592653589793 rad
       pos: 6.5,-5.5
       parent: 1
       type: Transform
-    - color: '#FF00EEFF'
+    - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 360
+  - uid: 356
     components:
     - pos: 8.5,-5.5
       parent: 1
       type: Transform
-    - color: '#FF00EEFF'
+    - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 361
+  - uid: 357
     components:
     - rot: 1.5707963267948966 rad
       pos: 2.5,-1.5
       parent: 1
       type: Transform
-    - color: '#FF00EEFF'
+    - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 362
+  - uid: 358
     components:
     - pos: 9.5,-0.5
       parent: 1
       type: Transform
-    - color: '#FF00EEFF'
+    - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 363
+  - uid: 359
     components:
     - rot: 3.141592653589793 rad
       pos: 8.5,-6.5
       parent: 1
       type: Transform
-    - color: '#FF00EEFF'
+    - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 364
+  - uid: 360
     components:
     - rot: 3.141592653589793 rad
       pos: 8.5,-6.5
       parent: 1
       type: Transform
-    - color: '#FF00EEFF'
+    - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 365
+  - uid: 361
     components:
     - rot: 1.5707963267948966 rad
       pos: 5.5,5.5
@@ -3835,7 +3811,7 @@ entities:
       type: AtmosPipeColor
 - proto: GasPipeStraight
   entities:
-  - uid: 366
+  - uid: 362
     components:
     - rot: -1.5707963267948966 rad
       pos: -2.5,-0.5
@@ -3843,7 +3819,7 @@ entities:
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 367
+  - uid: 363
     components:
     - rot: -1.5707963267948966 rad
       pos: 6.5,5.5
@@ -3851,37 +3827,37 @@ entities:
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 368
+  - uid: 364
     components:
     - rot: -1.5707963267948966 rad
       pos: 5.5,0.5
       parent: 1
       type: Transform
-    - color: '#FF00EEFF'
+    - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 369
+  - uid: 365
     components:
     - rot: 3.141592653589793 rad
       pos: 2.5,2.5
       parent: 1
       type: Transform
-    - color: '#FF00EEFF'
+    - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 370
+  - uid: 366
     components:
     - pos: 6.5,-4.5
       parent: 1
       type: Transform
-    - color: '#FF00EEFF'
+    - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 371
+  - uid: 367
     components:
     - pos: 4.5,-1.5
       parent: 1
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 372
+  - uid: 368
     components:
     - rot: 1.5707963267948966 rad
       pos: 2.5,-2.5
@@ -3889,15 +3865,15 @@ entities:
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 373
+  - uid: 369
     components:
     - rot: 3.141592653589793 rad
       pos: 2.5,4.5
       parent: 1
       type: Transform
-    - color: '#FF00EEFF'
+    - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 374
+  - uid: 370
     components:
     - rot: -1.5707963267948966 rad
       pos: 8.5,5.5
@@ -3905,15 +3881,15 @@ entities:
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 375
+  - uid: 371
     components:
     - rot: -1.5707963267948966 rad
       pos: 5.5,-1.5
       parent: 1
       type: Transform
-    - color: '#FF00EEFF'
+    - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 376
+  - uid: 372
     components:
     - rot: 1.5707963267948966 rad
       pos: 1.5,-2.5
@@ -3921,7 +3897,7 @@ entities:
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 377
+  - uid: 373
     components:
     - rot: 1.5707963267948966 rad
       pos: 3.5,-2.5
@@ -3929,45 +3905,45 @@ entities:
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 378
+  - uid: 374
     components:
     - rot: 3.141592653589793 rad
       pos: 2.5,1.5
       parent: 1
       type: Transform
-    - color: '#FF00EEFF'
+    - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 379
+  - uid: 375
     components:
     - rot: -1.5707963267948966 rad
       pos: 4.5,0.5
       parent: 1
       type: Transform
-    - color: '#FF00EEFF'
+    - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 380
+  - uid: 376
     components:
     - rot: -1.5707963267948966 rad
       pos: 4.5,-1.5
       parent: 1
       type: Transform
-    - color: '#FF00EEFF'
+    - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 381
+  - uid: 377
     components:
     - pos: 2.5,-2.5
       parent: 1
       type: Transform
-    - color: '#FF00EEFF'
+    - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 382
+  - uid: 378
     components:
     - pos: 2.5,-5.5
       parent: 1
       type: Transform
-    - color: '#FF00EEFF'
+    - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 383
+  - uid: 379
     components:
     - rot: -1.5707963267948966 rad
       pos: 7.5,5.5
@@ -3975,52 +3951,52 @@ entities:
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 384
+  - uid: 380
     components:
     - rot: 1.5707963267948966 rad
       pos: 7.5,-5.5
       parent: 1
       type: Transform
-    - color: '#FF00EEFF'
+    - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 385
+  - uid: 381
     components:
     - pos: 6.5,-3.5
       parent: 1
       type: Transform
-    - color: '#FF00EEFF'
+    - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 386
+  - uid: 382
     components:
     - rot: -1.5707963267948966 rad
       pos: 7.5,-0.5
       parent: 1
       type: Transform
-    - color: '#FF00EEFF'
+    - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 387
+  - uid: 383
     components:
     - rot: 1.5707963267948966 rad
       pos: 9.5,-6.5
       parent: 1
       type: Transform
-    - color: '#FF00EEFF'
+    - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 388
+  - uid: 384
     components:
     - pos: 6.5,1.5
       parent: 1
       type: Transform
-    - color: '#FF00EEFF'
+    - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 389
+  - uid: 385
     components:
     - pos: 6.5,3.5
       parent: 1
       type: Transform
-    - color: '#FF00EEFF'
+    - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 390
+  - uid: 386
     components:
     - rot: -1.5707963267948966 rad
       pos: 9.5,5.5
@@ -4028,81 +4004,65 @@ entities:
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 391
+  - uid: 387
     components:
     - pos: 0.5,-1.5
       parent: 1
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 392
+  - uid: 388
     components:
     - pos: 5.5,2.5
       parent: 1
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 393
+  - uid: 389
     components:
     - pos: 5.5,3.5
       parent: 1
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 394
+  - uid: 390
     components:
     - pos: 2.5,-3.5
       parent: 1
       type: Transform
-    - color: '#FF00EEFF'
+    - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 395
+  - uid: 391
     components:
     - pos: 2.5,-4.5
       parent: 1
       type: Transform
-    - color: '#FF00EEFF'
+    - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 396
+  - uid: 392
     components:
     - rot: 3.141592653589793 rad
       pos: 2.5,3.5
       parent: 1
       type: Transform
-    - color: '#FF00EEFF'
+    - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 397
+  - uid: 393
     components:
     - pos: 6.5,-2.5
       parent: 1
       type: Transform
-    - color: '#FF00EEFF'
+    - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 398
+  - uid: 394
     components:
     - rot: -1.5707963267948966 rad
       pos: 8.5,-0.5
       parent: 1
       type: Transform
-    - color: '#FF00EEFF'
+    - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 399
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 9.5,4.5
-      parent: 1
-      type: Transform
-    - color: '#FF00EEFF'
-      type: AtmosPipeColor
-  - uid: 400
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 8.5,4.5
-      parent: 1
-      type: Transform
-    - color: '#FF00EEFF'
-      type: AtmosPipeColor
-  - uid: 401
+  - uid: 395
     components:
     - rot: -1.5707963267948966 rad
       pos: -3.5,-0.5
@@ -4110,14 +4070,14 @@ entities:
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 402
+  - uid: 396
     components:
     - pos: 5.5,4.5
       parent: 1
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 403
+  - uid: 397
     components:
     - rot: -1.5707963267948966 rad
       pos: -1.5,-0.5
@@ -4125,14 +4085,14 @@ entities:
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 404
+  - uid: 398
     components:
     - pos: 6.5,2.5
       parent: 1
       type: Transform
-    - color: '#FF00EEFF'
+    - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 405
+  - uid: 399
     components:
     - rot: -1.5707963267948966 rad
       pos: -0.5,-0.5
@@ -4140,15 +4100,7 @@ entities:
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 406
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 7.5,4.5
-      parent: 1
-      type: Transform
-    - color: '#FF00EEFF'
-      type: AtmosPipeColor
-  - uid: 407
+  - uid: 400
     components:
     - pos: 4.5,0.5
       parent: 1
@@ -4157,22 +4109,30 @@ entities:
       type: AtmosPipeColor
 - proto: GasPipeTJunction
   entities:
-  - uid: 408
+  - uid: 401
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 7.5,4.5
+      parent: 1
+      type: Transform
+    - color: '#E100FFFF'
+      type: AtmosPipeColor
+  - uid: 402
     components:
     - rot: -1.5707963267948966 rad
       pos: 6.5,-1.5
       parent: 1
       type: Transform
-    - color: '#FF00EEFF'
+    - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 409
+  - uid: 403
     components:
     - pos: 3.5,0.5
       parent: 1
       type: Transform
-    - color: '#FF00EEFF'
+    - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 410
+  - uid: 404
     components:
     - rot: 1.5707963267948966 rad
       pos: 4.5,-0.5
@@ -4180,217 +4140,74 @@ entities:
       type: Transform
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 411
+  - uid: 405
     components:
     - rot: -1.5707963267948966 rad
       pos: 6.5,0.5
       parent: 1
       type: Transform
-    - color: '#FF00EEFF'
+    - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 412
+  - uid: 406
     components:
     - rot: 1.5707963267948966 rad
       pos: 6.5,-0.5
       parent: 1
       type: Transform
-    - color: '#FF00EEFF'
+    - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 413
+  - uid: 407
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,-0.5
       parent: 1
       type: Transform
-    - color: '#FF00EEFF'
+    - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 414
+  - uid: 408
     components:
     - rot: 3.141592653589793 rad
       pos: 3.5,-1.5
       parent: 1
       type: Transform
-    - color: '#FF00EEFF'
+    - color: '#E100FFFF'
+      type: AtmosPipeColor
+- proto: GasPort
+  entities:
+  - uid: 409
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 8.5,4.5
+      parent: 1
+      type: Transform
+    - color: '#E100FFFF'
       type: AtmosPipeColor
 - proto: GasVentPump
   entities:
-  - uid: 415
+  - uid: 410
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 2.5,-0.5
+      parent: 1
+      type: Transform
+    - color: '#E100FFFF'
+      type: AtmosPipeColor
+  - uid: 411
+    components:
+    - pos: 7.5,5.5
+      parent: 1
+      type: Transform
+    - color: '#E100FFFF'
+      type: AtmosPipeColor
+  - uid: 412
     components:
     - rot: -1.5707963267948966 rad
       pos: 10.5,-6.5
       parent: 1
       type: Transform
-    - color: '#FF00EEFF'
+    - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 416
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 10.5,4.5
-      parent: 1
-      type: Transform
-    - address: VNT-69E9-2D7C
-      transmitFrequency: 1621
-      receiveFrequency: 1621
-      type: DeviceNetwork
-    - gasThresholds:
-        Oxygen:
-          lowerWarnAround:
-            threshold: 1.5
-            enabled: True
-          upperWarnAround:
-            threshold: 0
-            enabled: False
-          lowerBound:
-            threshold: 0.1
-            enabled: True
-          upperBound:
-            threshold: 0
-            enabled: False
-          ignore: False
-        Nitrogen:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0
-            enabled: False
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0
-            enabled: False
-          ignore: True
-        CarbonDioxide:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.0025
-            enabled: True
-          ignore: False
-        Plasma:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0
-            enabled: False
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.0001
-            enabled: True
-          ignore: False
-        Tritium:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0
-            enabled: False
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.0001
-            enabled: True
-          ignore: False
-        WaterVapor:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 1.5
-            enabled: True
-          ignore: False
-        Miasma:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.05
-            enabled: True
-          ignore: False
-        NitrousOxide:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.01
-            enabled: True
-          ignore: False
-        Frezon:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0
-            enabled: False
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.0001
-            enabled: True
-          ignore: False
-      pressureThreshold:
-        lowerWarnAround:
-          threshold: 2.5
-          enabled: True
-        upperWarnAround:
-          threshold: 0.7
-          enabled: True
-        lowerBound:
-          threshold: 20
-          enabled: True
-        upperBound:
-          threshold: 550
-          enabled: True
-        ignore: False
-      temperatureThreshold:
-        lowerWarnAround:
-          threshold: 1.1
-          enabled: True
-        upperWarnAround:
-          threshold: 0.8
-          enabled: True
-        lowerBound:
-          threshold: 193.15
-          enabled: True
-        upperBound:
-          threshold: 393.15
-          enabled: True
-        ignore: False
-      type: AtmosMonitor
-    - color: '#FF00EEFF'
-      type: AtmosPipeColor
-  - uid: 417
+  - uid: 413
     components:
     - rot: 1.5707963267948966 rad
       pos: 1.5,5.5
@@ -4558,9 +4375,9 @@ entities:
           enabled: True
         ignore: False
       type: AtmosMonitor
-    - color: '#FF00EEFF'
+    - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 418
+  - uid: 414
     components:
     - rot: 1.5707963267948966 rad
       pos: 1.5,-6.5
@@ -4728,9 +4545,9 @@ entities:
           enabled: True
         ignore: False
       type: AtmosMonitor
-    - color: '#FF00EEFF'
+    - color: '#E100FFFF'
       type: AtmosPipeColor
-  - uid: 419
+  - uid: 415
     components:
     - rot: 3.141592653589793 rad
       pos: 9.5,-1.5
@@ -4896,11 +4713,11 @@ entities:
           enabled: True
         ignore: False
       type: AtmosMonitor
-    - color: '#FF00EEFF'
+    - color: '#E100FFFF'
       type: AtmosPipeColor
 - proto: GasVentScrubber
   entities:
-  - uid: 420
+  - uid: 416
     components:
     - rot: -1.5707963267948966 rad
       pos: 5.5,-0.5
@@ -5072,7 +4889,7 @@ entities:
       type: AtmosMonitor
     - color: '#80FF00FF'
       type: AtmosPipeColor
-  - uid: 421
+  - uid: 417
     components:
     - rot: -1.5707963267948966 rad
       pos: 10.5,5.5
@@ -5244,120 +5061,120 @@ entities:
       type: AtmosPipeColor
 - proto: GravityGeneratorMini
   entities:
-  - uid: 422
+  - uid: 418
     components:
     - pos: 9.5,5.5
       parent: 1
       type: Transform
 - proto: Grille
   entities:
-  - uid: 423
+  - uid: 419
     components:
     - pos: 11.5,-6.5
       parent: 1
       type: Transform
-  - uid: 424
+  - uid: 420
     components:
     - rot: -1.5707963267948966 rad
       pos: 0.5,-6.5
       parent: 1
       type: Transform
-  - uid: 425
+  - uid: 421
     components:
     - rot: -1.5707963267948966 rad
       pos: -2.5,-3.5
       parent: 1
       type: Transform
-  - uid: 426
+  - uid: 422
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,5.5
       parent: 1
       type: Transform
-  - uid: 427
+  - uid: 423
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,-4.5
       parent: 1
       type: Transform
-  - uid: 428
+  - uid: 424
     components:
     - rot: -1.5707963267948966 rad
       pos: 11.5,0.5
       parent: 1
       type: Transform
-  - uid: 429
+  - uid: 425
     components:
     - rot: -1.5707963267948966 rad
       pos: -3.5,-3.5
       parent: 1
       type: Transform
-  - uid: 430
+  - uid: 426
     components:
     - rot: 3.141592653589793 rad
       pos: 7.5,-1.5
       parent: 1
       type: Transform
-  - uid: 431
+  - uid: 427
     components:
     - rot: 3.141592653589793 rad
       pos: 7.5,0.5
       parent: 1
       type: Transform
-  - uid: 432
+  - uid: 428
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,-5.5
       parent: 1
       type: Transform
-  - uid: 433
+  - uid: 429
     components:
     - pos: 11.5,-5.5
       parent: 1
       type: Transform
-  - uid: 434
+  - uid: 430
     components:
     - rot: -1.5707963267948966 rad
       pos: 11.5,-0.5
       parent: 1
       type: Transform
-  - uid: 435
+  - uid: 431
     components:
     - rot: -1.5707963267948966 rad
       pos: 0.5,5.5
       parent: 1
       type: Transform
-  - uid: 436
+  - uid: 432
     components:
     - rot: -1.5707963267948966 rad
       pos: -3.5,2.5
       parent: 1
       type: Transform
-  - uid: 437
+  - uid: 433
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,3.5
       parent: 1
       type: Transform
-  - uid: 438
+  - uid: 434
     components:
     - rot: -1.5707963267948966 rad
       pos: -2.5,2.5
       parent: 1
       type: Transform
-  - uid: 439
+  - uid: 435
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,4.5
       parent: 1
       type: Transform
-  - uid: 440
+  - uid: 436
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,-6.5
       parent: 1
       type: Transform
-  - uid: 441
+  - uid: 437
     components:
     - rot: -1.5707963267948966 rad
       pos: 11.5,-1.5
@@ -5365,7 +5182,7 @@ entities:
       type: Transform
 - proto: Gyroscope
   entities:
-  - uid: 215
+  - uid: 209
     components:
     - pos: 9.5,4.5
       parent: 1
@@ -5375,42 +5192,42 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 217
+          - 211
         machine_parts: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 218
-          - 219
-          - 216
-          - 220
+          - 212
+          - 213
+          - 210
+          - 214
       type: ContainerContainer
 - proto: GyroscopeMachineCircuitboard
   entities:
-  - uid: 217
+  - uid: 211
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 215
+    - parent: 209
       type: Transform
     - canCollide: False
       type: Physics
 - proto: Joint
   entities:
-  - uid: 287
+  - uid: 281
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 281
+    - parent: 275
       type: Transform
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 302
+  - uid: 296
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 295
+    - parent: 289
       type: Transform
     - canCollide: False
       type: Physics
@@ -5441,81 +5258,9 @@ entities:
     - actions:
       - 4
       type: Actions
-- proto: LightImplant
-  entities:
-  - uid: 34
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 33
-      type: Transform
-    - toggleActionEntity: 35
-      type: UnpoweredFlashlight
-    - canCollide: False
-      type: Physics
-    - type: ActionsContainer
-    - containers:
-        actions: !type:Container
-          ents:
-          - 35
-      type: ContainerContainer
-  - uid: 41
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 40
-      type: Transform
-    - toggleActionEntity: 42
-      type: UnpoweredFlashlight
-    - canCollide: False
-      type: Physics
-    - type: ActionsContainer
-    - containers:
-        actions: !type:Container
-          ents:
-          - 42
-      type: ContainerContainer
-- proto: LightImplanter
-  entities:
-  - uid: 33
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 32
-      type: Transform
-    - implantData:
-        light implant: This implant emits light from the user's skin on activation.
-      type: Implanter
-    - containers:
-        implanter_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: 34
-      type: ContainerContainer
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
-  - uid: 40
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 39
-      type: Transform
-    - implantData:
-        light implant: This implant emits light from the user's skin on activation.
-      type: Implanter
-    - containers:
-        implanter_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: 41
-      type: ContainerContainer
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
 - proto: LockerDetectiveFilled
   entities:
-  - uid: 442
+  - uid: 438
     components:
     - pos: 7.5,-6.5
       parent: 1
@@ -5548,11 +5293,11 @@ entities:
     - air:
         volume: 200
         immutable: False
-        temperature: 292.97778
+        temperature: 293.13718
         moles:
-        - 1.7497417
-        - 6.5843496
-        - 0.00045677694
+        - 1.8859696
+        - 7.0949974
+        - 3.6542155E-05
         - 0
         - 0
         - 0
@@ -5569,15 +5314,14 @@ entities:
           occludes: True
           ents:
           - 33
-          - 38
-          - 37
-          - 36
+          - 34
+          - 35
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
           ent: null
       type: ContainerContainer
-  - uid: 39
+  - uid: 36
     components:
     - pos: 3.5,-1.5
       parent: 1
@@ -5587,9 +5331,9 @@ entities:
         immutable: False
         temperature: 293.08878
         moles:
-        - 1.7463328
-        - 6.570048
-        - 0.000129352
+        - 1.8856968
+        - 7.093853
+        - 1.034816E-05
         - 0
         - 0
         - 0
@@ -5605,10 +5349,9 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 45
-          - 43
-          - 44
-          - 40
+          - 37
+          - 39
+          - 38
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -5616,25 +5359,25 @@ entities:
       type: ContainerContainer
 - proto: LockerSecurityFilled
   entities:
-  - uid: 443
+  - uid: 439
     components:
     - pos: 8.5,0.5
       parent: 1
       type: Transform
 - proto: LockerWardenFilled
   entities:
-  - uid: 444
+  - uid: 440
     components:
     - pos: 8.5,-1.5
       parent: 1
       type: Transform
 - proto: Matchbox
   entities:
-  - uid: 288
+  - uid: 282
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 281
+    - parent: 275
       type: Transform
     - storageUsed: 5
       type: Storage
@@ -5643,20 +5386,20 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 289
-          - 290
-          - 291
-          - 292
-          - 293
+          - 283
+          - 284
+          - 285
+          - 286
+          - 287
       type: ContainerContainer
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-  - uid: 303
+  - uid: 297
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 295
+    - parent: 289
       type: Transform
     - storageUsed: 5
       type: Storage
@@ -5665,104 +5408,104 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 304
-          - 305
-          - 306
-          - 307
-          - 308
+          - 298
+          - 299
+          - 300
+          - 301
+          - 302
       type: ContainerContainer
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: Matchstick
   entities:
-  - uid: 289
+  - uid: 283
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 288
+    - parent: 282
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 290
+  - uid: 284
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 288
+    - parent: 282
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 291
+  - uid: 285
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 288
+    - parent: 282
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 292
+  - uid: 286
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 288
+    - parent: 282
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 293
+  - uid: 287
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 288
+    - parent: 282
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 304
+  - uid: 298
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 303
+    - parent: 297
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 305
+  - uid: 299
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 303
+    - parent: 297
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 306
+  - uid: 300
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 303
+    - parent: 297
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 307
+  - uid: 301
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 303
+    - parent: 297
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 308
+  - uid: 302
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 303
+    - parent: 297
       type: Transform
     - canCollide: False
       type: Physics
 - proto: MedkitOxygenFilled
   entities:
-  - uid: 51
+  - uid: 45
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 46
+    - parent: 40
       type: Transform
     - storageUsed: 28
       type: Storage
@@ -5771,100 +5514,100 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 52
-          - 54
-          - 53
-          - 62
-          - 55
+          - 46
+          - 48
+          - 47
           - 56
-          - 57
-          - 58
-          - 59
-          - 60
-          - 61
+          - 49
+          - 50
+          - 51
+          - 52
+          - 53
+          - 54
+          - 55
       type: ContainerContainer
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
 - proto: MicroManipulatorStockPart
   entities:
-  - uid: 218
+  - uid: 212
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 215
+    - parent: 209
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 219
+  - uid: 213
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 215
+    - parent: 209
       type: Transform
     - canCollide: False
       type: Physics
 - proto: PillDexalin
   entities:
+  - uid: 49
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 45
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 50
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 45
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 51
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 45
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 52
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 45
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 53
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 45
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 54
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 45
+      type: Transform
+    - canCollide: False
+      type: Physics
   - uid: 55
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 51
-      type: Transform
-    - canCollide: False
-      type: Physics
-  - uid: 56
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 51
-      type: Transform
-    - canCollide: False
-      type: Physics
-  - uid: 57
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 51
-      type: Transform
-    - canCollide: False
-      type: Physics
-  - uid: 58
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 51
-      type: Transform
-    - canCollide: False
-      type: Physics
-  - uid: 59
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 51
-      type: Transform
-    - canCollide: False
-      type: Physics
-  - uid: 60
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 51
-      type: Transform
-    - canCollide: False
-      type: Physics
-  - uid: 61
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 51
+    - parent: 45
       type: Transform
     - canCollide: False
       type: Physics
 - proto: PortableGeneratorPacman
   entities:
-  - uid: 179
+  - uid: 173
     components:
     - pos: 8.5,5.5
       parent: 1
@@ -5879,16 +5622,16 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 182
+          - 176
         machine_parts: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 181
-          - 180
+          - 175
+          - 174
       type: ContainerContainer
     - type: ItemCooldown
-  - uid: 183
+  - uid: 177
     components:
     - pos: 7.5,5.5
       parent: 1
@@ -5903,125 +5646,125 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 186
+          - 180
         machine_parts: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 185
-          - 184
+          - 179
+          - 178
       type: ContainerContainer
     - type: ItemCooldown
 - proto: PortableGeneratorPacmanMachineCircuitboard
   entities:
-  - uid: 182
+  - uid: 176
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 179
+    - parent: 173
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 186
+  - uid: 180
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 183
+    - parent: 177
       type: Transform
     - canCollide: False
       type: Physics
 - proto: PosterContrabandBorgFancy
   entities:
-  - uid: 445
+  - uid: 441
     components:
     - pos: -1.5,-3.5
       parent: 1
       type: Transform
 - proto: PosterContrabandDonutCorp
   entities:
-  - uid: 446
+  - uid: 442
     components:
     - pos: 3.5,-3.5
       parent: 1
       type: Transform
 - proto: PosterContrabandKosmicheskayaStantsiya
   entities:
-  - uid: 447
+  - uid: 443
     components:
     - pos: 4.5,-2.5
       parent: 1
       type: Transform
 - proto: PosterContrabandNuclearDeviceInformational
   entities:
-  - uid: 448
+  - uid: 444
     components:
     - pos: 1.5,-7.5
       parent: 1
       type: Transform
 - proto: PosterContrabandWehWatches
   entities:
-  - uid: 449
+  - uid: 445
     components:
     - pos: 1.5,6.5
       parent: 1
       type: Transform
 - proto: PosterLegit12Gauge
   entities:
-  - uid: 450
+  - uid: 446
     components:
     - pos: -1.5,2.5
       parent: 1
       type: Transform
 - proto: PosterLegitCarbonDioxide
   entities:
-  - uid: 451
+  - uid: 447
     components:
     - pos: 10.5,1.5
       parent: 1
       type: Transform
 - proto: PosterLegitEnlist
   entities:
-  - uid: 452
+  - uid: 448
     components:
     - pos: 8.5,3.5
       parent: 1
       type: Transform
 - proto: PosterLegitFruitBowl
   entities:
-  - uid: 453
+  - uid: 449
     components:
     - pos: 7.5,-7.5
       parent: 1
       type: Transform
 - proto: PosterLegitGetYourLEGS
   entities:
-  - uid: 454
+  - uid: 450
     components:
     - pos: 3.5,2.5
       parent: 1
       type: Transform
 - proto: PosterLegitLoveIan
   entities:
-  - uid: 455
+  - uid: 451
     components:
     - pos: 1.5,-3.5
       parent: 1
       type: Transform
-  - uid: 456
+  - uid: 452
     components:
     - pos: 6.5,-6.5
       parent: 1
       type: Transform
 - proto: PosterLegitPeriodicTable
   entities:
-  - uid: 457
+  - uid: 453
     components:
     - pos: 10.5,-2.5
       parent: 1
       type: Transform
 - proto: PosterLegitThereIsNoGasGiant
   entities:
-  - uid: 458
+  - uid: 454
     components:
     - pos: 1.5,2.5
       parent: 1
@@ -6046,7 +5789,7 @@ entities:
       type: Physics
 - proto: PowerCellRecharger
   entities:
-  - uid: 168
+  - uid: 162
     components:
     - pos: 9.5,-6.5
       parent: 1
@@ -6060,14 +5803,14 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 172
+          - 166
         machine_parts: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 170
-          - 171
-          - 169
+          - 164
+          - 165
+          - 163
       type: ContainerContainer
     - powerLoad: 0
       type: ApcPowerReceiver
@@ -6085,34 +5828,34 @@ entities:
       type: Physics
 - proto: Poweredlight
   entities:
-  - uid: 459
+  - uid: 455
     components:
     - pos: 3.5,0.5
       parent: 1
       type: Transform
-  - uid: 460
+  - uid: 456
     components:
     - rot: 3.141592653589793 rad
       pos: -3.5,-2.5
       parent: 1
       type: Transform
-  - uid: 461
+  - uid: 457
     components:
     - pos: 8.5,0.5
       parent: 1
       type: Transform
-  - uid: 462
+  - uid: 458
     components:
     - pos: -3.5,1.5
       parent: 1
       type: Transform
-  - uid: 463
+  - uid: 459
     components:
     - rot: 3.141592653589793 rad
       pos: 3.5,-1.5
       parent: 1
       type: Transform
-  - uid: 464
+  - uid: 460
     components:
     - rot: -1.5707963267948966 rad
       pos: 10.5,4.5
@@ -6120,19 +5863,33 @@ entities:
       type: Transform
 - proto: PoweredlightColoredRed
   entities:
-  - uid: 465
+  - uid: 461
     components:
     - rot: -1.5707963267948966 rad
       pos: 10.5,-5.5
       parent: 1
       type: Transform
+- proto: PoweredlightLED
+  entities:
+  - uid: 613
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 2.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 614
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 2.5,-4.5
+      parent: 1
+      type: Transform
 - proto: SheetGlass1
   entities:
-  - uid: 220
+  - uid: 214
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 215
+    - parent: 209
       type: Transform
     - count: 2
       type: Stack
@@ -6142,7 +5899,7 @@ entities:
       type: Physics
 - proto: SheetPlasma
   entities:
-  - uid: 466
+  - uid: 462
     components:
     - rot: 3.141592653589793 rad
       pos: 7.50222,4.459353
@@ -6150,7 +5907,7 @@ entities:
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 467
+  - uid: 463
     components:
     - rot: 3.141592653589793 rad
       pos: 7.517845,4.537478
@@ -6160,11 +5917,11 @@ entities:
       type: Physics
 - proto: SheetSteel1
   entities:
-  - uid: 226
+  - uid: 220
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 221
+    - parent: 215
       type: Transform
     - size: 5
       type: Item
@@ -6172,11 +5929,11 @@ entities:
       type: Stack
     - canCollide: False
       type: Physics
-  - uid: 233
+  - uid: 227
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 228
+    - parent: 222
       type: Transform
     - size: 5
       type: Item
@@ -6184,11 +5941,11 @@ entities:
       type: Stack
     - canCollide: False
       type: Physics
-  - uid: 240
+  - uid: 234
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 235
+    - parent: 229
       type: Transform
     - size: 5
       type: Item
@@ -6196,11 +5953,11 @@ entities:
       type: Stack
     - canCollide: False
       type: Physics
-  - uid: 247
+  - uid: 241
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 242
+    - parent: 236
       type: Transform
     - size: 5
       type: Item
@@ -6208,11 +5965,11 @@ entities:
       type: Stack
     - canCollide: False
       type: Physics
-  - uid: 254
+  - uid: 248
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 249
+    - parent: 243
       type: Transform
     - size: 5
       type: Item
@@ -6220,11 +5977,11 @@ entities:
       type: Stack
     - canCollide: False
       type: Physics
-  - uid: 261
+  - uid: 255
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 256
+    - parent: 250
       type: Transform
     - size: 5
       type: Item
@@ -6232,11 +5989,11 @@ entities:
       type: Stack
     - canCollide: False
       type: Physics
-  - uid: 268
+  - uid: 262
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 263
+    - parent: 257
       type: Transform
     - size: 5
       type: Item
@@ -6246,7 +6003,7 @@ entities:
       type: Physics
 - proto: ShuttersNormalOpen
   entities:
-  - uid: 321
+  - uid: 315
     components:
     - pos: 6.5,-3.5
       parent: 1
@@ -6256,15 +6013,15 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 322
+          - 316
       type: ContainerContainer
     - address: 4AA5-F3B3
       receiveFrequency: 1280
       type: DeviceNetwork
     - links:
-      - 490
+      - 486
       type: DeviceLinkSink
-  - uid: 323
+  - uid: 317
     components:
     - rot: -1.5707963267948966 rad
       pos: 11.5,-1.5
@@ -6275,15 +6032,15 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 324
+          - 318
       type: ContainerContainer
     - address: 4967-8FDB
       receiveFrequency: 1280
       type: DeviceNetwork
     - links:
-      - 489
+      - 485
       type: DeviceLinkSink
-  - uid: 325
+  - uid: 319
     components:
     - rot: -1.5707963267948966 rad
       pos: 11.5,0.5
@@ -6294,15 +6051,15 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 326
+          - 320
       type: ContainerContainer
     - address: 7927-5FE5
       receiveFrequency: 1280
       type: DeviceNetwork
     - links:
-      - 489
+      - 485
       type: DeviceLinkSink
-  - uid: 327
+  - uid: 321
     components:
     - rot: -1.5707963267948966 rad
       pos: 11.5,-0.5
@@ -6313,130 +6070,130 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 328
+          - 322
       type: ContainerContainer
     - address: 2F67-D620
       receiveFrequency: 1280
       type: DeviceNetwork
     - links:
-      - 489
+      - 485
       type: DeviceLinkSink
 - proto: ShuttleConsoleCircuitboard
   entities:
-  - uid: 318
+  - uid: 312
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 317
+    - parent: 311
       type: Transform
     - canCollide: False
       type: Physics
 - proto: ShuttleWindow
   entities:
-  - uid: 468
+  - uid: 464
     components:
     - pos: 11.5,-6.5
       parent: 1
       type: Transform
-  - uid: 469
+  - uid: 465
     components:
     - pos: -3.5,2.5
       parent: 1
       type: Transform
-  - uid: 470
+  - uid: 466
     components:
     - rot: 3.141592653589793 rad
       pos: 7.5,0.5
       parent: 1
       type: Transform
-  - uid: 471
+  - uid: 467
     components:
     - rot: 3.141592653589793 rad
       pos: 7.5,-1.5
       parent: 1
       type: Transform
-  - uid: 472
+  - uid: 468
     components:
     - rot: -1.5707963267948966 rad
       pos: 11.5,0.5
       parent: 1
       type: Transform
-  - uid: 473
+  - uid: 469
     components:
     - rot: -1.5707963267948966 rad
       pos: 11.5,-0.5
       parent: 1
       type: Transform
-  - uid: 474
+  - uid: 470
     components:
     - rot: -1.5707963267948966 rad
       pos: 11.5,-1.5
       parent: 1
       type: Transform
-  - uid: 475
+  - uid: 471
     components:
     - pos: 11.5,-5.5
       parent: 1
       type: Transform
-  - uid: 476
+  - uid: 472
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,-4.5
       parent: 1
       type: Transform
-  - uid: 477
+  - uid: 473
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,-5.5
       parent: 1
       type: Transform
-  - uid: 478
+  - uid: 474
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,-6.5
       parent: 1
       type: Transform
-  - uid: 479
+  - uid: 475
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,3.5
       parent: 1
       type: Transform
-  - uid: 480
+  - uid: 476
     components:
     - rot: -1.5707963267948966 rad
       pos: 0.5,-6.5
       parent: 1
       type: Transform
-  - uid: 481
+  - uid: 477
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,5.5
       parent: 1
       type: Transform
-  - uid: 482
+  - uid: 478
     components:
     - rot: -1.5707963267948966 rad
       pos: 0.5,5.5
       parent: 1
       type: Transform
-  - uid: 483
+  - uid: 479
     components:
     - rot: -1.5707963267948966 rad
       pos: -3.5,-3.5
       parent: 1
       type: Transform
-  - uid: 484
+  - uid: 480
     components:
     - pos: -2.5,-3.5
       parent: 1
       type: Transform
-  - uid: 485
+  - uid: 481
     components:
     - pos: -2.5,2.5
       parent: 1
       type: Transform
-  - uid: 486
+  - uid: 482
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,4.5
@@ -6444,79 +6201,80 @@ entities:
       type: Transform
 - proto: SignalButton
   entities:
-  - uid: 487
+  - uid: 483
     components:
     - rot: 3.141592653589793 rad
       pos: 1.5,-2.5
       parent: 1
       type: Transform
     - linkedPorts:
-        85:
+        79:
         - Pressed: DoorBolt
       type: DeviceLinkSource
-  - uid: 488
+  - uid: 484
     components:
     - pos: 1.5,1.5
       parent: 1
       type: Transform
     - linkedPorts:
-        87:
+        81:
         - Pressed: DoorBolt
       type: DeviceLinkSource
-  - uid: 489
+  - uid: 485
     components:
-    - pos: 9.5,1.5
+    - rot: 1.5707963267948966 rad
+      pos: 7.5,0.5
       parent: 1
       type: Transform
     - linkedPorts:
-        325:
+        319:
         - Pressed: Toggle
-        327:
+        321:
         - Pressed: Toggle
-        323:
+        317:
         - Pressed: Toggle
       type: DeviceLinkSource
-  - uid: 490
+  - uid: 486
     components:
     - pos: 8.5,-4.5
       parent: 1
       type: Transform
     - linkedPorts:
-        93:
+        87:
         - Pressed: DoorBolt
-        321:
+        315:
         - Pressed: Toggle
       type: DeviceLinkSource
-  - uid: 491
+  - uid: 487
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,-4.5
       parent: 1
       type: Transform
     - linkedPorts:
-        615:
+        611:
         - Pressed: DoorBolt
       type: DeviceLinkSource
-  - uid: 492
+  - uid: 488
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,3.5
       parent: 1
       type: Transform
     - linkedPorts:
-        614:
+        610:
         - Pressed: DoorBolt
       type: DeviceLinkSource
     - type: ItemCooldown
 - proto: SignBridge
   entities:
-  - uid: 493
+  - uid: 489
     components:
     - rot: 3.141592653589793 rad
       pos: 7.5,-1.5
       parent: 1
       type: Transform
-  - uid: 494
+  - uid: 490
     components:
     - rot: 3.141592653589793 rad
       pos: 7.5,0.5
@@ -6524,7 +6282,7 @@ entities:
       type: Transform
 - proto: SignConspiracyBoard
   entities:
-  - uid: 495
+  - uid: 491
     components:
     - rot: 3.141592653589793 rad
       pos: 8.5,-7.5
@@ -6532,26 +6290,26 @@ entities:
       type: Transform
 - proto: SignDirectionalBrig
   entities:
-  - uid: 496
+  - uid: 492
     components:
     - rot: 3.141592653589793 rad
       pos: 1.5,1.5
       parent: 1
       type: Transform
-  - uid: 497
+  - uid: 493
     components:
     - pos: 1.5,-2.5
       parent: 1
       type: Transform
 - proto: SignEngineering
   entities:
-  - uid: 498
+  - uid: 494
     components:
     - rot: 3.141592653589793 rad
       pos: 5.5,2.5
       parent: 1
       type: Transform
-  - uid: 499
+  - uid: 495
     components:
     - rot: 3.141592653589793 rad
       pos: 7.5,2.5
@@ -6559,27 +6317,27 @@ entities:
       type: Transform
 - proto: SignFlammableMed
   entities:
-  - uid: 500
+  - uid: 496
     components:
     - pos: 7.5,6.5
       parent: 1
       type: Transform
 - proto: SignGravity
   entities:
-  - uid: 501
+  - uid: 497
     components:
     - pos: 11.5,5.5
       parent: 1
       type: Transform
 - proto: SignSec
   entities:
-  - uid: 502
+  - uid: 498
     components:
     - rot: 3.141592653589793 rad
       pos: 7.5,-3.5
       parent: 1
       type: Transform
-  - uid: 503
+  - uid: 499
     components:
     - rot: 3.141592653589793 rad
       pos: 5.5,-3.5
@@ -6587,13 +6345,13 @@ entities:
       type: Transform
 - proto: SignShipDock
   entities:
-  - uid: 504
+  - uid: 500
     components:
     - rot: 3.141592653589793 rad
       pos: -3.5,-1.5
       parent: 1
       type: Transform
-  - uid: 505
+  - uid: 501
     components:
     - rot: 3.141592653589793 rad
       pos: -3.5,0.5
@@ -6601,59 +6359,59 @@ entities:
       type: Transform
 - proto: SMESBasic
   entities:
-  - uid: 506
+  - uid: 502
     components:
     - pos: 10.5,5.5
       parent: 1
       type: Transform
 - proto: SpawnPointDetective
   entities:
-  - uid: 507
+  - uid: 503
     components:
     - pos: 9.5,-5.5
       parent: 1
       type: Transform
 - proto: SpawnPointLatejoin
   entities:
-  - uid: 508
+  - uid: 504
     components:
     - pos: 2.5,-0.5
       parent: 1
       type: Transform
 - proto: SpawnPointSecurityOfficer
   entities:
-  - uid: 509
+  - uid: 505
     components:
     - pos: 7.5,4.5
       parent: 1
       type: Transform
 - proto: SpawnPointWarden
   entities:
-  - uid: 510
+  - uid: 506
     components:
     - pos: 1.5,-0.5
       parent: 1
       type: Transform
 - proto: StationRecordsComputerCircuitboard
   entities:
-  - uid: 320
+  - uid: 314
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 319
+    - parent: 313
       type: Transform
     - canCollide: False
       type: Physics
 - proto: SubstationBasic
   entities:
-  - uid: 511
+  - uid: 507
     components:
     - pos: 10.5,4.5
       parent: 1
       type: Transform
 - proto: SuitStorageSec
   entities:
-  - uid: 512
+  - uid: 508
     components:
     - pos: 9.5,-1.5
       parent: 1
@@ -6676,7 +6434,7 @@ entities:
         - 0
         - 0
       type: EntityStorage
-  - uid: 513
+  - uid: 509
     components:
     - pos: 10.5,-5.5
       parent: 1
@@ -6701,7 +6459,7 @@ entities:
       type: EntityStorage
 - proto: SuitStorageWarden
   entities:
-  - uid: 514
+  - uid: 510
     components:
     - pos: 0.5,-0.5
       parent: 1
@@ -6726,34 +6484,34 @@ entities:
       type: EntityStorage
 - proto: SyringeInaprovaline
   entities:
-  - uid: 62
+  - uid: 56
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 51
+    - parent: 45
       type: Transform
     - canCollide: False
       type: Physics
 - proto: TableWood
   entities:
-  - uid: 515
+  - uid: 511
     components:
     - pos: 9.5,0.5
       parent: 1
       type: Transform
-  - uid: 516
+  - uid: 512
     components:
     - pos: 9.5,-6.5
       parent: 1
       type: Transform
-  - uid: 517
+  - uid: 513
     components:
     - pos: 8.5,-6.5
       parent: 1
       type: Transform
 - proto: Thruster
   entities:
-  - uid: 221
+  - uid: 215
     components:
     - rot: 1.5707963267948966 rad
       pos: -1.5,-0.5
@@ -6764,18 +6522,18 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 227
+          - 221
         machine_parts: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 222
-          - 223
-          - 224
-          - 225
-          - 226
+          - 216
+          - 217
+          - 218
+          - 219
+          - 220
       type: ContainerContainer
-  - uid: 228
+  - uid: 222
     components:
     - rot: 1.5707963267948966 rad
       pos: 0.5,-4.5
@@ -6786,18 +6544,18 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 234
+          - 228
         machine_parts: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 229
-          - 230
-          - 231
-          - 232
-          - 233
+          - 223
+          - 224
+          - 225
+          - 226
+          - 227
       type: ContainerContainer
-  - uid: 235
+  - uid: 229
     components:
     - rot: 1.5707963267948966 rad
       pos: 0.5,3.5
@@ -6808,18 +6566,18 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 241
+          - 235
         machine_parts: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 236
-          - 237
-          - 238
-          - 239
-          - 240
+          - 230
+          - 231
+          - 232
+          - 233
+          - 234
       type: ContainerContainer
-  - uid: 242
+  - uid: 236
     components:
     - rot: 3.141592653589793 rad
       pos: 4.5,-3.5
@@ -6830,18 +6588,18 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 248
+          - 242
         machine_parts: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 243
-          - 244
-          - 245
-          - 246
-          - 247
+          - 237
+          - 238
+          - 239
+          - 240
+          - 241
       type: ContainerContainer
-  - uid: 249
+  - uid: 243
     components:
     - pos: 4.5,2.5
       parent: 1
@@ -6851,18 +6609,18 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 255
+          - 249
         machine_parts: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 250
-          - 251
-          - 252
-          - 253
-          - 254
+          - 244
+          - 245
+          - 246
+          - 247
+          - 248
       type: ContainerContainer
-  - uid: 256
+  - uid: 250
     components:
     - rot: -1.5707963267948966 rad
       pos: 8.5,-3.5
@@ -6875,94 +6633,96 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 262
+          - 256
         machine_parts: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 257
-          - 258
-          - 259
-          - 260
-          - 261
+          - 251
+          - 252
+          - 253
+          - 254
+          - 255
       type: ContainerContainer
-  - uid: 263
+  - uid: 257
     components:
     - rot: -1.5707963267948966 rad
       pos: 8.5,2.5
       parent: 1
       type: Transform
+    - enabled: False
+      type: Thruster
     - containers:
         machine_board: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 269
+          - 263
         machine_parts: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 264
-          - 265
-          - 266
-          - 267
-          - 268
+          - 258
+          - 259
+          - 260
+          - 261
+          - 262
       type: ContainerContainer
 - proto: ThrusterMachineCircuitboard
   entities:
-  - uid: 227
+  - uid: 221
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 221
+    - parent: 215
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 234
+  - uid: 228
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 228
+    - parent: 222
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 241
+  - uid: 235
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 235
+    - parent: 229
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 248
+  - uid: 242
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 242
+    - parent: 236
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 255
+  - uid: 249
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 249
+    - parent: 243
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 262
+  - uid: 256
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 256
+    - parent: 250
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 269
+  - uid: 263
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 263
+    - parent: 257
       type: Transform
     - canCollide: False
       type: Physics
@@ -6993,575 +6753,575 @@ entities:
     - type: InsideEntityStorage
 - proto: VendingMachineBooze
   entities:
-  - uid: 64
+  - uid: 58
     components:
     - pos: 4.5,0.5
       parent: 1
       type: Transform
-    - actionEntity: 65
+    - actionEntity: 59
       type: VendingMachine
     - actions:
-      - 65
+      - 59
       type: Actions
     - type: ActionsContainer
     - containers:
         actions: !type:Container
           ents:
-          - 65
+          - 59
       type: ContainerContainer
 - proto: VendingMachineCigs
   entities:
-  - uid: 66
+  - uid: 60
     components:
     - pos: 4.5,-1.5
       parent: 1
       type: Transform
-    - actionEntity: 67
+    - actionEntity: 61
       type: VendingMachine
     - actions:
-      - 67
+      - 61
       type: Actions
     - type: ActionsContainer
     - containers:
         actions: !type:Container
           ents:
-          - 67
+          - 61
       type: ContainerContainer
 - proto: WallShuttle
   entities:
-  - uid: 518
+  - uid: 514
     components:
     - pos: 5.5,-5.5
       parent: 1
       type: Transform
-  - uid: 519
+  - uid: 515
     components:
     - rot: 1.5707963267948966 rad
       pos: 11.5,1.5
       parent: 1
       type: Transform
-  - uid: 520
+  - uid: 516
     components:
     - rot: -1.5707963267948966 rad
       pos: -1.5,0.5
       parent: 1
       type: Transform
-  - uid: 521
+  - uid: 517
     components:
     - rot: -1.5707963267948966 rad
       pos: -2.5,0.5
       parent: 1
       type: Transform
-  - uid: 522
+  - uid: 518
     components:
     - rot: -1.5707963267948966 rad
       pos: 1.5,-7.5
       parent: 1
       type: Transform
-  - uid: 523
+  - uid: 519
     components:
     - pos: 4.5,1.5
       parent: 1
       type: Transform
-  - uid: 524
+  - uid: 520
     components:
     - rot: 3.141592653589793 rad
       pos: 5.5,2.5
       parent: 1
       type: Transform
-  - uid: 525
+  - uid: 521
     components:
     - rot: 3.141592653589793 rad
       pos: 5.5,3.5
       parent: 1
       type: Transform
-  - uid: 526
+  - uid: 522
     components:
     - rot: -1.5707963267948966 rad
       pos: 7.5,2.5
       parent: 1
       type: Transform
-  - uid: 527
+  - uid: 523
     components:
     - pos: 7.5,1.5
       parent: 1
       type: Transform
-  - uid: 528
+  - uid: 524
     components:
     - pos: 8.5,1.5
       parent: 1
       type: Transform
-  - uid: 529
+  - uid: 525
     components:
     - pos: 9.5,1.5
       parent: 1
       type: Transform
-  - uid: 530
+  - uid: 526
     components:
     - pos: 10.5,1.5
       parent: 1
       type: Transform
-  - uid: 531
+  - uid: 527
     components:
     - rot: 1.5707963267948966 rad
       pos: 11.5,-2.5
       parent: 1
       type: Transform
-  - uid: 532
+  - uid: 528
     components:
     - rot: 1.5707963267948966 rad
       pos: 10.5,-2.5
       parent: 1
       type: Transform
-  - uid: 533
+  - uid: 529
     components:
     - rot: 1.5707963267948966 rad
       pos: 9.5,-2.5
       parent: 1
       type: Transform
-  - uid: 534
+  - uid: 530
     components:
     - rot: 1.5707963267948966 rad
       pos: 8.5,-2.5
       parent: 1
       type: Transform
-  - uid: 535
+  - uid: 531
     components:
     - rot: -1.5707963267948966 rad
       pos: 6.5,6.5
       parent: 1
       type: Transform
-  - uid: 536
+  - uid: 532
     components:
     - rot: 1.5707963267948966 rad
       pos: 7.5,-2.5
       parent: 1
       type: Transform
-  - uid: 537
+  - uid: 533
     components:
     - rot: -1.5707963267948966 rad
       pos: 7.5,-3.5
       parent: 1
       type: Transform
-  - uid: 538
+  - uid: 534
     components:
     - pos: 5.5,-4.5
       parent: 1
       type: Transform
-  - uid: 539
+  - uid: 535
     components:
     - rot: -1.5707963267948966 rad
       pos: 9.5,-4.5
       parent: 1
       type: Transform
-  - uid: 540
+  - uid: 536
     components:
     - rot: -1.5707963267948966 rad
       pos: 8.5,-4.5
       parent: 1
       type: Transform
-  - uid: 541
+  - uid: 537
     components:
     - rot: -1.5707963267948966 rad
       pos: 10.5,-4.5
       parent: 1
       type: Transform
-  - uid: 542
+  - uid: 538
     components:
     - rot: -1.5707963267948966 rad
       pos: 11.5,-4.5
       parent: 1
       type: Transform
-  - uid: 543
+  - uid: 539
     components:
     - rot: -1.5707963267948966 rad
       pos: 7.5,6.5
       parent: 1
       type: Transform
-  - uid: 544
+  - uid: 540
     components:
     - rot: -1.5707963267948966 rad
       pos: 8.5,6.5
       parent: 1
       type: Transform
-  - uid: 545
+  - uid: 541
     components:
     - rot: -1.5707963267948966 rad
       pos: 9.5,6.5
       parent: 1
       type: Transform
-  - uid: 546
+  - uid: 542
     components:
     - rot: -1.5707963267948966 rad
       pos: 10.5,6.5
       parent: 1
       type: Transform
-  - uid: 547
+  - uid: 543
     components:
     - rot: -1.5707963267948966 rad
       pos: 11.5,6.5
       parent: 1
       type: Transform
-  - uid: 548
+  - uid: 544
     components:
     - rot: 1.5707963267948966 rad
       pos: 5.5,-3.5
       parent: 1
       type: Transform
-  - uid: 549
+  - uid: 545
     components:
     - rot: -1.5707963267948966 rad
       pos: 4.5,-2.5
       parent: 1
       type: Transform
-  - uid: 550
+  - uid: 546
     components:
     - rot: -1.5707963267948966 rad
       pos: 2.5,-7.5
       parent: 1
       type: Transform
-  - uid: 551
+  - uid: 547
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,-7.5
       parent: 1
       type: Transform
-  - uid: 552
+  - uid: 548
     components:
     - rot: -1.5707963267948966 rad
       pos: -3.5,0.5
       parent: 1
       type: Transform
-  - uid: 553
+  - uid: 549
     components:
     - rot: -1.5707963267948966 rad
       pos: -0.5,2.5
       parent: 1
       type: Transform
-  - uid: 554
+  - uid: 550
     components:
     - pos: 8.5,3.5
       parent: 1
       type: Transform
-  - uid: 555
+  - uid: 551
     components:
     - pos: 9.5,3.5
       parent: 1
       type: Transform
-  - uid: 556
+  - uid: 552
     components:
     - pos: 10.5,3.5
       parent: 1
       type: Transform
-  - uid: 557
+  - uid: 553
     components:
     - pos: 11.5,3.5
       parent: 1
       type: Transform
-  - uid: 558
+  - uid: 554
     components:
     - rot: -1.5707963267948966 rad
       pos: 9.5,-7.5
       parent: 1
       type: Transform
-  - uid: 559
+  - uid: 555
     components:
     - rot: -1.5707963267948966 rad
       pos: 10.5,-7.5
       parent: 1
       type: Transform
-  - uid: 560
+  - uid: 556
     components:
     - rot: -1.5707963267948966 rad
       pos: 11.5,-7.5
       parent: 1
       type: Transform
-  - uid: 561
+  - uid: 557
     components:
     - rot: -1.5707963267948966 rad
       pos: 11.5,5.5
       parent: 1
       type: Transform
-  - uid: 562
+  - uid: 558
     components:
     - rot: -1.5707963267948966 rad
       pos: 11.5,4.5
       parent: 1
       type: Transform
-  - uid: 563
+  - uid: 559
     components:
     - rot: -1.5707963267948966 rad
       pos: 6.5,5.5
       parent: 1
       type: Transform
-  - uid: 564
+  - uid: 560
     components:
     - rot: -1.5707963267948966 rad
       pos: 8.5,-7.5
       parent: 1
       type: Transform
-  - uid: 565
+  - uid: 561
     components:
     - rot: -1.5707963267948966 rad
       pos: 7.5,-7.5
       parent: 1
       type: Transform
-  - uid: 566
+  - uid: 562
     components:
     - rot: -1.5707963267948966 rad
       pos: 6.5,-7.5
       parent: 1
       type: Transform
-  - uid: 567
+  - uid: 563
     components:
     - rot: -1.5707963267948966 rad
       pos: 6.5,-6.5
       parent: 1
       type: Transform
-  - uid: 568
+  - uid: 564
     components:
     - rot: -1.5707963267948966 rad
       pos: -1.5,2.5
       parent: 1
       type: Transform
-  - uid: 569
+  - uid: 565
     components:
     - rot: -1.5707963267948966 rad
       pos: -4.5,0.5
       parent: 1
       type: Transform
-  - uid: 570
+  - uid: 566
     components:
     - rot: -1.5707963267948966 rad
       pos: -4.5,2.5
       parent: 1
       type: Transform
-  - uid: 571
+  - uid: 567
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,2.5
       parent: 1
       type: Transform
-  - uid: 572
+  - uid: 568
     components:
     - rot: -1.5707963267948966 rad
       pos: -0.5,-0.5
       parent: 1
       type: Transform
-  - uid: 573
+  - uid: 569
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,-3.5
       parent: 1
       type: Transform
-  - uid: 574
+  - uid: 570
     components:
     - rot: 3.141592653589793 rad
       pos: 3.5,6.5
       parent: 1
       type: Transform
-  - uid: 575
+  - uid: 571
     components:
     - rot: 3.141592653589793 rad
       pos: 3.5,1.5
       parent: 1
       type: Transform
-  - uid: 576
+  - uid: 572
     components:
     - rot: 3.141592653589793 rad
       pos: 3.5,2.5
       parent: 1
       type: Transform
-  - uid: 577
+  - uid: 573
     components:
     - rot: 3.141592653589793 rad
       pos: 1.5,-4.5
       parent: 1
       type: Transform
-  - uid: 578
+  - uid: 574
     components:
     - rot: -1.5707963267948966 rad
       pos: 3.5,-2.5
       parent: 1
       type: Transform
-  - uid: 579
+  - uid: 575
     components:
     - rot: -1.5707963267948966 rad
       pos: 1.5,-3.5
       parent: 1
       type: Transform
-  - uid: 580
+  - uid: 576
     components:
     - pos: 1.5,-2.5
       parent: 1
       type: Transform
-  - uid: 581
+  - uid: 577
     components:
     - rot: -1.5707963267948966 rad
       pos: 0.5,-7.5
       parent: 1
       type: Transform
-  - uid: 582
+  - uid: 578
     components:
     - rot: -1.5707963267948966 rad
       pos: 0.5,-5.5
       parent: 1
       type: Transform
-  - uid: 583
+  - uid: 579
     components:
     - rot: -1.5707963267948966 rad
       pos: 1.5,1.5
       parent: 1
       type: Transform
-  - uid: 584
+  - uid: 580
     components:
     - rot: -1.5707963267948966 rad
       pos: -1.5,-3.5
       parent: 1
       type: Transform
-  - uid: 585
+  - uid: 581
     components:
     - rot: -1.5707963267948966 rad
       pos: -0.5,-3.5
       parent: 1
       type: Transform
-  - uid: 586
+  - uid: 582
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,-3.5
       parent: 1
       type: Transform
-  - uid: 587
+  - uid: 583
     components:
     - rot: -1.5707963267948966 rad
       pos: -3.5,-1.5
       parent: 1
       type: Transform
-  - uid: 588
+  - uid: 584
     components:
     - rot: -1.5707963267948966 rad
       pos: -1.5,-1.5
       parent: 1
       type: Transform
-  - uid: 589
+  - uid: 585
     components:
     - rot: -1.5707963267948966 rad
       pos: -2.5,-1.5
       parent: 1
       type: Transform
-  - uid: 590
+  - uid: 586
     components:
     - rot: -1.5707963267948966 rad
       pos: -4.5,-1.5
       parent: 1
       type: Transform
-  - uid: 591
+  - uid: 587
     components:
     - rot: -1.5707963267948966 rad
       pos: -4.5,-3.5
       parent: 1
       type: Transform
-  - uid: 592
+  - uid: 588
     components:
     - rot: 3.141592653589793 rad
       pos: 1.5,6.5
       parent: 1
       type: Transform
-  - uid: 593
+  - uid: 589
     components:
     - rot: 3.141592653589793 rad
       pos: 2.5,6.5
       parent: 1
       type: Transform
-  - uid: 594
+  - uid: 590
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,6.5
       parent: 1
       type: Transform
-  - uid: 595
+  - uid: 591
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,4.5
       parent: 1
       type: Transform
-  - uid: 596
+  - uid: 592
     components:
     - rot: -1.5707963267948966 rad
       pos: 1.5,3.5
       parent: 1
       type: Transform
-  - uid: 597
+  - uid: 593
     components:
     - rot: -1.5707963267948966 rad
       pos: 1.5,2.5
       parent: 1
       type: Transform
-  - uid: 598
+  - uid: 594
     components:
     - pos: 5.5,5.5
       parent: 1
       type: Transform
-  - uid: 599
+  - uid: 595
     components:
     - pos: 5.5,4.5
       parent: 1
       type: Transform
-  - uid: 600
+  - uid: 596
     components:
     - pos: 5.5,-6.5
       parent: 1
       type: Transform
 - proto: WallShuttleDiagonal
   entities:
-  - uid: 601
+  - uid: 597
     components:
     - rot: 3.141592653589793 rad
       pos: 5.5,1.5
       parent: 1
       type: Transform
-  - uid: 602
+  - uid: 598
     components:
     - rot: 1.5707963267948966 rad
       pos: 7.5,-3.5
       parent: 1
       type: Transform
-  - uid: 603
+  - uid: 599
     components:
     - rot: -1.5707963267948966 rad
       pos: 5.5,-2.5
       parent: 1
       type: Transform
-  - uid: 604
+  - uid: 600
     components:
     - pos: 7.5,3.5
       parent: 1
       type: Transform
-  - uid: 605
+  - uid: 601
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,-1.5
       parent: 1
       type: Transform
-  - uid: 606
+  - uid: 602
     components:
     - rot: 3.141592653589793 rad
       pos: 1.5,-5.5
       parent: 1
       type: Transform
-  - uid: 607
+  - uid: 603
     components:
     - rot: -1.5707963267948966 rad
       pos: -0.5,0.5
       parent: 1
       type: Transform
-  - uid: 608
+  - uid: 604
     components:
     - rot: 1.5707963267948966 rad
       pos: 7.5,-4.5
       parent: 1
       type: Transform
-  - uid: 609
+  - uid: 605
     components:
     - rot: -1.5707963267948966 rad
       pos: 1.5,4.5
@@ -7569,7 +7329,7 @@ entities:
       type: Transform
 - proto: WallWeaponCapacitorRecharger
   entities:
-  - uid: 610
+  - uid: 606
     components:
     - pos: -0.5,-0.5
       parent: 1
@@ -7578,7 +7338,7 @@ entities:
       type: Charger
     - powerLoad: 0
       type: ApcPowerReceiver
-  - uid: 611
+  - uid: 607
     components:
     - pos: 8.5,1.5
       parent: 1
@@ -7587,7 +7347,7 @@ entities:
       type: Charger
     - powerLoad: 0
       type: ApcPowerReceiver
-  - uid: 612
+  - uid: 608
     components:
     - pos: 8.5,-2.5
       parent: 1
@@ -7598,14 +7358,14 @@ entities:
       type: ApcPowerReceiver
 - proto: WarpPointShip
   entities:
-  - uid: 613
+  - uid: 609
     components:
     - pos: 4.5,-0.5
       parent: 1
       type: Transform
 - proto: WeaponCapacitorRecharger
   entities:
-  - uid: 210
+  - uid: 204
     components:
     - pos: 8.5,-6.5
       parent: 1
@@ -7619,24 +7379,24 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 214
+          - 208
         machine_parts: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 212
-          - 213
-          - 211
+          - 206
+          - 207
+          - 205
       type: ContainerContainer
     - powerLoad: 0
       type: ApcPowerReceiver
 - proto: WeaponCapacitorRechargerCircuitboard
   entities:
-  - uid: 214
+  - uid: 208
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 210
+    - parent: 204
       type: Transform
     - canCollide: False
       type: Physics
@@ -7655,27 +7415,27 @@ entities:
     - type: InsideEntityStorage
 - proto: WindoorSecure
   entities:
-  - uid: 614
+  - uid: 610
     components:
     - pos: 2.5,4.5
       parent: 1
       type: Transform
     - invokeCounter: 2
       links:
-      - 492
+      - 488
       type: DeviceLinkSink
-  - uid: 615
+  - uid: 611
     components:
     - rot: 3.141592653589793 rad
       pos: 2.5,-5.5
       parent: 1
       type: Transform
     - links:
-      - 491
+      - 487
       type: DeviceLinkSink
 - proto: Wrench
   entities:
-  - uid: 616
+  - uid: 612
     components:
     - pos: 7.533099,4.573193
       parent: 1
@@ -7684,11 +7444,11 @@ entities:
       type: Physics
 - proto: XylophoneInstrument
   entities:
-  - uid: 294
+  - uid: 288
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 281
+    - parent: 275
       type: Transform
     - canCollide: False
       type: Physics

--- a/Resources/Prototypes/_NF/Shipyard/inquisitor.yml
+++ b/Resources/Prototypes/_NF/Shipyard/inquisitor.yml
@@ -2,7 +2,7 @@
   id: Inquisitor
   name: NSF Inquisitor
   description: A small detective-oriented ship with two cells for holding prisoners
-  price: 28072
+  price: 24906
   category: Small
   group: Security
   shuttlePath: /Maps/Shuttles/inquisitor.yml

--- a/Resources/Prototypes/_NF/Shipyard/inquisitor.yml
+++ b/Resources/Prototypes/_NF/Shipyard/inquisitor.yml
@@ -2,7 +2,7 @@
   id: Inquisitor
   name: NSF Inquisitor
   description: A small detective-oriented ship with two cells for holding prisoners
-  price: 24906
+  price: 26045
   category: Small
   group: Security
   shuttlePath: /Maps/Shuttles/inquisitor.yml

--- a/Resources/Prototypes/_NF/Shipyard/inquisitor.yml
+++ b/Resources/Prototypes/_NF/Shipyard/inquisitor.yml
@@ -1,0 +1,29 @@
+- type: vessel
+  id: Inquisitor
+  name: NSF Inquisitor
+  description: A small detective-oriented ship with two cells for holding prisoners
+  price: 28072
+  category: Small
+  group: Security
+  shuttlePath: /Maps/Shuttles/inquisitor.yml
+
+- type: gameMap
+  id: Inquisitor
+  mapName: 'NSF Inquisitor'
+  mapPath: /Maps/Shuttles/inquisitor.yml
+  minPlayers: 0
+  stations:
+    Inquisitor:
+      stationProto: StandardFrontierSecurityVessel
+      components:
+        - type: StationNameSetup
+          mapNameTemplate: 'NSF14 Inquisitor {1}'
+          nameGenerator:
+            !type:NanotrasenNameGenerator
+            prefixCreator: '14'
+        - type: StationJobs
+          overflowJobs: []
+          availableJobs:
+            SecurityOfficer: [ 0, 0 ]
+            Warden: [ 0, 0 ]
+            Detective: [ 0, 0 ]


### PR DESCRIPTION
## About the PR
The NSF Inquisitor is my first attempt at building a ship, using GitHub, and a whole bunch of other things, so if I mess something up please tell me.

A small, detective-oriented ship that fits a crew of three and can hold two prisoners.
Features:
- A detective room filled with all sorts of crime-solving gadgets
- Two prisoner cells with a prisoner transfer airlock
- Three suit storages and three lockers for each crewmember
- Cat ears

## Why / Balance
I noticed that there was only one detective-based ship, and I don't think it even works properly. I also wanted to try making a ship of my own to help contribute to Frontier.

## Media

https://www.youtube.com/watch?v=EFGI7QmwByc

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- add: Due to a lack of Detective-based ships, the NSF Inquisitor has been added to Security's shipyard!