### PR TITLE
Update civilianservices.yml

### DIFF
--- a/Resources/Prototypes/Research/civilianservices.yml
+++ b/Resources/Prototypes/Research/civilianservices.yml
@@ -91,7 +91,7 @@
   cost: 5000
   recipeUnlocks:
   - SurveillanceCameraRouterCircuitboard
-  - SurveillanceCameraWirelessRouterCircuitboard
+#  - SurveillanceCameraWirelessRouterCircuitboard # Frontier - Removal of range limits made it useless to build
   - SurveillanceWirelessCameraMovableCircuitboard
   - SurveillanceWirelessCameraAnchoredCircuitboard
   - SurveillanceCameraMonitorCircuitboard


### PR DESCRIPTION
## About the PR
Removing "SurveillanceCameraWirelessRouterCircuitboard" from civilian services communication tech.

## Why / Balance
No need for more then one server, setting on the pit as of now.

## Technical details
.yml

## Media
- [X] this PR does not require an ingame showcase

## Breaking changes
N/A

**Changelog**
N/A
