### PR TITLE
Scrapyard

### DIFF
--- a/Content.Client/Shipyard/UI/ShipyardConsoleMenu.xaml.cs
+++ b/Content.Client/Shipyard/UI/ShipyardConsoleMenu.xaml.cs
@@ -74,6 +74,7 @@ public sealed partial class ShipyardConsoleMenu : FancyWindow
             ShipyardConsoleUiKey.Security => "Security",
             ShipyardConsoleUiKey.BlackMarket => "BlackMarket",
             ShipyardConsoleUiKey.Expedition => "Expedition",
+            ShipyardConsoleUiKey.Scrap => "Scrap",
             _ => "Shipyard",
         };
 

--- a/Content.Shared/Shipyard/SharedShipyardSystem.cs
+++ b/Content.Shared/Shipyard/SharedShipyardSystem.cs
@@ -13,7 +13,8 @@ public enum ShipyardConsoleUiKey : byte
     Shipyard,
     Security,
     BlackMarket,
-    Expedition
+    Expedition,
+    Scrap
     // Syndicate
     //Not currently implemented. Could be used in the future to give other factions a variety of shuttle options,
     //like nukies, syndicate, or for evac purchases.

--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers.yml
@@ -161,6 +161,30 @@
       state: blackmarket_key
 
 - type: entity
+  id: ComputerShipyardScrap
+  parent: ComputerShipyard
+  name: scrapyard console
+  description: Used to purchase and sell "shuttles"
+  components:
+  - type: ActivatableUI
+    key: enum.ShipyardConsoleUiKey.Scrap
+  - type: UserInterface
+    interfaces:
+    - key: enum.ShipyardConsoleUiKey.Scrap
+      type: ShipyardConsoleBoundUserInterface
+  - type: Sprite
+    sprite: _NF/Structures/Machines/computers.rsi
+    layers:
+    - map: ["computerLayerBody"]
+      state: computer_blackmarket
+    - map: ["computerLayerKeyboard"]
+      state: generic_keyboard
+    - map: ["computerLayerScreen"]
+      state: shipyard_blackmarket   
+    - map: ["computerLayerKeys"]
+      state: blackmarket_key
+
+- type: entity
   name: cargo sale computer
   suffix: Normal
   parent: BaseStructureComputer

--- a/Resources/Prototypes/_NF/Shipyard/bison.yml
+++ b/Resources/Prototypes/_NF/Shipyard/bison.yml
@@ -4,7 +4,7 @@
   description: A heavy duty ship breaker with a durable hull and a substantial amount of living space, built for long journeys with self-sufficiency.
   price: 166138
   category: Large
-  group: Civilian
+  group: Scrap
   shuttlePath: /Maps/Shuttles/bison.yml
   
 - type: gameMap

--- a/Resources/Prototypes/_NF/Shipyard/svnugget.yml
+++ b/Resources/Prototypes/_NF/Shipyard/svnugget.yml
@@ -4,7 +4,7 @@
   description: A flying hunk of wood and metal disguised as a kitchen shuttle. Not FDA approved.
   price: 12250
   category: Small
-  group: Civilian
+  group: Scrap
   shuttlePath: /Maps/Shuttles/svnugget.yml
 
 - type: gameMap

--- a/Resources/Prototypes/_NF/Shipyard/svorange.yml
+++ b/Resources/Prototypes/_NF/Shipyard/svorange.yml
@@ -4,7 +4,7 @@
   description: A cargo slash salvage shuttle made from scavenged wrecks, comes with some damage.
   price: 16000 #Appraisal is 14500
   category: Small
-  group: Civilian
+  group: Scrap
   shuttlePath: /Maps/Shuttles/svorange.yml
 
 - type: gameMap

--- a/Resources/Prototypes/_NF/Shipyard/svtide.yml
+++ b/Resources/Prototypes/_NF/Shipyard/svtide.yml
@@ -4,7 +4,7 @@
   description: A cheaply made mass-produced shuttle made from salvaged wrecks. For the seasoned assistant.
   price: 9150
   category: Small
-  group: Civilian
+  group: Scrap
   shuttlePath: /Maps/Shuttles/svtide.yml
 
 - type: gameMap


### PR DESCRIPTION
## About the PR
Moving the more questionable ships from the shipyard to a new shipyard to be placed in frontier maints.

## Why / Balance
Noob traps.

## Technical details
.yml & 2 lines in C#

## Media
- [X] this PR does not require an ingame showcase

## Breaking changes
This ships wont be available till remapped

**Changelog**
:cl: dvir01
- tweak: The Bison and SV ships moved to the scrapyard shipyard, possibly found in the Frontier maints.