### PR TITLE
Yet more frontier map changes

### DIFF
--- a/Resources/Maps/frontier.yml
+++ b/Resources/Maps/frontier.yml
@@ -3981,9 +3981,11 @@ entities:
           7,0:
             0: 65535
           7,1:
-            0: 65535
+            0: 49151
+            1: 16384
           7,2:
-            0: 65535
+            0: 65531
+            1: 4
           7,3:
             0: 65535
           -8,0:
@@ -4112,7 +4114,7 @@ entities:
             0: 65535
           -10,3:
             0: 61951
-            1: 3584
+            2: 3584
           -9,0:
             0: 65535
           -9,1:
@@ -4160,7 +4162,8 @@ entities:
           8,0:
             0: 65535
           8,1:
-            0: 65535
+            0: 61439
+            1: 4096
           8,2:
             0: 65535
           8,3:
@@ -4189,7 +4192,7 @@ entities:
             0: 65535
           11,3:
             0: 65343
-            2: 192
+            1: 192
           12,0:
             0: 65535
           12,1:
@@ -4240,7 +4243,7 @@ entities:
             0: 12287
           2,4:
             0: 61439
-            2: 4096
+            1: 4096
           2,5:
             0: 65535
           2,6:
@@ -4474,10 +4477,10 @@ entities:
           - 0
           - 0
         - volume: 2500
-          temperature: 293.15
+          temperature: 293.14996
           moles:
-          - 0
-          - 6666.982
+          - 20.078888
+          - 75.53487
           - 0
           - 0
           - 0
@@ -4489,10 +4492,10 @@ entities:
           - 0
           - 0
         - volume: 2500
-          temperature: 293.14996
+          temperature: 293.15
           moles:
-          - 20.078888
-          - 75.53487
+          - 0
+          - 6666.982
           - 0
           - 0
           - 0
@@ -4542,6 +4545,16 @@ entities:
     - type: ProtectedGrid
     - type: StationEmpImmune
     - type: SpreaderGrid
+- proto: ActionToggleLight
+  entities:
+  - uid: 3135
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 3134
+      type: Transform
+    - container: 3134
+      type: InstantAction
 - proto: AirAlarm
   entities:
   - uid: 1836
@@ -4615,41 +4628,97 @@ entities:
     - pos: 37.5,23.5
       parent: 2173
       type: Transform
+    - links:
+      - 4959
+      type: DeviceLinkSink
+    - linkedPorts:
+        2566:
+        - DoorStatus: InputB
+      type: DeviceLinkSource
   - uid: 4120
     components:
     - pos: 36.5,23.5
       parent: 2173
       type: Transform
+    - links:
+      - 4959
+      type: DeviceLinkSink
+    - linkedPorts:
+        2566:
+        - DoorStatus: InputA
+      type: DeviceLinkSource
   - uid: 4121
     components:
     - pos: 37.5,20.5
       parent: 2173
       type: Transform
+    - links:
+      - 2566
+      type: DeviceLinkSink
+    - linkedPorts:
+        4959:
+        - DoorStatus: InputB
+      type: DeviceLinkSource
   - uid: 4122
     components:
     - pos: 36.5,20.5
       parent: 2173
       type: Transform
+    - links:
+      - 2566
+      type: DeviceLinkSink
+    - linkedPorts:
+        4959:
+        - DoorStatus: InputA
+      type: DeviceLinkSource
   - uid: 5743
     components:
     - pos: 43.5,10.5
       parent: 2173
       type: Transform
+    - links:
+      - 4971
+      type: DeviceLinkSink
+    - linkedPorts:
+        4113:
+        - DoorStatus: InputB
+      type: DeviceLinkSource
   - uid: 5812
     components:
     - pos: 42.5,10.5
       parent: 2173
       type: Transform
+    - links:
+      - 4971
+      type: DeviceLinkSink
+    - linkedPorts:
+        4113:
+        - DoorStatus: InputA
+      type: DeviceLinkSource
   - uid: 5819
     components:
     - pos: 43.5,7.5
       parent: 2173
       type: Transform
+    - links:
+      - 4113
+      type: DeviceLinkSink
+    - linkedPorts:
+        4971:
+        - DoorStatus: InputB
+      type: DeviceLinkSource
   - uid: 5847
     components:
     - pos: 42.5,7.5
       parent: 2173
       type: Transform
+    - links:
+      - 4113
+      type: DeviceLinkSink
+    - linkedPorts:
+        4971:
+        - DoorStatus: InputA
+      type: DeviceLinkSource
 - proto: AirlockCargoGlass
   entities:
   - uid: 4110
