### PR TITLE
Salvage Mobs, fix again

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
@@ -157,12 +157,12 @@
     spawned:
     - id: FoodMeatDragon
       amount: 3
-  - type: SalvageMobRestrictions
   # half damage, spread evenly
   - type: MeleeWeapon
     damage:
       groups:
         Brute: 12
+  - type: SalvageMobRestrictions # Frontier
 
 - type: entity
   id: ActionSpawnRift

--- a/Resources/Prototypes/Procedural/salvage_factions.yml
+++ b/Resources/Prototypes/Procedural/salvage_factions.yml
@@ -36,7 +36,7 @@
   configs:
     DefenseStructure: XenoWardingTower
     Mining: Xenos
-    Megafauna: MobXenoQueen
+    Megafauna: MobXenoQueenDungeon # Frontier
 
 - type: salvageFaction
   id: Carps


### PR DESCRIPTION
## About the PR
Fixing the salvage xeno queen to die on FTL again.

## Why / Balance
No need to have it running on frontier.

## Technical details
.yml

## Media
- [X] this PR does not require an ingame showcase

## Breaking changes
N/A

**Changelog**
N/A
