### PR TITLE
Adding missing items to vends

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/cargodrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/cargodrobe.yml
@@ -22,6 +22,8 @@
     ClothingUniformJumpsuitSalvageSpecialist: 2
     ClothingOuterWinterMiner: 2
     ClothingHeadsetMining: 2
+    ClothingShoesBootsSalvage: 2
+    ClothingMaskGasExplorer: 2
     ClothingNeckCloakMiner: 2
 # QM:
     ClothingUniformJumpsuitQMTurtleneck: 1

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/engidrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/engidrobe.yml
@@ -14,6 +14,7 @@
     ClothingHeadHatHardhatOrange: 3
     ClothingHeadsetEngineering: 3
     EncryptionKeyEngineering: 10
+    ClothingMaskGas: 3
     ClothingOuterWinterEngi: 2
     ClothingNeckScarfStripedOrange: 3
 # Atmost:
@@ -28,6 +29,7 @@
     ClothingOuterSuitFire: 2
     ClothingOuterWinterAtmos: 2
     ClothingNeckScarfStripedLightBlue: 3
+    ClothingMaskGasAtmos: 2
 # Senior:
     ClothingUniformJumpsuitSeniorEngineer: 1
     ClothingUniformJumpskirtSeniorEngineer: 1

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/medidrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/medidrobe.yml
@@ -12,6 +12,7 @@
     ClothingEyesHudMedical: 4 # Frontier - Not working yet
     ClothingHeadsetMedical: 4
     EncryptionKeyMedical: 10
+    ClothingMaskBreathMedical: 4
     ClothingHeadNurseHat: 4
     ClothingShoesColorWhite: 4
     ClothingHandsGlovesLatex: 4

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/secdrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/secdrobe.yml
@@ -17,6 +17,7 @@
     ClothingUniformJumpskirtSecGrey: 3
     ClothingUniformJumpsuitSecBlue: 3
     ClothingHeadsetSecuritySafe: 3 # Frontier - Ask SR or Sheriff for keys
+    ClothingMaskGasSecurity: 3
     ClothingUniformJumpsuitBrigmedic: 3
     ClothingUniformJumpskirtBrigmedic: 3
     ClothingOuterWinterSec: 2
@@ -24,6 +25,7 @@
     ClothingOuterArmorBasic: 2
     ClothingOuterArmorBasicSlim: 2 
     ClothingOuterCoatAMG: 2
+    ClothingMaskBreathMedicalSecurity: 3
     ClothingEyesBlindfold: 1
     ClothingShoesBootsJack: 3
     ClothingShoesBootsCombat: 1

--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -68,7 +68,7 @@
   - type: Armor
     modifiers:
       coefficients:
-        Heat: 0.80
+        Heat: 0.90 # Frontier 0.80<0.90
 
 - type: entity
   parent: ClothingMaskGasAtmos
@@ -109,8 +109,8 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.90
-        Slash: 0.90
+        Blunt: 0.95 # Frontier 0.90<0.95
+        Slash: 0.95 # Frontier 0.90<0.95
         Piercing: 0.95
         Heat: 0.95
 


### PR DESCRIPTION
## About the PR
* Added Salvage boots to cargodrob.
* Added missing gas maskes to cloth venders.
* Nerfed the explorer gas mask to match security.
* Nerfed the atmost/captain gas mask from 20% to 10% heat protection.

## Why / Balance
Missing items
The gas masks needed a nerf since they can be obtained without an issue.

## Technical details
.yml

## Media
N/A

## Breaking changes
N/A

**Changelog**
N/A
