### PR TITLE
Shuttle Console option to hide player shuttle labels

### DIFF
--- a/Content.Client/Shuttles/UI/RadarControl.cs
+++ b/Content.Client/Shuttles/UI/RadarControl.cs
@@ -42,6 +42,7 @@ public sealed class RadarControl : MapGridControl
     private Dictionary<EntityUid, List<DockingInterfaceState>> _docks = new();
 
     public bool ShowIFF { get; set; } = true;
+    public bool ShowIFFShuttles { get; set; } = true;
     public bool ShowDocks { get; set; } = true;
 
     /// <summary>
@@ -285,7 +286,20 @@ public sealed class RadarControl : MapGridControl
                     uiPosition = new Vector2(uiX + uiXCentre, uiY + uiYCentre);
                 }
 
-                label.Visible = true;
+                if (!ShowIFFShuttles)
+                {
+                    if (iff != null && (iff.Flags & IFFFlags.IsPlayerShuttle) != 0x0)
+                    {
+                        label.Visible = false;
+                    }
+                    else
+                        label.Visible = true;
+                }
+                else
+                {
+                    label.Visible = true;
+                }
+
                 label.Text = Loc.GetString("shuttle-console-iff-label", ("name", name), ("distance", $"{distance:0.0}"));
                 LayoutContainer.SetPosition(label, uiPosition);
             }

--- a/Content.Client/Shuttles/UI/ShuttleConsoleWindow.xaml
+++ b/Content.Client/Shuttles/UI/ShuttleConsoleWindow.xaml
@@ -104,6 +104,10 @@
                     Text="{Loc 'shuttle-console-iff-toggle'}"
                     TextAlign="Center"
                     ToggleMode="True"/>
+            <Button Name="IFFShuttlesToggle"
+                    Text="{Loc 'shuttle-console-iffshuttles-toggle'}"
+                    TextAlign="Center"
+                    ToggleMode="True"/>
             <Button Name="DockToggle"
                     Text="{Loc 'shuttle-console-dock-toggle'}"
                     TextAlign="Center"

--- a/Content.Client/Shuttles/UI/ShuttleConsoleWindow.xaml.cs
+++ b/Content.Client/Shuttles/UI/ShuttleConsoleWindow.xaml.cs
@@ -58,6 +58,9 @@ public sealed partial class ShuttleConsoleWindow : FancyWindow,
         IFFToggle.OnToggled += OnIFFTogglePressed;
         IFFToggle.Pressed = RadarScreen.ShowIFF;
 
+        IFFShuttlesToggle.OnToggled += OnIFFShuttlesTogglePressed;
+        IFFShuttlesToggle.Pressed = RadarScreen.ShowIFFShuttles;
+
         DockToggle.OnToggled += OnDockTogglePressed;
         DockToggle.Pressed = RadarScreen.ShowDocks;
 
@@ -75,6 +78,11 @@ public sealed partial class ShuttleConsoleWindow : FancyWindow,
         args.Button.Pressed = RadarScreen.ShowIFF;
     }
 
+    private void OnIFFShuttlesTogglePressed(BaseButton.ButtonEventArgs args)
+    {
+        RadarScreen.ShowIFFShuttles ^= true;
+        args.Button.Pressed = RadarScreen.ShowIFFShuttles;
+    }
     private void OnDockTogglePressed(BaseButton.ButtonEventArgs args)
     {
         RadarScreen.ShowDocks ^= true;

--- a/Content.Server/Shipyard/Systems/ShipyardSystem.Consoles.cs
+++ b/Content.Server/Shipyard/Systems/ShipyardSystem.Consoles.cs
@@ -31,6 +31,7 @@ using Content.Server.StationRecords;
 using Content.Server.StationRecords.Systems;
 using Content.Shared.Database;
 using Content.Shared.Preferences;
+using Content.Shared.Shuttles.Components;
 using static Content.Shared.Shipyard.Components.ShuttleDeedComponent;
 
 namespace Content.Server.Shipyard.Systems;
@@ -155,6 +156,7 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
                 B = 100,
                 A = 100
             });
+            _shuttle.AddIFFFlag(shuttle.Owner, IFFFlags.IsPlayerShuttle);
         }
 
         if (TryComp<AccessComponent>(targetId, out var newCap))

--- a/Content.Shared/Shuttles/Components/IFFComponent.cs
+++ b/Content.Shared/Shuttles/Components/IFFComponent.cs
@@ -38,13 +38,18 @@ public enum IFFFlags : byte
     /// <summary>
     /// Should the label for this grid be hidden at all ranges.
     /// </summary>
-    HideLabel,
+    HideLabel = 1,
 
     /// <summary>
     /// Should the grid hide entirely (AKA full stealth).
     /// Will also hide the label if that is not set.
     /// </summary>
-    Hide,
+    Hide = 2,
+
+    /// <summary>
+    /// Is this a player shuttle
+    /// </summary>
+    IsPlayerShuttle = 4,
 
     // TODO: Need one that hides its outline, just replace it with a bunch of triangles or lines or something.
 }

--- a/Resources/Locale/en-US/shuttles/console.ftl
+++ b/Resources/Locale/en-US/shuttles/console.ftl
@@ -37,5 +37,6 @@ shuttle-console-iff-label = {$name} ({$distance}m)
 # Buttons
 shuttle-console-strafing = Strafing mode
 shuttle-console-iff-toggle = Show IFF
+shuttle-console-iffshuttles-toggle = Show Shuttle Labels
 shuttle-console-dock-toggle = Show docks
 shuttle-console-undock = Undock


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Add button to hide player shuttle labels from shuttle console radar

## Why / Balance
Radar can get very clogged with player shuttle labels, makes it hard to read the station / POI labels

## Technical details
Add button to hide player shuttle labels from shuttle console radar, using IsPlayerShuttle IFFFlag
Add IsPlayerShuttle IFFFlag to shuttles bought at shipyard console

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
![2023-12-11 20_43_45-Space Station 14](https://github.com/InsanityMoose/frontier-station-14/assets/13352243/3be9a657-d9e9-491f-96f4-d737b5d2310d)
![2023-12-11 20_43_51-Space Station 14](https://github.com/InsanityMoose/frontier-station-14/assets/13352243/5051c291-dd92-4dd5-8d98-844a89b1a7d6)
![2023-12-11 20_44_09-Space Station 14](https://github.com/InsanityMoose/frontier-station-14/assets/13352243/025935d3-9e1e-4a78-996b-890506063bbf)
![2023-12-11 20_44_13-Space Station 14](https://github.com/InsanityMoose/frontier-station-14/assets/13352243/598df5c3-cc86-4476-b92c-2ed67ef18bd5)

**Changelog**
:cl:
- add: The shuttle console radar now has an option to hide shuttle labels
