### PR TITLE
Update crescent.yml

### DIFF
--- a/Resources/Maps/Shuttles/crescent.yml
+++ b/Resources/Maps/Shuttles/crescent.yml
@@ -35,7 +35,7 @@ entities:
     - chunks:
         0,0:
           ind: 0,0
-          tiles: WwAAAAADWwAAAAADWwAAAAADWwAAAAABWwAAAAADWwAAAAABcQAAAAAAGwAAAAADGwAAAAAAGwAAAAAAOAAAAAAAOAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAWwAAAAADWwAAAAACWwAAAAAAWwAAAAACWwAAAAADWwAAAAABcQAAAAAAGwAAAAACGwAAAAABGwAAAAADOAAAAAAAOAAAAAAAcQAAAAAAGwAAAAABGwAAAAACGwAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAGwAAAAADcQAAAAAAcQAAAAAAOAAAAAAAOAAAAAAAcQAAAAAAGwAAAAAAGwAAAAADGwAAAAAAOgAAAAAAOgAAAAAAOgAAAAAAOgAAAAAAOgAAAAAAOgAAAAAAcQAAAAAAOAAAAAAAOAAAAAAAOAAAAAAAOAAAAAAAOAAAAAAAcQAAAAAAGwAAAAAAGwAAAAADGwAAAAADOgAAAAAAOgAAAAAAOgAAAAAAOgAAAAAAOgAAAAAAOgAAAAAAGwAAAAACOAAAAAAAOAAAAAAAOAAAAAAAOAAAAAAAOAAAAAAAcQAAAAAAGwAAAAACGwAAAAABGwAAAAAAOgAAAAAAOgAAAAAAOgAAAAAAOgAAAAAAOgAAAAAAOgAAAAAAcQAAAAAAOAAAAAAAOAAAAAAAOAAAAAAAOAAAAAAAOAAAAAAAcQAAAAAAGwAAAAAAGwAAAAAAGwAAAAACcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAYAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAYAAAAAAAYAAAAAAAcQAAAAAAGwAAAAADGwAAAAADGwAAAAAAGwAAAAACGwAAAAABGwAAAAAAGwAAAAACGwAAAAABGwAAAAADGwAAAAABGwAAAAABGwAAAAACGwAAAAACGwAAAAACGwAAAAAAGwAAAAACGwAAAAAAGwAAAAABGwAAAAADGwAAAAABGwAAAAADGwAAAAACGwAAAAACGwAAAAAAGwAAAAABGwAAAAABGwAAAAACGwAAAAAAGwAAAAAAGwAAAAACGwAAAAADGwAAAAABGwAAAAAAGwAAAAACcQAAAAAAcQAAAAAAGwAAAAADcQAAAAAAcQAAAAAAYAAAAAAAcQAAAAAAYAAAAAAAYAAAAAAAcQAAAAAAcQAAAAAAGwAAAAACGwAAAAAAcQAAAAAAGwAAAAACYAAAAAAAcQAAAAAASwAAAAAASwAAAAAASwAAAAAAcQAAAAAAbgAAAAABbgAAAAACcQAAAAAAbgAAAAACbgAAAAAAcQAAAAAAGwAAAAABGwAAAAACcQAAAAAAGwAAAAACGwAAAAADcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAGwAAAAACGwAAAAADcQAAAAAAKwAAAAACGwAAAAAAcQAAAAAAbgAAAAACbgAAAAAAbgAAAAABbgAAAAACbgAAAAAAcQAAAAAALQAAAAAALQAAAAAALQAAAAAAcQAAAAAAGwAAAAACGwAAAAAAcQAAAAAAKwAAAAAAGwAAAAAAYAAAAAAAbgAAAAAAbgAAAAABbgAAAAADbgAAAAACbgAAAAABcQAAAAAALQAAAAAAJgAAAAAALQAAAAAAcQAAAAAAYAAAAAAAYAAAAAAAcQAAAAAAKwAAAAACGwAAAAADcQAAAAAAbgAAAAADbgAAAAADbgAAAAACbgAAAAADbgAAAAADcQAAAAAALQAAAAAALQAAAAAALQAAAAAAcQAAAAAAGwAAAAADGwAAAAABcQAAAAAAKwAAAAAAGwAAAAACGwAAAAAAbgAAAAAAbgAAAAACbgAAAAADbgAAAAACbgAAAAAAcQAAAAAALQAAAAAALQAAAAAALQAAAAAAcQAAAAAAGwAAAAAAGwAAAAADGwAAAAAC
+          tiles: WwAAAAADWwAAAAADWwAAAAADWwAAAAABWwAAAAADWwAAAAABcQAAAAAAGwAAAAADGwAAAAAAGwAAAAAAOAAAAAAAOAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAWwAAAAADWwAAAAACWwAAAAAAWwAAAAACWwAAAAADWwAAAAABcQAAAAAAGwAAAAACGwAAAAABGwAAAAADOAAAAAAAOAAAAAAAcQAAAAAAGwAAAAABGwAAAAACGwAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAGwAAAAADcQAAAAAAcQAAAAAAOAAAAAAAOAAAAAAAcQAAAAAAGwAAAAAAGwAAAAADGwAAAAAAOgAAAAAAOgAAAAAAOgAAAAAAOgAAAAAAOgAAAAAAOgAAAAAAOgAAAAAAOAAAAAAAOAAAAAAAOAAAAAAAOAAAAAAAOAAAAAAAcQAAAAAAGwAAAAAAGwAAAAADGwAAAAADOgAAAAAAOgAAAAAAOgAAAAAAOgAAAAAAOgAAAAAAOgAAAAAAGwAAAAACOAAAAAAAOAAAAAAAOAAAAAAAOAAAAAAAOAAAAAAAcQAAAAAAGwAAAAACGwAAAAABGwAAAAAAOgAAAAAAOgAAAAAAOgAAAAAAOgAAAAAAOgAAAAAAOgAAAAAAcQAAAAAAOAAAAAAAOAAAAAAAOAAAAAAAOAAAAAAAOAAAAAAAcQAAAAAAGwAAAAAAGwAAAAAAGwAAAAACcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAYAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAYAAAAAAAYAAAAAAAcQAAAAAAGwAAAAADGwAAAAADGwAAAAAAGwAAAAACGwAAAAABGwAAAAAAGwAAAAACGwAAAAABGwAAAAADGwAAAAABGwAAAAABGwAAAAACGwAAAAACGwAAAAACGwAAAAAAGwAAAAACGwAAAAAAGwAAAAABGwAAAAADGwAAAAABGwAAAAADGwAAAAACGwAAAAACGwAAAAAAGwAAAAABGwAAAAABGwAAAAACGwAAAAAAGwAAAAAAGwAAAAACGwAAAAADGwAAAAABGwAAAAAAGwAAAAACcQAAAAAAcQAAAAAAGwAAAAADcQAAAAAAcQAAAAAAYAAAAAAAcQAAAAAAYAAAAAAAYAAAAAAAcQAAAAAAcQAAAAAAGwAAAAACGwAAAAAAcQAAAAAAGwAAAAACYAAAAAAAcQAAAAAASwAAAAAASwAAAAAASwAAAAAAcQAAAAAAbgAAAAABbgAAAAACcQAAAAAAbgAAAAACbgAAAAAAcQAAAAAAGwAAAAABGwAAAAACcQAAAAAAGwAAAAACGwAAAAADcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAGwAAAAACGwAAAAADcQAAAAAAKwAAAAACGwAAAAAAcQAAAAAAbgAAAAACbgAAAAAAbgAAAAABbgAAAAACbgAAAAAAcQAAAAAALQAAAAAALQAAAAAALQAAAAAAcQAAAAAAGwAAAAACGwAAAAAAcQAAAAAAKwAAAAAAGwAAAAAAYAAAAAAAbgAAAAAAbgAAAAABbgAAAAADbgAAAAACbgAAAAABcQAAAAAALQAAAAAAJgAAAAAALQAAAAAAcQAAAAAAYAAAAAAAYAAAAAAAcQAAAAAAKwAAAAACGwAAAAADcQAAAAAAbgAAAAADbgAAAAADbgAAAAACbgAAAAADbgAAAAADcQAAAAAALQAAAAAALQAAAAAALQAAAAAAcQAAAAAAGwAAAAADGwAAAAABcQAAAAAAKwAAAAAAGwAAAAACGwAAAAAAbgAAAAAAbgAAAAACbgAAAAADbgAAAAACbgAAAAAAcQAAAAAALQAAAAAALQAAAAAALQAAAAAAcQAAAAAAGwAAAAAAGwAAAAADGwAAAAAC
           version: 6
         0,-1:
           ind: 0,-1
