### PR TITLE
Cargo Generators For Sell

### DIFF
--- a/Resources/Locale/en-US/_NF/prototypes/catalog/cargo/cargo-engineering.ftl
+++ b/Resources/Locale/en-US/_NF/prototypes/catalog/cargo/cargo-engineering.ftl
@@ -1,0 +1,8 @@
+ent-EnginePortableGeneratorJrPacman = { ent-PortableGeneratorJrPacman }
+    .desc = { ent-PortableGeneratorJrPacman.desc }
+
+ent-EnginePortableGeneratorPacman = { ent-PortableGeneratorPacman }
+    .desc = { ent-PortableGeneratorPacman.desc }
+
+ent-EnginePortableGeneratorSuperPacman = { ent-PortableGeneratorSuperPacman }
+    .desc = { ent-PortableGeneratorSuperPacman.desc }

--- a/Resources/Prototypes/_NF/Catalog/Cargo/cargo_engines.yml
+++ b/Resources/Prototypes/_NF/Catalog/Cargo/cargo_engines.yml
@@ -1,0 +1,29 @@
+- type: cargoProduct
+  id: EnginePortableGeneratorJrPacman
+  icon:
+    sprite: Structures/Power/Generation/portable_generator.rsi
+    state: portgen3
+  product: PortableGeneratorJrPacman
+  cost: 1000
+  category: Engineering
+  group: market
+
+- type: cargoProduct
+  id: EnginePortableGeneratorPacman
+  icon:
+    sprite: Structures/Power/Generation/portable_generator.rsi
+    state: portgen2
+  product: PortableGeneratorPacman
+  cost: 2000
+  category: Engineering
+  group: market
+
+- type: cargoProduct
+  id: EnginePortableGeneratorSuperPacman
+  icon:
+    sprite: Structures/Power/Generation/portable_generator.rsi
+    state: portgen1
+  product: PortableGeneratorSuperPacman
+  cost: 3000
+  category: Engineering
+  group: market

--- a/Resources/Prototypes/_NF/Catalog/Cargo/cargo_engines.yml
+++ b/Resources/Prototypes/_NF/Catalog/Cargo/cargo_engines.yml
@@ -4,7 +4,7 @@
     sprite: Structures/Power/Generation/portable_generator.rsi
     state: portgen3
   product: PortableGeneratorJrPacman
-  cost: 1000
+  cost: 1500
   category: Engineering
   group: market
 
@@ -14,7 +14,7 @@
     sprite: Structures/Power/Generation/portable_generator.rsi
     state: portgen2
   product: PortableGeneratorPacman
-  cost: 2000
+  cost: 2500
   category: Engineering
   group: market
 
@@ -24,6 +24,6 @@
     sprite: Structures/Power/Generation/portable_generator.rsi
     state: portgen1
   product: PortableGeneratorSuperPacman
-  cost: 3000
+  cost: 3500
   category: Engineering
   group: market


### PR DESCRIPTION
## About the PR
Sells the 3 generators in cargo
JrPacman - 1500
Pacman - 2500
SuperPacman - 3500

## Why / Balance
Allow people to buy extra generators instead of having to scrap them off ships. 

## Technical details
.yml

## Media
- [X] this PR does not require an ingame showcase

## Breaking changes
N/A

**Changelog**
:cl: dvir01
- add: NT managed to strike a deal with PACMAN Corp and will now sell generators in cargo.
