### PR TITLE
Diona Tags Fix

### DIFF
--- a/Content.Shared/StepTrigger/Components/ShoesRequiredStepTriggerImmuneComponent.cs
+++ b/Content.Shared/StepTrigger/Components/ShoesRequiredStepTriggerImmuneComponent.cs
@@ -1,0 +1,11 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.StepTrigger.Components;
+
+/// <summary>
+/// Frontier - This is used for immunity to cancelling step trigger events if the user is wearing shoes, such as for glass shards.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class ShoesRequiredStepTriggerImmuneComponent : Component  // Frontier
+{
+}

--- a/Content.Shared/StepTrigger/Systems/ShoesRequiredStepTriggerSystem.cs
+++ b/Content.Shared/StepTrigger/Systems/ShoesRequiredStepTriggerSystem.cs
@@ -26,7 +26,10 @@ public sealed class ShoesRequiredStepTriggerSystem : EntitySystem
         }
 
         if (HasComp<ShoesRequiredStepTriggerImmuneComponent>(args.Tripper)) // Frontier
+        {
+            args.Cancelled = true;
             return;
+        }
 
         if (!TryComp<InventoryComponent>(args.Tripper, out var inventory))
             return;

--- a/Content.Shared/StepTrigger/Systems/ShoesRequiredStepTriggerSystem.cs
+++ b/Content.Shared/StepTrigger/Systems/ShoesRequiredStepTriggerSystem.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared.Examine;
+using Content.Shared.Examine;
 using Content.Shared.Inventory;
 using Content.Shared.StepTrigger.Components;
 using Content.Shared.Tag;
@@ -24,6 +24,9 @@ public sealed class ShoesRequiredStepTriggerSystem : EntitySystem
             args.Cancelled = true;
             return;
         }
+
+        if (HasComp<ShoesRequiredStepTriggerImmuneComponent>(args.Tripper)) // Frontier
+            return;
 
         if (!TryComp<InventoryComponent>(args.Tripper, out var inventory))
             return;

--- a/Resources/Prototypes/Entities/Mobs/Species/diona.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/diona.yml
@@ -99,12 +99,7 @@
   - type: BodyEmotes
     soundsId: DionaBodyEmotes
   - type: IgnoreKudzu
-  - type: Tag
-    tags:
-    - ShoesRequiredStepTriggerImmune
-    - CanPilot
-    - FootstepSound
-    - DoorBumpOpener
+  - type: ShoesRequiredStepTriggerImmune # Frontier
 
 - type: entity
   parent: BaseSpeciesDummy


### PR DESCRIPTION
## About the PR
Remove tags from diona to help keep accidental tags missing in the case upstream adds new tags and we forgot to update it down to diona.

## Why / Balance
This update has no changes to diona other then removing the ``ShoesRequiredStepTriggerImmune`` tag from it and adding it back as a small comp

Im leaving this as a draft as this can be either added now, or after an upstream merge.

## Technical details
The original tag stay the same, this is just so we can clear the tags from diona.

## Media
N/A

## Breaking changes
N/A
Diona stay the same for this update.

**Changelog**
N/A
