### PR TITLE
Remove ID from emotional pets

### DIFF
--- a/Resources/Prototypes/_NF/Roles/Jobs/Fun/misc_startinggear.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Fun/misc_startinggear.yml
@@ -1,7 +1,7 @@
 - type: startingGear
   id: MobEmotionalSupportGear
-  equipment:
-    id: PassengerIDCard
+#  equipment:
+#    id: PassengerIDCard
 
 - type: startingGear
   id: MobClippyGear
@@ -17,11 +17,11 @@
 
 - type: startingGear
   id: MobCrispyGear
-  equipment:
+#  equipment:
 #    ears: ClothingHeadsetService
-    id: AgentIDCard
+#    id: ChefIDCard
 
 - type: startingGear
   id: MobMistakeGear
-  equipment:
-    id: PassengerIDCard
+#  equipment:
+#    id: PassengerIDCard


### PR DESCRIPTION
## About the PR
Ask SR for cards, no need for free ID cards with every pet.

## Why / Balance
Card not needed, sorry pets.

## Technical details
.yml

## Media
- [X] this PR does not require an ingame showcase

## Breaking changes
N/A

**Changelog**
N/A
