### PR TITLE
Restore Events

### DIFF
--- a/Content.Server/StationEvents/Components/GasLeakRuleComponent.cs
+++ b/Content.Server/StationEvents/Components/GasLeakRuleComponent.cs
@@ -1,4 +1,4 @@
-﻿using Content.Server.StationEvents.Events;
+using Content.Server.StationEvents.Events;
 using Content.Shared.Atmos;
 using Robust.Shared.Map;
 
@@ -9,10 +9,11 @@ public sealed partial class GasLeakRuleComponent : Component
 {
     public readonly Gas[] LeakableGases =
     {
-        Gas.Miasma,
-        Gas.Plasma,
-        Gas.Tritium,
-        Gas.Frezon,
+//        Gas.Miasma,
+//        Gas.Plasma,
+//        Gas.Tritium,
+//        Gas.Frezon,
+          Gas.WaterVapor,
     };
 
     /// <summary>

--- a/Content.Server/StationEvents/Events/VentClogRule.cs
+++ b/Content.Server/StationEvents/Events/VentClogRule.cs
@@ -44,7 +44,8 @@ public sealed class VentClogRule : StationEventSystem<VentClogRuleComponent>
                 continue;
 
             var pickAny = RobustRandom.Prob(Math.Min(0.05f * mod, 1.0f));
-            var reagent = RobustRandom.Pick(pickAny ? allReagents : component.SafeishVentChemicals);
+            //var reagent = RobustRandom.Pick(pickAny ? allReagents : component.SafeishVentChemicals);
+            var reagent = RobustRandom.Pick(component.SafeishVentChemicals);
 
             var weak = component.WeakReagents.Contains(reagent);
             var quantity = (weak ? component.WeakReagentQuantity : component.ReagentQuantity) * mod;

--- a/Content.Server/StationEvents/Events/VentClogRule.cs
+++ b/Content.Server/StationEvents/Events/VentClogRule.cs
@@ -45,7 +45,7 @@ public sealed class VentClogRule : StationEventSystem<VentClogRuleComponent>
 
             var pickAny = RobustRandom.Prob(Math.Min(0.05f * mod, 1.0f));
             //var reagent = RobustRandom.Pick(pickAny ? allReagents : component.SafeishVentChemicals);
-            var reagent = RobustRandom.Pick(component.SafeishVentChemicals);
+            var reagent = RobustRandom.Pick(component.SafeishVentChemicals); // Frontier - Safe clog only
 
             var weak = component.WeakReagents.Contains(reagent);
             var quantity = (weak ? component.WeakReagentQuantity : component.ReagentQuantity) * mod;

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -189,23 +189,23 @@
     # - id: SpawnPointGhostRatKing
       # prob: 0.005
 
-# - type: entity
-  # id: PowerGridCheck
-  # parent: BaseGameRule
-  # noSpawn: true
-  # components:
-  # - type: StationEvent
-    # weight: 10
-    # startAnnouncement: station-event-power-grid-check-start-announcement
-    # endAnnouncement: station-event-power-grid-check-end-announcement
-    # startAudio:
-      # path: /Audio/Announcements/power_off.ogg
-      # params:
-       # volume: -4
-    # startDelay: 12
-    # duration: 60
-    # maxDuration: 120
-  # - type: PowerGridCheckRule
+- type: entity
+  id: PowerGridCheck
+  parent: BaseGameRule
+  noSpawn: true
+  components:
+  - type: StationEvent
+    weight: 10
+    startAnnouncement: station-event-power-grid-check-start-announcement
+    endAnnouncement: station-event-power-grid-check-end-announcement
+    startAudio:
+      path: /Audio/Announcements/power_off.ogg
+      params:
+       volume: -4
+    startDelay: 12
+    duration: 60
+    maxDuration: 60 # Frontier 120<60
+  - type: PowerGridCheckRule
 
 - type: entity
   id: RandomSentience
@@ -241,21 +241,21 @@
     lightBreakChancePerSecond: 0.0003
     doorToggleChancePerSecond: 0.001
 
-# - type: entity
-  # id: VentClog
-  # parent: BaseGameRule
-  # noSpawn: true
-  # components:
-  # - type: StationEvent
-    # startAnnouncement: station-event-vent-clog-start-announcement
-    # startAudio:
-      # path: /Audio/Announcements/attention.ogg
-    # earliestStart: 15
-    # minimumPlayers: 15
-    # weight: 5
-    # startDelay: 50
-    # duration: 60
-  # - type: VentClogRule
+- type: entity
+  id: VentClog
+  parent: BaseGameRule
+  noSpawn: true
+  components:
+  - type: StationEvent
+    startAnnouncement: station-event-vent-clog-start-announcement
+    startAudio:
+      path: /Audio/Announcements/attention.ogg
+    earliestStart: 15
+    minimumPlayers: 15
+    weight: 5
+    startDelay: 50
+    duration: 60
+  - type: VentClogRule
 
 - type: entity
   id: VentCritters

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -117,21 +117,21 @@
     duration: 1
   - type: FalseAlarmRule
 
-# - type: entity
-  # id: GasLeak
-  # parent: BaseGameRule
-  # noSpawn: true
-  # components:
-  # - type: StationEvent
-    # startAnnouncement: station-event-gas-leak-start-announcement
-    # startAudio:
-      # path: /Audio/Announcements/attention.ogg
-    # endAnnouncement: station-event-gas-leak-end-announcement
-    # earliestStart: 10
-    # minimumPlayers: 5
-    # weight: 5
-    # startDelay: 20
-  # - type: GasLeakRule
+- type: entity
+  id: GasLeak
+  parent: BaseGameRule
+  noSpawn: true
+  components:
+  - type: StationEvent
+    startAnnouncement: station-event-gas-leak-start-announcement
+    startAudio:
+      path: /Audio/Announcements/attention.ogg
+    endAnnouncement: station-event-gas-leak-end-announcement
+    earliestStart: 10
+    minimumPlayers: 5
+    weight: 5
+    startDelay: 20
+  - type: GasLeakRule
 
 # - type: entity
   # id: KudzuGrowth


### PR DESCRIPTION
## About the PR
Restore some of the events

## Why / Balance
Grid power: seems to be working fine, lowered max time of power off from 120 to 60 to not piss people off too much over it.
Foam: Made the event use the safe chem options only
Gas Leak: Using only WaterVapor leaks, not major health risks

## Technical details
.yml
Few line of c# to fix the pools

## Media
- [ ] I have added screenshots/videos to this PR showcasing its changes ingame,

## Breaking changes
N/A

**Changelog**
N/A