@@ -658,8 +658,8 @@ entities:
           1,3:
             0: 65535
           2,0:
-            0: 65527
-            1: 8
+            1: 2185
+            0: 63350
           2,1:
             0: 65535
           2,2:
@@ -691,7 +691,8 @@ entities:
           -4,3:
             0: 65535
           -3,0:
-            0: 65535
+            0: 65527
+            1: 8
           -3,1:
             0: 65535
           -3,2:
@@ -699,7 +700,8 @@ entities:
           -3,3:
             0: 65535
           -2,0:
-            0: 65535
+            0: 65533
+            1: 2
           -2,1:
             0: 65535
           -2,2:
@@ -726,7 +728,8 @@ entities:
           4,0:
             0: 65535
           4,1:
-            0: 65535
+            0: 32767
+            1: 32768
           4,2:
             0: 65535
           4,3:
@@ -736,7 +739,8 @@ entities:
           5,0:
             0: 65392
           5,1:
-            0: 65535
+            0: 65503
+            1: 32
           5,2:
             0: 65535
           5,3:
@@ -746,7 +750,8 @@ entities:
           6,1:
             0: 63283
           6,2:
-            0: 65535
+            0: 40959
+            1: 24576
           6,3:
             0: 65535
           7,2:
@@ -756,9 +761,11 @@ entities:
           -8,3:
             0: 61160
           -7,2:
-            0: 65262
+            0: 48878
+            1: 16384
           -7,3:
-            0: 65535
+            0: 65275
+            1: 260
           -7,1:
             0: 60552
           -6,1:
@@ -776,7 +783,8 @@ entities:
           -5,2:
             0: 65535
           -5,3:
-            0: 65535
+            0: 65503
+            1: 32
           -8,4:
             0: 35054
           -8,5:
@@ -792,7 +800,8 @@ entities:
           -7,6:
             0: 65535
           -7,7:
-            0: 65535
+            0: 65467
+            1: 68
           -6,4:
             0: 32767
           -6,5:
