### PR TITLE
Custom shipyard listings

### DIFF
--- a/Content.Client/Shipyard/BUI/ShipyardConsoleBoundUserInterface.cs
+++ b/Content.Client/Shipyard/BUI/ShipyardConsoleBoundUserInterface.cs
@@ -42,12 +42,12 @@ public sealed class ShipyardConsoleBoundUserInterface : BoundUserInterface
         _menu.TargetIdButton.OnPressed += _ => SendMessage(new ItemSlotButtonPressedEvent("ShipyardConsole-targetId"));
     }
 
-    private void Populate(byte uiKey)
+    private void Populate(List<string> prototypes, string name)
     {
         if (_menu == null)
             return;
 
-        _menu.PopulateProducts((ShipyardConsoleUiKey) uiKey);
+        _menu.PopulateProducts(prototypes, name);
         _menu.PopulateCategories();
     }
 
@@ -61,7 +61,7 @@ public sealed class ShipyardConsoleBoundUserInterface : BoundUserInterface
         Balance = cState.Balance;
         ShipSellValue = cState.ShipSellValue;
         var castState = (ShipyardConsoleInterfaceState) state;
-        Populate(castState.UiKey);
+        Populate(castState.ShipyardPrototypes, castState.ShipyardName);
         _menu?.UpdateState(castState);
     }
 

--- a/Content.Server/Shipyard/Systems/ShipyardSystem.Consoles.cs
+++ b/Content.Server/Shipyard/Systems/ShipyardSystem.Consoles.cs
@@ -529,7 +529,7 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
             foreach (var proto in protos)
             {
                 if (proto.Group == group)
-                    availableShuttles.Add(proto.IDid);
+                    availableShuttles.Add(proto.ID);
             }
         }
 

--- a/Content.Server/Shipyard/Systems/ShipyardSystem.Consoles.cs
+++ b/Content.Server/Shipyard/Systems/ShipyardSystem.Consoles.cs
@@ -102,6 +102,13 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
             return;
         }
 
+        if (!GetAvailableShuttles(uid).Contains(vessel.ID))
+        {
+            PlayDenySound(uid, component);
+            _adminLogger.Add(LogType.Action, LogImpact.Medium, $"{ToPrettyString(player):player} tried to purchase a vessel that was never available.");
+            return;
+        }
+
         var name = vessel.Name;
         if (vessel.Price <= 0)
             return;
@@ -495,15 +502,62 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
         return false;
     }
 
+    /// <summary>
+    ///   Returns all shuttle prototype IDs the given shipyard console can offer.
+    /// </summary>
+    public List<string> GetAvailableShuttles(EntityUid uid, ShipyardConsoleUiKey? key = null, ShipyardListingComponent? listing = null)
+    {
+        var availableShuttles = new List<string>();
+
+        if (key == null && TryComp<UserInterfaceComponent>(uid, out var ui))
+        {
+            // Try to find a ui key that is an instance of the shipyard console ui key
+            foreach (var (k, v) in ui.Interfaces)
+            {
+                if (k is ShipyardConsoleUiKey shipyardKey)
+                {
+                    key = shipyardKey;
+                    break;
+                }
+            }
+        }
+
+        // Add all prototypes matching the ui key
+        if (key != null && key != ShipyardConsoleUiKey.Custom && ShipyardGroupMapping.TryGetValue(key.Value, out var group))
+        {
+            var protos = _prototypeManager.EnumeratePrototypes<VesselPrototype>();
+            foreach (var proto in protos)
+            {
+                if (proto.Group == group)
+                    availableShuttles.Add(proto.IDid);
+            }
+        }
+
+        // Add all prototypes specified in ShipyardListing
+        if (listing != null || TryComp(uid, out listing))
+        {
+            foreach (var shuttle in listing.Shuttles)
+            {
+                availableShuttles.Add(shuttle);
+            }
+        }
+
+        return availableShuttles;
+    }
+
     private void RefreshState(EntityUid uid, int balance, bool access, string? shipDeed, int shipSellValue, bool isTargetIdPresent, ShipyardConsoleUiKey uiKey)
     {
+        var listing = TryComp<ShipyardListingComponent>(uid, out var comp) ? comp : null;
+
         var newState = new ShipyardConsoleInterfaceState(
             balance,
             access,
             shipDeed,
             shipSellValue,
             isTargetIdPresent,
-            ((byte)uiKey));
+            ((byte)uiKey),
+            GetAvailableShuttles(uid, uiKey, listing),
+            uiKey.ToString());
 
         _ui.TrySetUiState(uid, uiKey, newState);
     }

