### PR TITLE
Fix job playtime

### DIFF
--- a/Content.Server/Players/PlayTimeTracking/PlayTimeTrackingManager.cs
+++ b/Content.Server/Players/PlayTimeTracking/PlayTimeTrackingManager.cs
@@ -147,11 +147,12 @@ public sealed partial class PlayTimeTrackingManager
         _playersDirty.Clear();
     }
 
-    private void RefreshSingleTracker(ICommonSession dirty, PlayTimeData data, TimeSpan time)
+    private void RefreshSingleTracker(ICommonSession dirty, PlayTimeData data, TimeSpan time, bool autoFlush = true) // Frontier: added the autoflush parameter
     {
         DebugTools.Assert(data.Initialized);
 
-        FlushSingleTracker(data, time);
+        if (autoFlush)
+            FlushSingleTracker(data, time);
 
         data.NeedRefreshTackers = false;
 
@@ -267,6 +268,9 @@ public sealed partial class PlayTimeTrackingManager
 
         foreach (var (player, data) in _playTimeData)
         {
+            // Frontier: refresh trackers on all players before saving them, but without flushing
+            RefreshSingleTracker(player, data, _timing.RealTime, autoFlush: false);
+
             foreach (var tracker in data.DbTrackersDirty)
             {
                 log.Add(new PlayTimeUpdate(player.UserId, tracker, data.TrackerTimes[tracker]));


### PR DESCRIPTION
## About the PR
Fixes playtime calculations. 

## Why / Balance
350 hours as "passenger" 😩 

## Technical details
The old code used to only calculate playtime trackers once per session, and that calculation was based on the JobComponent on the player's mind, which was only added once - either at round-start or upon late-join. Now the same code first tries to read the player's ID card and deduce their current job based on that. If their job title is Deputy, they receive playtime on JobSecurityOfficer, and so on.

In addition, the system now recalculates playtime trackers __for every player__ before saving them. This is done because there's no reliable way to guess when a player's job has changed, or at least I see none.

## Media
Results of testing (changed my character's job to scientist, CE and other roles for a few minutes, it had effect):
![image](https://github.com/new-frontiers-14/frontier-station-14/assets/69920617/254c9ca7-663a-4041-96e2-f9f1b0dfe98f)


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None

**Changelog**
:cl:
- fix: Changing your job IC should now correctly affect your play time on that job.
