### PR TITLE
Implemented IFF search

### DIFF
--- a/Content.Client/Shuttles/UI/RadarControl.cs
+++ b/Content.Client/Shuttles/UI/RadarControl.cs
@@ -46,6 +46,11 @@ public sealed class RadarControl : MapGridControl
     public bool ShowDocks { get; set; } = true;
 
     /// <summary>
+    ///   If present, called for every IFF. Must determine if it should or should not be shown.
+    /// </summary>
+    public Func<EntityUid, MapGridComponent, IFFComponent?, bool>? IFFFilter { get; set; } = null;
+
+    /// <summary>
     /// Currently hovered docked to show on the map.
     /// </summary>
     public EntityUid? HighlightedDock;
@@ -286,19 +291,11 @@ public sealed class RadarControl : MapGridControl
                     uiPosition = new Vector2(uiX + uiXCentre, uiY + uiYCentre);
                 }
 
-                if (!ShowIFFShuttles)
-                {
-                    if (iff != null && (iff.Flags & IFFFlags.IsPlayerShuttle) != 0x0)
-                    {
-                        label.Visible = false;
-                    }
-                    else
-                        label.Visible = true;
-                }
-                else
-                {
-                    label.Visible = true;
-                }
+                label.Visible = ShowIFFShuttles
+                                || iff == null || (iff.Flags & IFFFlags.IsPlayerShuttle) == 0x0;
+
+                if (IFFFilter != null)
+                    label.Visible &= IFFFilter(gUid, grid.Comp, iff);
 
                 label.Text = Loc.GetString("shuttle-console-iff-label", ("name", name), ("distance", $"{distance:0.0}"));
                 LayoutContainer.SetPosition(label, uiPosition);

--- a/Content.Client/Shuttles/UI/ShuttleConsoleWindow.xaml
+++ b/Content.Client/Shuttles/UI/ShuttleConsoleWindow.xaml
@@ -103,6 +103,7 @@
                            Align="Right"/>
                 </GridContainer>
             </BoxContainer>
+
             <Button Name="IFFToggle"
                     Text="{Loc 'shuttle-console-iff-toggle'}"
                     TextAlign="Center"
@@ -119,6 +120,13 @@
                     Text="{Loc 'shuttle-console-undock'}"
                     TextAlign="Center"
                     Disabled="True"/>
+
+            <!-- Frontier - IFF search -->
+            <BoxContainer Orientation="Vertical" HorizontalExpand="True" Name="IffSearchBox">
+                <Label Text="{Loc 'shuttle-console-iff-search'}"></Label>
+
+                <LineEdit Name="IffSearchCriteria" Access="Public" HorizontalExpand="True"></LineEdit>
+            </BoxContainer>
         </BoxContainer>
     </GridContainer>
 </controls:FancyWindow>

--- a/Content.Client/Shuttles/UI/ShuttleConsoleWindow.xaml.cs
+++ b/Content.Client/Shuttles/UI/ShuttleConsoleWindow.xaml.cs
@@ -65,6 +65,9 @@ public sealed partial class ShuttleConsoleWindow : FancyWindow,
         DockToggle.Pressed = RadarScreen.ShowDocks;
 
         UndockButton.OnPressed += OnUndockPressed;
+
+        // Frontier - IFF search
+        IffSearchCriteria.OnTextChanged += args => OnIffSearchChanged(args.Text);
     }
 
     private void WorldRangeChange(float value)
@@ -93,6 +96,19 @@ public sealed partial class ShuttleConsoleWindow : FancyWindow,
     {
         if (DockingScreen.ViewedDock == null) return;
         UndockPressed?.Invoke(DockingScreen.ViewedDock.Value);
+    }
+
+    private void OnIffSearchChanged(string text)
+    {
+        text = text.Trim();
+
+        RadarScreen.IFFFilter = text.Length == 0
+            ? null // If empty, do not filter
+            : (entity, grid, iff) => // Otherwise use simple search criteria
+            {
+                _entManager.TryGetComponent<MetaDataComponent>(entity, out var metadata);
+                return metadata != null && metadata.EntityName.Contains(text, StringComparison.OrdinalIgnoreCase);
+            };
     }
 
     public void SetMatrix(EntityCoordinates? coordinates, Angle? angle)

--- a/Resources/Locale/en-US/shuttles/console.ftl
+++ b/Resources/Locale/en-US/shuttles/console.ftl
@@ -34,6 +34,8 @@ shuttle-console-hyperspace-none = No destinations found
 shuttle-console-unknown = Unknown
 shuttle-console-iff-label = {$name} ({$distance}m)
 
+shuttle-console-iff-search = Search IFF
+
 # Buttons
 shuttle-console-strafing = Strafing mode
 shuttle-console-iff-toggle = Show IFF


### PR DESCRIPTION
## About the PR
Added a search bar to the shuttle console, which allows to filter IFFs by name

## Why / Balance
Mailmen will be happy

## Technical details
Client-side changes only

Added a new field to RadarControl - a reference to a filter function that accepts an EntityUID, a MapGridComponent, and an IFFComponent and return a boolean. The current code only uses the first argument (the uid), but other ones can be used to implement more advanced filtering later on. Made RadarControl's draw code call that filter function if it's not null.

I have genuinely spent more time trying to make dotnet recompile the client than writing the code.

## Media
https://github.com/new-frontiers-14/frontier-station-14/assets/69920617/89a11127-e4e5-44ac-9017-8e4c4b223072

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
N/A

**Changelog**
:cl:
- add: Added an IFF filtering feature to the shuttle console UI, allowing to search for specific IFFs
