### PR TITLE
Make voice mask not working in radio

### DIFF
--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -64,10 +64,26 @@ public sealed class RadioSystem : EntitySystem
         if (!_messages.Add(message))
             return;
 
-        var name = TryComp(messageSource, out VoiceMaskComponent? mask) && mask.Enabled
-            ? Identity.Name(messageSource, EntityManager) // Frontier
-            //? mask.VoiceName Frontier - Do not show fake name on radio.
-            : MetaData(messageSource).EntityName;
+        var name = MetaData(messageSource).EntityName;
+        var mode = "Unknown";
+
+        if (TryComp(messageSource, out VoiceMaskComponent? mask) && mask.Enabled)
+        {
+            switch (mask.Mode)
+            {
+                case RadioMode.Real:
+                    mode = Identity.Name(messageSource, EntityManager);
+                    break;
+                case RadioMode.Fake:
+                    mode = mask.VoiceName;
+                    break;
+                case RadioMode.Unknown:
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException($"No implemented mask radio behavior for {mask.VoiceName}!");
+            }
+            name = mode;
+        }
 
         name = FormattedMessage.EscapeText(name);
 

--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -71,16 +71,16 @@ public sealed class RadioSystem : EntitySystem
         {
             switch (mask.Mode)
             {
-                case RadioMode.Real:
+                case Mode.Real:
                     mode = Identity.Name(messageSource, EntityManager);
                     break;
-                case RadioMode.Fake:
+                case Mode.Fake:
                     mode = mask.VoiceName;
                     break;
-                case RadioMode.Unknown:
+                case Mode.Unknown:
                     break;
                 default:
-                    throw new ArgumentOutOfRangeException($"No implemented mask radio behavior for {mask.VoiceName}!");
+                    throw new ArgumentOutOfRangeException($"No implemented mask radio behavior for {mask.Mode}!");
             }
             name = mode;
         }

--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -13,6 +13,7 @@ using Robust.Shared.Player;
 using Robust.Shared.Random;
 using Robust.Shared.Replays;
 using Robust.Shared.Utility;
+using Content.Shared.IdentityManagement; // Frontier
 
 namespace Content.Server.Radio.EntitySystems;
 
@@ -64,7 +65,8 @@ public sealed class RadioSystem : EntitySystem
             return;
 
         var name = TryComp(messageSource, out VoiceMaskComponent? mask) && mask.Enabled
-            ? mask.VoiceName
+            ? Identity.Name(messageSource, EntityManager) // Frontier
+            //? mask.VoiceName Frontier - Do not show fake name on radio.
             : MetaData(messageSource).EntityName;
 
         name = FormattedMessage.EscapeText(name);

--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -64,7 +64,7 @@ public sealed class RadioSystem : EntitySystem
         if (!_messages.Add(message))
             return;
 
-        var name = MetaData(messageSource).EntityName;
+        var name = MetaData(messageSource).EntityName; // Frontier - code block to allow multi masks.
         var mode = "Unknown";
 
         if (TryComp(messageSource, out VoiceMaskComponent? mask) && mask.Enabled)
@@ -83,7 +83,7 @@ public sealed class RadioSystem : EntitySystem
                     throw new ArgumentOutOfRangeException($"No implemented mask radio behavior for {mask.Mode}!");
             }
             name = mode;
-        }
+        } // Frontier - code block to allow multi masks.
 
         name = FormattedMessage.EscapeText(name);
 

--- a/Content.Server/VoiceMask/VoiceMaskComponent.cs
+++ b/Content.Server/VoiceMask/VoiceMaskComponent.cs
@@ -1,9 +1,20 @@
 namespace Content.Server.VoiceMask;
 
+public enum RadioMode : byte // Frontier 
+{
+    Real,
+    Fake,
+    Unknown
+}
+
 [RegisterComponent]
 public sealed partial class VoiceMaskComponent : Component
 {
     [ViewVariables(VVAccess.ReadWrite)] public bool Enabled = true;
 
     [ViewVariables(VVAccess.ReadWrite)] public string VoiceName = "Unknown";
+
+    [ViewVariables(VVAccess.ReadWrite), DataField("mode")]
+    [AutoNetworkedField]
+    public RadioMode Mode = RadioMode.Unknown;
 }

