### PR TITLE
Mail Rework Part 1

### DIFF
--- a/Content.Client/Nyanotrasen/Mail/MailSystem.cs
+++ b/Content.Client/Nyanotrasen/Mail/MailSystem.cs
@@ -1,7 +1,10 @@
 using Robust.Client.GameObjects;
 using Content.Shared.Mail;
 using Content.Shared.StatusIcon;
-using Robust.Client.Utility;
+using Content.Shared.StatusIcon.Components;
+using Robust.Client.State;
+using Robust.Client.State;
+using Robust.Shared.Utility;
 using Robust.Shared.Prototypes;
 
 namespace Content.Client.Mail
@@ -28,19 +31,24 @@ namespace Content.Client.Mail
     ///       SecurityOfficer:
     ///         state: SecurityOfficer
     /// </remarks>
+        [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+        [Dependency] private readonly SpriteSystem _stateManager = default!;
+        [Dependency] private readonly SpriteSystem _spriteSystem = default!;
+
     public sealed class MailJobVisualizerSystem : VisualizerSystem<MailComponent>
     {
-        [Dependency] private readonly IPrototypeManager _prototype = default!;
         protected override void OnAppearanceChange(EntityUid uid, MailComponent component, ref AppearanceChangeEvent args)
         {
             if (args.Sprite == null)
+            args.Component.TryGetData(MailVisuals.JobIcon, out string job);
+
+            if (!_prototypeManager.TryIndex<StatusIconPrototype>(job, out var icon))
                 return;
 
-            if (args.Component.TryGetData(MailVisuals.JobIcon, out string job))
-            {
-                var jobIcon = _prototype.Index<StatusIconPrototype>(job);
-                args.Sprite.LayerSetTexture(MailVisualLayers.JobStamp, jobIcon.Icon.Frame0());
+            args.Sprite.LayerSetTexture(MailVisualLayers.JobStamp, _spriteSystem.Frame0(icon.Icon));
+                args.Sprite.LayerSetState(MailVisualLayers.JobStamp, job);
             }
+
         }
     }
 

--- a/Content.Client/Nyanotrasen/Mail/MailSystem.cs
+++ b/Content.Client/Nyanotrasen/Mail/MailSystem.cs
@@ -1,10 +1,6 @@
 using Robust.Client.GameObjects;
 using Content.Shared.Mail;
 using Content.Shared.StatusIcon;
-using Content.Shared.StatusIcon.Components;
-using Robust.Client.State;
-using Robust.Client.State;
-using Robust.Shared.Utility;
 using Robust.Shared.Prototypes;
 
 namespace Content.Client.Mail
@@ -31,24 +27,23 @@ namespace Content.Client.Mail
     ///       SecurityOfficer:
     ///         state: SecurityOfficer
     /// </remarks>
+    public sealed class MailJobVisualizerSystem : VisualizerSystem<MailComponent>
+    {
         [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
         [Dependency] private readonly SpriteSystem _stateManager = default!;
         [Dependency] private readonly SpriteSystem _spriteSystem = default!;
 
-    public sealed class MailJobVisualizerSystem : VisualizerSystem<MailComponent>
-    {
         protected override void OnAppearanceChange(EntityUid uid, MailComponent component, ref AppearanceChangeEvent args)
         {
             if (args.Sprite == null)
+                return;
+
             args.Component.TryGetData(MailVisuals.JobIcon, out string job);
 
             if (!_prototypeManager.TryIndex<StatusIconPrototype>(job, out var icon))
                 return;
 
             args.Sprite.LayerSetTexture(MailVisualLayers.JobStamp, _spriteSystem.Frame0(icon.Icon));
-                args.Sprite.LayerSetState(MailVisualLayers.JobStamp, job);
-            }
-
         }
     }
 

--- a/Content.Client/Nyanotrasen/Mail/MailSystem.cs
+++ b/Content.Client/Nyanotrasen/Mail/MailSystem.cs
@@ -30,7 +30,6 @@ namespace Content.Client.Mail
     public sealed class MailJobVisualizerSystem : VisualizerSystem<MailComponent>
     {
         [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
-        [Dependency] private readonly SpriteSystem _stateManager = default!;
         [Dependency] private readonly SpriteSystem _spriteSystem = default!;
 
         protected override void OnAppearanceChange(EntityUid uid, MailComponent component, ref AppearanceChangeEvent args)

--- a/Content.Server/Nyanotrasen/Mail/MailSystem.cs
+++ b/Content.Server/Nyanotrasen/Mail/MailSystem.cs
@@ -10,7 +10,6 @@ using Content.Server.Cargo.Components;
 using Content.Server.Cargo.Systems;
 using Content.Server.Chat.Systems;
 using Content.Shared.Chemistry.EntitySystems;
-using Content.Server.Chemistry.EntitySystems;
 using Content.Server.Damage.Components;
 using Content.Server.Destructible;
 using Content.Server.Destructible.Thresholds;
@@ -26,18 +25,15 @@ using Content.Server.Popups;
 using Content.Server.Power.Components;
 using Content.Server.Station.Components;
 using Content.Server.Station.Systems;
-using Content.Shared.Coordinates;
 using Content.Server.StationRecords.Systems;
 using Content.Server.Spawners.EntitySystems;
 using Content.Shared.Access.Components;
 using Content.Shared.Access.Systems;
-using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.Damage;
 using Content.Shared.Emag.Components;
 using Content.Shared.Destructible;
 using Content.Shared.Emag.Systems;
 using Content.Shared.Examine;
-using Content.Shared.Coordinates;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction;
 using Content.Shared.Interaction.Events;
@@ -46,7 +42,6 @@ using Content.Shared.Maps;
 using Content.Shared.PDA;
 using Content.Shared.Random.Helpers;
 using Content.Shared.Roles;
-using Content.Shared.StatusIcon;
 using Content.Shared.Storage;
 using Content.Shared.Tag;
 using Timer = Robust.Shared.Timing.Timer;
@@ -71,9 +66,7 @@ namespace Content.Server.Mail
         [Dependency] private readonly SharedAppearanceSystem _appearanceSystem = default!;
         [Dependency] private readonly SharedAudioSystem _audioSystem = default!;
         [Dependency] private readonly DamageableSystem _damageableSystem = default!;
-        [Dependency] private readonly StationRecordsSystem _recordsSystem = default!;
         [Dependency] private readonly MindSystem _mind = default!;
-        [Dependency] private readonly MetaDataSystem _meta = default!;
         [Dependency] private readonly ItemSystem _itemSystem = default!;
         [Dependency] private readonly MindSystem _mindSystem = default!;
         [Dependency] private readonly MetaDataSystem _metaDataSystem = default!;
@@ -694,6 +687,8 @@ namespace Content.Server.Mail
 
                 var mail = EntityManager.SpawnEntity(chosenParcel, Transform(uid).Coordinates);
                 SetupMail(mail, component, candidate);
+
+                _tagSystem.AddTag(mail, "Recyclable"); // Frontier - Make it so mail can be destroyed by reclaimer
             }
 
             if (_containerSystem.TryGetContainer(uid, "queued", out var queued))
@@ -727,6 +722,7 @@ namespace Content.Server.Mail
             _itemSystem.SetSize(uid, 1);
             _tagSystem.AddTag(uid, "Trash");
             _tagSystem.AddTag(uid, "Recyclable");
+            _tagSystem.AddTag(uid, "ClothMade"); // Frontier - Make it so moth can eat open mail.
             component.IsEnabled = false;
             UpdateMailTrashState(uid, true);
         }

--- a/Content.Server/Nyanotrasen/Mail/MailSystem.cs
+++ b/Content.Server/Nyanotrasen/Mail/MailSystem.cs
@@ -120,7 +120,7 @@ namespace Content.Server.Mail
                 return;
             }
 
-            AddComp<MailReceiverComponent>(args.SpawnResult.Value);
+            EnsureComp<MailReceiverComponent>(args.SpawnResult.Value);
         }
 
         private void OnRemove(EntityUid uid, MailComponent component, ComponentRemove args)