--- a/Content.Shared/Shipyard/BUI/ShipyardConsoleInterfaceState.cs
+++ b/Content.Shared/Shipyard/BUI/ShipyardConsoleInterfaceState.cs
@@ -12,13 +12,18 @@ public sealed class ShipyardConsoleInterfaceState : BoundUserInterfaceState
     public readonly bool IsTargetIdPresent;
     public readonly byte UiKey;
 
+    public readonly List<string> ShipyardPrototypes;
+    public readonly string ShipyardName;
+
     public ShipyardConsoleInterfaceState(
         int balance,
         bool accessGranted,
         string? shipDeedTitle,
         int shipSellValue,
         bool isTargetIdPresent,
-        byte uiKey)
+        byte uiKey,
+        List<string> shipyardPrototypes,
+        string shipyardName)
     {
         Balance = balance;
         AccessGranted = accessGranted;
@@ -26,5 +31,7 @@ public sealed class ShipyardConsoleInterfaceState : BoundUserInterfaceState
         ShipSellValue = shipSellValue;
         IsTargetIdPresent = isTargetIdPresent;
         UiKey = uiKey;
+        ShipyardPrototypes = shipyardPrototypes;
+        ShipyardName = shipyardName;
     }
 }

--- a/Content.Shared/Shipyard/Components/ShipyardListingComponent.cs
+++ b/Content.Shared/Shipyard/Components/ShipyardListingComponent.cs
@@ -1,0 +1,18 @@
+using Content.Shared.Shipyard.Prototypes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.List;
+
+namespace Content.Shared.Shipyard.Components;
+
+/// <summary>
+///   When applied to a shipyard console, adds all specified shuttles to the list of sold shuttles.
+///   Can also override the name of the console.
+/// </summary>
+[RegisterComponent]
+public sealed partial class ShipyardListingComponent : Component
+{
+    [ViewVariables, DataField(customTypeSerializer: typeof(PrototypeIdListSerializer<VesselPrototype>))]
+    public List<string> Shuttles = new();
+
+    [ViewVariables, DataField("name")]
+    public string? NameOverride = null;
+}

--- a/Content.Shared/Shipyard/Components/ShipyardListingComponent.cs
+++ b/Content.Shared/Shipyard/Components/ShipyardListingComponent.cs
@@ -5,14 +5,13 @@ namespace Content.Shared.Shipyard.Components;
 
 /// <summary>
 ///   When applied to a shipyard console, adds all specified shuttles to the list of sold shuttles.
-///   Can also override the name of the console.
 /// </summary>
 [RegisterComponent]
 public sealed partial class ShipyardListingComponent : Component
 {
+    /// <summary>
+    ///   All VesselPrototype IDs that should be listed in this shipyard console.
+    /// </summary>
     [ViewVariables, DataField(customTypeSerializer: typeof(PrototypeIdListSerializer<VesselPrototype>))]
     public List<string> Shuttles = new();
-
-    [ViewVariables, DataField("name")]
-    public string? NameOverride = null;
 }

--- a/Content.Shared/Shipyard/SharedShipyardSystem.cs
+++ b/Content.Shared/Shipyard/SharedShipyardSystem.cs
@@ -19,9 +19,7 @@ public enum ShipyardConsoleUiKey : byte
     // Not currently implemented. Could be used in the future to give other factions a variety of shuttle options, like nukies, syndicate, or for evac purchases.
     // Syndicate
     // Do not add any ship to this key. Shipyards using it are inherently empty and are populated using the ShipyardListingComponent.