@@ -800,7 +809,8 @@ entities:
           -6,6:
             0: 13107
           -6,7:
-            0: 13107
+            1: 1
+            0: 13106
           -5,4:
             0: 2303
           4,4:
@@ -814,7 +824,8 @@ entities:
           5,7:
             0: 34952
           6,4:
-            0: 65535
+            0: 44799
+            1: 20736
           6,5:
             0: 65535
           6,6:
@@ -856,7 +867,8 @@ entities:
           5,11:
             0: 68
           6,8:
-            0: 53247
+            1: 1
+            0: 53246
             2: 12288
           6,9:
             2: 307
@@ -878,7 +890,8 @@ entities:
           -3,5:
             0: 65535
           -3,6:
-            0: 61439
+            0: 27647
+            1: 33792
           -3,7:
             0: 140
           -2,4:
@@ -902,16 +915,18 @@ entities:
           0,5:
             0: 65535
           0,6:
-            0: 65535
+            0: 32767
+            1: 32768
           0,7:
             0: 36095
           1,4:
-            0: 65535
+            0: 61439
+            6: 4096
           1,5:
             0: 65535
           1,6:
             0: 57343
-            1: 8192
+            6: 8192
           1,7:
             0: 65535
           2,4:
@@ -919,7 +934,8 @@ entities:
           2,5:
             0: 65535
           2,6:
-            0: 65535
+            0: 57343
+            1: 8192
           2,7:
             0: 4919
           3,4:
@@ -1033,6 +1049,21 @@ entities:
           moles:
           - 6666.982
           - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.14993
+          moles:
+          - 18.472576
+          - 69.49208
           - 0
           - 0
           - 0
@@ -1575,6 +1606,11 @@ entities:
   - uid: 93
     components:
     - pos: 13.386792,2.5118203
+      parent: 1
+      type: Transform
+  - uid: 1176
+    components:
+    - pos: 13.667228,2.6111274
       parent: 1
       type: Transform
 - proto: AmeShielding
@@ -7117,7 +7153,7 @@ entities:
     - pos: 22.5,8.5
       parent: 1
       type: Transform
-  - uid: 1169
+  - uid: 1196
     components:
     - pos: 21.5,8.5
       parent: 1
@@ -7164,18 +7200,24 @@ entities:
     - pos: -8.5,27.5
       parent: 1
       type: Transform
-    - containers:
-        entity_storage: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 1177
-          - 1176
-        paper_label: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
-      type: ContainerContainer
+    - air:
+        volume: 200
+        immutable: False
+        temperature: 293.1496
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+      type: EntityStorage
 - proto: ClosetL3JanitorFilled
   entities:
   - uid: 1178
@@ -7183,6 +7225,24 @@ entities:
     - pos: -9.5,26.5
       parent: 1
       type: Transform
+    - air:
+        volume: 200
+        immutable: False
+        temperature: 293.1496
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+      type: EntityStorage
 - proto: ClosetL3ScienceFilled
   entities:
   - uid: 1179
@@ -7190,61 +7250,24 @@ entities:
     - pos: 26.5,19.5
       parent: 1
       type: Transform
-- proto: ClothingBackpackCaptain
-  entities:
-  - uid: 1181
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 1180
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
-- proto: ClothingBackpackSatchelCaptain
-  entities:
-  - uid: 1182
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 1180
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
-- proto: ClothingBeltSheathFilled
-  entities:
-  - uid: 1183
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 1180
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
-- proto: ClothingHandsGlovesCaptain
-  entities:
-  - uid: 1184
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 1180
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
-- proto: ClothingHeadHatCaptain
-  entities:
-  - uid: 1185
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 1180
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
+    - air:
+        volume: 200
+        immutable: False
+        temperature: 293.1496
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+      type: EntityStorage
 - proto: ClothingHeadHatCatEars
   entities:
   - uid: 1198
@@ -7259,105 +7282,6 @@ entities:
     - pos: -18.450588,5.9712296
       parent: 1
       type: Transform
-- proto: ClothingMaskGasCaptain
-  entities:
-  - uid: 1186
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 1180
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
-- proto: ClothingNeckCloakCap
-  entities:
-  - uid: 1187
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 1180
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
-- proto: ClothingNeckCloakCapFormal
-  entities:
-  - uid: 1188
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 1180
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
-- proto: ClothingNeckCloakRd
-  entities:
-  - uid: 1201
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 1200
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
-- proto: ClothingNeckMantleRD
-  entities:
-  - uid: 1202
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 1200
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
-- proto: ClothingOuterHardsuitCap
-  entities:
-  - uid: 1189
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 1180
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
-- proto: ClothingOuterHardsuitRd
-  entities:
-  - uid: 1203
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 1200
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
-- proto: ClothingOuterWinterHydro
-  entities:
-  - uid: 1212
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 1211
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
-- proto: ClothingOuterWinterRD
-  entities:
-  - uid: 1204
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 1200
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
 - proto: ClothingUnderSocksBee
   entities:
   - uid: 1214
@@ -7372,50 +7296,6 @@ entities:
     - pos: 28.819748,33.338997
       parent: 1
       type: Transform
