### PR TITLE
NT Rigger: A Dedicated Engi/Atmos Ship

### DIFF
--- a/Resources/Maps/Shuttles/rigger.yml
+++ b/Resources/Maps/Shuttles/rigger.yml
@@ -3244,13 +3244,6 @@ entities:
     - pos: -1.5,-9.5
       parent: 1
       type: Transform
-- proto: CrewMonitoringServer
-  entities:
-  - uid: 53
-    components:
-    - pos: -1.5,13.5
-      parent: 1
-      type: Transform
 - proto: DisposalPipe
   entities:
   - uid: 859
@@ -3445,11 +3438,6 @@ entities:
       type: Transform
 - proto: FireAxeCabinetFilled
   entities:
-  - uid: 1001
-    components:
-    - pos: 0.5,7.5
-      parent: 1
-      type: Transform
   - uid: 1002
     components:
     - rot: -1.5707963267948966 rad
@@ -6635,6 +6623,11 @@ entities:
       type: Transform
 - proto: TableReinforcedGlass
   entities:
+  - uid: 53
+    components:
+    - pos: -1.5,13.5
+      parent: 1
+      type: Transform
   - uid: 517
     components:
     - rot: -1.5707963267948966 rad
@@ -6824,6 +6817,18 @@ entities:
   - uid: 153
     components:
     - pos: -0.5,-7.5
+      parent: 1
+      type: Transform
+- proto: VendingMachineRestockMedical
+  entities:
+  - uid: 1001
+    components:
+    - pos: -1.4739108,13.573167
+      parent: 1
+      type: Transform
+  - uid: 1070
+    components:
+    - pos: -1.2176399,13.601657
       parent: 1
       type: Transform
 - proto: VendingMachineRobotics