--- a/Content.Server/Nyanotrasen/Mail/MailSystem.cs
+++ b/Content.Server/Nyanotrasen/Mail/MailSystem.cs
@@ -232,9 +232,6 @@ namespace Content.Server.Mail
             var query = EntityQueryEnumerator<StationBankAccountComponent>();
             while (query.MoveNext(out var station, out var account))
             {
-                if (_stationSystem.GetOwningStation(uid) != station)
-                    continue;
-
                 _cargoSystem.UpdateBankAccount(station, account, component.Bounty);
                 return;
             }

--- a/Content.Server/Nyanotrasen/Mail/MailSystem.cs
+++ b/Content.Server/Nyanotrasen/Mail/MailSystem.cs
@@ -123,8 +123,7 @@ namespace Content.Server.Mail
         private void OnSpawnPlayer(PlayerSpawningEvent args)
         {
             if (args.SpawnResult == null ||
-                args.Job == null ||
-                args.Station is not { } station)
+                args.Job == null )
             {
                 return;
             }

--- a/Content.Server/Nyanotrasen/Mail/MailSystem.cs
+++ b/Content.Server/Nyanotrasen/Mail/MailSystem.cs
@@ -25,7 +25,6 @@ using Content.Server.Popups;
 using Content.Server.Power.Components;
 using Content.Server.Station.Components;
 using Content.Server.Station.Systems;
