### PR TITLE
PietyVend Tweaks: increased stock, can be restocked with wardrobe restock crates

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chapel.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chapel.yml
@@ -1,28 +1,28 @@
 - type: vendingMachineInventory
   id: PietyVendInventory
   startingInventory:
-    ClothingUniformJumpsuitChaplain: 2
-    ClothingUniformJumpskirtChaplain: 2
-    ClothingUniformJumpsuitMonasticRobeDark: 1
-    ClothingUniformJumpsuitMonasticRobeLight: 1
-    ClothingOuterHoodieChaplain: 1
-    ClothingOuterHoodieBlack: 1
-    ClothingHeadHatHoodNunHood: 1
-    ClothingOuterNunRobe: 1
-    ClothingHeadHatFez: 1
-    ClothingHeadHatPlaguedoctor: 1
-    ClothingHeadHatWitch: 1
-    ClothingHeadHatWitch1: 1
-    ClothingOuterPlagueSuit: 1
-    ClothingMaskPlague: 1
-    ClothingHeadsetService: 2
-    RubberStampChaplain: 1
+    ClothingUniformJumpsuitChaplain: 3
+    ClothingUniformJumpskirtChaplain: 3
+    ClothingUniformJumpsuitMonasticRobeDark: 3
+    ClothingUniformJumpsuitMonasticRobeLight: 3
+    ClothingOuterHoodieChaplain: 3
+    ClothingOuterHoodieBlack: 3
+    ClothingHeadHatHoodNunHood: 3
+    ClothingOuterNunRobe: 3
+    ClothingHeadHatFez: 3
+    ClothingHeadHatPlaguedoctor: 3
+    ClothingHeadHatWitch: 3
+    ClothingHeadHatWitch3: 
+    ClothingOuterPlagueSuit: 3
+    ClothingMaskPlague: 3
+    ClothingHeadsetService: 4
+    RubberStampChaplain: 3
   emaggedInventory:
-    ClothingOuterArmorCult: 1
-    ClothingHeadHelmetCult: 1
+    ClothingOuterArmorCult: 2
+    ClothingHeadHelmetCult: 2
     ClothingOuterRobesCult: 3
     ClothingHeadHatHoodCulthood: 3
-    ClothingShoesCult: 4
+    ClothingShoesCult: 6
     BedsheetCult: 4
-    BibleNecronomicon: 1
+    BibleNecronomicon: 2
     ClothingNeckScarfStripedBlack: 3

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chapel.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chapel.yml
@@ -12,7 +12,7 @@
     ClothingHeadHatFez: 3
     ClothingHeadHatPlaguedoctor: 3
     ClothingHeadHatWitch: 3
-    ClothingHeadHatWitch3: 
+    ClothingHeadHatWitch1: 3
     ClothingOuterPlagueSuit: 3
     ClothingMaskPlague: 3
     ClothingHeadsetService: 4

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chapel.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chapel.yml
@@ -19,11 +19,11 @@
     RubberStampChaplain: 3
     Bible: 3
   emaggedInventory:
-    ClothingOuterArmorCult: 2
-    ClothingHeadHelmetCult: 2
+    ClothingOuterArmorCult: 1
+    ClothingHeadHelmetCult: 1
     ClothingOuterRobesCult: 3
     ClothingHeadHatHoodCulthood: 3
     ClothingShoesCult: 6
     BedsheetCult: 4
-    BibleNecronomicon: 2
+    BibleNecronomicon: 1
     ClothingNeckScarfStripedBlack: 3

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chapel.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chapel.yml
@@ -17,6 +17,7 @@
     ClothingMaskPlague: 3
     ClothingHeadsetService: 4
     RubberStampChaplain: 3
+    Bible: 3
   emaggedInventory:
     ClothingOuterArmorCult: 2
     ClothingHeadHelmetCult: 2

--- a/Resources/Prototypes/Entities/Objects/Specific/Service/vending_machine_restock.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Service/vending_machine_restock.yml
@@ -142,6 +142,7 @@
     - MailDrobeInventory
     - RepDrobeInventory
     - BoxingDrobeInventory
+    - PietyVendInventory
   - type: Sprite
     layers:
     - state: base


### PR DESCRIPTION
## About the PR
- Increased stock of PietyVend: increased quantity of items available for purchase items from 1 to 3.
- Changed Wardrobe Restock Crate so it could be used for restocking PietyVend.

## Why / Balance
- Increased the quantity of purchasable items to bring it closer to other cloth vendomats.
- PietyVend wasn't restockable.

## Technical details
.yml changes in base game files.

## Media
- [X] PR does not require an ingame showcase

**Changelog**
:cl: erhardsteinhauer
- tweak: PietyVend holds a bigger stock and can be restocked like other cloth vendomats.
