### PR TITLE
Beret to medidrobe

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/medidrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/medidrobe.yml
@@ -52,6 +52,7 @@
     ClothingUniformJumpsuitSeniorPhysician: 1
     ClothingUniformJumpskirtSeniorPhysician: 1
     ClothingOuterCoatLabSeniorPhysician: 1
+    ClothingHeadHatBeretBrigmedic: 1
 # CMO:
     ClothingUniformJumpsuitCMO: 1
     ClothingUniformJumpskirtCMO: 1


### PR DESCRIPTION
## About the PR
Added the medical beret that is used by brigmedic to the medidrobe, its so generic it can be used by all medical.

## Why / Balance
Nice looking

## Technical details
.yml

## Media
- [X] this PR does not require an ingame showcase

## Breaking changes
N/A

**Changelog**
N/A