-using Content.Server.StationRecords.Systems;
 using Content.Server.Spawners.EntitySystems;
 using Content.Shared.Access.Components;
 using Content.Shared.Access.Systems;
@@ -284,7 +283,7 @@ namespace Content.Server.Mail
             var query = EntityQueryEnumerator<StationBankAccountComponent>();
             while (query.MoveNext(out var station, out var account))
             {
-                //if (_stationSystem.GetOwningStation(uid) != station) // No need for this test
+                //if (_stationSystem.GetOwningStation(uid) != station) // Frontier - No need for this test
                 //    continue;
 
                 //_cargoSystem.UpdateBankAccount(station, account, component.Penalty); // Frontier - Dont remove money.
@@ -298,7 +297,7 @@ namespace Content.Server.Mail
                 PenalizeStationFailedDelivery(uid, component, "mail-penalty-lock");
 
             // if (component.IsEnabled)
-            //     OpenMail(uid, component); // Dont open the mail on destruction. // Frontier
+            //     OpenMail(uid, component); // Frontier - Dont open the mail on destruction.
 
             UpdateAntiTamperVisuals(uid, false);
         }

--- a/Content.Server/Nyanotrasen/Mail/MailSystem.cs
+++ b/Content.Server/Nyanotrasen/Mail/MailSystem.cs
@@ -218,7 +218,8 @@ namespace Content.Server.Mail
                 return;
             }
 
-            _popupSystem.PopupEntity(Loc.GetString("mail-unlocked-reward", ("bounty", component.Bounty)), uid, args.User);
+            //_popupSystem.PopupEntity(Loc.GetString("mail-unlocked-reward", ("bounty", component.Bounty)), uid, args.User);
+            _popupSystem.PopupEntity(Loc.GetString("mail-unlocked-reward"), uid, args.User); // Frontier - Remove the mention of station income
 
             component.IsProfitable = false;
 

