### PR TITLE
Frontier jobs order update + Brigmedic

### DIFF
--- a/Resources/Prototypes/Maps/frontier.yml
+++ b/Resources/Prototypes/Maps/frontier.yml
@@ -17,19 +17,21 @@
           overflowJobs:
             - Passenger
           availableJobs:
+            Passenger: [ -1, -1 ]
             HeadOfPersonnel: [ 1, 1 ]
             HeadOfSecurity: [ 1, 1 ]
-            SecurityOfficer: [ 0, 0 ]
             SeniorOfficer: [ 0, 0 ]
+            Brigmedic: [ 0, 0 ]
+            SecurityOfficer: [ 0, 0 ]
             SecurityCadet: [ 0, 0 ]
             StationTrafficController: [ 0, 0 ]
-            Borg: [ 0, 0 ]
             Valet: [ 1, 1 ]
             MailCarrier: [ 0, 0 ]
             Janitor: [ 1, 1 ]
+# Others:
+            Borg: [ 0, 0 ]
             Musician: [ 0, 0 ]
             Lawyer: [ 0, 0 ]
             Chaplain: [ 0, 0 ]
             Reporter: [ 0, 0 ]
             Psychologist: [ 0, 0 ]
-            Passenger: [ -1, -1 ]

--- a/Resources/Prototypes/Roles/Jobs/Security/brigmedic.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/brigmedic.yml
@@ -4,9 +4,9 @@
   description: job-description-brigmedic
   playTimeTracker: JobBrigmedic
   requirements:
-    - !type:DepartmentTimeRequirement
-      department: Medical
-      time: 10800 # 3 hrs
+#    - !type:DepartmentTimeRequirement
+#      department: Medical
+#      time: 10800 # 3 hrs
     - !type:OverallPlaytimeRequirement
       time: 21600 # 6 hrs
   startingGear: BrigmedicGear


### PR DESCRIPTION
## About the PR
Changes the order of jobs to put Passenger: at the top of frontier job lists.
Added brigmedic to the list so its no longer ship only based.
Removed medical requirement play time from brigmedic since its not simple to get playtime as medical unless a medical job open on ship, or psychologist.

## Why / Balance
Passenger was a bit hidden as the last one in the list
Brigmedic was a ship only starting job.

## Technical details
.yml

## Media
N/A

## Breaking changes
N/A

**Changelog**
N/A
