### PR TITLE
Additions to EngiVend and Vendomat inventory

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/engivend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/engivend.yml
@@ -5,7 +5,9 @@
     Multitool: 10
     ClothingEyesGlassesMeson: 10
     ClothingHeadHatWelding: 6
+    HolofanProjector: 10    # Frontier
     InflatableWallStack1: 24
     InflatableDoorStack1: 8
+    GeigerCounter: 10       # Frontier
     PowerCellMedium: 15
 #    NetworkConfigurator: 15

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/engivend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/engivend.yml
@@ -5,7 +5,7 @@
     Multitool: 10
     ClothingEyesGlassesMeson: 10
     ClothingHeadHatWelding: 6
-    HolofanProjector: 10    # Frontier
+#    HolofanProjector: 10    # Frontier
     InflatableWallStack1: 24
     InflatableDoorStack1: 8
     GeigerCounter: 10       # Frontier

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/vendomat.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/vendomat.yml
@@ -10,5 +10,6 @@
     MatterBinStockPart: 8
     CapacitorStockPart: 8
     MicroManipulatorStockPart: 8
+    Beaker: 8    # Frontier - beakers are required for some machines
     VulpTranslator: 10
     AirFreshener: 10


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
This PR adds the holofan projector and geiger counter to the EngiVend and glass beakers to the Vendomat.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
The holofan and geiger counter should really be accessible alongside the other tools.
The glass beakers are required for some of the machines in the CircuitVend, and setting up an autolathe just to print 2 beakers seems a bit inconvenient.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
YML

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- tweak: The EngiVend now sells geiger counters and holofan projectors.
- tweak: The Vendomat now sells glass beakers.

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
