### PR TITLE
Slimes are no longer ghost roles

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/slimes.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/slimes.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   name: basic slime
   id: MobAdultSlimes
   parent: [ SimpleMobBase, MobCombat ]
@@ -111,15 +111,6 @@
     successChance: 0.5
     interactSuccessString: petting-success-slimes
     interactFailureString: petting-failure-generic
-  - type: ReplacementAccent
-    accent: slimes
-  - type: GhostTakeoverAvailable
-  - type: GhostRole
-    makeSentient: true
-    name: ghost-role-information-slimes-name
-    description: ghost-role-information-slimes-description
-  - type: Speech
-    speechVerb: Slime
 
 - type: entity
   name: blue slime


### PR DESCRIPTION

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Removed the ghost role components from MobAdultSlimes

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Reagent slimes being ghost roles is problematic, and I don't think there are any other situations where slimes are/need to be a ghost role here, so.
- [X] This PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
Could affect other slime ghost roles but I don't think that will be an issue.

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- remove: Slimes can no longer be taken over as a ghost role.
<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