-    Custom,
-    // Ships that do not appear in normal console should be added here. No console must have this key.
-    None
+    Custom
 }
 
 public abstract class SharedShipyardSystem : EntitySystem
@@ -33,8 +31,7 @@ public abstract class SharedShipyardSystem : EntitySystem
         {ShipyardConsoleUiKey.BlackMarket, "BlackMarket"},
         {ShipyardConsoleUiKey.Expedition, "Expedition"},
         {ShipyardConsoleUiKey.Scrap, "Scrap"},
-        {ShipyardConsoleUiKey.Custom, "Custom"},
-        {ShipyardConsoleUiKey.None, "<DO NOT USE>"}
+        {ShipyardConsoleUiKey.Custom, "<DO NOT USE>"}
     };
 
     [Dependency] private readonly ItemSlotsSystem _itemSlotsSystem = default!;

--- a/Content.Shared/Shipyard/SharedShipyardSystem.cs
+++ b/Content.Shared/Shipyard/SharedShipyardSystem.cs
@@ -16,14 +16,15 @@ public enum ShipyardConsoleUiKey : byte
     BlackMarket,
     Expedition,
     Scrap,
-    // Not currently implemented. Could be used in the future to give other factions a variety of shuttle options, like nukies, syndicate, or for evac purchases.
-    // Syndicate
     // Do not add any ship to this key. Shipyards using it are inherently empty and are populated using the ShipyardListingComponent.
     Custom
 }
 
 public abstract class SharedShipyardSystem : EntitySystem
 {
+    /// <summary>
+    ///   Maps entries of the <see cref="ShipyardConsoleUiKey"/> enum to how they're specified in shuttle prototype files
+    /// </summary>
     public static readonly Dictionary<ShipyardConsoleUiKey, string> ShipyardGroupMapping = new()
     {
         {ShipyardConsoleUiKey.Shipyard, "Civilian"},

--- a/Content.Shared/Shipyard/SharedShipyardSystem.cs
+++ b/Content.Shared/Shipyard/SharedShipyardSystem.cs
@@ -7,6 +7,7 @@ using Content.Shared.Shipyard.Components;
 
 namespace Content.Shared.Shipyard;
 
+// Note: when adding a new ui key, don't forget to modify the dictionary in SharedShipyardSystem
 [NetSerializable, Serializable]
 public enum ShipyardConsoleUiKey : byte
 {
@@ -14,14 +15,28 @@ public enum ShipyardConsoleUiKey : byte
     Security,
     BlackMarket,
     Expedition,
-    Scrap
+    Scrap,
+    // Not currently implemented. Could be used in the future to give other factions a variety of shuttle options, like nukies, syndicate, or for evac purchases.
     // Syndicate
-    //Not currently implemented. Could be used in the future to give other factions a variety of shuttle options,
-    //like nukies, syndicate, or for evac purchases.
+    // Do not add any ship to this key. Shipyards using it are inherently empty and are populated using the ShipyardListingComponent.
+    Custom,
+    // Ships that do not appear in normal console should be added here. No console must have this key.
+    None
 }
 
 public abstract class SharedShipyardSystem : EntitySystem
 {
+    public static readonly Dictionary<ShipyardConsoleUiKey, string> ShipyardGroupMapping = new()
+    {
+        {ShipyardConsoleUiKey.Shipyard, "Civilian"},
+        {ShipyardConsoleUiKey.Security, "Security"},
+        {ShipyardConsoleUiKey.BlackMarket, "BlackMarket"},
+        {ShipyardConsoleUiKey.Expedition, "Expedition"},
+        {ShipyardConsoleUiKey.Scrap, "Scrap"},
+        {ShipyardConsoleUiKey.Custom, "Custom"},
+        {ShipyardConsoleUiKey.None, "<DO NOT USE>"}
+    };
+
     [Dependency] private readonly ItemSlotsSystem _itemSlotsSystem = default!;
 
     public override void Initialize()

--- a/Resources/Maps/Shuttles/empress.yml
+++ b/Resources/Maps/Shuttles/empress.yml
@@ -6940,7 +6940,7 @@ entities:
     - pos: 15.5,-6.5
       parent: 1
       type: Transform
-- proto: ComputerShipyardSecurity
+- proto: EmpressMothershipComputer
   entities:
   - uid: 118
     components:

--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers.yml
@@ -68,7 +68,7 @@
     interfaces:
     - key: enum.ShipyardConsoleUiKey.Shipyard
       type: ShipyardConsoleBoundUserInterface
-  - type: ItemSlots  
+  - type: ItemSlots
   - type: ContainerContainer
     containers:
       ShipyardConsole-targetId: !type:ContainerSlot {}
@@ -80,6 +80,23 @@
         !type:DamageTrigger
         damage: 0
 
+# Custom console
+- type: entity
+  id: BaseMothershipComputer
+  parent: ComputerShipyard
+  name: mothership console
+  description: Used on motherships to purchase and sell ships without returning to a station.
+  components:
+  - type: ActivatableUI
+    key: enum.ShipyardConsoleUiKey.Custom
+  - type: UserInterface
+    interfaces:
+    - key: enum.ShipyardConsoleUiKey.Custom
+      type: ShipyardConsoleBoundUserInterface
+  - type: ShipyardListing
+    name: Local
+
+# Hardcoded consoles
 - type: entity
   id: ComputerShipyardSecurity
   parent: ComputerShipyard
@@ -100,7 +117,7 @@
     - map: ["computerLayerKeyboard"]
       state: generic_keyboard
     - map: ["computerLayerScreen"]
-      state: shipyard_security      
+      state: shipyard_security
     - map: ["computerLayerKeys"]
       state: telesci_key
 
@@ -124,7 +141,7 @@
     - map: ["computerLayerKeyboard"]
       state: generic_keyboard
     - map: ["computerLayerScreen"]
-      state: shipyard_blackmarket   
+      state: shipyard_blackmarket
     - map: ["computerLayerKeys"]
       state: blackmarket_key
   - type: Destructible
@@ -156,7 +173,7 @@
     - map: ["computerLayerKeyboard"]
       state: generic_keyboard
     - map: ["computerLayerScreen"]
-      state: shipyard_blackmarket   
+      state: shipyard_blackmarket
     - map: ["computerLayerKeys"]
       state: blackmarket_key
 
@@ -180,7 +197,7 @@
     - map: ["computerLayerKeyboard"]
       state: generic_keyboard
     - map: ["computerLayerScreen"]
-      state: shipyard_blackmarket   
+      state: shipyard_blackmarket
     - map: ["computerLayerKeys"]
       state: blackmarket_key
 

--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers.yml
@@ -94,7 +94,6 @@
     - key: enum.ShipyardConsoleUiKey.Custom
       type: ShipyardConsoleBoundUserInterface
   - type: ShipyardListing
-    name: Local
 
 # Hardcoded consoles
 - type: entity

--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/mothership-computers.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/mothership-computers.yml
@@ -1,0 +1,27 @@
+# The empress console
+- type: entity
+  id: EmpressMothershipComputer
+  name: Empress mothership console
+  parent: BaseMothershipComputer
+  components:
+  - type: Sprite
+    sprite: _NF/Structures/Machines/computers.rsi
+    layers:
+    - map: ["computerLayerBody"]
+      state: computer
+    - map: ["computerLayerKeyboard"]
+      state: generic_keyboard
+    - map: ["computerLayerScreen"]
+      state: shipyard_security
+    - map: ["computerLayerKeys"]
+      state: telesci_key
+  - type: ShipyardListing
+    name: Empress
+    shuttles:
+    - Interceptor
+    - Fighter
+    - Cleric
+    - Hospitaller
+    - Inquisitor
+    - Rogue
+    - Templar

--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/mothership-computers.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/mothership-computers.yml
@@ -18,10 +18,6 @@
   - type: ShipyardListing
     name: Empress
     shuttles:
-    - Interceptor
     - Fighter
     - Cleric
-    - Hospitaller
-    - Inquisitor
     - Rogue
-    - Templar

--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/mothership-computers.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/mothership-computers.yml
@@ -16,7 +16,6 @@
     - map: ["computerLayerKeys"]
       state: telesci_key
   - type: ShipyardListing
-    name: Empress
     shuttles:
     - Fighter
     - Cleric

--- a/Resources/Prototypes/_NF/Shipyard/cleric.yml
+++ b/Resources/Prototypes/_NF/Shipyard/cleric.yml
@@ -4,7 +4,7 @@
   description: Small support vessel used for emergency rescues and first aid.
   price: 10800 #Appraisal is 10500
   category: Small
-  group: Security #Should be only available at a cruiser custom shipyard TODO
+  group: None
   shuttlePath: /Maps/Shuttles/cleric.yml
 
 - type: gameMap

--- a/Resources/Prototypes/_NF/Shipyard/fighter.yml
+++ b/Resources/Prototypes/_NF/Shipyard/fighter.yml
@@ -4,7 +4,7 @@
   description: Small attack vessel used for boarding and transport of prisoners.
   price: 9000 #not sure how much mark up % to add but the appraisal is 8491$
   category: Small
-  group: Security #Should be only available at a cruiser custom shipyard TODO
+  group: None
   shuttlePath: /Maps/Shuttles/fighter.yml
 
 - type: gameMap

--- a/Resources/Prototypes/_NF/Shipyard/rogue.yml
+++ b/Resources/Prototypes/_NF/Shipyard/rogue.yml
@@ -4,7 +4,7 @@
   description: Small assault vessel with a toggle for going dark in deep space.
   price: 8200 #the appraisal is 7941$
   category: Small
-  group: Security #Should be only available at a cruiser custom shipyard TODO
+  group: None
   shuttlePath: /Maps/Shuttles/rogue.yml
 
 - type: gameMap

--- a/Resources/Prototypes/_NF/Shipyard/spectre.yml
+++ b/Resources/Prototypes/_NF/Shipyard/spectre.yml
@@ -1,6 +1,6 @@
 - type: vessel
   id: Spectre
-  name: Spectre
+  name: NSS Spectre
   description: A large research mothership designed to be flown nexto a small fleet of other ships including salvage and food services.
   price: 195000
   category: Large
@@ -17,7 +17,7 @@
       stationProto: StandardFrontierVessel
       components:
         - type: StationNameSetup
-          mapNameTemplate: 'Spectre {1}' 
+          mapNameTemplate: 'Spectre {1}'
           nameGenerator:
             !type:NanotrasenNameGenerator
             prefixCreator: '14'


### PR DESCRIPTION
## About the PR
This PR adds support for custom, per-console shipyard lists. This is achieved using the ShipyardListingComponent. 

Additionally:
- It changes the empress' shipyard console to only sell small security ships.
- It removes the Cleric and the Fighter from the standard security shipyard, making them only available from the empress' console (as that's what was written in the TODOs of those ships)
- It fixes Spectre's shipyard name (as Dvir has requested)

## Why / Balance
Sec too greedy

Also I want to use this to add a small shipyard console to the caduceus in the future, as its specifics suggest that it should act as a mothership for a medical fleet rather than a standalone ship

## Technical details
Added a new shipyard ui key - custom (used only for custom consoles, inapplicable to shuttles)

Moved the shipyard listing logic from the client to the server side and added a check to make sure a player doesn't abuse the old hole in the system to purchase e.g. an Empress from a normal shipyard

## Media
https://cdn.discordapp.com/attachments/1127687656084611214/1191431182819270807/weeee-2024-01-01_20.11.54.mp4?ex=65a569c1&is=6592f4c1&hm=16e0ad111b425bc56061d1c7d032455b0449f747761b1839b25b227b6ce0991e&

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
Moved the ui-key-to-shuttle-group mapping from the client side code to a static dictionary in SharedShipyardSystem.

**Changelog**
:cl:
- tweak: The shipyard console on the Empress was changed to only sell small security ships
- tweak: The Cleric, the Rogue and the Fighter are now only available from the Empresses shipyard console.