--- a/Content.Server/Nyanotrasen/Mail/MailSystem.cs
+++ b/Content.Server/Nyanotrasen/Mail/MailSystem.cs
@@ -197,9 +197,15 @@ namespace Content.Server.Mail
 
             if (!HasComp<EmaggedComponent>(uid))
             {
-                if (idCard.FullName != component.Recipient || idCard.JobTitle != component.RecipientJob)
+                //if (idCard.FullName != component.Recipient || idCard.JobTitle != component.RecipientJob)
+                //{
+                //    _popupSystem.PopupEntity(Loc.GetString("mail-recipient-mismatch"), uid, args.User);
+                //    return;
+                //}
+
+                if (idCard.FullName != component.Recipient) // Frontier - Only match the name
                 {
-                    _popupSystem.PopupEntity(Loc.GetString("mail-recipient-mismatch"), uid, args.User);
+                    _popupSystem.PopupEntity(Loc.GetString("mail-recipient-mismatch-name"), uid, args.User);
                     return;
                 }
 

--- a/Resources/Locale/en-US/_Nyano/mail.ftl
+++ b/Resources/Locale/en-US/_Nyano/mail.ftl
@@ -1,4 +1,5 @@
 mail-recipient-mismatch = Recipient name or job does not match.
+mail-recipient-mismatch-name = Recipient name does not match.
 mail-invalid-access = Recipient name and job match, but access isn't as expected.
 mail-locked = The anti-tamper lock hasn't been removed. Tap the recipient's ID.
 mail-desc-far = A parcel of mail.

--- a/Resources/Locale/en-US/_Nyano/mail.ftl
+++ b/Resources/Locale/en-US/_Nyano/mail.ftl
@@ -8,7 +8,7 @@ mail-desc-priority = The anti-tamper lock's [color=yellow]yellow priority tape[/
 mail-desc-priority-inactive = The anti-tamper lock's [color=#886600]yellow priority tape[/color] is inactive.
 mail-unlocked = Anti-tamper system unlocked.
 mail-unlocked-by-emag = Anti-tamper system *BZZT*.
-mail-unlocked-reward = Anti-tamper system unlocked. {$bounty} spesos have been added to station's account.
+mail-unlocked-reward = Anti-tamper system unlocked.
 mail-penalty-lock = ANTI-TAMPER LOCK BROKEN. STATION BANK ACCOUNT PENALIZED BY {$credits} SPESOS.
 mail-penalty-fragile = INTEGRITY COMPROMISED. STATION BANK ACCOUNT PENALIZED BY {$credits} SPESOS.
 mail-penalty-expired = DELIVERY PAST DUE. STATION BANK ACCOUNT PENALIZED BY {$credits} SPESOS.

--- a/Resources/Prototypes/DeltaV/Entities/Mobs/Player/vulpkanin.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Mobs/Player/vulpkanin.yml
@@ -26,7 +26,6 @@
     - type: CameraRecoil
     - type: Examiner
     - type: CanHostGuardian
-    - type: MailReceiver
     - type: NpcFactionMember
       factions:
         - NanoTrasen

--- a/Resources/Prototypes/Entities/Mobs/Player/arachnid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/arachnid.yml
@@ -11,4 +11,3 @@
     damageRecovery:
       types:
         Asphyxiation: -0.5 # Recovery will suck without chems
-  - type: MailReceiver

--- a/Resources/Prototypes/Entities/Mobs/Player/diona.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/diona.yml
@@ -11,4 +11,3 @@
       damageRecovery:
         types:
           Asphyxiation: -1.0
-    - type: MailReceiver

--- a/Resources/Prototypes/Entities/Mobs/Player/dwarf.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/dwarf.yml
@@ -3,5 +3,4 @@
   name: Urist McHands The Dwarf
   parent: BaseMobDwarf
   id: MobDwarf
-  components:
-    - type: MailReceiver
+

--- a/Resources/Prototypes/Entities/Mobs/Player/human.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/human.yml
@@ -3,8 +3,6 @@
   name: Urist McHands
   parent: BaseMobHuman
   id: MobHuman
-  components:
-  - type: MailReceiver
 
 #Syndie
 - type: entity

--- a/Resources/Prototypes/Entities/Mobs/Player/moth.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/moth.yml
@@ -3,5 +3,3 @@
   name: Urist McFluff
   parent: BaseMobMoth
   id: MobMoth
-  components:
-  - type: MailReceiver

--- a/Resources/Prototypes/Entities/Mobs/Player/reptilian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/reptilian.yml
@@ -3,6 +3,4 @@
   name: Urisst' Mzhand
   parent: BaseMobReptilian
   id: MobReptilian
-  components:
-    - type: MailReceiver
 #Weh

--- a/Resources/Prototypes/Entities/Mobs/Player/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/slime.yml
@@ -2,5 +2,3 @@
   save: false
   parent: BaseMobSlimePerson
   id: MobSlimePerson
-  components:
-    - type: MailReceiver

--- a/Resources/Prototypes/Entities/Mobs/Player/vox.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/vox.yml
@@ -3,5 +3,3 @@
   name: Vox
   parent: BaseMobVox
   id: MobVox
-  components:
-    - type: MailReceiver

--- a/Resources/Prototypes/_Nyano/Entities/Mobs/Player/felinid.yml
+++ b/Resources/Prototypes/_Nyano/Entities/Mobs/Player/felinid.yml
@@ -3,12 +3,3 @@
   name: Urist McFelinid
   parent: [MobFelinidBase, BaseMob]
   id: MobFelinid
-  components:
-  - type: Respirator
-    damage:
-      types:
-        Asphyxiation: 1.0
-    damageRecovery:
-      types:
-        Asphyxiation: -1.0
-  - type: MailReceiver

--- a/Resources/Prototypes/_Nyano/Entities/Mobs/Player/oni.yml
+++ b/Resources/Prototypes/_Nyano/Entities/Mobs/Player/oni.yml
@@ -3,12 +3,3 @@
   name: Urist McOni
   parent: [MobOniBase, BaseMob]
   id: MobOni
-  components:
-  - type: Respirator
-    damage:
-      types:
-        Asphyxiation: 1.0
-    damageRecovery:
-      types:
-        Asphyxiation: -1.0
-  - type: MailReceiver

--- a/Resources/Prototypes/_Nyano/Entities/Objects/Specific/Mail/base_mail.yml
+++ b/Resources/Prototypes/_Nyano/Entities/Objects/Specific/Mail/base_mail.yml
@@ -95,8 +95,17 @@
   - type: DamageOtherOnHit
     damage:
       types:
-        Blunt: 5
+        Blunt: 1 # Frontier - 5<1, death by 1000 cuts.
   - type: CargoSellBlacklist
+  - type: Food # Frontier - Moth food
+    requiresSpecialDigestion: true
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 1
+        reagents:
+        - ReagentId: Fiber
+          Quantity: 1
 
 # This empty parcel is allowed to exist and evade the tests for the admin
 # mailto command.

--- a/Resources/Prototypes/_Nyano/Entities/Objects/Specific/Mail/base_mail.yml
+++ b/Resources/Prototypes/_Nyano/Entities/Objects/Specific/Mail/base_mail.yml
@@ -18,7 +18,6 @@
       map: ["enum.MailVisualLayers.FragileStamp"]
       visible: false
     - map: ["enum.MailVisualLayers.JobStamp"]
-      sprite: Interface/Misc/job_icons.rsi
       scale: 0.5, 0.5
       offset: 0.275, 0.2
     - state: locked

--- a/Resources/Prototypes/_Nyano/Entities/Objects/Specific/Mail/base_mail.yml
+++ b/Resources/Prototypes/_Nyano/Entities/Objects/Specific/Mail/base_mail.yml
@@ -104,7 +104,7 @@
       food:
         maxVol: 1
         reagents:
-        - ReagentId: Fiber
+        - ReagentId: Nothing
           Quantity: 1
 
 # This empty parcel is allowed to exist and evade the tests for the admin


### PR DESCRIPTION
## About the PR
Match closer to DeltaV code to rebase the mail system.

Changes include:

- [X] Open mail size 20<1
- [X] Moths can eat open mail (When we re add the option for moth to eat cloth it will fix itself), its only 1 fiber per envelop, moth cannot eat closed mail.
- [X] Paper cuts damage 5<1
- [X] Mail receiver comp moved to automated, removed from all races.
- [X] Closed mail can be used in reclaimer, to destroy it on the case of too much mail (Remove lags)
- [X] Change the notification about open mail income to not mention income to station bank.
- [X] Ignore job title when opening mail, need to rework it to DNA later.

## Why / Balance
Mail need some love, this is part one of a bigger rework I want to do, have to start with something.

## Technical details
.yml
C#

## Media
- [ ] I have added screenshots/videos to this PR showcasing its changes ingame,

## Breaking changes
Didn't find any new issues. 

**Changelog**
:cl: dvir01
- tweak: Mail bags can fit more open mail.
- tweak: Mail is now made from normal paper that isn't infused with steel, paper cuts wont hurt as much.
- tweak: Closed mail is a bit less bulky as it used to be and will fit into reclaimers.