### PR TITLE
Bananium Anomaly Generator

### DIFF
--- a/Content.Server/Anomaly/Components/AnomalyGeneratorComponent.cs
+++ b/Content.Server/Anomaly/Components/AnomalyGeneratorComponent.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared.Anomaly;
+using Content.Shared.Anomaly;
 using Content.Shared.Materials;
 using Content.Shared.Radio;
 using Robust.Shared.Audio;
@@ -37,13 +37,13 @@ public sealed partial class AnomalyGeneratorComponent : Component
     /// The material needed to generate an anomaly
     /// </summary>
     [DataField("requiredMaterial", customTypeSerializer: typeof(PrototypeIdSerializer<MaterialPrototype>)), ViewVariables(VVAccess.ReadWrite)]
-    public string RequiredMaterial = "Plasma";
+    public string RequiredMaterial = "Bananium"; // Frontier - Plasma to Bananium
 
     /// <summary>
     /// The amount of material needed to generate a single anomaly
     /// </summary>
     [DataField("materialPerAnomaly"), ViewVariables(VVAccess.ReadWrite)]
-    public int MaterialPerAnomaly = 1500; // a bit less than a stack of plasma
+    public int MaterialPerAnomaly = 1000; // Frontier - Plasma to Bananium, 1500 to 1000
 
     /// <summary>
     /// The random anomaly spawner entity

--- a/Resources/Locale/en-US/anomaly/anomaly.ftl
+++ b/Resources/Locale/en-US/anomaly/anomaly.ftl
@@ -26,7 +26,7 @@ anomaly-scanner-particle-containment = - [color=goldenrod]Containment type:[/col
 anomaly-scanner-pulse-timer = Time until next pulse: [color=gray]{$time}[/color]
 
 anomaly-generator-ui-title = Anomaly Generator
-anomaly-generator-fuel-display = Fuel:
+anomaly-generator-fuel-display = Bananium:
 anomaly-generator-cooldown = Cooldown: [color=gray]{$time}[/color]
 anomaly-generator-no-cooldown = Cooldown: [color=gray]Complete[/color]
 anomaly-generator-yes-fire = Status: [color=forestgreen]Ready[/color]

--- a/Resources/Prototypes/Entities/Structures/Machines/anomaly_equipment.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/anomaly_equipment.yml
@@ -245,7 +245,8 @@
   - type: MaterialStorage
     whitelist:
       tags:
-        - RawMaterial
+#        - Sheet # Frontier
+        - RawMaterial # Frontier
     materialWhiteList:
 #    - Plasma # Frontier
     - Bananium # Frontier

--- a/Resources/Prototypes/Entities/Structures/Machines/anomaly_equipment.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/anomaly_equipment.yml
@@ -245,9 +245,10 @@
   - type: MaterialStorage
     whitelist:
       tags:
-        - Sheet
+        - RawMaterial
     materialWhiteList:
-    - Plasma
+#    - Plasma # Frontier
+    - Bananium # Frontier
   - type: Fixtures
     fixtures:
       fix1:

--- a/Resources/ServerInfo/Guidebook/Science/AnomalousResearch.xml
+++ b/Resources/ServerInfo/Guidebook/Science/AnomalousResearch.xml
@@ -16,7 +16,7 @@ Scanners, vessels, and A.P.E.s are all used in the containment and observation o
 <GuideEntityEmbed Entity="MachineAnomalyGenerator"/>
 </Box>
 
-The anomaly generator can produce a random anomaly somewhere on the station at the cost of plasma.
+The anomaly generator can produce a random anomaly somewhere on the station at the cost of bananium.
 
 ## Anomalies
 Anomalies are static objects that appear on the station. They cannot be moved, and must be worked around, no matter their location.


### PR DESCRIPTION
## About the PR
Making the anomaly generator require a material that either need you to go mine for, or buy from miners.

## Why / Balance
Plasma is too cheap and simple for a money machine.

## Technical details
yml
C#

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame,

![image](https://github.com/new-frontiers-14/frontier-station-14/assets/39403717/f032bde5-51fa-45ee-bd37-c9ac980a3f5e)


## Breaking changes
N/A

**Changelog**
:cl: dvir01
- tweak: Anomaly generator now require bananium processed ore.