### PR TITLE
Lower Power Use for recycler & material reclaimer

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/material_reclaimer.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/material_reclaimer.yml
@@ -100,5 +100,7 @@
     solution: output
   - type: StaticPrice
     price: 500
+  - type: ApcPowerReceiver # Frontier
+    powerLoad: 500 # Allows us to not use the 1000 baseline
   - type: MaterialReclaimerMagnetPickup # Frontier
     range: 0.30

--- a/Resources/Prototypes/Entities/Structures/Machines/recycler.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/recycler.yml
@@ -111,3 +111,5 @@
   - type: MaterialStorage
   - type: Conveyor
   - type: Rotatable
+  - type: ApcPowerReceiver # Frontier
+    powerLoad: 500 # Allows us to not use the 1000 baseline

--- a/Resources/Prototypes/Entities/Structures/Piping/Disposal/units.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Disposal/units.yml
@@ -73,7 +73,7 @@
     price: 62
   - type: PowerSwitch
   - type: ApcPowerReceiver # Frontier
-    powerLoad: 250 # Allows up to not use the 1000 baseline
+    powerLoad: 250 # Allows us to not use the 1000 baseline
 
 - type: entity
   id: DisposalUnit


### PR DESCRIPTION
## About the PR
Update the recycler & material reclaimer machines to use 500>1000 power.

## Why / Balance
Machines were using the same 1000 base line most machines are using.

There is a need for a real power system for machines rework, posted about it on discord and this is just a temp fix before building a real system to allow dynamic use of power based on machine activity, and not just idle 24/7 1000 baseline.

## Technical details
.yml

## Media
- [X] this PR does not require an ingame showcase

## Breaking changes
N/A

**Changelog**
N/A