### PR TITLE
Vending Random Eject Rework

### DIFF
--- a/Content.Server/VendingMachines/VendingMachineSystem.cs
+++ b/Content.Server/VendingMachines/VendingMachineSystem.cs
@@ -408,16 +408,22 @@ namespace Content.Server.VendingMachines
             if (!Resolve(uid, ref vendComponent))
                 return;
 
+            if (!this.IsPowered(uid, EntityManager))
+                return;
+
+            if (vendComponent.Ejecting)
+                return;
+
+            if (vendComponent.EjectRandomMax <= vendComponent.EjectRandomCounter)
+            {
+                _audioSystem.PlayPvs(_audioSystem.GetSound(vendComponent.SoundDeny), uid);
+                _popupSystem.PopupEntity(Loc.GetString("shuttle-ftl-proximity"), uid, PopupType.MediumCaution);
+                return;
+            }
+
             var availableItems = GetAvailableInventory(uid, vendComponent);
             if (availableItems.Count <= 0)
                 return;
-
-            if (!vendComponent.Ejecting)
-                return;
-
-            if (vendComponent.EjectRandomMax > vendComponent.EjectRandomCounter)
-                return;
-
             var item = _random.Pick(availableItems);
 
             if (forceEject)

--- a/Content.Server/VendingMachines/VendingMachineSystem.cs
+++ b/Content.Server/VendingMachines/VendingMachineSystem.cs
@@ -438,8 +438,6 @@ namespace Content.Server.VendingMachines
             else
                 TryEjectVendorItem(uid, item.Type, item.ID, throwItem, 0, vendComponent);
             vendComponent.EjectRandomCounter += 1;
-
-
         }
 
         private void EjectItem(EntityUid uid, VendingMachineComponent? vendComponent = null, bool forceEject = false)

--- a/Content.Shared/VendingMachines/VendingMachineComponent.cs
+++ b/Content.Shared/VendingMachines/VendingMachineComponent.cs
@@ -48,7 +48,7 @@ namespace Content.Shared.VendingMachines
         /// The time it takes to regain a single charge
         /// </summary>
         [DataField("rechargeDuration"), ViewVariables(VVAccess.ReadWrite)]
-        public TimeSpan RechargeDuration = TimeSpan.FromSeconds(1800);
+        public TimeSpan RechargeDuration = TimeSpan.FromSeconds(3600);
 
         /// <summary>
         /// The time when the next charge will be added

--- a/Content.Shared/VendingMachines/VendingMachineComponent.cs
+++ b/Content.Shared/VendingMachines/VendingMachineComponent.cs
@@ -35,14 +35,26 @@ namespace Content.Shared.VendingMachines
         /// <summary>
         /// Used by the server to determine how many items the machine allowed to eject from random triggers.
         /// </summary>
-        [DataField("ejectRandomMax")]
-        public float EjectRandomMax = 3f;
+        [DataField("ejectRandomMax"), ViewVariables(VVAccess.ReadWrite)]
+        public float EjectRandomMax = 2;
 
         /// <summary>
         /// Used by the server to determine how many items the machine ejected from random triggers.
         /// </summary>
-        [DataField("ejectRandomCounter")]
-        public float EjectRandomCounter = 0f;
+        [DataField("ejectRandomCounter"), ViewVariables(VVAccess.ReadWrite)]
+        public float EjectRandomCounter = 2;
+
+        /// <summary>
+        /// The time it takes to regain a single charge
+        /// </summary>
+        [DataField("rechargeDuration"), ViewVariables(VVAccess.ReadWrite)]
+        public TimeSpan RechargeDuration = TimeSpan.FromSeconds(1800);
+
+        /// <summary>
+        /// The time when the next charge will be added
+        /// </summary>
+        [DataField("nextChargeTime", customTypeSerializer: typeof(TimeOffsetSerializer))]
+        public TimeSpan NextChargeTime;
 
         [ViewVariables]
         public Dictionary<string, VendingMachineInventoryEntry> Inventory = new();

--- a/Resources/Locale/en-US/_NF/vending-machines/vending-machine-component.ftl
+++ b/Resources/Locale/en-US/_NF/vending-machines/vending-machine-component.ftl
@@ -1,0 +1,3 @@
+##  VendingMachineComponent
+
+vending-machine-component-try-eject-access-abused = Vending protection active


### PR DESCRIPTION
## About the PR
Fixed vending force eject to work again
Changed it to work based on charges.
Machines gets 1 free eject every 60 minutes by default, for max of 2 charges saved (3 if you consider the timer refresh)

## Why / Balance
Giving sentient vending machines a bit more gameplay, no longer limited by 3 items, giving them few more free items in total they can vend over the shift.

## Technical details
C# changes.

## Media
- [X] this PR does not require an ingame showcase

## Breaking changes
N/A
Might need to change the numbers on "rare" vends like the ContraVend to give it only 3 vends for free over the full shift, or dont, its not a big issue.

**Changelog**
N/A
Im not even sure what can be told to players about this.