@@ -7084,7 +7153,7 @@ entities:
   entities:
   - uid: 5863
     components:
-    - pos: 32.034,18.765917
+    - pos: 32.18598,18.718346
       parent: 2173
       type: Transform
 - proto: BoxNitrileGloves
@@ -16781,13 +16850,6 @@ entities:
     - pos: -44.616962,7.589852
       parent: 2173
       type: Transform
-- proto: ClothingOuterHardsuitSecurity
-  entities:
-  - uid: 2565
-    components:
-    - pos: 30.590927,7.5639086
-      parent: 2173
-      type: Transform
 - proto: ClothingUniformJumpskirtParamedic
   entities:
   - uid: 2448
@@ -20380,9 +20442,9 @@ entities:
       - 2354
       - 2355
       type: DeviceList
-- proto: FireAxeCabinetCommand
+- proto: FireAxeCabinetFilledCommand
   entities:
-  - uid: 4113
+  - uid: 516
     components:
     - pos: 9.5,14.5
       parent: 2173
@@ -21106,9 +21168,13 @@ entities:
   entities:
   - uid: 2825
     components:
-    - pos: 32.40657,7.5812006
-      parent: 2173
+    - flags: InContainer
+      type: MetaData
+    - parent: 4976
       type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
 - proto: FloodlightBroken
   entities:
   - uid: 2809
@@ -21734,6 +21800,14 @@ entities:
       type: AtmosPipeColor
 - proto: GasPipeStraight
   entities:
+  - uid: 525
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 38.5,18.5
+      parent: 2173
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
   - uid: 1002
     components:
     - rot: -1.5707963267948966 rad
@@ -22021,6 +22095,14 @@ entities:
       parent: 2173
       type: Transform
     - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 2560
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 37.5,17.5
+      parent: 2173
+      type: Transform
+    - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 2679
     components:
@@ -24663,21 +24745,13 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 4957
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 38.5,17.5
-      parent: 2173
-      type: Transform
-    - color: '#0055CCFF'
-      type: AtmosPipeColor
   - uid: 4958
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 37.5,17.5
+    - rot: 3.141592653589793 rad
+      pos: 37.5,19.5
       parent: 2173
       type: Transform
-    - color: '#0055CCFF'
+    - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 4963
     components:
@@ -24735,32 +24809,9 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 4971
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 39.5,18.5
-      parent: 2173
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 4972
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 38.5,18.5
-      parent: 2173
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
   - uid: 4975
     components:
     - pos: 36.5,19.5
-      parent: 2173
-      type: Transform
-    - color: '#0055CCFF'
-      type: AtmosPipeColor
-  - uid: 4976
-    components:
-    - pos: 36.5,20.5
       parent: 2173
       type: Transform
     - color: '#0055CCFF'
@@ -24772,6 +24823,14 @@ entities:
       parent: 2173
       type: Transform
     - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 4990
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 36.5,18.5
+      parent: 2173
+      type: Transform
+    - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 5023
     components:
@@ -26613,13 +26672,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 5880
-    components:
-    - pos: 37.5,20.5
-      parent: 2173
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
   - uid: 5881
     components:
     - pos: 37.5,21.5
@@ -27497,6 +27549,14 @@ entities:
       type: AtmosPipeColor
 - proto: GasPipeTJunction
   entities:
+  - uid: 623
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 38.5,17.5
+      parent: 2173
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
   - uid: 1111
     components:
     - rot: 3.141592653589793 rad
@@ -27564,6 +27624,13 @@ entities:
     components:
     - rot: -1.5707963267948966 rad
       pos: 6.5,25.5
+      parent: 2173
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 2561
+    components:
+    - pos: 39.5,18.5
       parent: 2173
       type: Transform
     - color: '#990000FF'
@@ -27958,22 +28025,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 4959
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 36.5,18.5
-      parent: 2173
-      type: Transform
-    - color: '#0055CCFF'
-      type: AtmosPipeColor
-  - uid: 4989
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 37.5,19.5
-      parent: 2173
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
   - uid: 5031
     components:
     - rot: -1.5707963267948966 rad
@@ -28366,6 +28417,13 @@ entities:
     components:
     - rot: -1.5707963267948966 rad
       pos: 8.5,23.5
+      parent: 2173
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 2565
+    components:
+    - pos: 38.5,18.5
       parent: 2173
       type: Transform
     - color: '#0055CCFF'
