### PR TITLE
Lockers Changes

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/service.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/service.yml
@@ -6,7 +6,7 @@
   - type: StorageFill
     contents:
       - id: ClothingOuterArmorBasicSlim
-      - id: WeaponShotgunDoubleBarreledRubber
+#      - id: WeaponShotgunDoubleBarreledRubber # Frontier
       - id: DrinkShaker
       - id: ClothingEyesHudBeer
       - id: DrinkBottleBeer
@@ -15,8 +15,8 @@
         prob: 0.5
       - id: DrinkBottleBeer
         prob: 0.5
-      - id: BoxBeanbag
-        amount: 2
+#      - id: BoxBeanbag # Frontier
+#        amount: 2  # Frontier
       - id: RagItem
         amount: 2
 

--- a/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
@@ -357,7 +357,6 @@
         - id: ClothingNeckCloakPirateCap # Frontier
         - id: JetpackBlackFilled # Frontier
         - id: HandheldGPSBasic # Frontier
-        - id: HandheldGPSBasic # Frontier
         - id: ClothingShoesBootsMagPirateFilled # Frontier
 
 #Wizard


### PR DESCRIPTION
## About the PR
Removed duplicated HandheldGPSBasic from one of the pirate lockers.
Removed shotgun from bar locker.

## Why / Balance
The bartender can go buy one
This is an upstream meme.

## Technical details
.yml

## Media
- [X] this PR does not require an ingame showcase

## Breaking changes
N/A

**Changelog**
N/A