--- a/Resources/Maps/Shuttles/rigger.yml
+++ b/Resources/Maps/Shuttles/rigger.yml
@@ -1,0 +1,7588 @@
+meta:
+  format: 6
+  postmapinit: false
+tilemap:
+  0: Space
+  27: FloorDark
+  30: FloorDarkHerringbone
+  32: FloorDarkMono
+  59: FloorLaundry
+  85: FloorSteelCheckerDark
+  96: FloorTechMaint
+  101: FloorWhiteDiagonal
+  111: FloorWoodTile
+  112: Lattice
+  113: Plating
+entities:
+- proto: ""
+  entities:
+  - uid: 1
+    components:
+    - name: grid
+      type: MetaData
+    - pos: -0.5426248,-0.4928913
+      parent: invalid
+      type: Transform
+    - chunks:
+        0,0:
+          ind: 0,0
+          tiles: GwAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGwAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGwAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGwAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGwAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGwAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGwAAAAAAYAAAAAAAGwAAAAAAGwAAAAAAcQAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAVQAAAAAAVQAAAAAAVQAAAAAAcQAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAVQAAAAAAVQAAAAAAVQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAVQAAAAAAVQAAAAAAVQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAVQAAAAAAVQAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAcQAAAAAAYAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZQAAAAAAcQAAAAAAOwAAAAAAOwAAAAAAcQAAAAAAcQAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZQAAAAAAcQAAAAAAOwAAAAAAcQAAAAAAcQAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          version: 6
+        0,-1:
+          ind: 0,-1
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAYAAAAAAAYAAAAAAAYAAAAAAAcQAAAAAAcQAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAYAAAAAAAYAAAAAAAYAAAAAAAYAAAAAAAcQAAAAAAcQAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAYAAAAAAAYAAAAAAAYAAAAAAAYAAAAAAAYAAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAYAAAAAAAYAAAAAAAYAAAAAAAYAAAAAAAYAAAAAAAYAAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAYAAAAAAAYAAAAAAAYAAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAYAAAAAAAYAAAAAAAYAAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAYAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAGwAAAAAAGwAAAAAAYAAAAAAAcQAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAYAAAAAAAcQAAAAAAcAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGwAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGwAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGwAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGwAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          version: 6
+        -1,-1:
+          ind: -1,-1
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcQAAAAAAIAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcQAAAAAAcQAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAIAAAAAAAYAAAAAAAYAAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAIAAAAAAAGwAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAIAAAAAAAGwAAAAAAGwAAAAAAIAAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAGwAAAAAAGwAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAIAAAAAAAYAAAAAAAIAAAAAAAGwAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAIAAAAAAAYAAAAAAAIAAAAAAAGwAAAAAAGwAAAAAAIAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAIAAAAAAAYAAAAAAAIAAAAAAAIAAAAAAAGwAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAYAAAAAAAYAAAAAAAcQAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAYAAAAAAAYAAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAcQAAAAAAGwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAYAAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAcQAAAAAAGwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAYAAAAAAAGwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAYAAAAAAAGwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAYAAAAAAAcQAAAAAAYAAAAAAA
+          version: 6
+        -1,0:
+          ind: -1,0
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAYAAAAAAAcQAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAYAAAAAAAcQAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAcQAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAcQAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAcQAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAcQAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAIAAAAAAAIAAAAAAAGwAAAAAAGwAAAAAAcQAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAYAAAAAAAYAAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAYAAAAAAAYAAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAYAAAAAAAYAAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAYAAAAAAAcQAAAAAAGwAAAAAAGwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAHgAAAAAAHgAAAAAAHgAAAAAAHgAAAAAAHgAAAAAAcQAAAAAAGwAAAAAAGwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAIAAAAAAAIAAAAAAAHgAAAAAAHgAAAAAAHgAAAAAAbwAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAIAAAAAAAHgAAAAAAHgAAAAAAHgAAAAAAHgAAAAAAbwAAAAAAcQAAAAAAZQAAAAAAZQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAHgAAAAAAHgAAAAAAbwAAAAAAcQAAAAAAZQAAAAAAZQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAIAAAAAAAIAAAAAAAHgAAAAAAHgAAAAAAHgAAAAAAcQAAAAAAZQAAAAAAZQAAAAAA
+          version: 6
+        0,1:
+          ind: 0,1
+          tiles: cQAAAAAAcQAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          version: 6
+        -1,1:
+          ind: -1,1
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          version: 6
+      type: MapGrid
+    - type: Broadphase
+    - bodyStatus: InAir
+      angularDamping: 0.05
+      linearDamping: 0.05
+      fixedRotation: False
+      bodyType: Dynamic
+      type: Physics
+    - fixtures: {}
+      type: Fixtures
+    - type: OccluderTree
+    - type: SpreaderGrid
+    - type: Shuttle
+    - type: GridPathfinding
+    - gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+      type: Gravity
+    - chunkCollection:
+        version: 2
+        nodes:
+        - node:
+            color: '#FFFFFFFF'
+            id: Arrows
+          decals:
+            126: -3,-12
+            127: -2,-12
+            128: -1,-12
+            188: -1,-14
+            189: -2,-14
+            190: -3,-14
+        - node:
+            angle: 4.71238898038469 rad
+            color: '#FFFFFFFF'
+            id: Arrows
+          decals:
+            9: -5,-8
+            10: -5,-9
+            191: -7,-9
+            192: -7,-8
+        - node:
+            color: '#FFFFFFFF'
+            id: Bot
+          decals:
+            0: -1,-9
+            1: -2,-9
+            2: -3,-9
+            3: -3,-10
+            4: -2,-10
+            5: -1,-10
+        - node:
+            color: '#FFFFFFFF'
+            id: BotGreyscale
+          decals:
+            111: -8,15
+            112: -7,15
+            113: -9,14
+            114: -9,12
+            115: -6,15
+            116: -5,15
+            117: -6,11
+            145: -1,-6
+            146: 0,-6
+            151: -7,-4
+            152: -7,-5
+            153: -6,-5
+            154: -7,-11
+            155: -6,-12
+            156: -2,-8
+            157: -1,-8
+            158: -1,2
+            159: -1,5
+            160: -1,6
+            161: 6,-9
+            162: 6,-10
+            177: -6,6
+            178: -5,6
+            179: 5,-8
+            180: 6,-8
+            182: 4,-8
+        - node:
+            angle: 4.71238898038469 rad
+            color: '#FFFFFFFF'
+            id: BotGreyscale
+          decals:
+            193: -3,-1
+            194: -3,0
+            195: -3,1
+        - node:
+            color: '#FFFFFFFF'
+            id: BotLeftGreyscale
+          decals:
+            183: -7,-8
+            184: -7,-9
+            185: -3,-14
+            186: -2,-14
+            187: -1,-14
+        - node:
+            color: '#FFFFFFFF'
+            id: BoxGreyscale
+          decals:
+            107: -8,12
+            108: -9,13
+            109: -8,14
+            110: -7,14
+            118: 2,-9
+        - node:
+            angle: 4.71238898038469 rad
+            color: '#FFFFFFFF'
+            id: BoxGreyscale
+          decals:
+            7: -5,-10
+            8: -5,-12
+        - node:
+            color: '#334E6DFF'
+            id: BrickTileWhiteCornerNe
+          decals:
+            18: -4,15
+        - node:
+            color: '#334E6DFF'
+            id: BrickTileWhiteCornerNw
+          decals:
+            26: -8,15
+            27: -9,14
+        - node:
+            color: '#334E6DFF'
+            id: BrickTileWhiteCornerSe
+          decals:
+            17: -4,11
+        - node:
+            color: '#334E6DFF'
+            id: BrickTileWhiteCornerSw
+          decals:
+            28: -9,12
+            29: -8,11
+        - node:
+            color: '#334E6DFF'
+            id: BrickTileWhiteInnerNw
+          decals:
+            30: -8,14
+        - node:
+            color: '#334E6DFF'
+            id: BrickTileWhiteInnerSw
+          decals:
+            31: -8,12
+        - node:
+            color: '#169C9CFF'
+            id: BrickTileWhiteLineE
+          decals:
+            45: -3,-2
+            46: -3,-3
+        - node:
+            color: '#169C9CFF'
+            id: BrickTileWhiteLineN
+          decals:
+            140: -1,6
+            141: 0,6
+        - node:
+            color: '#334E6DFF'
+            id: BrickTileWhiteLineN
+          decals:
+            23: -5,15
+            24: -6,15
+            25: -7,15
+        - node:
+            color: '#52B4E9FF'
+            id: BrickTileWhiteLineN
+          decals:
+            14: -2,15
+            15: -1,15
+            16: 0,15
+        - node:
+            color: '#EFB34196'
+            id: BrickTileWhiteLineN
+          decals:
+            163: -6,6
+            164: -5,6
+            165: -3,6
+            166: -4,6
+            171: 1,-8
+            172: 2,-8
+            173: 3,-8
+            174: 4,-8
+            175: 5,-8
+            176: 6,-8
+        - node:
+            color: '#169C9CFF'
+            id: BrickTileWhiteLineS
+          decals:
+            135: -1,-6
+            136: 0,-6
+            137: 1,-6
+            138: 2,-6
+            139: 3,-6
+        - node:
+            color: '#334E6DFF'
+            id: BrickTileWhiteLineS
+          decals:
+            19: -5,11
+            20: -6,11
+            21: -7,11
+        - node:
+            color: '#52B4E9FF'
+            id: BrickTileWhiteLineS
+          decals:
+            11: -2,13
+            12: -1,13
+            13: 0,13
+        - node:
+            color: '#EFB34196'
+            id: BrickTileWhiteLineS
+          decals:
+            42: -7,-5
+            43: -6,-5
+            44: -5,-5
+            167: -3,8
+            168: -4,8
+            169: -4,-5
+            170: -3,-5
+        - node:
+            color: '#334E6DFF'
+            id: BrickTileWhiteLineW
+          decals:
+            22: -9,13
+        - node:
+            color: '#0096FFFF'
+            id: DeliveryGreyscale
+          decals:
+            87: -6,9
+            88: -7,9
+            89: -7,8
+        - node:
+            color: '#3AB3DAFF'
+            id: DeliveryGreyscale
+          decals:
+            148: -1,-1
+        - node:
+            color: '#B02E26FF'
+            id: DeliveryGreyscale
+          decals:
+            143: 3,-5
+            144: 3,-6
+        - node:
+            color: '#F9801DFF'
+            id: DeliveryGreyscale
+          decals:
+            147: -1,1
+        - node:
+            color: '#FF0000FF'
+            id: DeliveryGreyscale
+          decals:
+            149: -1,0
+        - node:
+            color: '#334E6DFF'
+            id: HerringboneOverlay
+          decals:
+            39: -8,13
+            40: -7,13
+            41: -6,13
+        - node:
+            color: '#FFFFFFFF'
+            id: LoadingArea
+          decals:
+            125: -4,-11
+        - node:
+            angle: 4.71238898038469 rad
+            color: '#FFFFFFFF'
+            id: LoadingArea
+          decals:
+            6: -4,-7
+        - node:
+            color: '#FFFFFFFF'
+            id: MiniTileSteelLineE
+          decals:
+            121: 3,11
+            122: 3,10
+            123: 3,9
+            124: 3,8
+        - node:
+            color: '#FFFFFFFF'
+            id: StandClear
+          decals:
+            69: 7,5
+            129: -4,-13
+            130: -4,-15
+        - node:
+            angle: 1.5707963267948966 rad
+            color: '#FFFFFFFF'
+            id: StandClear
+          decals:
+            70: -7,0
+            71: -7,1
+            72: -7,2
+            73: -7,3
+            74: -7,4
+            75: -8,-7
+            76: -6,-7
+            77: 9,2
+            78: 9,3
+            79: 9,4
+            80: 4,6
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnCornerSW
+          decals:
+            83: -6,-4
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnCornerSmallNE
+          decals:
+            106: 0,-5
+            201: -4,-2
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnCornerSmallNW
+          decals:
+            94: 4,-10
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnCornerSmallSE
+          decals:
+            150: 0,5
+            202: -4,2
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnCornerSmallSW
+          decals:
+            85: -5,-4
+            86: -6,-3
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnLineE
+          decals:
+            52: -7,4
+            53: -7,3
+            54: -7,2
+            55: -7,1
+            56: -7,0
+            57: -6,-7
+            58: -8,-7
+            64: 9,4
+            65: 9,3
+            66: 9,2
+            82: 4,6
+            95: 0,4
+            96: 0,3
+            97: 0,2
+            98: 0,1
+            99: 0,0
+            100: 0,-1
+            101: 0,-2
+            102: 0,-3
+            103: 0,-4
+            196: -4,-1
+            197: -4,0
+            198: -4,1
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnLineN
+          decals:
+            68: 7,5
+            133: -4,-15
+            134: -4,-13
+            200: -3,2
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnLineS
+          decals:
+            47: -7,0
+            48: -7,1
+            49: -7,2
+            50: -7,3
+            51: -7,4
+            59: -8,-7
+            60: -6,-7
+            61: 9,4
+            62: 9,3
+            63: 9,2
+            81: 4,6
+            84: -5,-5
+            93: 4,-9
+            119: -5,8
+            120: -5,9
+            181: 4,-8
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnLineW
+          decals:
+            67: 7,5
+            90: 1,-10
+            91: 2,-10
+            92: 3,-10
+            104: 1,-5
+            105: 2,-5
+            131: -4,-13
+            132: -4,-15
+            142: 3,-5
+            199: -3,-2
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinInnerNe
+          decals:
+            33: -5,11
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinInnerSe
+          decals:
+            35: -5,15
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinLineE
+          decals:
+            36: -5,12
+            37: -5,13
+            38: -5,14
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinLineN
+          decals:
+            32: -4,11
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinLineS
+          decals:
+            34: -4,15
+      type: DecalGrid
+    - version: 2
+      data:
+        tiles:
+          0,0:
+            0: 65535
+          0,1:
+            0: 65535
+          0,-1:
+            0: 65535
+          0,2:
+            0: 65535
+          0,3:
+            0: 65535
+          1,0:
+            0: 65527
+            1: 8
+          1,1:
+            0: 65535
+          1,2:
+            0: 65535
+          1,3:
+            0: 4983
+          2,0:
+            1: 1
+            0: 13106
+          2,1:
+            0: 4403
+          2,2:
+            0: 1
+          0,-4:
+            0: 65520
+          0,-3:
+            0: 65535
+          0,-2:
+            0: 65535
+          1,-4:
+            0: 29456
+          1,-3:
+            0: 65535
+          1,-2:
+            0: 65535
+          1,-1:
+            0: 63479
+            2: 8
+            3: 2048
+          2,-2:
+            0: 12560
+          2,-1:
+            2: 1
+            0: 12850
+            3: 256
+          -3,-3:
+            0: 52360
+          -3,-2:
+            0: 52428
+          -3,-1:
+            0: 52428
+          -2,-4:
+            0: 65216
+          -2,-3:
+            0: 65535
+          -2,-2:
+            0: 65535
+          -2,-1:
+            0: 65535
+          -1,-4:
+            0: 65520
+          -1,-3:
+            0: 65535
+          -1,-2:
+            0: 65535
+          -1,-1:
+            0: 65535
+          -3,1:
+            0: 61166
+          -3,2:
+            0: 61166
+          -3,3:
+            0: 52462
+          -3,0:
+            0: 52428
+          -2,0:
+            0: 65535
+          -2,1:
+            0: 65535
+          -2,2:
+            0: 65535
+          -2,3:
+            0: 65535
+          -1,0:
+            0: 65535
+          -1,1:
+            0: 65535
+          -1,2:
+            0: 65535
+          -1,3:
+            0: 65535
+          0,4:
+            0: 15
+          -2,4:
+            0: 15
+          -1,4:
+            0: 15
+          -3,4:
+            0: 8
+        uniqueMixes:
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 21.824879
+          - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 0
+          - 0
+          - 0
+          - 6666.982
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 6666.982
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 0
+          - 6666.982
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        chunkSize: 4
+      type: GridAtmosphere
+    - type: GasTileOverlay
+    - type: RadiationGridResistance
+    - id: rigger
+      type: BecomesStation
+- proto: AirAlarm
+  entities:
+  - uid: 317
+    components:
+    - name: ignition chamber output
+      type: MetaData
+    - pos: 1.5,5.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 250
+      - 249
+      type: DeviceNetwork
+    - devices:
+      - 249
+      - 250
+      type: DeviceList
+    - enabled: False
+      type: AccessReader
+    - type: Emagged
+  - uid: 318
+    components:
+    - name: ignition chamber vent
+      type: MetaData
+    - pos: 2.5,5.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 253
+      type: DeviceNetwork
+    - devices:
+      - 253
+      type: DeviceList
+    - enabled: False
+      type: AccessReader
+    - type: Emagged
+  - uid: 449
+    components:
+    - pos: 3.5,5.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 915
+      - 914
+      - 913
+      - 245
+      - 218
+      - 5
+      - 279
+      type: DeviceNetwork
+    - devices:
+      - 915
+      - 914
+      - 913
+      - 245
+      - 218
+      - 5
+      - 279
+      type: DeviceList
+  - uid: 479
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 0.5,-7.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 285
+      - 424
+      - 446
+      type: DeviceNetwork
+    - devices:
+      - 285
+      - 424
+      - 446
+      type: DeviceList
+  - uid: 480
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 0.5,-9.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 882
+      - 881
+      - 883
+      type: DeviceNetwork
+    - devices:
+      - 882
+      - 881
+      - 883
+      type: DeviceList
+  - uid: 481
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -1.5,5.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 911
+      - 910
+      - 912
+      type: DeviceNetwork
+    - devices:
+      - 912
+      - 910
+      - 911
+      type: DeviceList
+  - uid: 482
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -7.5,10.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 931
+      - 929
+      - 930
+      type: DeviceNetwork
+    - devices:
+      - 931
+      - 929
+      - 930
+      type: DeviceList
+  - uid: 864
+    components:
+    - pos: 3.5,12.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 960
+      - 966
+      - 959
+      - 961
+      - 967
+      - 958
+      type: DeviceNetwork
+    - devices:
+      - 960
+      - 966
+      - 959
+      - 961
+      - 967
+      - 958
+      type: DeviceList
+- proto: AirCanister
+  entities:
+  - uid: 916
+    components:
+    - pos: -6.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 917
+    components:
+    - pos: -5.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 928
+    components:
+    - pos: -6.5,8.5
+      parent: 1
+      type: Transform
+- proto: Airlock
+  entities:
+  - uid: 526
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 2.5,12.5
+      parent: 1
+      type: Transform
+- proto: AirlockAtmosphericsGlass
+  entities:
+  - uid: 304
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 1.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 405
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -1.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 411
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -1.5,-2.5
+      parent: 1
+      type: Transform
+- proto: AirlockCommandGlass
+  entities:
+  - uid: 492
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -3.5,10.5
+      parent: 1
+      type: Transform
+- proto: AirlockEngineeringGlass
+  entities:
+  - uid: 193
+    components:
+    - pos: -0.5,-12.5
+      parent: 1
+      type: Transform
+    - links:
+      - 824
+      type: DeviceLinkSink
+  - uid: 219
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -2.5,-5.5
+      parent: 1
+      type: Transform
+  - uid: 220
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -3.5,-5.5
+      parent: 1
+      type: Transform
+  - uid: 328
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -2.5,7.5
+      parent: 1
+      type: Transform
+  - uid: 338
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -5.5,-7.5
+      parent: 1
+      type: Transform
+    - links:
+      - 824
+      type: DeviceLinkSink
+  - uid: 339
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -5.5,-8.5
+      parent: 1
+      type: Transform
+    - links:
+      - 824
+      type: DeviceLinkSink
+  - uid: 346
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 1.5,-6.5
+      parent: 1
+      type: Transform
+  - uid: 353
+    components:
+    - pos: -2.5,-12.5
+      parent: 1
+      type: Transform
+    - links:
+      - 824
+      type: DeviceLinkSink
+  - uid: 367
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -3.5,7.5
+      parent: 1
+      type: Transform
+  - uid: 779
+    components:
+    - pos: -1.5,-12.5
+      parent: 1
+      type: Transform
+    - links:
+      - 824
+      type: DeviceLinkSink
+- proto: AirlockExternalGlass
+  entities:
+  - uid: 155
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 4.5,6.5
+      parent: 1
+      type: Transform
+- proto: AirlockGlassShuttle
+  entities:
+  - uid: 7
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -7.5,-8.5
+      parent: 1
+      type: Transform
+  - uid: 10
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -7.5,-7.5
+      parent: 1
+      type: Transform
+  - uid: 159
+    components:
+    - pos: -2.5,-14.5
+      parent: 1
+      type: Transform
+  - uid: 238
+    components:
+    - pos: -1.5,-14.5
+      parent: 1
+      type: Transform
+  - uid: 329
+    components:
+    - pos: -0.5,-14.5
+      parent: 1
+      type: Transform
+- proto: AirlockMedicalGlass
+  entities:
+  - uid: 502
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 0.5,12.5
+      parent: 1
+      type: Transform
+- proto: AirSensor
+  entities:
+  - uid: 218
+    components:
+    - pos: 1.5,-4.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 449
+      type: DeviceNetwork
+  - uid: 285
+    components:
+    - pos: 3.5,-8.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 479
+      type: DeviceNetwork
+  - uid: 883
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -3.5,-8.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 480
+      type: DeviceNetwork
+  - uid: 912
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -3.5,1.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 481
+      type: DeviceNetwork
+  - uid: 931
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -5.5,14.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 482
+      type: DeviceNetwork
+  - uid: 966
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 3.5,10.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 864
+      type: DeviceNetwork
+  - uid: 967
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -0.5,14.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 864
+      type: DeviceNetwork
+- proto: AmeController
+  entities:
+  - uid: 234
+    components:
+    - pos: 4.5,-11.5
+      parent: 1
+      type: Transform
+    - containers:
+        AmeFuel: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: 16
+      type: ContainerContainer
+- proto: AmeJar
+  entities:
+  - uid: 16
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 234
+      type: Transform
+    - canCollide: False
+      type: Physics
+  - uid: 423
+    components:
+    - pos: 5.554286,-10.349485
+      parent: 1
+      type: Transform
+- proto: AmeShielding
+  entities:
+  - uid: 181
+    components:
+    - pos: 1.5,-12.5
+      parent: 1
+      type: Transform
+  - uid: 213
+    components:
+    - pos: 2.5,-12.5
+      parent: 1
+      type: Transform
+  - uid: 231
+    components:
+    - pos: 3.5,-12.5
+      parent: 1
+      type: Transform
+  - uid: 232
+    components:
+    - pos: 2.5,-11.5
+      parent: 1
+      type: Transform
+  - uid: 233
+    components:
+    - pos: 1.5,-11.5
+      parent: 1
+      type: Transform
+  - uid: 235
+    components:
+    - pos: 1.5,-10.5
+      parent: 1
+      type: Transform
+  - uid: 236
+    components:
+    - pos: 2.5,-10.5
+      parent: 1
+      type: Transform
+  - uid: 242
+    components:
+    - pos: 3.5,-10.5
+      parent: 1
+      type: Transform
+  - uid: 254
+    components:
+    - pos: 3.5,-11.5
+      parent: 1
+      type: Transform
+- proto: APCBasic
+  entities:
+  - uid: 368
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -4.5,-5.5
+      parent: 1
+      type: Transform
+  - uid: 557
+    components:
+    - pos: 4.5,-6.5
+      parent: 1
+      type: Transform
+  - uid: 559
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -5.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 560
+    components:
+    - pos: 1.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 610
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 0.5,-10.5
+      parent: 1
+      type: Transform
+- proto: AtmosDeviceFanTiny
+  entities:
+  - uid: 8
+    components:
+    - pos: -6.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 32
+    components:
+    - pos: -6.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 42
+    components:
+    - pos: -7.5,-8.5
+      parent: 1
+      type: Transform
+  - uid: 111
+    components:
+    - pos: -2.5,-14.5
+      parent: 1
+      type: Transform
+  - uid: 143
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 4.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 148
+    components:
+    - pos: -1.5,-14.5
+      parent: 1
+      type: Transform
+  - uid: 158
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -0.5,-14.5
+      parent: 1
+      type: Transform
+  - uid: 171
+    components:
+    - pos: -3.5,-14.5
+      parent: 1
+      type: Transform
+  - uid: 185
+    components:
+    - pos: -7.5,-6.5
+      parent: 1
+      type: Transform
+  - uid: 337
+    components:
+    - pos: -7.5,-7.5
+      parent: 1
+      type: Transform
+  - uid: 372
+    components:
+    - pos: -6.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 373
+    components:
+    - pos: -6.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 374
+    components:
+    - pos: -6.5,0.5
+      parent: 1
+      type: Transform
+- proto: AtmosFixNitrogenMarker
+  entities:
+  - uid: 183
+    components:
+    - pos: 7.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 188
+    components:
+    - pos: 8.5,-1.5
+      parent: 1
+      type: Transform
+- proto: AtmosFixOxygenMarker
+  entities:
+  - uid: 136
+    components:
+    - pos: 7.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 168
+    components:
+    - pos: 8.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 530
+    components:
+    - pos: 8.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 1015
+    components:
+    - pos: 7.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 1016
+    components:
+    - pos: 7.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 1017
+    components:
+    - pos: 8.5,-3.5
+      parent: 1
+      type: Transform
+- proto: AtmosFixPlasmaMarker
+  entities:
+  - uid: 95
+    components:
+    - pos: 7.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 127
+    components:
+    - pos: 8.5,0.5
+      parent: 1
+      type: Transform
+- proto: Autolathe
+  entities:
+  - uid: 314
+    components:
+    - pos: -6.5,-3.5
+      parent: 1
+      type: Transform
+- proto: BenchSofaCorpCorner
+  entities:
+  - uid: 832
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 3.5,8.5
+      parent: 1
+      type: Transform
+    - canCollide: False
+      bodyType: Static
+      type: Physics
+    - fixtures: {}
+      type: Fixtures
+  - uid: 840
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -0.5,8.5
+      parent: 1
+      type: Transform
+    - canCollide: False
+      bodyType: Static
+      type: Physics
+    - fixtures: {}
+      type: Fixtures
+- proto: BenchSofaCorpLeft
+  entities:
+  - uid: 518
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -0.5,9.5
+      parent: 1
+      type: Transform
+    - bodyType: Static
+      type: Physics
+- proto: BenchSofaCorpMiddle
+  entities:
+  - uid: 528
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 1.5,8.5
+      parent: 1
+      type: Transform
+    - bodyType: Static
+      type: Physics
+  - uid: 539
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,8.5
+      parent: 1
+      type: Transform
+    - bodyType: Static
+      type: Physics
+  - uid: 540
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 2.5,8.5
+      parent: 1
+      type: Transform
+    - bodyType: Static
+      type: Physics
+- proto: BenchSofaCorpRight
+  entities:
+  - uid: 833
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 3.5,9.5
+      parent: 1
+      type: Transform
+    - bodyType: Static
+      type: Physics
+- proto: BlastDoor
+  entities:
+  - uid: 79
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 9.5,3.5
+      parent: 1
+      type: Transform
+    - links:
+      - 416
+      - 321
+      type: DeviceLinkSink
+  - uid: 87
+    components:
+    - pos: 7.5,5.5
+      parent: 1
+      type: Transform
+    - links:
+      - 320
+      - 321
+      type: DeviceLinkSink
+  - uid: 129
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 9.5,2.5
+      parent: 1
+      type: Transform
+    - links:
+      - 416
+      - 321
+      type: DeviceLinkSink
+  - uid: 130
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 9.5,4.5
+      parent: 1
+      type: Transform
+    - links:
+      - 416
+      - 321
+      type: DeviceLinkSink
+  - uid: 164
+    components:
+    - pos: -3.5,-14.5
+      parent: 1
+      type: Transform
+    - links:
+      - 1014
+      type: DeviceLinkSink
+  - uid: 191
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -7.5,-6.5
+      parent: 1
+      type: Transform
+    - links:
+      - 394
+      type: DeviceLinkSink
+  - uid: 347
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -5.5,-6.5
+      parent: 1
+      type: Transform
+    - links:
+      - 394
+      type: DeviceLinkSink
+  - uid: 425
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -6.5,4.5
+      parent: 1
+      type: Transform
+    - links:
+      - 445
+      - 444
+      type: DeviceLinkSink
+  - uid: 426
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -6.5,3.5
+      parent: 1
+      type: Transform
+    - links:
+      - 445
+      - 444
+      type: DeviceLinkSink
+  - uid: 427
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -6.5,2.5
+      parent: 1
+      type: Transform
+    - links:
+      - 445
+      - 444
+      type: DeviceLinkSink
+  - uid: 428
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -6.5,1.5
+      parent: 1
+      type: Transform
+    - links:
+      - 445
+      - 444
+      type: DeviceLinkSink
+  - uid: 429
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -6.5,0.5
+      parent: 1
+      type: Transform
+    - links:
+      - 445
+      - 444
+      type: DeviceLinkSink
+  - uid: 536
+    components:
+    - pos: -3.5,-12.5
+      parent: 1
+      type: Transform
+    - links:
+      - 1014
+      type: DeviceLinkSink
+- proto: BookshelfFilled
+  entities:
+  - uid: 744
+    components:
+    - pos: -3.5,15.5
+      parent: 1
+      type: Transform
+- proto: BorgModuleConstruction
+  entities:
+  - uid: 1059
+    components:
+    - pos: -2.7174199,3.2826922
+      parent: 1
+      type: Transform
+- proto: BoxDarts
+  entities:
+  - uid: 224
+    components:
+    - pos: 3.4302099,9.316309
+      parent: 1
+      type: Transform
+- proto: Bucket
+  entities:
+  - uid: 1029
+    components:
+    - pos: 2.246398,14.452408
+      parent: 1
+      type: Transform
+- proto: CableApcExtension
+  entities:
+  - uid: 80
+    components:
+    - pos: 6.5,-0.5
+      parent: 1
+      type: Transform
+  - uid: 362
+    components:
+    - pos: 7.5,-5.5
+      parent: 1
+      type: Transform
+  - uid: 379
+    components:
+    - pos: 8.5,-5.5
+      parent: 1
+      type: Transform
+  - uid: 381
+    components:
+    - pos: 8.5,-6.5
+      parent: 1
+      type: Transform
+  - uid: 577
+    components:
+    - pos: -4.5,-5.5
+      parent: 1
+      type: Transform
+  - uid: 578
+    components:
+    - pos: -4.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 619
+    components:
+    - pos: -5.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 620
+    components:
+    - pos: -5.5,11.5
+      parent: 1
+      type: Transform
+  - uid: 621
+    components:
+    - pos: -5.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 622
+    components:
+    - pos: -5.5,13.5
+      parent: 1
+      type: Transform
+  - uid: 623
+    components:
+    - pos: -6.5,13.5
+      parent: 1
+      type: Transform
+  - uid: 624
+    components:
+    - pos: -7.5,13.5
+      parent: 1
+      type: Transform
+  - uid: 625
+    components:
+    - pos: -8.5,13.5
+      parent: 1
+      type: Transform
+  - uid: 626
+    components:
+    - pos: -5.5,13.5
+      parent: 1
+      type: Transform
+  - uid: 627
+    components:
+    - pos: -5.5,14.5
+      parent: 1
+      type: Transform
+  - uid: 628
+    components:
+    - pos: -5.5,15.5
+      parent: 1
+      type: Transform
+  - uid: 629
+    components:
+    - pos: 1.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 630
+    components:
+    - pos: 1.5,11.5
+      parent: 1
+      type: Transform
+  - uid: 631
+    components:
+    - pos: 1.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 632
+    components:
+    - pos: 3.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 633
+    components:
+    - pos: 2.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 634
+    components:
+    - pos: 4.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 635
+    components:
+    - pos: 5.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 636
+    components:
+    - pos: 5.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 637
+    components:
+    - pos: 5.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 638
+    components:
+    - pos: 0.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 639
+    components:
+    - pos: 0.5,13.5
+      parent: 1
+      type: Transform
+  - uid: 640
+    components:
+    - pos: 0.5,14.5
+      parent: 1
+      type: Transform
+  - uid: 642
+    components:
+    - pos: 0.5,-10.5
+      parent: 1
+      type: Transform
+  - uid: 643
+    components:
+    - pos: -0.5,-10.5
+      parent: 1
+      type: Transform
+  - uid: 644
+    components:
+    - pos: -1.5,-10.5
+      parent: 1
+      type: Transform
+  - uid: 645
+    components:
+    - pos: -2.5,-10.5
+      parent: 1
+      type: Transform
+  - uid: 646
+    components:
+    - pos: -3.5,-10.5
+      parent: 1
+      type: Transform
+  - uid: 647
+    components:
+    - pos: -4.5,-10.5
+      parent: 1
+      type: Transform
+  - uid: 648
+    components:
+    - pos: -5.5,-10.5
+      parent: 1
+      type: Transform
+  - uid: 649
+    components:
+    - pos: -1.5,-9.5
+      parent: 1
+      type: Transform
+  - uid: 650
+    components:
+    - pos: -1.5,-8.5
+      parent: 1
+      type: Transform
+  - uid: 651
+    components:
+    - pos: -1.5,-7.5
+      parent: 1
+      type: Transform
+  - uid: 652
+    components:
+    - pos: -6.5,-10.5
+      parent: 1
+      type: Transform
+  - uid: 653
+    components:
+    - pos: -5.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 654
+    components:
+    - pos: -6.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 655
+    components:
+    - pos: -6.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 656
+    components:
+    - pos: -4.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 657
+    components:
+    - pos: -4.5,-2.5
+      parent: 1
+      type: Transform
+  - uid: 658
+    components:
+    - pos: -4.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 659
+    components:
+    - pos: -3.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 660
+    components:
+    - pos: -2.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 661
+    components:
+    - pos: -2.5,-5.5
+      parent: 1
+      type: Transform
+  - uid: 662
+    components:
+    - pos: -2.5,-13.5
+      parent: 1
+      type: Transform
+  - uid: 663
+    components:
+    - pos: -2.5,-12.5
+      parent: 1
+      type: Transform
+  - uid: 664
+    components:
+    - pos: -2.5,-11.5
+      parent: 1
+      type: Transform
+  - uid: 665
+    components:
+    - pos: -6.5,-8.5
+      parent: 1
+      type: Transform
+  - uid: 666
+    components:
+    - pos: -5.5,-8.5
+      parent: 1
+      type: Transform
+  - uid: 667
+    components:
+    - pos: -4.5,-8.5
+      parent: 1
+      type: Transform
+  - uid: 668
+    components:
+    - pos: -3.5,-8.5
+      parent: 1
+      type: Transform
+  - uid: 669
+    components:
+    - pos: -2.5,-8.5
+      parent: 1
+      type: Transform
+  - uid: 670
+    components:
+    - pos: -4.5,-0.5
+      parent: 1
+      type: Transform
+  - uid: 671
+    components:
+    - pos: -4.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 672
+    components:
+    - pos: -4.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 673
+    components:
+    - pos: -4.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 674
+    components:
+    - pos: -4.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 675
+    components:
+    - pos: -4.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 676
+    components:
+    - pos: -4.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 677
+    components:
+    - pos: -4.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 678
+    components:
+    - pos: -3.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 679
+    components:
+    - pos: -2.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 680
+    components:
+    - pos: -2.5,7.5
+      parent: 1
+      type: Transform
+  - uid: 681
+    components:
+    - pos: -3.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 682
+    components:
+    - pos: -2.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 683
+    components:
+    - pos: -4.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 684
+    components:
+    - pos: -3.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 685
+    components:
+    - pos: -2.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 686
+    components:
+    - pos: -5.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 687
+    components:
+    - pos: -5.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 688
+    components:
+    - pos: -6.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 689
+    components:
+    - pos: -6.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 690
+    components:
+    - pos: -5.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 691
+    components:
+    - pos: -6.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 692
+    components:
+    - pos: -3.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 693
+    components:
+    - pos: -2.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 694
+    components:
+    - pos: -7.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 695
+    components:
+    - pos: 4.5,-6.5
+      parent: 1
+      type: Transform
+  - uid: 696
+    components:
+    - pos: 4.5,-7.5
+      parent: 1
+      type: Transform
+  - uid: 697
+    components:
+    - pos: 4.5,-8.5
+      parent: 1
+      type: Transform
+  - uid: 698
+    components:
+    - pos: 4.5,-9.5
+      parent: 1
+      type: Transform
+  - uid: 699
+    components:
+    - pos: 4.5,-9.5
+      parent: 1
+      type: Transform
+  - uid: 700
+    components:
+    - pos: 4.5,-10.5
+      parent: 1
+      type: Transform
+  - uid: 701
+    components:
+    - pos: 3.5,-7.5
+      parent: 1
+      type: Transform
+  - uid: 702
+    components:
+    - pos: 2.5,-7.5
+      parent: 1
+      type: Transform
+  - uid: 703
+    components:
+    - pos: 1.5,-7.5
+      parent: 1
+      type: Transform
+  - uid: 704
+    components:
+    - pos: 1.5,-6.5
+      parent: 1
+      type: Transform
+  - uid: 705
+    components:
+    - pos: 1.5,-5.5
+      parent: 1
+      type: Transform
+  - uid: 706
+    components:
+    - pos: 1.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 707
+    components:
+    - pos: 1.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 708
+    components:
+    - pos: 1.5,-2.5
+      parent: 1
+      type: Transform
+  - uid: 709
+    components:
+    - pos: -0.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 710
+    components:
+    - pos: 0.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 711
+    components:
+    - pos: 4.5,-6.5
+      parent: 1
+      type: Transform
+  - uid: 712
+    components:
+    - pos: 4.5,-5.5
+      parent: 1
+      type: Transform
+  - uid: 713
+    components:
+    - pos: 4.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 714
+    components:
+    - pos: 4.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 715
+    components:
+    - pos: 4.5,-2.5
+      parent: 1
+      type: Transform
+  - uid: 716
+    components:
+    - pos: 4.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 717
+    components:
+    - pos: 4.5,-0.5
+      parent: 1
+      type: Transform
+  - uid: 718
+    components:
+    - pos: 4.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 719
+    components:
+    - pos: 4.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 720
+    components:
+    - pos: 4.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 721
+    components:
+    - pos: 4.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 722
+    components:
+    - pos: 4.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 723
+    components:
+    - pos: 1.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 724
+    components:
+    - pos: 1.5,-0.5
+      parent: 1
+      type: Transform
+  - uid: 725
+    components:
+    - pos: 1.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 726
+    components:
+    - pos: 1.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 727
+    components:
+    - pos: 1.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 728
+    components:
+    - pos: 1.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 729
+    components:
+    - pos: 1.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 730
+    components:
+    - pos: 0.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 731
+    components:
+    - pos: 0.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 732
+    components:
+    - pos: 0.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 733
+    components:
+    - pos: 1.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 734
+    components:
+    - pos: 2.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 735
+    components:
+    - pos: 3.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 736
+    components:
+    - pos: 4.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 737
+    components:
+    - pos: 5.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 738
+    components:
+    - pos: 6.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 739
+    components:
+    - pos: 6.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 740
+    components:
+    - pos: 6.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 741
+    components:
+    - pos: 6.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 742
+    components:
+    - pos: 6.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 743
+    components:
+    - pos: 6.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 745
+    components:
+    - pos: 6.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 746
+    components:
+    - pos: 6.5,-2.5
+      parent: 1
+      type: Transform
+  - uid: 747
+    components:
+    - pos: 6.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 748
+    components:
+    - pos: 6.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 749
+    components:
+    - pos: 5.5,-6.5
+      parent: 1
+      type: Transform
+  - uid: 750
+    components:
+    - pos: 6.5,-6.5
+      parent: 1
+      type: Transform
+  - uid: 751
+    components:
+    - pos: 6.5,-5.5
+      parent: 1
+      type: Transform
+  - uid: 752
+    components:
+    - pos: 6.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 757
+    components:
+    - pos: -4.5,11.5
+      parent: 1
+      type: Transform
+  - uid: 758
+    components:
+    - pos: -3.5,11.5
+      parent: 1
+      type: Transform
+  - uid: 759
+    components:
+    - pos: -3.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 760
+    components:
+    - pos: 1.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 761
+    components:
+    - pos: 1.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 762
+    components:
+    - pos: 0.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 763
+    components:
+    - pos: -0.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 764
+    components:
+    - pos: -1.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 765
+    components:
+    - pos: -1.5,11.5
+      parent: 1
+      type: Transform
+  - uid: 766
+    components:
+    - pos: -0.5,11.5
+      parent: 1
+      type: Transform
+  - uid: 767
+    components:
+    - pos: 0.5,11.5
+      parent: 1
+      type: Transform
+  - uid: 782
+    components:
+    - pos: 2.5,-14.5
+      parent: 1
+      type: Transform
+  - uid: 783
+    components:
+    - pos: 3.5,-14.5
+      parent: 1
+      type: Transform
+  - uid: 784
+    components:
+    - pos: 4.5,-14.5
+      parent: 1
+      type: Transform
+  - uid: 785
+    components:
+    - pos: 4.5,-13.5
+      parent: 1
+      type: Transform
+  - uid: 786
+    components:
+    - pos: 5.5,-13.5
+      parent: 1
+      type: Transform
+  - uid: 787
+    components:
+    - pos: 5.5,-12.5
+      parent: 1
+      type: Transform
+  - uid: 788
+    components:
+    - pos: 6.5,-12.5
+      parent: 1
+      type: Transform
+  - uid: 789
+    components:
+    - pos: 4.5,-12.5
+      parent: 1
+      type: Transform
+  - uid: 790
+    components:
+    - pos: 4.5,-11.5
+      parent: 1
+      type: Transform
+  - uid: 791
+    components:
+    - pos: -7.5,-12.5
+      parent: 1
+      type: Transform
+  - uid: 792
+    components:
+    - pos: -6.5,-12.5
+      parent: 1
+      type: Transform
+  - uid: 793
+    components:
+    - pos: -6.5,-13.5
+      parent: 1
+      type: Transform
+  - uid: 794
+    components:
+    - pos: -5.5,-13.5
+      parent: 1
+      type: Transform
+  - uid: 795
+    components:
+    - pos: -5.5,-14.5
+      parent: 1
+      type: Transform
+  - uid: 796
+    components:
+    - pos: -6.5,-11.5
+      parent: 1
+      type: Transform
+  - uid: 797
+    components:
+    - pos: 2.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 798
+    components:
+    - pos: 3.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 799
+    components:
+    - pos: 4.5,15.5
+      parent: 1
+      type: Transform
+  - uid: 800
+    components:
+    - pos: 5.5,14.5
+      parent: 1
+      type: Transform
+  - uid: 801
+    components:
+    - pos: 4.5,14.5
+      parent: 1
+      type: Transform
+  - uid: 802
+    components:
+    - pos: 3.5,14.5
+      parent: 1
+      type: Transform
+  - uid: 803
+    components:
+    - pos: 3.5,15.5
+      parent: 1
+      type: Transform
+  - uid: 804
+    components:
+    - pos: 2.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 805
+    components:
+    - pos: 5.5,13.5
+      parent: 1
+      type: Transform
+  - uid: 806
+    components:
+    - pos: 5.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 807
+    components:
+    - pos: 5.5,11.5
+      parent: 1
+      type: Transform
+  - uid: 808
+    components:
+    - pos: -4.5,15.5
+      parent: 1
+      type: Transform
+  - uid: 809
+    components:
+    - pos: 5.5,-7.5
+      parent: 1
+      type: Transform
+  - uid: 865
+    components:
+    - pos: 7.5,-11.5
+      parent: 1
+      type: Transform
+  - uid: 866
+    components:
+    - pos: 6.5,-11.5
+      parent: 1
+      type: Transform
+  - uid: 869
+    components:
+    - pos: 6.5,13.5
+      parent: 1
+      type: Transform
+  - uid: 870
+    components:
+    - pos: 5.5,13.5
+      parent: 1
+      type: Transform
+  - uid: 972
+    components:
+    - pos: -0.5,14.5
+      parent: 1
+      type: Transform
+  - uid: 973
+    components:
+    - pos: -1.5,14.5
+      parent: 1
+      type: Transform
+  - uid: 1022
+    components:
+    - pos: 6.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 1023
+    components:
+    - pos: 7.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 1038
+    components:
+    - pos: -5.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 1039
+    components:
+    - pos: -6.5,6.5
+      parent: 1
+      type: Transform
+- proto: CableHV
+  entities:
+  - uid: 93
+    components:
+    - pos: 6.5,-9.5
+      parent: 1
+      type: Transform
+  - uid: 117
+    components:
+    - pos: 4.5,-10.5
+      parent: 1
+      type: Transform
+  - uid: 119
+    components:
+    - pos: 5.5,-10.5
+      parent: 1
+      type: Transform
+  - uid: 134
+    components:
+    - pos: 6.5,-8.5
+      parent: 1
+      type: Transform
+  - uid: 163
+    components:
+    - pos: 5.5,-9.5
+      parent: 1
+      type: Transform
+  - uid: 198
+    components:
+    - pos: 6.5,-7.5
+      parent: 1
+      type: Transform
+  - uid: 228
+    components:
+    - pos: 5.5,-8.5
+      parent: 1
+      type: Transform
+  - uid: 255
+    components:
+    - pos: 4.5,-11.5
+      parent: 1
+      type: Transform
+  - uid: 535
+    components:
+    - pos: 2.5,-7.5
+      parent: 1
+      type: Transform
+  - uid: 1005
+    components:
+    - pos: 3.5,-7.5
+      parent: 1
+      type: Transform
+  - uid: 1011
+    components:
+    - pos: 4.5,-7.5
+      parent: 1
+      type: Transform
+  - uid: 1033
+    components:
+    - pos: 5.5,-7.5
+      parent: 1
+      type: Transform
+- proto: CableMV
+  entities:
+  - uid: 331
+    components:
+    - pos: -5.5,11.5
+      parent: 1
+      type: Transform
+  - uid: 541
+    components:
+    - pos: 1.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 558
+    components:
+    - pos: -4.5,11.5
+      parent: 1
+      type: Transform
+  - uid: 561
+    components:
+    - pos: 6.5,-7.5
+      parent: 1
+      type: Transform
+  - uid: 562
+    components:
+    - pos: 5.5,-7.5
+      parent: 1
+      type: Transform
+  - uid: 563
+    components:
+    - pos: 4.5,-7.5
+      parent: 1
+      type: Transform
+  - uid: 564
+    components:
+    - pos: 4.5,-6.5
+      parent: 1
+      type: Transform
+  - uid: 565
+    components:
+    - pos: 3.5,-7.5
+      parent: 1
+      type: Transform
+  - uid: 566
+    components:
+    - pos: 2.5,-7.5
+      parent: 1
+      type: Transform
+  - uid: 567
+    components:
+    - pos: 1.5,-7.5
+      parent: 1
+      type: Transform
+  - uid: 568
+    components:
+    - pos: 1.5,-6.5
+      parent: 1
+      type: Transform
+  - uid: 569
+    components:
+    - pos: -3.5,11.5
+      parent: 1
+      type: Transform
+  - uid: 571
+    components:
+    - pos: -3.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 572
+    components:
+    - pos: -3.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 573
+    components:
+    - pos: -3.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 574
+    components:
+    - pos: -3.5,7.5
+      parent: 1
+      type: Transform
+  - uid: 575
+    components:
+    - pos: -5.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 579
+    components:
+    - pos: -3.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 580
+    components:
+    - pos: -3.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 581
+    components:
+    - pos: -3.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 582
+    components:
+    - pos: -3.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 583
+    components:
+    - pos: -3.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 584
+    components:
+    - pos: -3.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 585
+    components:
+    - pos: -3.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 586
+    components:
+    - pos: -3.5,-0.5
+      parent: 1
+      type: Transform
+  - uid: 587
+    components:
+    - pos: -3.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 588
+    components:
+    - pos: -3.5,-2.5
+      parent: 1
+      type: Transform
+  - uid: 589
+    components:
+    - pos: -2.5,-2.5
+      parent: 1
+      type: Transform
+  - uid: 590
+    components:
+    - pos: -1.5,-2.5
+      parent: 1
+      type: Transform
+  - uid: 591
+    components:
+    - pos: -0.5,-2.5
+      parent: 1
+      type: Transform
+  - uid: 592
+    components:
+    - pos: 0.5,-2.5
+      parent: 1
+      type: Transform
+  - uid: 593
+    components:
+    - pos: 0.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 594
+    components:
+    - pos: 0.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 595
+    components:
+    - pos: 0.5,-5.5
+      parent: 1
+      type: Transform
+  - uid: 596
+    components:
+    - pos: 1.5,-5.5
+      parent: 1
+      type: Transform
+  - uid: 597
+    components:
+    - pos: -3.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 598
+    components:
+    - pos: -3.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 599
+    components:
+    - pos: -3.5,-5.5
+      parent: 1
+      type: Transform
+  - uid: 600
+    components:
+    - pos: -3.5,-6.5
+      parent: 1
+      type: Transform
+  - uid: 601
+    components:
+    - pos: -3.5,-7.5
+      parent: 1
+      type: Transform
+  - uid: 602
+    components:
+    - pos: -3.5,-8.5
+      parent: 1
+      type: Transform
+  - uid: 603
+    components:
+    - pos: -3.5,-9.5
+      parent: 1
+      type: Transform
+  - uid: 604
+    components:
+    - pos: -3.5,-10.5
+      parent: 1
+      type: Transform
+  - uid: 605
+    components:
+    - pos: -3.5,-10.5
+      parent: 1
+      type: Transform
+  - uid: 606
+    components:
+    - pos: -2.5,-10.5
+      parent: 1
+      type: Transform
+  - uid: 607
+    components:
+    - pos: -1.5,-10.5
+      parent: 1
+      type: Transform
+  - uid: 608
+    components:
+    - pos: -0.5,-10.5
+      parent: 1
+      type: Transform
+  - uid: 609
+    components:
+    - pos: 0.5,-10.5
+      parent: 1
+      type: Transform
+  - uid: 612
+    components:
+    - pos: -2.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 613
+    components:
+    - pos: -3.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 614
+    components:
+    - pos: -1.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 615
+    components:
+    - pos: 1.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 616
+    components:
+    - pos: 1.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 617
+    components:
+    - pos: 1.5,11.5
+      parent: 1
+      type: Transform
+  - uid: 618
+    components:
+    - pos: 1.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 641
+    components:
+    - pos: -4.5,-5.5
+      parent: 1
+      type: Transform
+  - uid: 841
+    components:
+    - pos: 1.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 842
+    components:
+    - pos: 0.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 843
+    components:
+    - pos: -0.5,8.5
+      parent: 1
+      type: Transform
+- proto: CableTerminal
+  entities:
+  - uid: 160
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 5.5,-9.5
+      parent: 1
+      type: Transform
+  - uid: 227
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 5.5,-8.5
+      parent: 1
+      type: Transform
+- proto: CapacitorStockPart
+  entities:
+  - uid: 325
+    components:
+    - pos: -2.377158,3.2595437
+      parent: 1
+      type: Transform
+  - uid: 326
+    components:
+    - pos: -2.1644638,3.2595437
+      parent: 1
+      type: Transform
+- proto: CarpetBlack
+  entities:
+  - uid: 834
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 3.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 835
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 3.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 836
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 2.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 837
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 2.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 838
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 1.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 839
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 1.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 968
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 969
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 970
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -0.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 971
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -0.5,9.5
+      parent: 1
+      type: Transform
+- proto: Catwalk
+  entities:
+  - uid: 433
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -7.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 434
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -7.5,-0.5
+      parent: 1
+      type: Transform
+  - uid: 435
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -7.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 436
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -7.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 437
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -7.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 438
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -7.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 439
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -7.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 440
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -7.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 441
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -7.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 753
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 5.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 754
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 6.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 755
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 7.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 756
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 5.5,5.5
+      parent: 1
+      type: Transform
+- proto: Chair
+  entities:
+  - uid: 531
+    components:
+    - pos: 0.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 534
+    components:
+    - pos: 1.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 1021
+    components:
+    - pos: 2.5,10.5
+      parent: 1
+      type: Transform
+- proto: ChairOfficeDark
+  entities:
+  - uid: 1034
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 2.5,-8.5
+      parent: 1
+      type: Transform
+- proto: ChairPilotSeat
+  entities:
+  - uid: 345
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -8.5,13.5
+      parent: 1
+      type: Transform
+  - uid: 550
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -7.5,14.5
+      parent: 1
+      type: Transform
+  - uid: 551
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -7.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 553
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -6.5,14.5
+      parent: 1
+      type: Transform
+- proto: CircuitImprinter
+  entities:
+  - uid: 420
+    components:
+    - pos: -5.5,-4.5
+      parent: 1
+      type: Transform
+- proto: ClothingBackpackDuffelMedical
+  entities:
+  - uid: 1065
+    components:
+    - pos: -0.5030486,13.763605
+      parent: 1
+      type: Transform
+    - storageUsed: 105
+      type: Storage
+    - containers:
+        storagebase: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 1066
+          - 1067
+          - 1068
+          - 1069
+      type: ContainerContainer
+    - type: ItemCooldown
+- proto: ClothingBeltParamedicFilled
+  entities:
+  - uid: 1064
+    components:
+    - pos: -0.5065114,13.386103
+      parent: 1
+      type: Transform
+- proto: ClothingHeadHelmetVoidParamed
+  entities:
+  - uid: 1066
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 1065
+      type: Transform
+    - canCollide: False
+      type: Physics
+- proto: ClothingOuterCoatParamedicWB
+  entities:
+  - uid: 1069
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 1065
+      type: Transform
+    - canCollide: False
+      type: Physics
+- proto: ClothingOuterHardsuitVoidParamed
+  entities:
+  - uid: 1067
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 1065
+      type: Transform
+    - group:
+      - hoverMessage: ""
+        contextText: verb-examine-group-other
+        icon: /Textures/Interface/examine-star.png
+        components:
+        - Armor
+        - ClothingSpeedModifier
+        entries:
+        - message: >-
+            It provides the following protection:
+
+            - [color=yellow]Slash[/color] damage reduced by [color=lightblue]5%[/color].
+
+            - [color=yellow]Heat[/color] damage reduced by [color=lightblue]10%[/color].
+
+            - [color=yellow]Radiation[/color] damage reduced by [color=lightblue]25%[/color].
+
+            - [color=yellow]Caustic[/color] damage reduced by [color=lightblue]50%[/color].
+          priority: 0
+          component: Armor
+        - message: This decreases your speed by [color=yellow]10%[/color].
+          priority: 0
+          component: ClothingSpeedModifier
+        title: null
+      type: GroupExamine
+    - canCollide: False
+      type: Physics
+- proto: ClothingUniformJumpsuitParamedic
+  entities:
+  - uid: 1068
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 1065
+      type: Transform
+    - canCollide: False
+      type: Physics
+- proto: ComfyChair
+  entities:
+  - uid: 547
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -3.5,14.5
+      parent: 1
+      type: Transform
+  - uid: 548
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -3.5,12.5
+      parent: 1
+      type: Transform
+- proto: ComputerCrewMonitoring
+  entities:
+  - uid: 543
+    components:
+    - pos: -7.5,15.5
+      parent: 1
+      type: Transform
+- proto: ComputerPowerMonitoring
+  entities:
+  - uid: 298
+    components:
+    - pos: 2.5,-7.5
+      parent: 1
+      type: Transform
+- proto: ComputerShuttle
+  entities:
+  - uid: 287
+    components:
+    - pos: -8.5,14.5
+      parent: 1
+      type: Transform
+- proto: ComputerStationRecords
+  entities:
+  - uid: 545
+    components:
+    - pos: -6.5,15.5
+      parent: 1
+      type: Transform
+- proto: ComputerSurveillanceCameraMonitor
+  entities:
+  - uid: 544
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -8.5,12.5
+      parent: 1
+      type: Transform
+- proto: ConveyorBelt
+  entities:
+  - uid: 122
+    components:
+    - pos: -3.5,-11.5
+      parent: 1
+      type: Transform
+    - links:
+      - 862
+      type: DeviceLinkSink
+  - uid: 123
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -5.5,-6.5
+      parent: 1
+      type: Transform
+    - links:
+      - 290
+      type: DeviceLinkSink
+  - uid: 150
+    components:
+    - pos: -3.5,-12.5
+      parent: 1
+      type: Transform
+    - links:
+      - 862
+      type: DeviceLinkSink
+  - uid: 151
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -6.5,-6.5
+      parent: 1
+      type: Transform
+    - links:
+      - 290
+      type: DeviceLinkSink
+  - uid: 156
+    components:
+    - pos: -3.5,-13.5
+      parent: 1
+      type: Transform
+    - links:
+      - 862
+      type: DeviceLinkSink
+  - uid: 157
+    components:
+    - pos: -3.5,-14.5
+      parent: 1
+      type: Transform
+    - links:
+      - 862
+      type: DeviceLinkSink
+  - uid: 190
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -7.5,-6.5
+      parent: 1
+      type: Transform
+    - links:
+      - 290
+      type: DeviceLinkSink
+  - uid: 393
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -4.5,-6.5
+      parent: 1
+      type: Transform
+    - links:
+      - 290
+      type: DeviceLinkSink
+- proto: CrateEngineeringCableBulk
+  entities:
+  - uid: 472
+    components:
+    - pos: -5.5,-1.5
+      parent: 1
+      type: Transform
+- proto: CrateMaterialGlass
+  entities:
+  - uid: 975
+    components:
+    - pos: -2.5,-9.5
+      parent: 1
+      type: Transform
+- proto: CrateMaterialSteel
+  entities:
+  - uid: 920
+    components:
+    - pos: -0.5,-9.5
+      parent: 1
+      type: Transform
+  - uid: 923
+    components:
+    - pos: -1.5,-9.5
+      parent: 1
+      type: Transform
+- proto: CrewMonitoringServer
+  entities:
+  - uid: 53
+    components:
+    - pos: -1.5,13.5
+      parent: 1
+      type: Transform
+- proto: DisposalPipe
+  entities:
+  - uid: 859
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 5.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 860
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 6.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 861
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 7.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 1020
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 8.5,8.5
+      parent: 1
+      type: Transform
+- proto: DisposalTrunk
+  entities:
+  - uid: 858
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 4.5,8.5
+      parent: 1
+      type: Transform
+- proto: DisposalUnit
+  entities:
+  - uid: 863
+    components:
+    - pos: 4.5,8.5
+      parent: 1
+      type: Transform
+- proto: DrinkMugMetal
+  entities:
+  - uid: 845
+    components:
+    - pos: 6.5791116,10.125744
+      parent: 1
+      type: Transform
+  - uid: 846
+    components:
+    - pos: 6.3446736,10.061763
+      parent: 1
+      type: Transform
+  - uid: 850
+    components:
+    - pos: 6.5151734,9.805839
+      parent: 1
+      type: Transform
+  - uid: 852
+    components:
+    - pos: 6.2807355,9.741858
+      parent: 1
+      type: Transform
+  - uid: 855
+    components:
+    - pos: 6.621737,9.357971
+      parent: 1
+      type: Transform
+  - uid: 856
+    components:
+    - pos: 6.4299245,9.571241
+      parent: 1
+      type: Transform
+  - uid: 857
+    components:
+    - pos: 6.302048,9.272663
+      parent: 1
+      type: Transform
+- proto: DrinkVacuumFlask
+  entities:
+  - uid: 844
+    components:
+    - pos: 6.856175,9.357971
+      parent: 1
+      type: Transform
+  - uid: 851
+    components:
+    - pos: 6.8135514,10.232379
+      parent: 1
+      type: Transform
+  - uid: 853
+    components:
+    - pos: 6.856175,9.613895
+      parent: 1
+      type: Transform
+  - uid: 854
+    components:
+    - pos: 6.8135514,9.912474
+      parent: 1
+      type: Transform
+- proto: EmergencyLight
+  entities:
+  - uid: 272
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -0.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 276
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 1.5,-8.5
+      parent: 1
+      type: Transform
+  - uid: 283
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -0.5,-10.5
+      parent: 1
+      type: Transform
+  - uid: 514
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -2.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 552
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 2.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 1061
+    components:
+    - pos: -0.5,15.5
+      parent: 1
+      type: Transform
+  - uid: 1062
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -5.5,11.5
+      parent: 1
+      type: Transform
+  - uid: 1063
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -5.5,8.5
+      parent: 1
+      type: Transform
+- proto: ExosuitFabricator
+  entities:
+  - uid: 322
+    components:
+    - pos: -2.5,0.5
+      parent: 1
+      type: Transform
+- proto: ExtinguisherCabinetFilled
+  entities:
+  - uid: 1003
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -6.5,-2.5
+      parent: 1
+      type: Transform
+  - uid: 1004
+    components:
+    - pos: 3.5,-6.5
+      parent: 1
+      type: Transform
+  - uid: 1006
+    components:
+    - pos: 3.5,7.5
+      parent: 1
+      type: Transform
+  - uid: 1007
+    components:
+    - pos: -1.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 1008
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -4.5,7.5
+      parent: 1
+      type: Transform
+- proto: FaxMachineShip
+  entities:
+  - uid: 527
+    components:
+    - pos: -7.5,11.5
+      parent: 1
+      type: Transform
+- proto: FireAxeCabinetFilled
+  entities:
+  - uid: 1001
+    components:
+    - pos: 0.5,7.5
+      parent: 1
+      type: Transform
+  - uid: 1002
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -2.5,13.5
+      parent: 1
+      type: Transform
+- proto: FirelockEdge
+  entities:
+  - uid: 245
+    components:
+    - pos: 1.5,-5.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 449
+      type: DeviceNetwork
+  - uid: 913
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -0.5,-2.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 449
+      type: DeviceNetwork
+  - uid: 914
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -0.5,-1.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 449
+      type: DeviceNetwork
+  - uid: 915
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 0.5,6.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 449
+      type: DeviceNetwork
+- proto: FloorDrain
+  entities:
+  - uid: 525
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 2.5,14.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+- proto: GasMixer
+  entities:
+  - uid: 271
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 3.5,0.5
+      parent: 1
+      type: Transform
+- proto: GasMixerFlipped
+  entities:
+  - uid: 261
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 1.5,-3.5
+      parent: 1
+      type: Transform
+    - inletTwoConcentration: 0.22000003
+      inletOneConcentration: 0.78
+      type: GasMixer
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+- proto: GasOutletInjector
+  entities:
+  - uid: 172
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 8.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 177
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 8.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 180
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 7.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 820
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 8.5,-1.5
+      parent: 1
+      type: Transform
+- proto: GasPassiveVent
+  entities:
+  - uid: 263
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 7.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 264
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 7.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 265
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 7.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 335
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 7.5,-5.5
+      parent: 1
+      type: Transform
+  - uid: 476
+    components:
+    - pos: 8.5,7.5
+      parent: 1
+      type: Transform
+- proto: GasPipeBend
+  entities:
+  - uid: 49
+    components:
+    - pos: 8.5,-0.5
+      parent: 1
+      type: Transform
+  - uid: 73
+    components:
+    - pos: 0.5,-0.5
+      parent: 1
+      type: Transform
+    - color: '#449DFFFF'
+      type: AtmosPipeColor
+  - uid: 96
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 1.5,-0.5
+      parent: 1
+      type: Transform
+    - color: '#F94541FF'
+      type: AtmosPipeColor
+  - uid: 161
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,-2.5
+      parent: 1
+      type: Transform
+    - color: '#449DFFFF'
+      type: AtmosPipeColor
+  - uid: 244
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 7.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 269
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,-4.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 270
+    components:
+    - pos: 1.5,0.5
+      parent: 1
+      type: Transform
+    - color: '#F94541FF'
+      type: AtmosPipeColor
+  - uid: 278
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 1.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 282
+    components:
+    - pos: -0.5,-4.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 453
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -0.5,-5.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 781
+    components:
+    - pos: 8.5,-2.5
+      parent: 1
+      type: Transform
+  - uid: 826
+    components:
+    - pos: 0.5,-3.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 877
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -4.5,-4.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 896
+    components:
+    - pos: -3.5,-4.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 907
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -4.5,6.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 908
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -3.5,6.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 918
+    components:
+    - pos: -3.5,8.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 932
+    components:
+    - pos: -4.5,11.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 933
+    components:
+    - pos: -5.5,12.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 934
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -5.5,11.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 937
+    components:
+    - pos: -3.5,13.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 938
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -3.5,11.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 942
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -1.5,8.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 950
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -2.5,8.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 1019
+    components:
+    - pos: 8.5,1.5
+      parent: 1
+      type: Transform
+- proto: GasPipeFourway
+  entities:
+  - uid: 334
+    components:
+    - pos: 2.5,-5.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 941
+    components:
+    - pos: -1.5,11.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+- proto: GasPipeStraight
+  entities:
+  - uid: 50
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 2.5,-0.5
+      parent: 1
+      type: Transform
+  - uid: 86
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 8.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 105
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 4.5,1.5
+      parent: 1
+      type: Transform
+    - color: '#EB6B00FF'
+      type: AtmosPipeColor
+  - uid: 106
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 2.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 118
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 1.5,-2.5
+      parent: 1
+      type: Transform
+  - uid: 144
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 0.5,0.5
+      parent: 1
+      type: Transform
+    - color: '#F94541FF'
+      type: AtmosPipeColor
+  - uid: 170
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 3.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 186
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 6.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 189
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 0.5,1.5
+      parent: 1
+      type: Transform
+    - color: '#EB6B00FF'
+      type: AtmosPipeColor
+  - uid: 196
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 6.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 199
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 4.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 205
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 2.5,1.5
+      parent: 1
+      type: Transform
+    - color: '#EB6B00FF'
+      type: AtmosPipeColor
+  - uid: 207
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 3.5,-0.5
+      parent: 1
+      type: Transform
+    - color: '#F94541FF'
+      type: AtmosPipeColor
+  - uid: 225
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 3.5,-2.5
+      parent: 1
+      type: Transform
+    - color: '#449DFFFF'
+      type: AtmosPipeColor
+  - uid: 243
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 6.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 248
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 3.5,-0.5
+      parent: 1
+      type: Transform
+  - uid: 251
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 4.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 252
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 3.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 260
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 7.5,-2.5
+      parent: 1
+      type: Transform
+  - uid: 266
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 6.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 267
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 3.5,-2.5
+      parent: 1
+      type: Transform
+  - uid: 268
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 4.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 273
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 6.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 275
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 4.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 277
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 7.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 280
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 4.5,-2.5
+      parent: 1
+      type: Transform
+    - color: '#449DFFFF'
+      type: AtmosPipeColor
+  - uid: 284
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 6.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 286
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 4.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 294
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 7.5,-0.5
+      parent: 1
+      type: Transform
+  - uid: 295
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 6.5,-2.5
+      parent: 1
+      type: Transform
+  - uid: 323
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 2.5,-2.5
+      parent: 1
+      type: Transform
+    - color: '#449DFFFF'
+      type: AtmosPipeColor
+  - uid: 324
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 3.5,1.5
+      parent: 1
+      type: Transform
+    - color: '#EB6B00FF'
+      type: AtmosPipeColor
+  - uid: 342
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 3.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 361
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 6.5,-0.5
+      parent: 1
+      type: Transform
+  - uid: 363
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 3.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 430
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 2.5,-6.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 431
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 2.5,-7.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 442
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 1.5,-5.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 443
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 0.5,-5.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 448
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 1.5,-5.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 450
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 1.5,-6.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 451
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 4.5,-5.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 452
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 1.5,-7.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 611
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -2.5,9.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 811
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 2.5,-0.5
+      parent: 1
+      type: Transform
+    - color: '#F94541FF'
+      type: AtmosPipeColor
+  - uid: 827
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 4.5,-0.5
+      parent: 1
+      type: Transform
+    - color: '#F94541FF'
+      type: AtmosPipeColor
+  - uid: 828
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 1.5,-2.5
+      parent: 1
+      type: Transform
+    - color: '#449DFFFF'
+      type: AtmosPipeColor
+  - uid: 829
+    components:
+    - pos: 0.5,-1.5
+      parent: 1
+      type: Transform
+    - color: '#449DFFFF'
+      type: AtmosPipeColor
+  - uid: 873
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -1.5,-3.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 874
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -1.5,-4.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 875
+    components:
+    - pos: -2.5,-5.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 876
+    components:
+    - pos: -2.5,-6.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 878
+    components:
+    - pos: -3.5,-5.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 879
+    components:
+    - pos: -3.5,-6.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 880
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -2.5,-3.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 884
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -2.5,-3.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 885
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -2.5,-2.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 886
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -2.5,-1.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 888
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -2.5,0.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 889
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -2.5,1.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 890
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -2.5,2.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 891
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -2.5,3.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 892
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -2.5,4.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 893
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -2.5,5.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 894
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -2.5,6.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 895
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -2.5,7.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 897
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -3.5,-3.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 898
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -4.5,-2.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 899
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -4.5,-1.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 900
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -4.5,-0.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 901
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -4.5,1.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 902
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -4.5,2.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 903
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -4.5,3.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 904
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -4.5,4.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 905
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -4.5,5.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 906
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -3.5,7.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 924
+    components:
+    - pos: -4.5,10.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 935
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -5.5,13.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 936
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -4.5,13.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 939
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -3.5,12.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 940
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -2.5,11.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 943
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -3.5,9.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 944
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -1.5,9.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 945
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -0.5,9.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 947
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 1.5,9.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 948
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 2.5,9.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 949
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 3.5,9.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 951
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -1.5,9.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 952
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -1.5,10.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 953
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -1.5,12.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 954
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -1.5,13.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 955
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -0.5,11.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 956
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 0.5,11.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 957
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 1.5,11.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 962
+    components:
+    - pos: 0.5,13.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 963
+    components:
+    - pos: 0.5,12.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 964
+    components:
+    - pos: 0.5,11.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 965
+    components:
+    - pos: 0.5,10.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 974
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 1.5,1.5
+      parent: 1
+      type: Transform
+    - color: '#EB6B00FF'
+      type: AtmosPipeColor
+- proto: GasPipeTJunction
+  entities:
+  - uid: 226
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 3.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 247
+    components:
+    - pos: 7.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 262
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 1.5,-4.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 289
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -0.5,-3.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 356
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 2.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 432
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 3.5,-5.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 871
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -2.5,-4.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 872
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -4.5,-3.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 887
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -2.5,-0.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 909
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -4.5,0.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 921
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -4.5,8.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 922
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -4.5,9.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 946
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,9.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+- proto: GasPort
+  entities:
+  - uid: 169
+    components:
+    - name: N2 connector port
+      type: MetaData
+    - rot: 1.5707963267948966 rad
+      pos: -0.5,0.5
+      parent: 1
+      type: Transform
+    - color: '#F94541FF'
+      type: AtmosPipeColor
+  - uid: 206
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -0.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 293
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -0.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 308
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 3.5,-5.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 354
+    components:
+    - name: plasma connector port
+      type: MetaData
+    - rot: 1.5707963267948966 rad
+      pos: -0.5,1.5
+      parent: 1
+      type: Transform
+    - color: '#EB6B00FF'
+      type: AtmosPipeColor
+  - uid: 359
+    components:
+    - pos: 3.5,-4.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 825
+    components:
+    - name: O2 connector port
+      type: MetaData
+    - rot: 1.5707963267948966 rad
+      pos: -0.5,-0.5
+      parent: 1
+      type: Transform
+    - color: '#449DFFFF'
+      type: AtmosPipeColor
+  - uid: 926
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -6.5,8.5
+      parent: 1
+      type: Transform
+- proto: GasPressurePump
+  entities:
+  - uid: 15
+    components:
+    - name: waste loop pump
+      type: MetaData
+    - rot: 1.5707963267948966 rad
+      pos: 5.5,-5.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 211
+    components:
+    - name: O2 output pump
+      type: MetaData
+    - rot: -1.5707963267948966 rad
+      pos: 5.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 214
+    components:
+    - name: N2 output pump
+      type: MetaData
+    - rot: -1.5707963267948966 rad
+      pos: 5.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 216
+    components:
+    - name: ignition chamber output pump
+      type: MetaData
+    - rot: -1.5707963267948966 rad
+      pos: 5.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 217
+    components:
+    - name: plasma output pump
+      type: MetaData
+    - rot: -1.5707963267948966 rad
+      pos: 5.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 475
+    components:
+    - name: ignition chamber vent pump
+      type: MetaData
+    - rot: 3.141592653589793 rad
+      pos: 8.5,6.5
+      parent: 1
+      type: Transform
+- proto: GasThermoMachineFreezer
+  entities:
+  - uid: 414
+    components:
+    - pos: -0.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 415
+    components:
+    - pos: -0.5,5.5
+      parent: 1
+      type: Transform
+- proto: GasThermoMachineHeater
+  entities:
+  - uid: 369
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -0.5,2.5
+      parent: 1
+      type: Transform
+- proto: GasValve
+  entities:
+  - uid: 385
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 6.5,-5.5
+      parent: 1
+      type: Transform
+- proto: GasVentPump
+  entities:
+  - uid: 279
+    components:
+    - pos: -0.5,-2.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 449
+      type: DeviceNetwork
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 446
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 1.5,-8.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 479
+      type: DeviceNetwork
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 882
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -3.5,-7.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 480
+      type: DeviceNetwork
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 910
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -3.5,0.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 481
+      type: DeviceNetwork
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 930
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -6.5,12.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 482
+      type: DeviceNetwork
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 960
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 4.5,9.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 864
+      type: DeviceNetwork
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 961
+    components:
+    - pos: 0.5,14.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 864
+      type: DeviceNetwork
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+- proto: GasVentScrubber
+  entities:
+  - uid: 5
+    components:
+    - pos: 2.5,-4.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 449
+      type: DeviceNetwork
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 249
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 8.5,3.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 317
+      type: DeviceNetwork
+  - uid: 250
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 8.5,2.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 317
+      type: DeviceNetwork
+  - uid: 253
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 8.5,4.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 318
+      type: DeviceNetwork
+  - uid: 424
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 2.5,-8.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 479
+      type: DeviceNetwork
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 881
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -2.5,-7.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 480
+      type: DeviceNetwork
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 911
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -3.5,-0.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 481
+      type: DeviceNetwork
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 929
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -6.5,13.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 482
+      type: DeviceNetwork
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 958
+    components:
+    - pos: -1.5,14.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 864
+      type: DeviceNetwork
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 959
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 2.5,11.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 864
+      type: DeviceNetwork
+    - color: '#990000FF'
+      type: AtmosPipeColor
+- proto: GasVolumePump
+  entities:
+  - uid: 291
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 0.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 292
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 0.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 375
+    components:
+    - name: plasma input pump
+      type: MetaData
+    - rot: 1.5707963267948966 rad
+      pos: 5.5,1.5
+      parent: 1
+      type: Transform
+    - color: '#EB6B00FF'
+      type: AtmosPipeColor
+  - uid: 477
+    components:
+    - name: ignition chamber input pump
+      type: MetaData
+    - rot: 1.5707963267948966 rad
+      pos: 5.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 812
+    components:
+    - name: O2 input pump
+      type: MetaData
+    - rot: 1.5707963267948966 rad
+      pos: 5.5,-2.5
+      parent: 1
+      type: Transform
+    - color: '#449DFFFF'
+      type: AtmosPipeColor
+  - uid: 927
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -5.5,8.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 1018
+    components:
+    - name: N2 input pump
+      type: MetaData
+    - rot: 1.5707963267948966 rad
+      pos: 5.5,-0.5
+      parent: 1
+      type: Transform
+    - color: '#F94541FF'
+      type: AtmosPipeColor
+- proto: GravityGeneratorMini
+  entities:
+  - uid: 195
+    components:
+    - pos: 4.5,-7.5
+      parent: 1
+      type: Transform
+- proto: Grille
+  entities:
+  - uid: 9
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -6.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 17
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -6.5,-0.5
+      parent: 1
+      type: Transform
+  - uid: 25
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -5.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 27
+    components:
+    - pos: -4.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 36
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -8.5,11.5
+      parent: 1
+      type: Transform
+  - uid: 43
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -6.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 51
+    components:
+    - pos: 4.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 74
+    components:
+    - pos: 6.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 76
+    components:
+    - pos: 6.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 81
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -7.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 88
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -8.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 89
+    components:
+    - pos: 4.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 91
+    components:
+    - pos: 4.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 97
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -7.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 125
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 6.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 133
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -7.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 137
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -7.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 138
+    components:
+    - pos: 6.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 139
+    components:
+    - pos: 4.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 140
+    components:
+    - pos: 4.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 142
+    components:
+    - pos: 4.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 146
+    components:
+    - pos: 4.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 149
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -7.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 178
+    components:
+    - pos: 6.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 179
+    components:
+    - pos: 6.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 192
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 4.5,-5.5
+      parent: 1
+      type: Transform
+  - uid: 194
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 2.5,-6.5
+      parent: 1
+      type: Transform
+  - uid: 256
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 8.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 288
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -9.5,11.5
+      parent: 1
+      type: Transform
+  - uid: 311
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -9.5,15.5
+      parent: 1
+      type: Transform
+  - uid: 316
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -9.5,14.5
+      parent: 1
+      type: Transform
+  - uid: 343
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -8.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 349
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -9.5,13.5
+      parent: 1
+      type: Transform
+  - uid: 351
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -8.5,15.5
+      parent: 1
+      type: Transform
+  - uid: 355
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -9.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 395
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 5.5,-6.5
+      parent: 1
+      type: Transform
+  - uid: 398
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 5.5,7.5
+      parent: 1
+      type: Transform
+  - uid: 400
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 7.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 401
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 7.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 402
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 7.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 404
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -1.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 408
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -1.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 409
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -1.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 410
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -1.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 412
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -1.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 485
+    components:
+    - pos: -2.5,11.5
+      parent: 1
+      type: Transform
+  - uid: 487
+    components:
+    - pos: -4.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 1040
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 4.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 1041
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 4.5,-2.5
+      parent: 1
+      type: Transform
+  - uid: 1042
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 4.5,-0.5
+      parent: 1
+      type: Transform
+- proto: GroundTobacco
+  entities:
+  - uid: 1025
+    components:
+    - pos: -3.3039844,13.8782
+      parent: 1
+      type: Transform
+  - uid: 1026
+    components:
+    - pos: -3.4457805,13.849817
+      parent: 1
+      type: Transform
+  - uid: 1027
+    components:
+    - pos: -3.5733974,13.920773
+      parent: 1
+      type: Transform
+- proto: Gyroscope
+  entities:
+  - uid: 246
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 5.5,-7.5
+      parent: 1
+      type: Transform
+  - uid: 1037
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -7.5,6.5
+      parent: 1
+      type: Transform
+- proto: HolofanProjector
+  entities:
+  - uid: 1057
+    components:
+    - pos: -0.69590646,-3.6085553
+      parent: 1
+      type: Transform
+- proto: HospitalCurtainsOpen
+  entities:
+  - uid: 507
+    components:
+    - pos: 0.5,15.5
+      parent: 1
+      type: Transform
+  - uid: 511
+    components:
+    - pos: -1.5,15.5
+      parent: 1
+      type: Transform
+  - uid: 512
+    components:
+    - pos: -0.5,15.5
+      parent: 1
+      type: Transform
+  - uid: 524
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 3.5,13.5
+      parent: 1
+      type: Transform
+- proto: Igniter
+  entities:
+  - uid: 258
+    components:
+    - pos: 8.040113,3.9907713
+      parent: 1
+      type: Transform
+    - links:
+      - 45
+      type: DeviceLinkSink
+- proto: InflatableDoorStack
+  entities:
+  - uid: 1056
+    components:
+    - pos: -0.3699959,-3.5660625
+      parent: 1
+      type: Transform
+- proto: InflatableWallStack
+  entities:
+  - uid: 1054
+    components:
+    - pos: -0.6392264,-3.367762
+      parent: 1
+      type: Transform
+  - uid: 1055
+    components:
+    - pos: -0.29914552,-3.2969403
+      parent: 1
+      type: Transform
+- proto: KitchenMicrowave
+  entities:
+  - uid: 496
+    components:
+    - pos: 6.5,10.5
+      parent: 1
+      type: Transform
+- proto: LockerAtmosphericsFilledHardsuit
+  entities:
+  - uid: 366
+    components:
+    - pos: 0.5,-5.5
+      parent: 1
+      type: Transform
+  - uid: 447
+    components:
+    - pos: -0.5,-5.5
+      parent: 1
+      type: Transform
+- proto: LockerChiefEngineerFilledHardsuit
+  entities:
+  - uid: 546
+    components:
+    - pos: -5.5,11.5
+      parent: 1
+      type: Transform
+- proto: LockerEngineerFilledHardsuit
+  entities:
+  - uid: 364
+    components:
+    - pos: 3.5,-7.5
+      parent: 1
+      type: Transform
+  - uid: 365
+    components:
+    - pos: -4.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 819
+    components:
+    - pos: -5.5,6.5
+      parent: 1
+      type: Transform
+- proto: LockerFreezer
+  entities:
+  - uid: 498
+    components:
+    - pos: 5.5,11.5
+      parent: 1
+      type: Transform
+- proto: LockerWallMedicalFilled
+  entities:
+  - uid: 516
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 1.5,14.5
+      parent: 1
+      type: Transform
+- proto: MachineCryoSleepPod
+  entities:
+  - uid: 508
+    components:
+    - pos: 0.5,15.5
+      parent: 1
+      type: Transform
+- proto: Matchbox
+  entities:
+  - uid: 1028
+    components:
+    - pos: -3.6584756,13.480848
+      parent: 1
+      type: Transform
+- proto: MaterialReclaimer
+  entities:
+  - uid: 48
+    components:
+    - pos: -2.5,1.5
+      parent: 1
+      type: Transform
+- proto: MatterBinStockPart
+  entities:
+  - uid: 467
+    components:
+    - pos: -2.7679088,2.3573534
+      parent: 1
+      type: Transform
+  - uid: 468
+    components:
+    - pos: -2.831847,2.6132777
+      parent: 1
+      type: Transform
+  - uid: 469
+    components:
+    - pos: -2.7892215,2.8052208
+      parent: 1
+      type: Transform
+  - uid: 470
+    components:
+    - pos: -2.7252834,3.018491
+      parent: 1
+      type: Transform
+- proto: MedicalBed
+  entities:
+  - uid: 509
+    components:
+    - pos: -0.5,15.5
+      parent: 1
+      type: Transform
+  - uid: 510
+    components:
+    - pos: -1.5,15.5
+      parent: 1
+      type: Transform
+- proto: MicroManipulatorStockPart
+  entities:
+  - uid: 463
+    components:
+    - pos: -2.3203456,2.4213345
+      parent: 1
+      type: Transform
+  - uid: 464
+    components:
+    - pos: -2.299033,2.6772587
+      parent: 1
+      type: Transform
+  - uid: 465
+    components:
+    - pos: -2.362971,2.8478749
+      parent: 1
+      type: Transform
+  - uid: 466
+    components:
+    - pos: -2.3203456,3.018491
+      parent: 1
+      type: Transform
+- proto: MopItem
+  entities:
+  - uid: 1030
+    components:
+    - pos: 2.5299902,14.395643
+      parent: 1
+      type: Transform
+- proto: NitrogenCanister
+  entities:
+  - uid: 1050
+    components:
+    - pos: 8.5,-1.5
+      parent: 1
+      type: Transform
+- proto: OxygenCanister
+  entities:
+  - uid: 1051
+    components:
+    - pos: 8.5,-3.5
+      parent: 1
+      type: Transform
+- proto: PartRodMetal
+  entities:
+  - uid: 458
+    components:
+    - pos: -2.5141208,3.8284311
+      parent: 1
+      type: Transform
+  - uid: 459
+    components:
+    - pos: -2.4075572,3.4658718
+      parent: 1
+      type: Transform
+  - uid: 460
+    components:
+    - pos: -2.4501827,3.679142
+      parent: 1
+      type: Transform
+- proto: PlasmaCanister
+  entities:
+  - uid: 1049
+    components:
+    - pos: 8.5,0.5
+      parent: 1
+      type: Transform
+- proto: PlasticFlapsAirtightClear
+  entities:
+  - uid: 30
+    components:
+    - pos: -3.5,-14.5
+      parent: 1
+      type: Transform
+  - uid: 377
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -5.5,-6.5
+      parent: 1
+      type: Transform
+  - uid: 378
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -7.5,-6.5
+      parent: 1
+      type: Transform
+  - uid: 471
+    components:
+    - pos: -3.5,-12.5
+      parent: 1
+      type: Transform
+- proto: PortableGeneratorPacmanMachineCircuitboard
+  entities:
+  - uid: 306
+    components:
+    - pos: -2.5756724,4.1535835
+      parent: 1
+      type: Transform
+- proto: PortableScrubber
+  entities:
+  - uid: 309
+    components:
+    - pos: 3.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 419
+    components:
+    - pos: 3.5,-5.5
+      parent: 1
+      type: Transform
+- proto: PottedPlantRandom
+  entities:
+  - uid: 554
+    components:
+    - pos: -6.5,11.5
+      parent: 1
+      type: Transform
+- proto: PowerCellRecharger
+  entities:
+  - uid: 461
+    components:
+    - pos: -2.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 462
+    components:
+    - pos: -2.5,3.5
+      parent: 1
+      type: Transform
+- proto: PoweredlightLED
+  entities:
+  - uid: 980
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 1.5,-9.5
+      parent: 1
+      type: Transform
+  - uid: 981
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -0.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 982
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -0.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 983
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -2.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 984
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -4.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 985
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -0.5,-9.5
+      parent: 1
+      type: Transform
+  - uid: 986
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -5.5,11.5
+      parent: 1
+      type: Transform
+  - uid: 987
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -4.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 988
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 1.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 989
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -1.5,14.5
+      parent: 1
+      type: Transform
+  - uid: 990
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -7.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 991
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -7.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 994
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 6.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 1060
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 3.5,4.5
+      parent: 1
+      type: Transform
+- proto: PoweredSmallLight
+  entities:
+  - uid: 473
+    components:
+    - pos: 7.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 976
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 8.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 977
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 8.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 978
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 8.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 979
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 7.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 992
+    components:
+    - pos: 2.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 993
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 2.5,13.5
+      parent: 1
+      type: Transform
+- proto: Protolathe
+  entities:
+  - uid: 352
+    components:
+    - pos: -6.5,-4.5
+      parent: 1
+      type: Transform
+- proto: Rack
+  entities:
+  - uid: 37
+    components:
+    - pos: -5.5,-2.5
+      parent: 1
+      type: Transform
+  - uid: 336
+    components:
+    - pos: -4.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 360
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 5.5,-10.5
+      parent: 1
+      type: Transform
+  - uid: 1053
+    components:
+    - pos: -0.5,-3.5
+      parent: 1
+      type: Transform
+- proto: RandomFoodMeal
+  entities:
+  - uid: 849
+    components:
+    - pos: 1.5,9.5
+      parent: 1
+      type: Transform
+- proto: RandomPainting
+  entities:
+  - uid: 555
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -2.5,14.5
+      parent: 1
+      type: Transform
+  - uid: 556
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -2.5,12.5
+      parent: 1
+      type: Transform
+- proto: RandomPosterAny
+  entities:
+  - uid: 1009
+    components:
+    - pos: 3.5,14.5
+      parent: 1
+      type: Transform
+  - uid: 1010
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 1.5,7.5
+      parent: 1
+      type: Transform
+  - uid: 1012
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -1.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 1013
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 0.5,-8.5
+      parent: 1
+      type: Transform
+- proto: RandomSnacks
+  entities:
+  - uid: 847
+    components:
+    - pos: 0.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 848
+    components:
+    - pos: 2.5,9.5
+      parent: 1
+      type: Transform
+- proto: ReinforcedPlasmaWindow
+  entities:
+  - uid: 58
+    components:
+    - pos: 6.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 75
+    components:
+    - pos: 6.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 128
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 6.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 141
+    components:
+    - pos: 6.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 173
+    components:
+    - pos: 6.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 176
+    components:
+    - pos: 6.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 257
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 8.5,5.5
+      parent: 1
+      type: Transform
+- proto: ReinforcedWindow
+  entities:
+  - uid: 12
+    components:
+    - pos: 4.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 26
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -6.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 33
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -1.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 38
+    components:
+    - pos: 4.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 47
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -6.5,-0.5
+      parent: 1
+      type: Transform
+  - uid: 54
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -9.5,14.5
+      parent: 1
+      type: Transform
+  - uid: 55
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -8.5,15.5
+      parent: 1
+      type: Transform
+  - uid: 56
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -8.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 57
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -9.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 60
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -8.5,11.5
+      parent: 1
+      type: Transform
+  - uid: 64
+    components:
+    - pos: 4.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 90
+    components:
+    - pos: 4.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 102
+    components:
+    - pos: 4.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 103
+    components:
+    - pos: 4.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 104
+    components:
+    - pos: 4.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 135
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -1.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 221
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 2.5,-6.5
+      parent: 1
+      type: Transform
+  - uid: 312
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -9.5,11.5
+      parent: 1
+      type: Transform
+  - uid: 313
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -9.5,15.5
+      parent: 1
+      type: Transform
+  - uid: 315
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -7.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 327
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -1.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 332
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 5.5,7.5
+      parent: 1
+      type: Transform
+  - uid: 340
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -6.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 341
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -5.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 344
+    components:
+    - pos: -4.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 348
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -8.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 350
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -9.5,13.5
+      parent: 1
+      type: Transform
+  - uid: 358
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -1.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 380
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -7.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 382
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 5.5,-6.5
+      parent: 1
+      type: Transform
+  - uid: 383
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -7.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 384
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -7.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 386
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -7.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 387
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -1.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 519
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 7.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 520
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 7.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 521
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 7.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 919
+    components:
+    - pos: -2.5,11.5
+      parent: 1
+      type: Transform
+  - uid: 925
+    components:
+    - pos: -4.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 1044
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 4.5,-2.5
+      parent: 1
+      type: Transform
+  - uid: 1045
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 4.5,-0.5
+      parent: 1
+      type: Transform
+- proto: ResearchAndDevelopmentServer
+  entities:
+  - uid: 46
+    components:
+    - pos: -5.5,15.5
+      parent: 1
+      type: Transform
+- proto: SheetGlass
+  entities:
+  - uid: 392
+    components:
+    - pos: -4.4961915,-4.4792156
+      parent: 1
+      type: Transform
+  - uid: 456
+    components:
+    - pos: -4.4961915,-4.4792156
+      parent: 1
+      type: Transform
+  - uid: 457
+    components:
+    - pos: -4.4961915,-4.4792156
+      parent: 1
+      type: Transform
+- proto: SheetPlastic
+  entities:
+  - uid: 830
+    components:
+    - pos: -5.3717155,-2.3743224
+      parent: 1
+      type: Transform
+  - uid: 831
+    components:
+    - pos: -4.284774,-4.400389
+      parent: 1
+      type: Transform
+- proto: SheetRPGlass
+  entities:
+  - uid: 296
+    components:
+    - pos: -4.618571,-4.5239058
+      parent: 1
+      type: Transform
+- proto: SheetSteel
+  entities:
+  - uid: 13
+    components:
+    - pos: -5.4978824,-2.4958038
+      parent: 1
+      type: Transform
+  - uid: 14
+    components:
+    - pos: -5.4978824,-2.4958038
+      parent: 1
+      type: Transform
+  - uid: 28
+    components:
+    - pos: -5.4978824,-2.4958038
+      parent: 1
+      type: Transform
+  - uid: 1058
+    components:
+    - pos: -0.45501596,-3.3960907
+      parent: 1
+      type: Transform
+- proto: ShuttersWindow
+  entities:
+  - uid: 376
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 4.5,-4.5
+      parent: 1
+      type: Transform
+    - links:
+      - 1052
+      type: DeviceLinkSink
+  - uid: 1043
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 4.5,-5.5
+      parent: 1
+      type: Transform
+    - links:
+      - 1052
+      type: DeviceLinkSink
+- proto: SignalButton
+  entities:
+  - uid: 45
+    components:
+    - name: igniter signal button
+      type: MetaData
+    - pos: 2.5,5.5
+      parent: 1
+      type: Transform
+    - linkedPorts:
+        258:
+        - Pressed: Trigger
+      type: DeviceLinkSource
+- proto: SignalButtonDirectional
+  entities:
+  - uid: 320
+    components:
+    - name: access blast door switch
+      type: MetaData
+    - pos: 7.5,7.5
+      parent: 1
+      type: Transform
+    - linkedPorts:
+        87:
+        - Pressed: Toggle
+      type: DeviceLinkSource
+  - uid: 321
+    components:
+    - name: blast doors switch
+      type: MetaData
+    - rot: 3.141592653589793 rad
+      pos: 8.5,1.5
+      parent: 1
+      type: Transform
+    - linkedPorts:
+        129:
+        - Pressed: Toggle
+        79:
+        - Pressed: Toggle
+        130:
+        - Pressed: Toggle
+        87:
+        - Pressed: Toggle
+      type: DeviceLinkSource
+  - uid: 394
+    components:
+    - name: portside loading blast doors switch
+      type: MetaData
+    - rot: 1.5707963267948966 rad
+      pos: -5.5,-9.5
+      parent: 1
+      type: Transform
+    - linkedPorts:
+        347:
+        - Pressed: Toggle
+        191:
+        - Pressed: Toggle
+      type: DeviceLinkSource
+  - uid: 416
+    components:
+    - name: ignition chamber vent blast doors
+      type: MetaData
+    - pos: 1.5,5.5
+      parent: 1
+      type: Transform
+    - linkedPorts:
+        130:
+        - Pressed: Toggle
+        79:
+        - Pressed: Toggle
+        129:
+        - Pressed: Toggle
+      type: DeviceLinkSource
+  - uid: 444
+    components:
+    - name: portside blast doors switch
+      type: MetaData
+    - rot: 1.5707963267948966 rad
+      pos: -6.5,-1.5
+      parent: 1
+      type: Transform
+    - linkedPorts:
+        429:
+        - Pressed: Toggle
+        428:
+        - Pressed: Toggle
+        427:
+        - Pressed: Toggle
+        426:
+        - Pressed: Toggle
+        425:
+        - Pressed: Toggle
+      type: DeviceLinkSource
+  - uid: 445
+    components:
+    - name: portside blast doors switch
+      type: MetaData
+    - rot: 1.5707963267948966 rad
+      pos: -6.5,6.5
+      parent: 1
+      type: Transform
+    - linkedPorts:
+        425:
+        - Pressed: Toggle
+        426:
+        - Pressed: Toggle
+        427:
+        - Pressed: Toggle
+        428:
+        - Pressed: Toggle
+        429:
+        - Pressed: Toggle
+      type: DeviceLinkSource
+  - uid: 824
+    components:
+    - name: bolts switch
+      type: MetaData
+    - rot: -1.5707963267948966 rad
+      pos: -1.5,-6.5
+      parent: 1
+      type: Transform
+    - linkedPorts:
+        338:
+        - Pressed: DoorBolt
+        339:
+        - Pressed: DoorBolt
+        353:
+        - Pressed: DoorBolt
+        779:
+        - Pressed: DoorBolt
+        193:
+        - Pressed: DoorBolt
+      type: DeviceLinkSource
+  - uid: 1014
+    components:
+    - name: sternside loading blast doors switch
+      type: MetaData
+    - rot: 3.141592653589793 rad
+      pos: -4.5,-12.5
+      parent: 1
+      type: Transform
+    - linkedPorts:
+        536:
+        - Pressed: Toggle
+        164:
+        - Pressed: Toggle
+      type: DeviceLinkSource
+  - uid: 1052
+    components:
+    - name: emergency main atmos room vent
+      type: MetaData
+    - pos: 3.5,5.5
+      parent: 1
+      type: Transform
+    - state: True
+      type: SignalSwitch
+    - linkedPorts:
+        376:
+        - Pressed: Toggle
+        1043:
+        - Pressed: Toggle
+      type: DeviceLinkSource
+    - type: ItemCooldown
+- proto: SignAtmos
+  entities:
+  - uid: 821
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -1.5,-0.5
+      parent: 1
+      type: Transform
+- proto: SignDirectionalBar
+  entities:
+  - uid: 1036
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -2.4981225,10.71793
+      parent: 1
+      type: Transform
+- proto: SignDirectionalBridge
+  entities:
+  - uid: 1035
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -2.5,10.5
+      parent: 1
+      type: Transform
+- proto: SignElectricalMed
+  entities:
+  - uid: 1032
+    components:
+    - pos: 6.5,-10.5
+      parent: 1
+      type: Transform
+- proto: SignEngine
+  entities:
+  - uid: 474
+    components:
+    - pos: 0.5,-6.5
+      parent: 1
+      type: Transform
+- proto: SignFire
+  entities:
+  - uid: 259
+    components:
+    - pos: 6.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 297
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 6.5,1.5
+      parent: 1
+      type: Transform
+- proto: Sink
+  entities:
+  - uid: 522
+    components:
+    - pos: 2.5,14.5
+      parent: 1
+      type: Transform
+- proto: SMESBasic
+  entities:
+  - uid: 240
+    components:
+    - pos: 6.5,-8.5
+      parent: 1
+      type: Transform
+  - uid: 241
+    components:
+    - pos: 6.5,-9.5
+      parent: 1
+      type: Transform
+- proto: SmokingPipeFilledTobacco
+  entities:
+  - uid: 1024
+    components:
+    - pos: -3.176369,13.49504
+      parent: 1
+      type: Transform
+- proto: soda_dispenser
+  entities:
+  - uid: 497
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 6.5,8.5
+      parent: 1
+      type: Transform
+- proto: SpawnPointAtmos
+  entities:
+  - uid: 814
+    components:
+    - pos: -0.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 815
+    components:
+    - pos: 0.5,-4.5
+      parent: 1
+      type: Transform
+- proto: SpawnPointBorg
+  entities:
+  - uid: 454
+    components:
+    - pos: -3.5,0.5
+      parent: 1
+      type: Transform
+- proto: SpawnPointLatejoin
+  entities:
+  - uid: 817
+    components:
+    - pos: 2.5,13.5
+      parent: 1
+      type: Transform
+- proto: SpawnPointParamedic
+  entities:
+  - uid: 810
+    components:
+    - pos: 0.5,14.5
+      parent: 1
+      type: Transform
+- proto: SpawnPointSeniorEngineer
+  entities:
+  - uid: 816
+    components:
+    - pos: -5.5,13.5
+      parent: 1
+      type: Transform
+- proto: SpawnPointStationEngineer
+  entities:
+  - uid: 813
+    components:
+    - pos: 3.5,-8.5
+      parent: 1
+      type: Transform
+  - uid: 822
+    components:
+    - pos: -5.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 823
+    components:
+    - pos: -4.5,5.5
+      parent: 1
+      type: Transform
+- proto: SubstationBasic
+  entities:
+  - uid: 237
+    components:
+    - pos: 6.5,-7.5
+      parent: 1
+      type: Transform
+- proto: SurveillanceCameraGeneral
+  entities:
+  - uid: 995
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 1.5,-8.5
+      parent: 1
+      type: Transform
+  - uid: 996
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -0.5,-8.5
+      parent: 1
+      type: Transform
+  - uid: 997
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -2.5,-0.5
+      parent: 1
+      type: Transform
+  - uid: 998
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -2.5,-0.5
+      parent: 1
+      type: Transform
+  - uid: 999
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 3.5,11.5
+      parent: 1
+      type: Transform
+  - uid: 1000
+    components:
+    - pos: 8.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 1031
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 1.5,4.5
+      parent: 1
+      type: Transform
+- proto: SurveillanceCameraRouterGeneral
+  entities:
+  - uid: 780
+    components:
+    - pos: -4.5,15.5
+      parent: 1
+      type: Transform
+- proto: Table
+  entities:
+  - uid: 31
+    components:
+    - pos: -2.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 422
+    components:
+    - pos: -2.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 455
+    components:
+    - pos: -2.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 493
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 6.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 494
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 6.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 495
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 6.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 529
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -6.5,11.5
+      parent: 1
+      type: Transform
+  - uid: 532
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 2.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 533
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 537
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 1.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 542
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -7.5,11.5
+      parent: 1
+      type: Transform
+- proto: TableCarpet
+  entities:
+  - uid: 549
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -3.5,13.5
+      parent: 1
+      type: Transform
+- proto: TableReinforcedGlass
+  entities:
+  - uid: 517
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -0.5,13.5
+      parent: 1
+      type: Transform
+- proto: TargetDarts
+  entities:
+  - uid: 223
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -1.5,11.5
+      parent: 1
+      type: Transform
+- proto: Thruster
+  entities:
+  - uid: 330
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 8.5,-6.5
+      parent: 1
+      type: Transform
+  - uid: 333
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 8.5,-5.5
+      parent: 1
+      type: Transform
+  - uid: 538
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 2.5,-14.5
+      parent: 1
+      type: Transform
+  - uid: 768
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 3.5,-14.5
+      parent: 1
+      type: Transform
+  - uid: 769
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 4.5,-14.5
+      parent: 1
+      type: Transform
+  - uid: 770
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -5.5,-14.5
+      parent: 1
+      type: Transform
+  - uid: 771
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -6.5,-13.5
+      parent: 1
+      type: Transform
+  - uid: 772
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -7.5,-12.5
+      parent: 1
+      type: Transform
+  - uid: 773
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 5.5,-13.5
+      parent: 1
+      type: Transform
+  - uid: 774
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 6.5,-12.5
+      parent: 1
+      type: Transform
+  - uid: 775
+    components:
+    - pos: 2.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 776
+    components:
+    - pos: 3.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 777
+    components:
+    - pos: 4.5,15.5
+      parent: 1
+      type: Transform
+  - uid: 778
+    components:
+    - pos: 5.5,14.5
+      parent: 1
+      type: Transform
+  - uid: 867
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 7.5,-11.5
+      parent: 1
+      type: Transform
+  - uid: 868
+    components:
+    - pos: 6.5,13.5
+      parent: 1
+      type: Transform
+- proto: ToiletDirtyWater
+  entities:
+  - uid: 523
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 3.5,13.5
+      parent: 1
+      type: Transform
+- proto: TwoWayLever
+  entities:
+  - uid: 290
+    components:
+    - pos: -4.5,-9.5
+      parent: 1
+      type: Transform
+    - linkedPorts:
+        393:
+        - Left: Forward
+        - Right: Reverse
+        - Middle: Off
+        123:
+        - Left: Forward
+        - Right: Reverse
+        - Middle: Off
+        151:
+        - Left: Forward
+        - Right: Reverse
+        - Middle: Off
+        190:
+        - Left: Forward
+        - Right: Reverse
+        - Middle: Off
+      type: DeviceLinkSource
+  - uid: 862
+    components:
+    - pos: -4.5,-11.5
+      parent: 1
+      type: Transform
+    - linkedPorts:
+        122:
+        - Left: Forward
+        - Right: Reverse
+        - Middle: Off
+        150:
+        - Left: Forward
+        - Right: Reverse
+        - Middle: Off
+        156:
+        - Left: Forward
+        - Right: Reverse
+        - Middle: Off
+        157:
+        - Left: Forward
+        - Right: Reverse
+        - Middle: Off
+      type: DeviceLinkSource
+- proto: VendingMachineAtmosDrobe
+  entities:
+  - uid: 390
+    components:
+    - pos: -5.5,-11.5
+      parent: 1
+      type: Transform
+- proto: VendingMachineCigs
+  entities:
+  - uid: 505
+    components:
+    - pos: 4.5,11.5
+      parent: 1
+      type: Transform
+- proto: VendingMachineEngiDrobe
+  entities:
+  - uid: 403
+    components:
+    - pos: -6.5,-10.5
+      parent: 1
+      type: Transform
+- proto: VendingMachineEngivend
+  entities:
+  - uid: 153
+    components:
+    - pos: -0.5,-7.5
+      parent: 1
+      type: Transform
+- proto: VendingMachineRobotics
+  entities:
+  - uid: 389
+    components:
+    - pos: -2.5,-0.5
+      parent: 1
+      type: Transform
+- proto: VendingMachineTankDispenserEVA
+  entities:
+  - uid: 388
+    components:
+    - pos: -7.5,-1.5
+      parent: 1
+      type: Transform
+- proto: VendingMachineWallMedical
+  entities:
+  - uid: 515
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 1.5,13.5
+      parent: 1
+      type: Transform
+- proto: VendingMachineYouTool
+  entities:
+  - uid: 391
+    components:
+    - pos: -1.5,-7.5
+      parent: 1
+      type: Transform
+- proto: WallReinforced
+  entities:
+  - uid: 3
+    components:
+    - pos: 4.5,-12.5
+      parent: 1
+      type: Transform
+  - uid: 4
+    components:
+    - pos: 4.5,13.5
+      parent: 1
+      type: Transform
+  - uid: 6
+    components:
+    - pos: 2.5,-13.5
+      parent: 1
+      type: Transform
+  - uid: 18
+    components:
+    - pos: 6.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 19
+    components:
+    - pos: 5.5,13.5
+      parent: 1
+      type: Transform
+  - uid: 20
+    components:
+    - pos: 6.5,11.5
+      parent: 1
+      type: Transform
+  - uid: 21
+    components:
+    - pos: 5.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 22
+    components:
+    - pos: 5.5,-12.5
+      parent: 1
+      type: Transform
+  - uid: 23
+    components:
+    - pos: -0.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 24
+    components:
+    - pos: 9.5,-0.5
+      parent: 1
+      type: Transform
+  - uid: 29
+    components:
+    - pos: -3.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 34
+    components:
+    - pos: 9.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 35
+    components:
+    - pos: 7.5,-9.5
+      parent: 1
+      type: Transform
+  - uid: 39
+    components:
+    - pos: 3.5,15.5
+      parent: 1
+      type: Transform
+  - uid: 40
+    components:
+    - pos: 6.5,-10.5
+      parent: 1
+      type: Transform
+  - uid: 41
+    components:
+    - pos: 1.5,15.5
+      parent: 1
+      type: Transform
+  - uid: 52
+    components:
+    - pos: -6.5,-2.5
+      parent: 1
+      type: Transform
+  - uid: 59
+    components:
+    - pos: 1.5,-13.5
+      parent: 1
+      type: Transform
+  - uid: 61
+    components:
+    - pos: -2.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 62
+    components:
+    - pos: 4.5,-13.5
+      parent: 1
+      type: Transform
+  - uid: 63
+    components:
+    - pos: 7.5,-7.5
+      parent: 1
+      type: Transform
+  - uid: 65
+    components:
+    - pos: -1.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 66
+    components:
+    - pos: 6.5,-11.5
+      parent: 1
+      type: Transform
+  - uid: 67
+    components:
+    - pos: 7.5,-6.5
+      parent: 1
+      type: Transform
+  - uid: 68
+    components:
+    - pos: -4.5,-14.5
+      parent: 1
+      type: Transform
+  - uid: 69
+    components:
+    - pos: -5.5,-13.5
+      parent: 1
+      type: Transform
+  - uid: 70
+    components:
+    - pos: -6.5,-12.5
+      parent: 1
+      type: Transform
+  - uid: 71
+    components:
+    - pos: -7.5,-11.5
+      parent: 1
+      type: Transform
+  - uid: 72
+    components:
+    - pos: -7.5,-5.5
+      parent: 1
+      type: Transform
+  - uid: 77
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 9.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 78
+    components:
+    - pos: 4.5,-6.5
+      parent: 1
+      type: Transform
+  - uid: 82
+    components:
+    - pos: 9.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 83
+    components:
+    - pos: 8.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 84
+    components:
+    - pos: 7.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 85
+    components:
+    - pos: 6.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 92
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 6.5,7.5
+      parent: 1
+      type: Transform
+  - uid: 94
+    components:
+    - pos: 7.5,7.5
+      parent: 1
+      type: Transform
+  - uid: 98
+    components:
+    - pos: -4.5,-13.5
+      parent: 1
+      type: Transform
+  - uid: 99
+    components:
+    - pos: 1.5,-14.5
+      parent: 1
+      type: Transform
+  - uid: 100
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 6.5,-6.5
+      parent: 1
+      type: Transform
+  - uid: 101
+    components:
+    - pos: 3.5,-13.5
+      parent: 1
+      type: Transform
+  - uid: 107
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 4.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 108
+    components:
+    - pos: 5.5,-11.5
+      parent: 1
+      type: Transform
+  - uid: 109
+    components:
+    - pos: 7.5,-8.5
+      parent: 1
+      type: Transform
+  - uid: 110
+    components:
+    - pos: 7.5,-10.5
+      parent: 1
+      type: Transform
+  - uid: 112
+    components:
+    - pos: 4.5,14.5
+      parent: 1
+      type: Transform
+  - uid: 113
+    components:
+    - pos: 3.5,14.5
+      parent: 1
+      type: Transform
+  - uid: 114
+    components:
+    - pos: 0.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 115
+    components:
+    - pos: 1.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 116
+    components:
+    - pos: 2.5,15.5
+      parent: 1
+      type: Transform
+  - uid: 126
+    components:
+    - pos: 6.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 131
+    components:
+    - pos: 9.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 132
+    components:
+    - pos: 4.5,7.5
+      parent: 1
+      type: Transform
+  - uid: 145
+    components:
+    - pos: 0.5,-12.5
+      parent: 1
+      type: Transform
+  - uid: 147
+    components:
+    - pos: 7.5,11.5
+      parent: 1
+      type: Transform
+  - uid: 152
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -7.5,-2.5
+      parent: 1
+      type: Transform
+  - uid: 154
+    components:
+    - pos: 0.5,-13.5
+      parent: 1
+      type: Transform
+  - uid: 165
+    components:
+    - pos: -4.5,-12.5
+      parent: 1
+      type: Transform
+  - uid: 167
+    components:
+    - pos: 0.5,-14.5
+      parent: 1
+      type: Transform
+  - uid: 174
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 9.5,-2.5
+      parent: 1
+      type: Transform
+  - uid: 175
+    components:
+    - pos: 9.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 184
+    components:
+    - pos: -7.5,-9.5
+      parent: 1
+      type: Transform
+  - uid: 187
+    components:
+    - pos: -6.5,-11.5
+      parent: 1
+      type: Transform
+  - uid: 197
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 2.5,7.5
+      parent: 1
+      type: Transform
+  - uid: 212
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 9.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 229
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 3.5,7.5
+      parent: 1
+      type: Transform
+  - uid: 230
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 1.5,7.5
+      parent: 1
+      type: Transform
+  - uid: 274
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 6.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 281
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 8.5,-0.5
+      parent: 1
+      type: Transform
+  - uid: 299
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 8.5,-2.5
+      parent: 1
+      type: Transform
+  - uid: 300
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 6.5,-2.5
+      parent: 1
+      type: Transform
+  - uid: 301
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 6.5,-0.5
+      parent: 1
+      type: Transform
+  - uid: 302
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 3.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 303
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 2.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 305
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 1.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 310
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -7.5,7.5
+      parent: 1
+      type: Transform
+  - uid: 319
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 8.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 357
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 7.5,-2.5
+      parent: 1
+      type: Transform
+  - uid: 370
+    components:
+    - pos: -6.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 371
+    components:
+    - pos: -6.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 396
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -6.5,-9.5
+      parent: 1
+      type: Transform
+  - uid: 397
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -5.5,-9.5
+      parent: 1
+      type: Transform
+  - uid: 399
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 7.5,-0.5
+      parent: 1
+      type: Transform
+  - uid: 406
+    components:
+    - pos: -6.5,7.5
+      parent: 1
+      type: Transform
+  - uid: 417
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -6.5,-5.5
+      parent: 1
+      type: Transform
+  - uid: 418
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -5.5,-5.5
+      parent: 1
+      type: Transform
+  - uid: 421
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -7.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 478
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 7.5,-4.5
+      parent: 1
+      type: Transform
+- proto: WallSolid
+  entities:
+  - uid: 2
+    components:
+    - pos: 0.5,-6.5
+      parent: 1
+      type: Transform
+  - uid: 11
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -4.5,-5.5
+      parent: 1
+      type: Transform
+  - uid: 44
+    components:
+    - pos: 0.5,-10.5
+      parent: 1
+      type: Transform
+  - uid: 120
+    components:
+    - pos: 0.5,-11.5
+      parent: 1
+      type: Transform
+  - uid: 121
+    components:
+    - pos: -7.5,-10.5
+      parent: 1
+      type: Transform
+  - uid: 124
+    components:
+    - pos: 0.5,-7.5
+      parent: 1
+      type: Transform
+  - uid: 162
+    components:
+    - pos: -5.5,-12.5
+      parent: 1
+      type: Transform
+  - uid: 166
+    components:
+    - pos: 0.5,-8.5
+      parent: 1
+      type: Transform
+  - uid: 182
+    components:
+    - pos: 0.5,-9.5
+      parent: 1
+      type: Transform
+  - uid: 200
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 0.5,7.5
+      parent: 1
+      type: Transform
+  - uid: 201
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -0.5,7.5
+      parent: 1
+      type: Transform
+  - uid: 202
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -1.5,7.5
+      parent: 1
+      type: Transform
+  - uid: 203
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -1.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 204
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -1.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 208
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -1.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 209
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -1.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 210
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -1.5,-0.5
+      parent: 1
+      type: Transform
+  - uid: 215
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -1.5,-5.5
+      parent: 1
+      type: Transform
+  - uid: 307
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 3.5,-6.5
+      parent: 1
+      type: Transform
+  - uid: 407
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -0.5,-6.5
+      parent: 1
+      type: Transform
+  - uid: 413
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -1.5,-6.5
+      parent: 1
+      type: Transform
+  - uid: 483
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -6.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 484
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -5.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 486
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -2.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 488
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -2.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 489
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -2.5,13.5
+      parent: 1
+      type: Transform
+  - uid: 490
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -2.5,14.5
+      parent: 1
+      type: Transform
+  - uid: 491
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -2.5,15.5
+      parent: 1
+      type: Transform
+  - uid: 499
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 1.5,14.5
+      parent: 1
+      type: Transform
+  - uid: 500
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 1.5,13.5
+      parent: 1
+      type: Transform
+  - uid: 501
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 1.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 503
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -1.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 504
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 3.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 506
+    components:
+    - pos: 4.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 513
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -0.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 570
+    components:
+    - pos: -4.5,7.5
+      parent: 1
+      type: Transform
+  - uid: 576
+    components:
+    - pos: -5.5,7.5
+      parent: 1
+      type: Transform
+- proto: WarningN2
+  entities:
+  - uid: 1046
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 6.5,-2.5
+      parent: 1
+      type: Transform
+- proto: WarningO2
+  entities:
+  - uid: 1047
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 6.5,-4.5
+      parent: 1
+      type: Transform
+- proto: WarningPlasma
+  entities:
+  - uid: 1048
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 6.5,-0.5
+      parent: 1
+      type: Transform
+- proto: WarpPointShip
+  entities:
+  - uid: 818
+    components:
+    - pos: -3.5,2.5
+      parent: 1
+      type: Transform
+- proto: WindoorSecure
+  entities:
+  - uid: 222
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -4.5,8.5
+      parent: 1
+      type: Transform
+- proto: WindowReinforcedDirectional
+  entities:
+  - uid: 239
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -4.5,9.5
+      parent: 1
+      type: Transform
+...

