### PR TITLE
Add open jobs count to ship names

### DIFF
--- a/Content.Client/NewFrontier/Latejoin/VesselListControl.xaml.cs
+++ b/Content.Client/NewFrontier/Latejoin/VesselListControl.xaml.cs
@@ -44,6 +44,10 @@ public sealed partial class VesselListControl : BoxContainer
 
     private int DefaultComparison(NetEntity x, NetEntity y)
     {
+        if (_gameTicker.StationNames[x] == "Frontier Outpost" && _gameTicker.JobsAvailable[x].ContainsKey("Passenger"))
+        {
+            return 0;
+        }
         return (int)(_gameTicker.JobsAvailable[x].Values.Sum(a => a ?? 0) - _gameTicker.JobsAvailable[y].Values.Sum(b => b ?? 0));
     }
 
@@ -72,10 +76,12 @@ public sealed partial class VesselListControl : BoxContainer
             if (VesselItemList.Any(x => ((NetEntity)x.Metadata!) == key))
                 continue;
 
+            var jobsAvailable = _gameTicker.JobsAvailable[key].Values.Sum(a => a ?? 0).ToString();
+
             var item = new ItemList.Item(VesselItemList)
             {
                 Metadata = key,
-                Text = name
+                Text = name + $" ({jobsAvailable})"
             };
 
             if (!string.IsNullOrEmpty(FilterLineEdit.Text) &&


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
This PR adds the number of open jobs per ship in the late join spawn selection menu.
Also sorts frontier on top in the list (please test and verify / code review this one)

## Why / Balance
New players won't need to click every ship anymore to check if there are any open spots.
Also, I myself wasnt aware that the list was sorted by open jobs, so uh, yeah.

## Technical details
It gets the number of open jobs for that ship/station and puts it in the title.

## Media
![image](https://github.com/new-frontiers-14/frontier-station-14/assets/1354802/5955b406-09ce-405e-8a04-67904f7b4d00)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
none

**Changelog**

:cl:
- add: open jobs count in pre-round lobby spawn selection
- tweak: Sort frontier station on top before others
