### PR TITLE
Trashbag Magnet Pickup 

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/trashbag.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/trashbag.yml
@@ -34,6 +34,7 @@
     sprite: Objects/Specific/Janitorial/trashbag.rsi
   - type: Item
     size: 125
+  - type: MagnetPickup # Frontier
 
 - type: entity
   name: trash bag


### PR DESCRIPTION
## About the PR
Allow a trashbag in belt to use the magnet option

## Why / Balance
Just running around and sucking in trash.

## Technical details
.yml

## Media
- [X] this PR does not require an ingame showcase

## Breaking changes
N/A

**Changelog**
:cl: dvir01
- tweak: Trash bags in belts has a vacuum function now, TECHNOLOGY.
