### PR TITLE
Decade Dove Cargo Pallet Fix

### DIFF
--- a/Resources/Maps/Shuttles/decadedove.yml
+++ b/Resources/Maps/Shuttles/decadedove.yml
@@ -633,7 +633,7 @@ entities:
     - pos: 1.5,4.5
       parent: 1
       type: Transform
-    - secondsUntilStateChange: -14652.679
+    - secondsUntilStateChange: -14820.753
       state: Opening
       type: Door
   - uid: 311
@@ -707,7 +707,7 @@ entities:
       pos: -9.5,-0.5
       parent: 1
       type: Transform
-    - secondsUntilStateChange: -1269.4619
+    - secondsUntilStateChange: -1437.5358
       state: Opening
       type: Door
   - uid: 418
@@ -2083,12 +2083,6 @@ entities:
       type: Transform
 - proto: CargoPallet
   entities:
-  - uid: 43
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -2.5,1.5
-      parent: 1
-      type: Transform
   - uid: 71
     components:
     - pos: -5.5,1.5
@@ -2109,21 +2103,9 @@ entities:
     - pos: -5.5,2.5
       parent: 1
       type: Transform
-  - uid: 178
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -2.5,2.5
-      parent: 1
-      type: Transform
   - uid: 249
     components:
     - pos: -5.5,-0.5
-      parent: 1
-      type: Transform
-  - uid: 474
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -2.5,-0.5
       parent: 1
       type: Transform
 - proto: Catwalk
@@ -3911,6 +3893,8 @@ entities:
     - pos: 9.5,1.5
       parent: 1
       type: Transform
+    - locked: False
+      type: Lock
     - air:
         volume: 200
         immutable: False


### PR DESCRIPTION
## About the PR
-Removes stray cargo pallets underneath some walls.

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

- [X] This PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- fix: Stray cargo pallets on the Decade Dove have been removed.
<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