-- proto: ClothingUniformJumpskirtCapFormalDress
-  entities:
-  - uid: 1190
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 1180
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
-- proto: ClothingUniformJumpskirtCaptain
-  entities:
-  - uid: 1191
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 1180
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
-- proto: ClothingUniformJumpskirtJanimaid
-  entities:
-  - uid: 1176
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 1175
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
-- proto: ClothingUniformJumpskirtJanimaidmini
-  entities:
-  - uid: 1177
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 1175
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
 - proto: ClothingUniformJumpskirtNurse
   entities:
   - uid: 1216
@@ -7430,50 +7310,6 @@ entities:
     - pos: -18.469084,5.312676
       parent: 1
       type: Transform
-- proto: ClothingUniformJumpskirtResearchDirector
-  entities:
-  - uid: 1205
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 1200
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
-- proto: ClothingUniformJumpsuitCapFormal
-  entities:
-  - uid: 1192
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 1180
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
-- proto: ClothingUniformJumpsuitCaptain
-  entities:
-  - uid: 1193
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 1180
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
-- proto: ClothingUniformJumpsuitResearchDirector
-  entities:
-  - uid: 1206
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 1200
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
 - proto: ComfyChair
   entities:
   - uid: 1218
@@ -7647,58 +7483,29 @@ entities:
     - pos: -25.5,11.5
       parent: 1
       type: Transform
+    - air:
+        volume: 200
+        immutable: False
+        temperature: 293.1496
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+      type: EntityStorage
 - proto: CrateChemistrySupplies
   entities:
   - uid: 1240
     components:
     - pos: -25.5,12.5
-      parent: 1
-      type: Transform
-- proto: CrateEmergencyAdvancedKit
-  entities:
-  - uid: 1241
-    components:
-    - pos: -23.5,28.5
-      parent: 1
-      type: Transform
-- proto: CrateEngineeringSolar
-  entities:
-  - uid: 1242
-    components:
-    - pos: 25.5,11.5
-      parent: 1
-      type: Transform
-  - uid: 1243
-    components:
-    - pos: 26.5,11.5
-      parent: 1
-      type: Transform
-- proto: CrateFoodBarSupply
-  entities:
-  - uid: 1244
-    components:
-    - pos: -8.5,0.5
-      parent: 1
-      type: Transform
-- proto: CrateFoodCooking
-  entities:
-  - uid: 1245
-    components:
-    - pos: 8.5,0.5
-      parent: 1
-      type: Transform
-- proto: CrateHydroponicsSeeds
-  entities:
-  - uid: 1246
-    components:
-    - pos: 11.5,2.5
-      parent: 1
-      type: Transform
-- proto: CrateHydroponicsTools
-  entities:
-  - uid: 1211
-    components:
-    - pos: 11.5,0.5
       parent: 1
       type: Transform
     - air:
@@ -7719,18 +7526,132 @@ entities:
         - 0
         - 0
       type: EntityStorage
-    - containers:
-        entity_storage: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 1213
-          - 1212
-        paper_label: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
-      type: ContainerContainer
+- proto: CrateEmergencyAdvancedKit
+  entities:
+  - uid: 1241
+    components:
+    - pos: -23.5,28.5
+      parent: 1
+      type: Transform
+    - air:
+        volume: 200
+        immutable: False
+        temperature: 293.1496
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+      type: EntityStorage
+- proto: CrateEngineeringSolar
+  entities:
+  - uid: 1242
+    components:
+    - pos: 25.5,11.5
+      parent: 1
+      type: Transform
+    - air:
+        volume: 200
+        immutable: False
+        temperature: 293.1496
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+      type: EntityStorage
+  - uid: 1243
+    components:
+    - pos: 26.5,11.5
+      parent: 1
+      type: Transform
+    - air:
+        volume: 200
+        immutable: False
+        temperature: 293.1496
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+      type: EntityStorage
+- proto: CrateFoodBarSupply
+  entities:
+  - uid: 1244
+    components:
+    - pos: -8.5,0.5
+      parent: 1
+      type: Transform
+    - air:
+        volume: 200
+        immutable: False
+        temperature: 293.1496
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+      type: EntityStorage
+- proto: CrateFoodCooking
+  entities:
+  - uid: 2404
+    components:
+    - pos: 2.5,3.5
+      parent: 1
+      type: Transform
+- proto: CrateFreezer
+  entities:
+  - uid: 1202
+    components:
+    - pos: 8.5,0.5
+      parent: 1
+      type: Transform
+- proto: CrateHydroponicsSeeds
+  entities:
+  - uid: 1201
+    components:
+    - pos: 8.5,3.5
+      parent: 1
+      type: Transform
+- proto: CrateHydroponicsTools
+  entities:
+  - uid: 1203
+    components:
+    - pos: 11.5,2.5
+      parent: 1
+      type: Transform
 - proto: CrateMedicalSecure
   entities:
   - uid: 1247
@@ -7738,13 +7659,24 @@ entities:
     - pos: -18.5,13.5
       parent: 1
       type: Transform
-- proto: CrewMonitoringServer
-  entities:
-  - uid: 1248
-    components:
-    - pos: 29.5,31.5
-      parent: 1
-      type: Transform
+    - air:
+        volume: 200
+        immutable: False
+        temperature: 293.1496
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+      type: EntityStorage
 - proto: CryoPod
   entities:
   - uid: 201
@@ -7927,28 +7859,6 @@ entities:
     - pos: 10.5,15.5
       parent: 1
       type: Transform
