### PR TITLE
QOL changes on the matter of life and death

### DIFF
--- a/Content.Server/Body/Systems/BodySystem.cs
+++ b/Content.Server/Body/Systems/BodySystem.cs
@@ -42,7 +42,8 @@ public sealed class BodySystem : SharedBodySystem
     {
         if (_mobState.IsDead(uid) && _mindSystem.TryGetMind(uid, out var mindId, out var mind))
         {
-            mind.TimeOfDeath ??= _gameTiming.RealTime;
+            // mind.TimeOfDeath ??= _gameTiming.RealTime;
+            mind.TimeOfDeath ??= _gameTiming.CurTime; // Frontier - fix returning to body messing with the your TOD
             _ticker.OnGhostAttempt(mindId, true, mind: mind);
         }
     }

--- a/Content.Server/Morgue/CrematoriumSystem.cs
+++ b/Content.Server/Morgue/CrematoriumSystem.cs
@@ -168,7 +168,7 @@ public sealed class CrematoriumSystem : EntitySystem
         }
 
         _popup.PopupEntity(Loc.GetString("crematorium-entity-storage-component-suicide-message-others",
-                ("victim", Identity.Entity(victim, EntityManager))),
+            ("victim", Identity.Entity(victim, EntityManager))),
             victim, Filter.PvsExcept(victim), true, PopupType.LargeCaution);
 
         if (_entityStorage.CanInsert(victim, uid))

--- a/Content.Server/Nyanotrasen/Item/PseudoItem/PseudoItemComponent.cs
+++ b/Content.Server/Nyanotrasen/Item/PseudoItem/PseudoItemComponent.cs
@@ -1,4 +1,6 @@
 
+using Content.Shared._NF.Cloning;
+
 namespace Content.Server.Item.PseudoItem
 {
     /// <summary>
@@ -6,7 +8,7 @@ namespace Content.Server.Item.PseudoItem
     /// but not under most conditions.
     /// </summary>
     [RegisterComponent]
-    public sealed partial class PseudoItemComponent : Component
+    public sealed partial class PseudoItemComponent : Component, ITransferredByCloning
     {
         [DataField("size")]
         public int Size = 120;

--- a/Content.Server/_NF/SizeAttribute/SizeAttributeComponent.cs
+++ b/Content.Server/_NF/SizeAttribute/SizeAttributeComponent.cs
@@ -1,8 +1,10 @@
 
+using Content.Shared._NF.Cloning;
+
 namespace Content.Server.SizeAttribute
 {
     [RegisterComponent]
-    public sealed partial class SizeAttributeComponent : Component
+    public sealed partial class SizeAttributeComponent : Component, ITransferredByCloning
     {
         [DataField("short")]
         public bool Short = false;

--- a/Content.Shared/_NF/Cloning/ITransferredByCloning.cs
+++ b/Content.Shared/_NF/Cloning/ITransferredByCloning.cs
@@ -1,0 +1,9 @@
+namespace Content.Shared._NF.Cloning;
+
+/// <summary>
+///   Indicates that this Component should be transferred to the new entity when the entity is cloned (for example, using a cloner)
+/// </summary>
+public interface ITransferredByCloning
+{
+}
+


### PR DESCRIPTION
## About the PR
- Crematories will no longer accept connected players or alive mobs, similarly to biomass reclaimers.
- Fixed a bug where if and only if you clicked the "return to body" button while being a ghost, ghostrespawn would require waiting hours before respawning, depending on how long the shift was going on for and how slow the server was running.
- Added support for components that are carried over upon cloning. Currently this is used to carry over the "small" and "tall" traits, but later it can be used to add support for lasting genetic changes.

## Why / Balance
The first one is because MY BODY WAS CREMATED ALIVE THAT ONE SHIFT GOD DAMN IT!!! And not only mine, those raiders cremate half the station!!! 

The rest are because why not.

## Technical details
C# changes
Added an ITransferredByCloning interface and applied it to SizeAttribute and PseudoItem

## Media
Change # 1: https://cdn.discordapp.com/attachments/1127687656084611214/1190060682696208464/weeee-2023-12-29_01.33.10.mp4?ex=65a06d61&is=658df861&hm=a066802dad500abb13fa63f1f9509b550dcb64f6bf71a7a577241eca5f21aa83&

Change # 3: https://cdn.discordapp.com/attachments/1127687656084611214/1190091607500935178/aaaaaaaa.mp4?ex=65a08a2e&is=658e152e&hm=e19bcfa71d6129c78b47be358875140e43bb36c8ee62840081de50a0ab333df7&

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None

**Changelog**
:cl:
- tweak: Crematoriums can no longer be used to cremate alive mobs and players with an active soul
- tweak: Cloning now preserves your size. Small creatures will no longer become massive after being cloned!