@@ -28764,14 +28822,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 6124
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 37.5,18.5
-      parent: 2173
-      type: Transform
-    - color: '#0055CCFF'
-      type: AtmosPipeColor
 - proto: GasVentScrubber
   entities:
   - uid: 4397
@@ -28990,10 +29040,10 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 4990
+  - uid: 4957
     components:
-    - rot: 1.5707963267948966 rad
-      pos: 36.5,19.5
+    - rot: 3.141592653589793 rad
+      pos: 39.5,17.5
       parent: 2173
       type: Transform
     - color: '#990000FF'
@@ -31397,6 +31447,42 @@ entities:
           occludes: True
           ent: null
       type: ContainerContainer
+  - uid: 4976
+    components:
+    - pos: 32.5,7.5
+      parent: 2173
+      type: Transform
+    - air:
+        volume: 200
+        immutable: False
+        temperature: 293.1496
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+      type: EntityStorage
+    - containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 2825
+          - 2562
+          - 2563
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+      type: ContainerContainer
 - proto: HandheldCrewMonitor
   entities:
   - uid: 2453
@@ -31495,6 +31581,18 @@ entities:
   - uid: 5691
     components:
     - pos: -49.177635,6.6028957
+      parent: 2173
+      type: Transform
+- proto: Implanter
+  entities:
+  - uid: 6148
+    components:
+    - pos: 31.54015,18.498941
+      parent: 2173
+      type: Transform
+  - uid: 6149
+    components:
+    - pos: 31.654732,18.769773
       parent: 2173
       type: Transform
 - proto: IngotGold1
@@ -31614,21 +31712,29 @@ entities:
       pos: -3.5,20.5
       parent: 2173
       type: Transform
-- proto: JetpackSecurityFilled
-  entities:
-  - uid: 2566
-    components:
-    - pos: 30.353123,7.600494
-      parent: 2173
-      type: Transform
 - proto: LampGold
   entities:
   - uid: 3134
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 32.575436,18.856201
+    - pos: 32.68497,18.905191
       parent: 2173
       type: Transform
+    - toggleActionEntity: 3135
+      type: HandheldLight
+    - containers:
+        cell_slot: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+        actions: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 3135
+      type: ContainerContainer
+    - canCollide: True
+      type: Physics
+    - type: ActionsContainer
 - proto: LessLethalVendingMachine
   entities:
   - uid: 4293
@@ -31714,6 +31820,24 @@ entities:
     - pos: 30.5,8.5
       parent: 2173
       type: Transform
+    - air:
+        volume: 200
+        immutable: False
+        temperature: 293.1496
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+      type: EntityStorage
 - proto: LockerWeldingSuppliesFilled
   entities:
   - uid: 6021
@@ -31723,6 +31847,86 @@ entities:
       type: Transform
     - locked: False
       type: Lock
+- proto: LogicGate
+  entities:
+  - uid: 2566
+    components:
+    - anchored: True
+      rot: 3.141592653589793 rad
+      pos: 37.5,19.5
+      parent: 2173
+      type: Transform
+    - links:
+      - 4120
+      - 4119
+      type: DeviceLinkSink
+    - linkedPorts:
+        4122:
+        - Output: DoorBolt
+        4121:
+        - Output: DoorBolt
+      type: DeviceLinkSource
+    - canCollide: False
+      bodyType: Static
+      type: Physics
+  - uid: 4113
+    components:
+    - anchored: True
+      pos: 42.5,11.5
+      parent: 2173
+      type: Transform
+    - links:
+      - 5812
+      - 5743
+      type: DeviceLinkSink
+    - linkedPorts:
+        5847:
+        - Output: DoorBolt
+        5819:
+        - Output: DoorBolt
+      type: DeviceLinkSource
+    - canCollide: False
+      bodyType: Static
+      type: Physics
+  - uid: 4959
+    components:
+    - anchored: True
+      pos: 36.5,19.5
+      parent: 2173
+      type: Transform
+    - links:
+      - 4122
+      - 4121
+      type: DeviceLinkSink
+    - linkedPorts:
+        4120:
+        - Output: DoorBolt
+        4119:
+        - Output: DoorBolt
+      type: DeviceLinkSource
+    - canCollide: False
+      bodyType: Static
+      type: Physics
+  - uid: 4971
+    components:
+    - anchored: True
+      rot: 3.141592653589793 rad
+      pos: 43.5,11.5
+      parent: 2173
+      type: Transform
+    - links:
+      - 5847
+      - 5819
+      type: DeviceLinkSink
+    - linkedPorts:
+        5812:
+        - Output: DoorBolt
+        5743:
+        - Output: DoorBolt
+      type: DeviceLinkSource
+    - canCollide: False
+      bodyType: Static
+      type: Physics
 - proto: MachineCryoSleepPod
   entities:
   - uid: 1394
