### PR TITLE
 let ghosts hear traffic radio

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/observer.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/observer.yml
@@ -51,6 +51,7 @@
     - Service
     - Supply
     - Syndicate
+    - Traffic
     globalReceive: true
   - type: Physics
     bodyType: KinematicController

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -238,6 +238,7 @@
     affectedChannels:
     - Common
     - Service
+    - Traffic # Frontier
     lightBreakChancePerSecond: 0.0003
     doorToggleChancePerSecond: 0.001
 

--- a/Resources/Prototypes/_NF/Events/events.yml
+++ b/Resources/Prototypes/_NF/Events/events.yml
@@ -1,4 +1,30 @@
 - type: entity
+  id: BluespaceCargo
+  parent: BaseGameRule
+  noSpawn: true
+  components:
+  - type: StationEvent
+    weight: 5
+    startDelay: 30
+    duration: 35
+  - type: BluespaceCargoRule
+
+- type: entity
+  id: BluespaceSyndicateCrate
+  parent: BaseGameRule
+  noSpawn: true
+  components:
+  - type: StationEvent
+    startAudio:
+      path: /Audio/Announcements/attention.ogg
+    weight: 1
+    startDelay: 30
+    duration: 35
+    earliestStart: 90
+    minimumPlayers: 20
+  - type: BluespaceSyndicateCrateRule
+
+- type: entity
   id: BluespaceCacheError
   parent: BaseGameRule
   noSpawn: true
@@ -57,33 +83,6 @@
   - type: BluespaceErrorRule
     gridPath: /Maps/Bluespace/vaultsmall.yml
     rewardFactor: 1
-
-- type: entity
-  id: BluespaceCargo
-  parent: BaseGameRule
-  noSpawn: true
-  components:
-  - type: StationEvent
-    weight: 5
-    startDelay: 30
-    duration: 35
-  - type: BluespaceCargoRule
-
-
-- type: entity
-  id: BluespaceSyndicateCrate
-  parent: BaseGameRule
-  noSpawn: true
-  components:
-  - type: StationEvent
-    startAudio:
-      path: /Audio/Announcements/attention.ogg
-    weight: 1
-    startDelay: 30
-    duration: 35
-    earliestStart: 90
-    minimumPlayers: 20
-  - type: BluespaceSyndicateCrateRule
 
 - type: entity
   id: BluespaceAsteroid


### PR DESCRIPTION
## About the PR
Fix to allow ghosts to hear traffic channel
Also add it to solar flare event

## Why / Balance
Was missing

## Technical details
.yml

## Media
- [X] this PR does not require an ingame showcase

## Breaking changes
N/A

**Changelog**
N/A
