### PR TITLE
Allows Captains to access Air Alarms

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Wallmounts/air_alarm.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/air_alarm.yml
@@ -62,7 +62,7 @@
     boardName: wires-board-name-airalarm
     layoutId: AirAlarm
   - type: AccessReader
-    access: [["Atmospherics"]]
+    access: [["Atmospherics"], ["Captain"]] # Frontier: allowed ["Captain"] to access air alarms
   - type: ContainerFill
     containers:
       board: [ AirAlarmElectronics ]


### PR DESCRIPTION
## About the PR
Allows Captains to access Air Alarms.

## Why / Balance
Inability of ship owners to access air alarms on their ships is inconvenient. And dangerous during "gas leak event".

## Technical details
.yml changes

## Media
- [X] This PR does not require an ingame showcase

**Changelog**
:cl: erhardsteinhauer
- tweak: Air Alarm parameters are now can be altered by Captains.