--- a/Resources/Prototypes/_NF/Shipyard/rigger.yml
+++ b/Resources/Prototypes/_NF/Shipyard/rigger.yml
@@ -9,7 +9,7 @@
 
 - type: gameMap
   id: rigger
-  mapName: 'NT rigger'
+  mapName: 'NT Rigger'
   mapPath: /Maps/Shuttles/rigger.yml
   minPlayers: 0
   stations:

--- a/Resources/Prototypes/_NF/Shipyard/rigger.yml
+++ b/Resources/Prototypes/_NF/Shipyard/rigger.yml
@@ -1,0 +1,31 @@
+- type: vessel
+  id: rigger
+  name: NT Rigger
+  description: The Rigger is a medium-sized engineering vessel outfitted for deep space construction projects. Features atmospherics setup with mixing/ignition chamber. Designed to work in pair with smaller salvage ship.
+  price: 88000
+  category: Medium
+  group: Civilian
+  shuttlePath: /Maps/Shuttles/rigger.yml
+
+- type: gameMap
+  id: rigger
+  mapName: 'NT rigger'
+  mapPath: /Maps/Shuttles/rigger.yml
+  minPlayers: 0
+  stations:
+    rigger:
+      stationProto: StandardFrontierVessel
+      components:
+        - type: StationNameSetup
+          mapNameTemplate: '{0} Rigger {1}'
+          nameGenerator:
+            !type:NanotrasenNameGenerator
+            prefixCreator: '14'
+        - type: StationJobs
+          overflowJobs: []
+          availableJobs:
+            ChiefEngineer: [ 0, 0 ]
+            Paramedic: [ 0, 0 ]
+            AtmosphericTechnician: [ 0, 0 ]
+            StationEngineer: [ 0, 0 ]
+            Borg: [ 0, 0 ]