--- a/Content.Server/VoiceMask/VoiceMaskComponent.cs
+++ b/Content.Server/VoiceMask/VoiceMaskComponent.cs
@@ -1,6 +1,6 @@
 namespace Content.Server.VoiceMask;
 
-public enum RadioMode : byte // Frontier 
+public enum Mode : byte // Frontier 
 {
     Real,
     Fake,
@@ -16,5 +16,5 @@ public sealed partial class VoiceMaskComponent : Component
 
     [ViewVariables(VVAccess.ReadWrite), DataField("mode")]
     [AutoNetworkedField]
-    public RadioMode Mode = RadioMode.Unknown;
+    public Mode Mode = Mode.Unknown;
 }

--- a/Content.Server/VoiceMask/VoiceMaskComponent.cs
+++ b/Content.Server/VoiceMask/VoiceMaskComponent.cs
@@ -14,7 +14,7 @@ public sealed partial class VoiceMaskComponent : Component
 
     [ViewVariables(VVAccess.ReadWrite)] public string VoiceName = "Unknown";
 
-    [ViewVariables(VVAccess.ReadWrite), DataField("mode")]
+    [ViewVariables(VVAccess.ReadWrite), DataField("mode")] // Frontier 
     [AutoNetworkedField]
     public Mode Mode = Mode.Unknown;
 }

--- a/Content.Server/VoiceMask/VoiceMaskSystem.Equip.cs
+++ b/Content.Server/VoiceMask/VoiceMaskSystem.Equip.cs
@@ -22,6 +22,20 @@ public sealed partial class VoiceMaskSystem
         var comp = EnsureComp<VoiceMaskComponent>(user);
         comp.VoiceName = component.LastSetName;
 
+        switch (component.RadioMode)
+        {
+            case RadioMode.Real:
+                comp.Mode = Mode.Real;
+                break;
+            case RadioMode.Fake:
+                comp.Mode = Mode.Fake;
+                break;
+            case RadioMode.Unknown:
+                break;
+            default:
+                throw new ArgumentOutOfRangeException($"No implemented mask radio behavior for {component.RadioMode}!");
+        }
+
         _actions.AddAction(user, ref component.ActionEntity, component.Action, uid);
     }
 

--- a/Content.Server/VoiceMask/VoiceMaskSystem.Equip.cs
+++ b/Content.Server/VoiceMask/VoiceMaskSystem.Equip.cs
@@ -22,7 +22,7 @@ public sealed partial class VoiceMaskSystem
         var comp = EnsureComp<VoiceMaskComponent>(user);
         comp.VoiceName = component.LastSetName;
 
-        switch (component.RadioMode)
+        switch (component.RadioMode) // Frontier - code block to allow multi masks.
         {
             case RadioMode.Real:
                 comp.Mode = Mode.Real;
@@ -34,7 +34,7 @@ public sealed partial class VoiceMaskSystem
                 break;
             default:
                 throw new ArgumentOutOfRangeException($"No implemented mask radio behavior for {component.RadioMode}!");
-        }
+        } // Frontier - code block to allow multi masks.
 
         _actions.AddAction(user, ref component.ActionEntity, component.Action, uid);
     }

--- a/Content.Server/VoiceMask/VoiceMaskerComponent.cs
+++ b/Content.Server/VoiceMask/VoiceMaskerComponent.cs
@@ -20,7 +20,7 @@ public sealed partial class VoiceMaskerComponent : Component
 
     [DataField("actionEntity")] public EntityUid? ActionEntity;
 
-    [ViewVariables(VVAccess.ReadWrite), DataField("radioMode")]
+    [ViewVariables(VVAccess.ReadWrite), DataField("radioMode")] // Frontier 
     [AutoNetworkedField]
     public RadioMode RadioMode = RadioMode.Unknown;
 }

--- a/Content.Server/VoiceMask/VoiceMaskerComponent.cs
+++ b/Content.Server/VoiceMask/VoiceMaskerComponent.cs
@@ -12,4 +12,8 @@ public sealed partial class VoiceMaskerComponent : Component
     public string Action = "ActionChangeVoiceMask";
 
     [DataField("actionEntity")] public EntityUid? ActionEntity;
+
+    [ViewVariables(VVAccess.ReadWrite), DataField("mode")]
+    [AutoNetworkedField]
+    public RadioMode Mode = RadioMode.Unknown;
 }