-- proto: DoorRemoteResearch
-  entities:
-  - uid: 1207
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 1200
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
-- proto: DrinkFlask
-  entities:
-  - uid: 1194
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 1180
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
 - proto: DrinkGlass
   entities:
   - uid: 1275
@@ -7961,17 +7871,6 @@ entities:
     - pos: 5.4697385,16.483053
       parent: 1
       type: Transform
-- proto: DrinkRumBottleFull
-  entities:
-  - uid: 1195
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 1180
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
 - proto: DrinkShaker
   entities:
   - uid: 1277
@@ -8018,20 +7917,6 @@ entities:
     - pos: -5.6021686,13.64361
       parent: 1
       type: Transform
-- proto: EncryptionKeyCommand
-  entities:
-  - uid: 1285
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 6.525608,31.487883
-      parent: 1
-      type: Transform
-  - uid: 1286
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 5.478733,31.503508
-      parent: 1
-      type: Transform
 - proto: EncryptionKeyMedical
   entities:
   - uid: 1287
@@ -8044,6 +7929,14 @@ entities:
   - uid: 1288
     components:
     - pos: -12.591112,4.8010683
+      parent: 1
+      type: Transform
+- proto: ExtinguisherCabinetFilled
+  entities:
+  - uid: 1182
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 27.5,27.5
       parent: 1
       type: Transform
 - proto: FaxMachineShip
@@ -8583,6 +8476,8 @@ entities:
       pos: 16.5,8.5
       parent: 1
       type: Transform
+    - color: '#0335FCFF'
+      type: AtmosPipeColor
 - proto: GasFilter
   entities:
   - uid: 1385
@@ -9148,6 +9043,12 @@ entities:
       type: Transform
 - proto: GasPipeStraight
   entities:
+  - uid: 1169
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 21.5,8.5
+      parent: 1
+      type: Transform
   - uid: 1467
     components:
     - rot: -1.5707963267948966 rad
@@ -9369,12 +9270,6 @@ entities:
   - uid: 1500
     components:
     - pos: 22.5,9.5
-      parent: 1
-      type: Transform
-  - uid: 1501
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 21.5,8.5
       parent: 1
       type: Transform
   - uid: 1502
@@ -13934,6 +13829,8 @@ entities:
       pos: 18.5,8.5
       parent: 1
       type: Transform
+    - color: '#0335FCFF'
+      type: AtmosPipeColor
 - proto: GeigerCounter
   entities:
   - uid: 2111
@@ -14417,12 +14314,12 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 213
-          - 210
-          - 212
-          - 211
-          - 208
           - 209
+          - 208
+          - 211
+          - 212
+          - 210
+          - 213
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -14523,17 +14420,6 @@ entities:
     - pos: -11.5,14.5
       parent: 1
       type: Transform
-- proto: HydroponicsToolClippers
-  entities:
-  - uid: 1213
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 1211
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
 - proto: hydroponicsTrayAnchored
   entities:
   - uid: 2217
@@ -14587,22 +14473,11 @@ entities:
     - pos: 26.5,34.5
       parent: 1
       type: Transform
-- proto: JetpackCaptainFilled
-  entities:
-  - uid: 1196
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 1180
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
 - proto: KitchenMicrowave
   entities:
-  - uid: 2226
+  - uid: 1195
     components:
-    - pos: 4.5,5.5
+    - pos: 5.5,5.5
       parent: 1
       type: Transform
 - proto: KitchenReagentGrinder
@@ -14638,92 +14513,29 @@ entities:
     - pos: 19.5,7.5
       parent: 1
       type: Transform
+    - air:
+        volume: 200
+        immutable: False
+        temperature: 293.1496
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+      type: EntityStorage
 - proto: LockerBoozeFilled
   entities:
   - uid: 2232
     components:
     - pos: -6.5,0.5
-      parent: 1
-      type: Transform
-- proto: LockerBotanistFilled
-  entities:
-  - uid: 2233
-    components:
-    - pos: 11.5,1.5
-      parent: 1
-      type: Transform
-- proto: LockerCaptain
-  entities:
-  - uid: 1180
-    components:
-    - pos: 4.5,19.5
-      parent: 1
-      type: Transform
-    - containers:
-        entity_storage: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 1196
-          - 1182
-          - 1186
-          - 1183
-          - 1194
-          - 1185
-          - 1189
-          - 1191
-          - 1193
-          - 1184
-          - 1197
-          - 1192
-          - 1188
-          - 1190
-          - 1187
-          - 1195
-          - 1181
-        paper_label: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
-      type: ContainerContainer
-- proto: LockerChiefEngineerFilledHardsuit
-  entities:
-  - uid: 2234
-    components:
-    - pos: 3.5,27.5
-      parent: 1
-      type: Transform
-- proto: LockerChiefMedicalOfficerFilledHardsuit
-  entities:
-  - uid: 2235
-    components:
-    - pos: 9.5,27.5
-      parent: 1
-      type: Transform
-- proto: LockerEngineerFilledHardsuit
-  entities:
-  - uid: 2236
-    components:
-    - pos: 21.5,5.5
-      parent: 1
-      type: Transform
-- proto: LockerMedicalFilled
-  entities:
-  - uid: 2237
-    components:
-    - pos: -25.5,28.5
-      parent: 1
-      type: Transform
-  - uid: 2238
-    components:
-    - pos: -25.5,29.5
-      parent: 1
-      type: Transform
-- proto: LockerResearchDirector
-  entities:
-  - uid: 1200
-    components:
-    - pos: 5.5,27.5
       parent: 1
       type: Transform
     - air:
