### PR TITLE
Allow vending machines to be repaired

### DIFF
--- a/Content.Server/VendingMachines/VendingMachineSystem.cs
+++ b/Content.Server/VendingMachines/VendingMachineSystem.cs
@@ -27,6 +27,8 @@ using Robust.Shared.Audio;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
+using Content.Shared.Tools.Components;
+using Content.Shared.Tools.Systems;
 
 namespace Content.Server.VendingMachines
 {
@@ -46,6 +48,8 @@ namespace Content.Server.VendingMachines
         [Dependency] private readonly ThrowingSystem _throwingSystem = default!;
         [Dependency] private readonly UserInterfaceSystem _userInterfaceSystem = default!;
         [Dependency] private readonly IGameTiming _timing = default!;
+
+        [Dependency] private readonly DamageableSystem _damageableSystem = default!;
 
         private ISawmill _sawmill = default!;
 
@@ -71,6 +75,8 @@ namespace Content.Server.VendingMachines
             SubscribeLocalEvent<VendingMachineComponent, RestockDoAfterEvent>(OnDoAfter);
 
             SubscribeLocalEvent<VendingMachineRestockComponent, PriceCalculationEvent>(OnPriceCalculation);
+
+            SubscribeLocalEvent<VendingMachineComponent, WeldableChangedEvent>(OnWeldChanged); // Frontier - Allow repair
         }
 
         private void OnComponentMapInit(EntityUid uid, VendingMachineComponent component, MapInitEvent args)
@@ -156,6 +162,22 @@ namespace Content.Server.VendingMachines
         {
             vendComponent.Broken = true;
             TryUpdateVisualState(uid, vendComponent);
+            EnsureComp<WeldableComponent>(uid);
+        }
+
+        private void OnWeldChanged(EntityUid uid, VendingMachineComponent component, WeldableChangedEvent args)
+        {
+            if (!EntityManager.TryGetComponent(uid, out DamageableComponent? damageable) || damageable.TotalDamage == 0)
+                return;
+
+            if (component.Broken)
+            {
+                component.Broken = false;
+                TryUpdateVisualState(uid, component);
+                EntityManager.RemoveComponent<WeldableComponent>(uid);
+                // Repair all damage
+                _damageableSystem.SetAllDamage(uid, damageable, 0);
+            }
         }
 
         private void OnEmagged(EntityUid uid, VendingMachineComponent component, ref GotEmaggedEvent args)


### PR DESCRIPTION
## About the PR
When a vending machine gets broken it can now be fixed to working state with full health.

## Why / Balance
Why not.

## Technical details
C#
When the machine move into broken visuals we add the ``WeldableComponent`` to it.
Then we add the ``WeldableChangedEvent`` event and make the machine go back to full health and working state.
Finally we remove the ``WeldableComponent`` so the machine can only be fixed when its broken.

## Media
- [ ] I have added screenshots/videos to this PR showcasing its changes ingame,

## Breaking changes
N/A

**Changelog**
:cl: dvir01
- tweak: Using welding tools on broken vending machines will restore them to working order.