### PR TITLE
Condiment Station Layer Update

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -124,9 +124,12 @@
           !type:PhysShapeAabb
           bounds: "-0.3,-0.16,0.3,0.40"
         mask:
-        - MachineMask
-        layer:
-        - MachineLayer
+        - Impassable # Frontier
+#        - MidImpassable # Frontier - Do not add this, it will block shutters from closing on it.
+        - LowImpassable # Frontier
+#        - MachineMask # Frontier
+#        layer: # Frontier
+#        - MachineLayer # Frontier
         density: 190
   - type: Advertise
     pack: CondimentVendAds


### PR DESCRIPTION
## About the PR
Change the layer of the condiment station.

## Why / Balance
Allow the shutters in the Skipper and McCargo to close over it.

## Technical details
.yml

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame,

https://github.com/new-frontiers-14/frontier-station-14/assets/39403717/888e1b13-98d1-4d1e-8698-95933c0c58f2

## Breaking changes
You can walk over the condiment station, but this is a plus if anything.

**Changelog**
N/A