@@ -14744,26 +14556,193 @@ entities:
         - 0
         - 0
       type: EntityStorage
-    - containers:
-        entity_storage: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 1207
-          - 1208
-          - 1206
-          - 1209
-          - 1201
-          - 1210
-          - 1203
-          - 1204
-          - 1202
-          - 1205
-        paper_label: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
-      type: ContainerContainer
+- proto: LockerBotanistFilled
+  entities:
+  - uid: 2233
+    components:
+    - pos: 11.5,1.5
+      parent: 1
+      type: Transform
+    - air:
+        volume: 200
+        immutable: False
+        temperature: 293.1496
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+      type: EntityStorage
+- proto: LockerCaptainFilledHardsuit
+  entities:
+  - uid: 1180
+    components:
+    - pos: 4.5,19.5
+      parent: 1
+      type: Transform
+    - air:
+        volume: 200
+        immutable: False
+        temperature: 293.1495
+        moles:
+        - 1.606311
+        - 6.042789
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+      type: EntityStorage
+- proto: LockerChemistryFilled
+  entities:
+  - uid: 1183
+    components:
+    - pos: -17.5,13.5
+      parent: 1
+      type: Transform
+- proto: LockerChiefEngineerFilledHardsuit
+  entities:
+  - uid: 2234
+    components:
+    - pos: 3.5,27.5
+      parent: 1
+      type: Transform
+    - air:
+        volume: 200
+        immutable: False
+        temperature: 293.1496
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+      type: EntityStorage
+- proto: LockerChiefMedicalOfficerFilledHardsuit
+  entities:
+  - uid: 2235
+    components:
+    - pos: 9.5,27.5
+      parent: 1
+      type: Transform
+    - air:
+        volume: 200
+        immutable: False
+        temperature: 293.1496
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+      type: EntityStorage
+- proto: LockerEngineerFilledHardsuit
+  entities:
+  - uid: 2236
+    components:
+    - pos: 21.5,5.5
+      parent: 1
+      type: Transform
+    - air:
+        volume: 200
+        immutable: False
+        temperature: 293.1496
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+      type: EntityStorage
+- proto: LockerMedicalFilled
+  entities:
+  - uid: 1186
+    components:
+    - pos: -25.5,29.5
+      parent: 1
+      type: Transform
+  - uid: 2237
+    components:
+    - pos: -25.5,28.5
+      parent: 1
+      type: Transform
+    - air:
+        volume: 200
+        immutable: False
+        temperature: 293.1496
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+      type: EntityStorage
+- proto: LockerResearchDirectorFilledHardsuit
+  entities:
+  - uid: 1181
+    components:
+    - pos: 5.5,27.5
+      parent: 1
+      type: Transform
+    - air:
+        volume: 200
+        immutable: False
+        temperature: 293.1495
+        moles:
+        - 1.606311
+        - 6.042789
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+      type: EntityStorage
 - proto: LockerScienceFilled
   entities:
   - uid: 2239
@@ -14771,11 +14750,47 @@ entities:
     - pos: 24.5,18.5
       parent: 1
       type: Transform
+    - air:
+        volume: 200
+        immutable: False
+        temperature: 293.1496
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+      type: EntityStorage
   - uid: 2240
     components:
     - pos: 24.5,19.5
       parent: 1
       type: Transform
+    - air:
+        volume: 200
+        immutable: False
+        temperature: 293.1496
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+      type: EntityStorage
 - proto: LockerWallMedicalFilled
   entities:
   - uid: 2241
@@ -14921,6 +14936,11 @@ entities:
       type: Transform
 - proto: PaperBin10
   entities:
+  - uid: 1194
+    components:
+    - pos: 8.5,29.5
+      parent: 1
+      type: Transform
   - uid: 2262
     components:
     - rot: -1.5707963267948966 rad
@@ -15100,6 +15120,17 @@ entities:
       type: Transform
 - proto: Poweredlight
   entities:
+  - uid: 1286
+    components:
+    - pos: 8.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 1501
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 5.5,3.5
+      parent: 1
+      type: Transform
   - uid: 2291
     components:
     - pos: 20.5,13.5
@@ -15250,18 +15281,6 @@ entities:
     components:
     - rot: 1.5707963267948966 rad
       pos: -4.5,0.5
-      parent: 1
-      type: Transform
-  - uid: 2318
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 5.5,3.5
-      parent: 1
-      type: Transform
-  - uid: 2319
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 7.5,3.5
       parent: 1
       type: Transform
   - uid: 2320
@@ -15742,16 +15761,6 @@ entities:
       pos: -22.5,7.5
       parent: 1
       type: Transform
-  - uid: 2403
-    components:
-    - pos: 26.5,9.5
-      parent: 1
-      type: Transform
-  - uid: 2404
-    components:
-    - pos: 26.5,8.5
-      parent: 1
-      type: Transform
   - uid: 2405
     components:
     - pos: 25.5,7.5
@@ -15833,6 +15842,46 @@ entities:
     components:
     - rot: 1.5707963267948966 rad
       pos: -3.5,13.5