--- a/Resources/Prototypes/_NF/Shipyard/rigger.yml
+++ b/Resources/Prototypes/_NF/Shipyard/rigger.yml
@@ -2,7 +2,7 @@
   id: rigger
   name: NT Rigger
   description: The Rigger is a medium-sized engineering vessel outfitted for deep space construction projects. Features atmospherics setup with mixing/ignition chamber. Designed to work in pair with smaller salvage ship.
-  price: 88000
+  price: 90100
   category: Medium
   group: Civilian
   shuttlePath: /Maps/Shuttles/rigger.yml

--- a/Resources/Prototypes/_NF/Shipyard/rigger.yml
+++ b/Resources/Prototypes/_NF/Shipyard/rigger.yml
@@ -17,7 +17,7 @@
       stationProto: StandardFrontierVessel
       components:
         - type: StationNameSetup
-          mapNameTemplate: '{0} Rigger {1}'
+          mapNameTemplate: 'Rigger {1}'
           nameGenerator:
             !type:NanotrasenNameGenerator
             prefixCreator: '14'


### PR DESCRIPTION
## About the PR
A medium-sized (531 tile) ship that is designed to serve as a mobile platform for construction projects in space. Features a functional atmos setup completed with a mixing chamber.

## Why / Balance
While most ships are self-sufficient as far as the engineering part goes (or can be easily modified to be), I haven't seen a design that has a fully functioning gas mixing chamber that allows the creation of tritium and frezon.

## Media
![NT Rigger](https://github.com/new-frontiers-14/frontier-station-14/assets/65374927/3bfc1b83-0a9e-4b22-966b-d9c79a06a5bf)
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- add: NT Rigger - a medium-sized dedicated engineering/atmospherics ship suitable for daring deep space construction projects.
