### PR TITLE
Sci Kit

### DIFF
--- a/Resources/Locale/en-US/_NF/prototypes/catalog/fills/crates/science-crates.ftl
+++ b/Resources/Locale/en-US/_NF/prototypes/catalog/fills/crates/science-crates.ftl
@@ -1,0 +1,2 @@
+ent-CrateScienceLabBundle = scientist lab kit
+    .desc = Contains a full kit to build your very own science lab.

--- a/Resources/Prototypes/_NF/Catalog/Cargo/cargo_science.yml
+++ b/Resources/Prototypes/_NF/Catalog/Cargo/cargo_science.yml
@@ -1,0 +1,9 @@
+- type: cargoProduct
+  id: ScienceLabBundle
+  icon:
+    sprite: Objects/Misc/module.rsi
+    state: cpu_science
+  product: CrateScienceLabBundle
+  cost: 20000
+  category: Science
+  group: market

--- a/Resources/Prototypes/_NF/Catalog/Fills/Backpacks/duffelbag.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/Backpacks/duffelbag.yml
@@ -17,10 +17,8 @@
   components:
     - type: StorageFill
       contents:
-        - id: SheetSteel1
-          amount: 45
         - id: SheetGlass1
-          amount: 13
+          amount: 14
         - id: SheetPGlass1
           amount: 10
         - id: SheetPlasma1
@@ -30,6 +28,6 @@
         - id: MatterBinStockPart
           amount: 10
         - id: CapacitorStockPart
-          amount: 6
+          amount: 8
         - id: MicroManipulatorStockPart
           amount: 5

--- a/Resources/Prototypes/_NF/Catalog/Fills/Backpacks/duffelbag.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/Backpacks/duffelbag.yml
@@ -9,3 +9,27 @@
       - id: WeaponLauncherChinaLakeEmp
       - id: GrenadeEmp
         amount: 8
+
+- type: entity
+  id: ClothingBackpackDuffelScienceBundle
+  parent: ClothingBackpackDuffelScience
+  suffix: Science Kit
+  components:
+    - type: StorageFill
+      contents:
+        - id: SheetSteel1
+          amount: 45
+        - id: SheetGlass1
+          amount: 13
+        - id: SheetPGlass1
+          amount: 10
+        - id: SheetPlasma1
+          amount: 5
+        - id: Beaker
+          amount: 4
+        - id: MatterBinStockPart
+          amount: 10
+        - id: CapacitorStockPart
+          amount: 6
+        - id: MicroManipulatorStockPart
+          amount: 5

--- a/Resources/Prototypes/_NF/Catalog/Fills/Crates/science.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/Crates/science.yml
@@ -13,7 +13,10 @@
       - id: ProtolatheMachineCircuitboard
       - id: AnalysisComputerCircuitboard
       - id: ResearchComputerCircuitboard
+      - id: APECircuitboard
       - id: AnomalyScanner
       - id: NodeScanner
       - id: CableApcStack
+      - id: SheetSteel
+        amount: 2
       - id: ClothingBackpackDuffelScienceBundle

--- a/Resources/Prototypes/_NF/Catalog/Fills/Crates/science.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/Crates/science.yml
@@ -1,0 +1,19 @@
+- type: entity
+  id: CrateScienceLabBundle
+  parent: CrateScienceSecure
+  components:
+  - type: StorageFill
+    contents:
+      - id: ExosuitFabricatorMachineCircuitboard
+      - id: AnomalyVesselCircuitboard
+      - id: CircuitImprinterMachineCircuitboard
+      - id: ResearchAndDevelopmentServerMachineCircuitboard
+      - id: ArtifactAnalyzerMachineCircuitboard
+      - id: AutolatheMachineCircuitboard
+      - id: ProtolatheMachineCircuitboard
+      - id: AnalysisComputerCircuitboard
+      - id: ResearchComputerCircuitboard
+      - id: AnomalyScanner
+      - id: NodeScanner
+      - id: CableApcStack
+      - id: ClothingBackpackDuffelScienceBundle


### PR DESCRIPTION
## About the PR
Added a crate with everything needed to start a lab.

## Why / Balance
Can we stop buying sci ships just to gut them now?

## Technical details
This kit has all the machines a full lab will start with and all the mats to build the machines.

## Media
- [X] this PR does not require an ingame showcase

## Breaking changes
N/A

**Changelog**
:cl: dvir01
- add: Cargo has a new crate for scientists, contains a full kit to start your very own science lab, everything you need in one crate!