+      parent: 1
+      type: Transform
+- proto: RandomDrinkBottle
+  entities:
+  - uid: 1191
+    components:
+    - pos: -3.5,5.5
+      parent: 1
+      type: Transform
+- proto: RandomDrinkGlass
+  entities:
+  - uid: 1189
+    components:
+    - pos: -3.5,3.5
+      parent: 1
+      type: Transform
+- proto: RandomFoodBakedSingle
+  entities:
+  - uid: 1185
+    components:
+    - pos: 4.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 1197
+    components:
+    - pos: 2.5,-0.5
+      parent: 1
+      type: Transform
+- proto: RandomFoodMeal
+  entities:
+  - uid: 1192
+    components:
+    - pos: 0.5,4.5
+      parent: 1
+      type: Transform
+- proto: RandomFoodSingle
+  entities:
+  - uid: 1200
+    components:
+    - pos: -4.5,0.5
       parent: 1
       type: Transform
 - proto: RandomPosterAny
@@ -16316,28 +16365,6 @@ entities:
     - pos: 29.5,33.5
       parent: 1
       type: Transform
-- proto: ResearchAndDevelopmentServerMachineCircuitboard
-  entities:
-  - uid: 1208
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 1200
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
-- proto: ResearchComputerCircuitboard
-  entities:
-  - uid: 1209
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 1200
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
 - proto: Rickenbacker4003Instrument
   entities:
   - uid: 2512
@@ -16352,17 +16379,6 @@ entities:
     - pos: 5.3989453,12.53084
       parent: 1
       type: Transform
-- proto: RubberStampRd
-  entities:
-  - uid: 1210
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 1200
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
 - proto: ScienceTechFab
   entities:
   - uid: 2514
@@ -17396,9 +17412,9 @@ entities:
       type: Transform
 - proto: SpawnPointScientist
   entities:
-  - uid: 2665
+  - uid: 1184
     components:
-    - pos: 24.5,18.5
+    - pos: 27.5,18.5
       parent: 1
       type: Transform
 - proto: SpawnPointStationEngineer
@@ -17487,9 +17503,9 @@ entities:
       type: Transform
 - proto: SuitStorageBasic
   entities:
-  - uid: 2678
+  - uid: 1177
     components:
-    - pos: 24.5,32.5
+    - pos: 29.5,31.5
       parent: 1
       type: Transform
 - proto: SuitStorageEVA
@@ -17499,6 +17515,24 @@ entities:
     - pos: -27.5,14.5
       parent: 1
       type: Transform
+    - air:
+        volume: 200
+        immutable: False
+        temperature: 293.1496
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+      type: EntityStorage
   - uid: 2680
     components:
     - pos: 28.5,14.5
@@ -17580,10 +17614,52 @@ entities:
       type: Transform
 - proto: Table
   entities:
-  - uid: 2688
+  - uid: 1207
     components:
     - rot: 1.5707963267948966 rad
-      pos: -0.5,2.5
+      pos: -5.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 1208
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -6.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 1210
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 3.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 1211
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 4.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 1212
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -7.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 1213
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -7.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 1245
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 7.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 1246
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 8.5,5.5
       parent: 1
       type: Transform
   - uid: 2689
@@ -17632,9 +17708,15 @@ entities:
       type: Transform
 - proto: TableCounterMetal
   entities:
-  - uid: 2697
+  - uid: 1190
     components:
-    - pos: 3.5,5.5
+    - pos: 5.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 1285
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 6.5,3.5
       parent: 1
       type: Transform
   - uid: 2698
@@ -17645,27 +17727,6 @@ entities:
   - uid: 2699
     components:
     - pos: -3.5,4.5
-      parent: 1
-      type: Transform
-  - uid: 2700
-    components:
-    - pos: -5.5,5.5
-      parent: 1
-      type: Transform
-  - uid: 2701
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -6.5,5.5
-      parent: 1
-      type: Transform
-  - uid: 2702
-    components:
-    - pos: 4.5,5.5
-      parent: 1
-      type: Transform
-  - uid: 2703
-    components:
-    - pos: 5.5,5.5
       parent: 1
       type: Transform
   - uid: 2704
@@ -17713,16 +17774,6 @@ entities:
     - pos: -25.5,22.5
       parent: 1
       type: Transform
-  - uid: 2713
-    components:
-    - pos: 2.5,3.5
-      parent: 1
-      type: Transform
-  - uid: 2714
-    components:
-    - pos: 3.5,3.5
-      parent: 1
-      type: Transform
   - uid: 2715
     components:
     - pos: -26.5,23.5
@@ -17731,27 +17782,6 @@ entities:
   - uid: 2716
     components:
     - pos: -28.5,23.5
-      parent: 1
-      type: Transform
-  - uid: 2717
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -7.5,5.5
-      parent: 1
-      type: Transform
-  - uid: 2718
-    components:
-    - pos: -7.5,4.5
-      parent: 1
-      type: Transform
-  - uid: 2719
-    components:
-    - pos: 8.5,5.5
-      parent: 1
-      type: Transform
-  - uid: 2720
-    components:
-    - pos: 7.5,5.5
       parent: 1
       type: Transform
 - proto: TableGlass
@@ -17810,11 +17840,6 @@ entities:
   - uid: 2732
     components:
     - pos: -19.5,11.5
-      parent: 1
-      type: Transform
-  - uid: 2733
-    components:
-    - pos: -17.5,13.5
       parent: 1
       type: Transform
 - proto: TableReinforced
