### PR TITLE
Disables auto-punctuation for emotes

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -213,7 +213,7 @@ public sealed partial class ChatSystem : SharedChatSystem
         }
 
         bool shouldCapitalize = (desiredType != InGameICChatType.Emote);
-        bool shouldPunctuate = _configurationManager.GetCVar(CCVars.ChatPunctuation);
+        bool shouldPunctuate = _configurationManager.GetCVar(CCVars.ChatPunctuation) && (desiredType != InGameICChatType.Emote);
         // Capitalizing the word I only happens in English, so we check language here
         bool shouldCapitalizeTheWordI = (!CultureInfo.CurrentCulture.IsNeutralCulture && CultureInfo.CurrentCulture.Parent.Name == "en")
             || (CultureInfo.CurrentCulture.IsNeutralCulture && CultureInfo.CurrentCulture.Name == "en");


### PR DESCRIPTION
After a while playing without emotes on frontier-pt I noticed some emotes in English would still work.

Having a period at the end of emote messages prevented a lot of emotes from triggering a sound effect, because they have to match the message exactly for it to work.

Instead of making sure each and every emote has a . and ! replicate, I removed the auto punctuation for emotes.

Emotes are usually not full sentences so the period on them probably won't be missed a lot. They don't express what people are saying, so it's less likely the lack of a period impacts on meaning, attitude, tone or rhythm.

Cheers