### PR TITLE
Liquidated

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_atmospherics.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_atmospherics.yml
@@ -18,15 +18,15 @@
   category: Atmospherics
   group: market
 
-- type: cargoProduct
-  id: AtmosphericsLiquidOxygen
-  icon:
-    sprite: Structures/Storage/canister.rsi
-    state: blue
-  product: LiquidOxygenCanister
-  cost: 3500
-  category: Atmospherics
-  group: market
+# - type: cargoProduct
+  # id: AtmosphericsLiquidOxygen
+  # icon:
+    # sprite: Structures/Storage/canister.rsi
+    # state: blue
+  # product: LiquidOxygenCanister
+  # cost: 3500
+  # category: Atmospherics
+  # group: market
 
 - type: cargoProduct
   id: AtmosphericsNitrogen
@@ -38,15 +38,15 @@
   category: Atmospherics
   group: market
 
-- type: cargoProduct
-  id: AtmosphericsLiquidNitrogen
-  icon:
-    sprite: Structures/Storage/canister.rsi
-    state: red
-  product: LiquidNitrogenCanister
-  cost: 3500
-  category: Atmospherics
-  group: market
+# - type: cargoProduct
+  # id: AtmosphericsLiquidNitrogen
+  # icon:
+    # sprite: Structures/Storage/canister.rsi
+    # state: red
+  # product: LiquidNitrogenCanister
+  # cost: 3500
+  # category: Atmospherics
+  # group: market
 
 - type: cargoProduct
   id: AtmosphericsCarbonDioxide
@@ -78,38 +78,38 @@
   category: Atmospherics
   group: market
 
-#- type: cargoProduct
-#  name: "water vapor canister"
-#  id: AtmosphericsWaterVapor
-#  description: "Water vapor canister"
-#  icon:
-#    sprite: Structures/Storage/canister.rsi
-#    state: water_vapor
-#  product: WaterVaporCanister
-#  cost: 2600
-#  category: Atmospherics
-#  group: market
+# - type: cargoProduct
+ # name: "water vapor canister"
+ # id: AtmosphericsWaterVapor
+ # description: "Water vapor canister"
+ # icon:
+   # sprite: Structures/Storage/canister.rsi
+   # state: water_vapor
+ # product: WaterVaporCanister
+ # cost: 2600
+ # category: Atmospherics
+ # group: market
 
-#- type: cargoProduct
-#  name: "plasma canister"
-#  id: AtmosphericsPlasma
-#  description: "Plasma canister"
-#  icon:
-#    sprite: Structures/Storage/canister.rsi
-#    state: orange
-#  product: PlasmaCanister
-#  cost: 8500
-#  category: Atmospherics
-#  group: market
+# - type: cargoProduct
+ # name: "plasma canister"
+ # id: AtmosphericsPlasma
+ # description: "Plasma canister"
+ # icon:
+   # sprite: Structures/Storage/canister.rsi
+   # state: orange
+ # product: PlasmaCanister
+ # cost: 8500
+ # category: Atmospherics
+ # group: market
 
-#- type: cargoProduct
-#  name: "tritium canister"
-#  id: AtmosphericsTritium
-#  description: "Tritium canister"
-#  icon:
-#    sprite: Structures/Storage/canister.rsi
-#    state: green
-#  product: TritiumCanister
-#  cost: 15500
-#  category: Atmospherics
-#  group: market
+# - type: cargoProduct
+ # name: "tritium canister"
+ # id: AtmosphericsTritium
+ # description: "Tritium canister"
+ # icon:
+   # sprite: Structures/Storage/canister.rsi
+   # state: green
+ # product: TritiumCanister
+ # cost: 15500
+ # category: Atmospherics
+ # group: market

--- a/Resources/Prototypes/Entities/World/Debris/wrecks.yml
+++ b/Resources/Prototypes/Entities/World/Debris/wrecks.yml
@@ -25,6 +25,8 @@
             prob: 0.3
           - id: SalvageCanisterSpawner
             prob: 0.3
+          - id: SalvageLiquidCanisterSpawner # Frontier
+            prob: 0.03
           - id: SalvageMobSpawner
             prob: 0.3
           - id: SpawnMobBearSalvage

--- a/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/salvage.yml
+++ b/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/salvage.yml
@@ -1,0 +1,22 @@
+# NOTE! All mobs that come out of this should have Salvage rulesets.
+# These rulesets exist because Salvage mobs kept harassing the station and going out of control.
+
+- type: entity
+  name: Salvage Liquid Canister Spawner
+  id: SalvageLiquidCanisterSpawner
+  parent: MarkerBase
+  components:
+    - type: Sprite
+      layers:
+        - state: red
+        - sprite: Structures/Storage/canister.rsi
+          state: blue
+    - type: RandomSpawner
+      rarePrototypes:
+        - LiquidCarbonDioxideCanister
+      rareChance: 0.03
+      prototypes:
+        - LiquidOxygenCanister
+        - LiquidNitrogenCanister
+      chance: 0.9
+      offset: 0.0


### PR DESCRIPTION
## About the PR
Removed O2 and N2 liquid canisters from cargo.

## Why / Balance
Balance issues

## Technical details
.yml

## Media
N/A

## Breaking changes
N/A

**Changelog**
:cl: dvir01
- remove: Removed liquid O2 and N2 from cargo, moved them to salvage wrecks as rare finds.