@@ -18157,20 +18182,16 @@ entities:
       type: Transform
 - proto: VendingMachineChefDrobe
   entities:
-  - uid: 2788
+  - uid: 1248
     components:
-    - flags: SessionSpecific
-      type: MetaData
     - pos: 8.5,1.5
       parent: 1
       type: Transform
 - proto: VendingMachineChefvend
   entities:
-  - uid: 2789
+  - uid: 1206
     components:
-    - flags: SessionSpecific
-      type: MetaData
-    - pos: 4.5,3.5
+    - pos: 3.5,5.5
       parent: 1
       type: Transform
 - proto: VendingMachineChemDrobe
@@ -18193,18 +18214,9 @@ entities:
       type: Transform
 - proto: VendingMachineCondiments
   entities:
-  - uid: 2792
+  - uid: 1193
     components:
-    - flags: SessionSpecific
-      type: MetaData
-    - pos: -0.5,2.5
-      parent: 1
-      type: Transform
-  - uid: 2793
-    components:
-    - flags: SessionSpecific
-      type: MetaData
-    - pos: 5.5,5.5
+    - pos: 0.5,5.5
       parent: 1
       type: Transform
 - proto: VendingMachineCuddlyCritterVend
@@ -18218,11 +18230,9 @@ entities:
       type: Transform
 - proto: VendingMachineDinnerware
   entities:
-  - uid: 2795
+  - uid: 1209
     components:
-    - flags: SessionSpecific
-      type: MetaData
-    - pos: 5.5,3.5
+    - pos: 4.5,5.5
       parent: 1
       type: Transform
 - proto: VendingMachineEngiDrobe
@@ -18234,13 +18244,18 @@ entities:
     - pos: 19.5,5.5
       parent: 1
       type: Transform
+- proto: VendingMachineEngivend
+  entities:
+  - uid: 1188
+    components:
+    - pos: 26.5,9.5
+      parent: 1
+      type: Transform
 - proto: VendingMachineHydrobe
   entities:
-  - uid: 2797
+  - uid: 1204
     components:
-    - flags: SessionSpecific
-      type: MetaData
-    - pos: 10.5,5.5
+    - pos: 11.5,0.5
       parent: 1
       type: Transform
 - proto: VendingMachineJaniDrobe
@@ -18268,6 +18283,20 @@ entities:
     - flags: SessionSpecific
       type: MetaData
     - pos: -16.5,1.5
+      parent: 1
+      type: Transform
+- proto: VendingMachineMediDrobe
+  entities:
+  - uid: 2226
+    components:
+    - pos: -28.5,25.5
+      parent: 1
+      type: Transform
+- proto: VendingMachineNutri
+  entities:
+  - uid: 2238
+    components:
+    - pos: 10.5,0.5
       parent: 1
       type: Transform
 - proto: VendingMachineRoboDrobe
@@ -18338,6 +18367,13 @@ entities:
     - flags: SessionSpecific
       type: MetaData
     - pos: -2.5,18.5
+      parent: 1
+      type: Transform
+- proto: VendingMachineYouTool
+  entities:
+  - uid: 1187
+    components:
+    - pos: 26.5,8.5
       parent: 1
       type: Transform
 - proto: WallmountTelevision
@@ -20482,11 +20518,6 @@ entities:
     - pos: -3.5,2.5
       parent: 1
       type: Transform
-  - uid: 3218
-    components:
-    - pos: 6.5,3.5
-      parent: 1
-      type: Transform
   - uid: 3219
     components:
     - pos: 21.5,13.5
@@ -21605,17 +21636,6 @@ entities:
     - pos: -10.5,13.5
       parent: 1
       type: Transform
-- proto: WeaponAntiqueLaser
-  entities:
-  - uid: 1197
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 1180
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
 - proto: WeaponCapacitorRecharger
   entities:
   - uid: 3429
@@ -21659,6 +21679,20 @@ entities:
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
+- proto: Windoor
+  entities:
+  - uid: 1205
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 6.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 2318
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 6.5,3.5
+      parent: 1
+      type: Transform
 - proto: WindoorSecure
   entities:
   - uid: 3431
@@ -21705,6 +21739,19 @@ entities:
     components:
     - rot: -1.5707963267948966 rad
       pos: 27.5,24.5
+      parent: 1
+      type: Transform
+- proto: WindowDirectional
+  entities:
+  - uid: 2319
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 6.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 2403
+    components:
+    - pos: 6.5,3.5
       parent: 1
       type: Transform
 ...


### PR DESCRIPTION
## About the PR
Small changes all around

Fixed the RD locker
Removed the health monitor server
Removed the command headset keys
Added paperbin in bridge for fax
Updated the cap locker to baseline
Added missing vend machines:
engi+tool in the back of engi storage
Medical drob in medical
Seeds in botanic.
Added chem locker
Changed kitchen layout a bit.
Added missing freezer in chef backroom

Thats about it

## Why / Balance
I love this ship, needed small changed to keep it up to date and removed radio keys and rd door remote.

## Technical details
.yml

## Media
- [ ] I have added screenshots/videos to this PR showcasing its changes ingame,

## Breaking changes
N/A No need to even update price. sell price is now 180000

**Changelog**
:cl: dvir01
- tweak: Improved some aspects of the beloved crescent.