### PR TITLE
Remove shitcurity and cargonia references

### DIFF
--- a/Resources/Maps/Shuttles/praeda.yml
+++ b/Resources/Maps/Shuttles/praeda.yml
@@ -1763,7 +1763,7 @@ entities:
   entities:
   - uid: 160
     components:
-    - desc: A banner displaying the colors of the cargo department.
+    - desc: A banner displaying the colors of the cargo department. Hail Cargonia!
       name: Cargo banner
       type: MetaData
     - pos: 0.5,-4.5
@@ -1771,7 +1771,7 @@ entities:
       type: Transform
   - uid: 161
     components:
-    - desc: A banner displaying the colors of the cargo department.
+    - desc: A banner displaying the colors of the cargo department. Hail Cargonia!
       name: Cargo banner
       type: MetaData
     - pos: -4.5,-19.5
@@ -1779,7 +1779,7 @@ entities:
       type: Transform
   - uid: 162
     components:
-    - desc: A banner displaying the colors of the cargo department.
+    - desc: A banner displaying the colors of the cargo department. Hail Cargonia!
       name: Cargo banner
       type: MetaData
     - pos: 5.5,-19.5

--- a/Resources/Maps/Shuttles/praeda.yml
+++ b/Resources/Maps/Shuttles/praeda.yml
@@ -1763,7 +1763,7 @@ entities:
   entities:
   - uid: 160
     components:
-    - desc: A banner displaying the colors of the cargo department. Hail Cargonia!
+    - desc: A banner displaying the colors of the cargo department.
       name: Cargo banner
       type: MetaData
     - pos: 0.5,-4.5
@@ -1771,7 +1771,7 @@ entities:
       type: Transform
   - uid: 161
     components:
-    - desc: A banner displaying the colors of the cargo department. Hail Cargonia!
+    - desc: A banner displaying the colors of the cargo department.
       name: Cargo banner
       type: MetaData
     - pos: -4.5,-19.5
@@ -1779,7 +1779,7 @@ entities:
       type: Transform
   - uid: 162
     components:
-    - desc: A banner displaying the colors of the cargo department. Hail Cargonia!
+    - desc: A banner displaying the colors of the cargo department.
       name: Cargo banner
       type: MetaData
     - pos: 5.5,-19.5

--- a/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
@@ -115,7 +115,7 @@
   parent: ClothingEyesBase
   id: ClothingEyesGlassesSunglasses
   name: sun glasses
-  description: Useful for security. # Frontier
+  description: Useful for security. # Frontier - description change
   components:
   - type: Sprite
     sprite: Clothing/Eyes/Glasses/sunglasses.rsi

--- a/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
@@ -115,7 +115,7 @@
   parent: ClothingEyesBase
   id: ClothingEyesGlassesSunglasses
   name: sun glasses
-  description: Useful both for security and cargonia.
+  description: Useful for security. # Frontier
   components:
   - type: Sprite
     sprite: Clothing/Eyes/Glasses/sunglasses.rsi

--- a/Resources/Prototypes/Entities/Clothing/Eyes/specific.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/specific.yml
@@ -2,7 +2,7 @@
   parent: ClothingEyesBase
   id: ClothingEyesChameleon # no flash immunity, sorry
   name: sun glasses
-  description: Useful both for security and cargonia.
+  description: Useful for security. # Frontier
   suffix: Chameleon
   components:
     - type: Tag
@@ -18,4 +18,3 @@
       interfaces:
         - key: enum.ChameleonUiKey.Key
           type: ChameleonBoundUserInterface
-

--- a/Resources/Prototypes/Entities/Clothing/Eyes/specific.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/specific.yml
@@ -2,7 +2,7 @@
   parent: ClothingEyesBase
   id: ClothingEyesChameleon # no flash immunity, sorry
   name: sun glasses
-  description: Useful for security. # Frontier
+  description: Useful for security. # Frontier - description change
   suffix: Chameleon
   components:
     - type: Tag

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_bottles.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_bottles.yml
@@ -97,7 +97,7 @@
   parent: DrinkBottleBaseFull
   id: DrinkCognacBottleFull
   name: cognac bottle
-  description: A sweet and strongly alchoholic drink, made after numerous distillations and years of maturing. # Frontier
+  description: A sweet and strongly alchoholic drink, made after numerous distillations and years of maturing. # Frontier - description change
   components:
   - type: SolutionContainerManager
     solutions:

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_bottles.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_bottles.yml
@@ -97,7 +97,7 @@
   parent: DrinkBottleBaseFull
   id: DrinkCognacBottleFull
   name: cognac bottle
-  description: A sweet and strongly alchoholic drink, made after numerous distillations and years of maturing. You might as well not scream 'SHITCURITY' this time.
+  description: A sweet and strongly alchoholic drink, made after numerous distillations and years of maturing. # Frontier
   components:
   - type: SolutionContainerManager
     solutions:

--- a/Resources/Prototypes/Entities/Structures/Decoration/banners.yml
+++ b/Resources/Prototypes/Entities/Structures/Decoration/banners.yml
@@ -41,7 +41,7 @@
   id: BannerCargo
   parent: BannerBase
   name: cargo banner
-  description: A banner displaying the colors of the cargo department. # Frontier
+  description: A banner displaying the colors of the cargo department. # Frontier - description change
   components:
   - type: Sprite
     sprite: Structures/Decoration/banner.rsi

--- a/Resources/Prototypes/Entities/Structures/Decoration/banners.yml
+++ b/Resources/Prototypes/Entities/Structures/Decoration/banners.yml
@@ -101,7 +101,7 @@
   id: BannerSecurity
   parent: BannerBase
   name: security banner
-  description: A banner displaying the colors of the security department. # Frontier
+  description: A banner displaying the colors of the security department. # Frontier - description change
   components:
   - type: Sprite
     sprite: Structures/Decoration/banner.rsi

--- a/Resources/Prototypes/Entities/Structures/Decoration/banners.yml
+++ b/Resources/Prototypes/Entities/Structures/Decoration/banners.yml
@@ -41,7 +41,7 @@
   id: BannerCargo
   parent: BannerBase
   name: cargo banner
-  description: A banner displaying the colors of the cargo department. Not. Cargonia.
+  description: A banner displaying the colors of the cargo department. # Frontier
   components:
   - type: Sprite
     sprite: Structures/Decoration/banner.rsi
@@ -101,7 +101,7 @@
   id: BannerSecurity
   parent: BannerBase
   name: security banner
-  description: A banner displaying the colors of the shitcurity department. Security, my bad.
+  description: A banner displaying the colors of the security department. # Frontier
   components:
   - type: Sprite
     sprite: Structures/Decoration/banner.rsi
@@ -146,5 +146,3 @@
   - type: Sprite
     sprite: Structures/Decoration/banner.rsi
     state: banner-green
-
-


### PR DESCRIPTION
## About the PR
Removes "Shitcurity" and "Cargonia" from entity descriptions.

## Why / Balance
"Shitcurity", and similarly "Cargonia", are harmful references in an MRP server.

## Media

- [X] This PR does not require an ingame showcase

## Breaking changes
N/A

**Changelog**
N/A