@@ -33163,16 +33367,6 @@ entities:
     - pos: -43.5,11.5
       parent: 2173
       type: Transform
-  - uid: 2560
-    components:
-    - pos: 30.5,7.5
-      parent: 2173
-      type: Transform
-  - uid: 2561
-    components:
-    - pos: 32.5,7.5
-      parent: 2173
-      type: Transform
   - uid: 4158
     components:
     - pos: -28.5,14.5
@@ -33715,12 +33909,6 @@ entities:
   - uid: 622
     components:
     - pos: 41.5,19.5
-      parent: 2173
-      type: Transform
-  - uid: 623
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 39.5,21.5
       parent: 2173
       type: Transform
   - uid: 666
@@ -35655,6 +35843,11 @@ entities:
       pos: 22.5,27.5
       parent: 2173
       type: Transform
+  - uid: 4989
+    components:
+    - pos: 39.5,21.5
+      parent: 2173
+      type: Transform
   - uid: 4994
     components:
     - rot: 1.5707963267948966 rad
@@ -36584,6 +36777,31 @@ entities:
       pos: -3.5,36.5
       parent: 2173
       type: Transform
+- proto: SuitStorageSec
+  entities:
+  - uid: 4972
+    components:
+    - pos: 30.5,7.5
+      parent: 2173
+      type: Transform
+    - air:
+        volume: 200
+        immutable: False
+        temperature: 293.1496
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+      type: EntityStorage
 - proto: SurveillanceCameraRouterGeneral
   entities:
   - uid: 2365
@@ -38758,11 +38976,6 @@ entities:
     - pos: 12.5,19.5
       parent: 2173
       type: Transform
-  - uid: 516
-    components:
-    - pos: 38.5,21.5
-      parent: 2173
-      type: Transform
   - uid: 517
     components:
     - pos: 12.5,28.5
@@ -38791,11 +39004,6 @@ entities:
   - uid: 524
     components:
     - pos: 35.5,20.5
-      parent: 2173
-      type: Transform
-  - uid: 525
-    components:
-    - pos: 35.5,21.5
       parent: 2173
       type: Transform
   - uid: 526
@@ -40212,6 +40420,16 @@ entities:
       pos: 32.5,13.5
       parent: 2173
       type: Transform
+  - uid: 5880
+    components:
+    - pos: 35.5,21.5
+      parent: 2173
+      type: Transform
+  - uid: 6124
+    components:
+    - pos: 38.5,21.5
+      parent: 2173
+      type: Transform
 - proto: WallSolid
   entities:
   - uid: 256
@@ -41098,24 +41316,26 @@ entities:
       pos: 45.5,13.5
       parent: 2173
       type: Transform
-  - uid: 3135
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 31.5,18.5
-      parent: 2173
-      type: Transform
 - proto: WeaponDisabler
   entities:
   - uid: 2562
     components:
-    - pos: 32.251442,7.68249
-      parent: 2173
+    - flags: InContainer
+      type: MetaData
+    - parent: 4976
       type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
   - uid: 2563
     components:
-    - pos: 32.489246,7.5361485
-      parent: 2173
+    - flags: InContainer
+      type: MetaData
+    - parent: 4976
       type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
   - uid: 2564
     components:
     - pos: 38.46429,14.810719


### PR DESCRIPTION
## About the PR
Doing few more changes

Added 2 implanters on table in sec, removed the unused charger from there.
![image](https://github.com/new-frontiers-14/frontier-station-14/assets/39403717/9ca0c3e9-2189-4a65-8957-1ae74afcdbef)

Replaced the 2 racks with secured storage to keep people off the "loot"
![image](https://github.com/new-frontiers-14/frontier-station-14/assets/39403717/2ec6efc4-8ad6-46d1-8be7-d29a926c6f50)

Sec doors smart cycle, logic gate inside to keep it away from peoples messing with them:
![image](https://github.com/new-frontiers-14/frontier-station-14/assets/39403717/b322d755-b429-4c65-a207-9f16b12d80d3)
![image](https://github.com/new-frontiers-14/frontier-station-14/assets/39403717/1637f686-3e4b-4882-b16e-76a1729747e2)

Fireaxe is back at SR area after it was missing.

## Why / Balance
Making sec area a bit more secured

## Technical details
Maaping.

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame,

## Breaking changes
N/A

**Changelog**
N/A