### PR TITLE
Upstream Diona

### DIFF
--- a/Resources/Prototypes/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/Damage/modifier_sets.yml
@@ -131,8 +131,9 @@
   id: Diona
   coefficients:
     Blunt: 0.7
-    Slash: 0.7
-    Heat: 1.4
+    Slash: 0.8
+    Heat: 1.5
+    Shock: 1.2
 
 - type: damageModifierSet
   id: Moth # Slightly worse at everything but cold

--- a/Resources/Prototypes/Entities/Mobs/Species/diona.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/diona.yml
@@ -10,11 +10,11 @@
   - type: Hunger
     starvationDamage:
       types:
-        Bloodloss: 0.1
+        Bloodloss: 0.5
     baseDecayRate: 0.0083
   - type: Thirst
     baseDecayRate: 0.0083
-  - type: Carriable # Carrying system from nyanotrasen.  
+  - type: Carriable # Carrying system from nyanotrasen.
   - type: Icon
     sprite: Mobs/Species/Diona/parts.rsi
     state: full
@@ -29,7 +29,6 @@
       Brute:
         sprite: Mobs/Effects/brute_damage.rsi
         color: "#75b1f0"
-  - type: Perishable
   - type: Butcherable
     butcheringType: Spike
     spawned:
@@ -99,12 +98,6 @@
   - type: BodyEmotes
     soundsId: DionaBodyEmotes
   - type: IgnoreKudzu
-  - type: Tag
-    tags:
-    - ShoesRequiredStepTriggerImmune
-    - CanPilot
-    - FootstepSound
-    - DoorBumpOpener
 
 - type: entity
   parent: BaseSpeciesDummy


### PR DESCRIPTION
## About the PR
Putting Diona back to what they were on upstream, no more walking over glass shared, thats part of what diona are.

## Why / Balance
Diona back to be diona.

## Technical details
Having tags system on any species can get us to have upstream conflicts since the tag system replaced tag, not carry tags over parent to child entity.

## Media
N/A

## Breaking changes
N/A

**Changelog**
:cl: dvir01
- tweak: Diona DNA back to normal.
