### PR TITLE
Block artifact activating on protected grid

### DIFF
--- a/Content.Server/Xenoarchaeology/XenoArtifacts/ArtifactSystem.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/ArtifactSystem.cs
@@ -7,6 +7,7 @@ using Content.Server.Xenoarchaeology.Equipment.Components;
 using Content.Server.Xenoarchaeology.XenoArtifacts.Events;
 using Content.Server.Xenoarchaeology.XenoArtifacts.Triggers.Components;
 using Content.Shared.CCVar;
+using Content.Shared.Tiles;
 using Content.Shared.Xenoarchaeology.XenoArtifacts;
 using JetBrains.Annotations;
 using Robust.Shared.Configuration;
@@ -148,6 +149,14 @@ public sealed partial class ArtifactSystem : EntitySystem
         // check if artifact is under suppression field
         if (component.IsSuppressed)
             return false;
+
+        // Frontier - check if artifact in on a protected grid
+        var xform = Transform(uid);
+        if (xform.GridUid != null)
+        {
+            if (HasComp<ProtectedGridComponent>(xform.GridUid.Value))
+                return false;
+        }
 
         // check if artifact isn't under cooldown
         var timeDif = _gameTiming.CurTime - component.LastActivationTime;

--- a/Content.Server/Xenoarchaeology/XenoArtifacts/ArtifactSystem.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/ArtifactSystem.cs
@@ -150,7 +150,7 @@ public sealed partial class ArtifactSystem : EntitySystem
         if (component.IsSuppressed)
             return false;
 
-        // Frontier - check if artifact in on a protected grid
+        // Frontier - check if artifact on a protected grid
         var xform = Transform(uid);
         if (xform.GridUid != null)
         {


### PR DESCRIPTION
## About the PR
Block artifact activating on protected grid simple as that.

## Why / Balance
Killing people on frontier from people who keep getting artifacts with deadly effects to pulse on frontier.

## Technical details
c# added a scan for arti to test the grid for ``ProtectedGridComponent``

## Media
- [X] this PR does not require an ingame showcase

## Breaking changes
N/A

**Changelog**
N/A
