### PR TITLE
Add PR workflow for automatically labeling mapping changes.

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,12 +1,8 @@
-﻿"Changes: Sprites":
-- '**/*.rsi/*.png'
+"Map":
+- 'Resources/Maps/**/*.yml' # All .yml files in the Resources/Maps directory, recursive.
+- 'Resources/Prototypes/Maps/frontier.yml'
+- 'Resources/Prototypes/_NF/Shipyard/*.yml' # POI's are also here for some reason.
 
-"Changes: Map":
-- 'Resources/Maps/*.yml'
-- 'Resources/Prototypes/Maps/*.yml'
-
-"Changes: UI":
-- '**/*.xaml*'
-
-"No C#":
-- all: ["!**/*.cs"]
+"Shuttle":
+- 'Resources/Maps/Shuttles/*.yml' # All .yml files directly in the Resources/Maps/Shuttles directory.
+- 'Resources/Prototypes/_NF/Shipyard/*.yml' # Shuttles!

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,24 @@
+# This workflow will triage pull requests and apply a label based on the
+# paths that are modified in the pull request.
+#
+# To use this workflow, you will need to set up a .github/labeler.yml
+# file with configuration.  For more information, see:
+# https://github.com/actions/labeler
+
+# This is entirely a github default file, except for this comment, but it should be fine. -Tsjip
+
+name: Labeler
+on: [pull_request_target]
+
+jobs:
+  label:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+    - uses: actions/labeler@v4
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Uses this GH action: https://github.com/actions/labeler
Existing contents in `.github/labeler.yml` were unused, so they were removed entirely and replaced with the new target contents. Currently this would only auto-assign the following labels: Map, Shuttle

Labels should exist on the repo already. ( @dvir001 )

This is the currently configured behavior:
- If any mapping change is detected, the Map label is added.
- If additionally the mapping change in question is a shuttle, the Shuttle label is added as well.

Better behavior can be made if POI prototypes are moved to a separate folder, and not in `Resources/Prototypes/_NF/Shipyard`.

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

No CL.