--- a/Content.Server/VoiceMask/VoiceMaskerComponent.cs
+++ b/Content.Server/VoiceMask/VoiceMaskerComponent.cs
@@ -3,6 +3,13 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototy
 
 namespace Content.Server.VoiceMask;
 
+public enum RadioMode : byte // Frontier 
+{
+    Real,
+    Fake,
+    Unknown
+}
+
 [RegisterComponent]
 public sealed partial class VoiceMaskerComponent : Component
 {
@@ -13,7 +20,7 @@ public sealed partial class VoiceMaskerComponent : Component
 
     [DataField("actionEntity")] public EntityUid? ActionEntity;
 
-    [ViewVariables(VVAccess.ReadWrite), DataField("mode")]
+    [ViewVariables(VVAccess.ReadWrite), DataField("radioMode")]
     [AutoNetworkedField]
-    public RadioMode Mode = RadioMode.Unknown;
+    public RadioMode RadioMode = RadioMode.Unknown;
 }

--- a/Resources/Prototypes/Entities/Clothing/Masks/specific.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/specific.yml
@@ -24,7 +24,7 @@
 - type: entity
   parent: ClothingMaskGasChameleon
   id: ClothingMaskGasVoiceChameleon
-  suffix: Voice Mask, Chameleon
+  suffix: Voice Mask, Chameleon, Radio Unknown Name # Frontier - Extended suffix
   components:
     - type: VoiceMasker
       default: ClothingMaskGas

--- a/Resources/Prototypes/_NF/Entities/Clothing/Masks/specific.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Masks/specific.yml
@@ -5,6 +5,4 @@
   components:
     - type: VoiceMasker
       default: ClothingMaskGas
-      mode: Fake
-    - type: StaticPrice
-      price: 500
+      radioMode: Fake

--- a/Resources/Prototypes/_NF/Entities/Clothing/Masks/specific.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Masks/specific.yml
@@ -1,0 +1,10 @@
+﻿- type: entity
+  parent: ClothingMaskGasVoiceChameleon
+  id: ClothingMaskGasVoiceChameleonRadio
+  suffix: Voice Mask, Chameleon, Radio
+  components:
+    - type: VoiceMasker
+      default: ClothingMaskGas
+      mode: Fake
+    - type: StaticPrice
+      price: 500

--- a/Resources/Prototypes/_NF/Entities/Clothing/Masks/specific.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Masks/specific.yml
@@ -1,6 +1,6 @@
 ﻿- type: entity
   parent: ClothingMaskGasVoiceChameleon
-  id: ClothingMaskGasVoiceChameleonRadio
+  id: ClothingMaskGasVoiceChameleonFakeName
   suffix: Voice Mask, Chameleon, Radio Fake Name
   components:
     - type: VoiceMasker
@@ -9,7 +9,7 @@
 
 - type: entity
   parent: ClothingMaskGasVoiceChameleon
-  id: ClothingMaskGasVoiceChameleonRadio
+  id: ClothingMaskGasVoiceChameleonRealName
   suffix: Voice Mask, Chameleon, Radio Real Name
   components:
     - type: VoiceMasker

--- a/Resources/Prototypes/_NF/Entities/Clothing/Masks/specific.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Masks/specific.yml
@@ -1,8 +1,17 @@
 ﻿- type: entity
   parent: ClothingMaskGasVoiceChameleon
   id: ClothingMaskGasVoiceChameleonRadio
-  suffix: Voice Mask, Chameleon, Radio
+  suffix: Voice Mask, Chameleon, Radio Fake Name
   components:
     - type: VoiceMasker
       default: ClothingMaskGas
       radioMode: Fake
+
+- type: entity
+  parent: ClothingMaskGasVoiceChameleon
+  id: ClothingMaskGasVoiceChameleonRadio
+  suffix: Voice Mask, Chameleon, Radio Real Name
+  components:
+    - type: VoiceMasker
+      default: ClothingMaskGas
+      radioMode: Real


### PR DESCRIPTION
## About the PR
Normal voice mask no longer fully work in radio, it shows name as unknown

Added 2 new masks for admins
One that fake the name on radio and one that only shows real name on radio

## Why / Balance
Its near impossible to locate someone who is pretending to be someone else on the radio in frontier.

## Technical details
A bit of a revert of https://github.com/space-wizards/space-station-14/pull/13858

## Media
N/A

## Breaking changes
N/A

**Changelog**
:cl: dvir01
- tweak: Voice masks over radio shows you as "Unknown".
