### PR TITLE
Cargo Piano Orders

### DIFF
--- a/Resources/Locale/en-US/_NF/prototypes/catalog/cargo/cargo-fun.ftl
+++ b/Resources/Locale/en-US/_NF/prototypes/catalog/cargo/cargo-fun.ftl
@@ -1,2 +1,14 @@
 ent-FloorsFun = { ent-CrateFloorsFun }
     .desc = { ent-CrateFloorsFun.desc }
+
+ent-FunPianoInstrument = { ent-PianoInstrument }
+    .desc = { ent-PianoInstrument.desc }
+
+ent-FunUprightPianoInstrument = { ent-UprightPianoInstrument }
+    .desc = { ent-UprightPianoInstrument.desc }
+
+ent-FunChurchOrganInstrument = { ent-ChurchOrganInstrument }
+    .desc = { ent-ChurchOrganInstrument.desc }
+
+ent-FunMinimoogInstrument = { ent-MinimoogInstrument }
+    .desc = { ent-MinimoogInstrument.desc }

--- a/Resources/Prototypes/_NF/Catalog/Cargo/cargo_fun.yml
+++ b/Resources/Prototypes/_NF/Catalog/Cargo/cargo_fun.yml
@@ -7,3 +7,44 @@
   cost: 500
   category: Fun
   group: market
+
+- type: cargoProduct
+  id: FunPianoInstrument
+  icon:
+    sprite: Objects/Fun/Instruments/structureinstruments.rsi
+    state: piano
+  product: PianoInstrument
+  cost: 1000
+  category: Fun
+  group: market
+
+- type: cargoProduct
+  id: FunUprightPianoInstrument
+  icon:
+    sprite: Objects/Fun/Instruments/structureinstruments.rsi
+    state: piano-upright
+  product: UprightPianoInstrument
+  cost: 1000
+  category: Fun
+  group: market
+
+- type: cargoProduct
+  id: FunChurchOrganInstrument
+  icon:
+    sprite: Objects/Fun/Instruments/structureinstruments.rsi
+    state: church-organ
+  product: ChurchOrganInstrument
+  cost: 1000
+  category: Fun
+  group: market
+
+- type: cargoProduct
+  id: FunMinimoogInstrument
+  icon:
+    sprite: Objects/Fun/Instruments/structureinstruments.rsi
+    state: minimoog
+  product: MinimoogInstrument
+  cost: 1000
+  category: Fun
+  group: market
+


### PR DESCRIPTION
## About the PR
Added 4 "piano" like instruments to cargo.

Piano
Upright Piano
Church Organ
Minimoog

## Why / Balance
No way to get them unless you buy ships that has them.

## Technical details
.yml

## Media
- [X] this PR does not require an ingame showcase

## Breaking changes
N/A

**Changelog**
:cl: dvir01
- add: NT listened to people needs, and now selling 4 piano like instruments in cargo
