### PR TITLE
Sleeping inside bags

### DIFF
--- a/Content.Server/Nyanotrasen/Item/PseudoItem/AllowsSleepInsideComponent.cs
+++ b/Content.Server/Nyanotrasen/Item/PseudoItem/AllowsSleepInsideComponent.cs
@@ -1,0 +1,9 @@
+namespace Content.Server.Item.PseudoItem;
+
+/// <summary>
+///   Signifies that pseudo-item creatures can sleep inside the container to which this component was added.
+/// </summary>
+[RegisterComponent]
+public sealed partial class AllowsSleepInsideComponent : Component
+{
+}

--- a/Content.Server/Nyanotrasen/Item/PseudoItem/PseudoItemSystem.cs
+++ b/Content.Server/Nyanotrasen/Item/PseudoItem/PseudoItemSystem.cs
@@ -187,10 +187,11 @@ public sealed class PseudoItemSystem : EntitySystem
         args.Cancel();
     }
 
-    // Frontier
+    // Frontier - show a popup when a pseudo-item falls asleep inside a bag.
     private void OnTrySleeping(EntityUid uid, PseudoItemComponent component, TryingToSleepEvent args)
     {
-        if (!HasComp<SleepingComponent>(uid))
+        var parent = Transform(uid).ParentUid;
+        if (!HasComp<SleepingComponent>(uid) && parent is { Valid: true } && HasComp<AllowsSleepInsideComponent>(parent))
             _popup.PopupEntity(Loc.GetString("popup-sleep-in-bag", ("entity", uid)), uid);
     }
 }

--- a/Content.Server/Nyanotrasen/Item/PseudoItem/PseudoItemSystem.cs
+++ b/Content.Server/Nyanotrasen/Item/PseudoItem/PseudoItemSystem.cs
@@ -1,5 +1,9 @@
+using Content.Server.Actions;
+using Content.Server.Bed.Sleep;
 using Content.Server.DoAfter;
+using Content.Server.Popups;
 using Content.Server.Storage.EntitySystems;
+using Content.Shared.Bed.Sleep;
 using Content.Shared.DoAfter;
 using Content.Shared.Hands;
 using Content.Shared.IdentityManagement;
@@ -18,6 +22,8 @@ public sealed class PseudoItemSystem : EntitySystem
     [Dependency] private readonly ItemSystem _itemSystem = default!;
     [Dependency] private readonly DoAfterSystem _doAfter = default!;
     [Dependency] private readonly TagSystem _tagSystem = default!;
+    [Dependency] private readonly ActionsSystem _actions = default!; // Frontier
+    [Dependency] private readonly PopupSystem _popup = default!; // Frontier
 
     [ValidatePrototypeId<TagPrototype>]
     private const string PreventTag = "PreventLabel";
@@ -32,6 +38,7 @@ public sealed class PseudoItemSystem : EntitySystem
         SubscribeLocalEvent<PseudoItemComponent, DropAttemptEvent>(OnDropAttempt);
         SubscribeLocalEvent<PseudoItemComponent, PseudoItemInsertDoAfterEvent>(OnDoAfter);
         SubscribeLocalEvent<PseudoItemComponent, ContainerGettingInsertedAttemptEvent>(OnInsertAttempt);
+        SubscribeLocalEvent<PseudoItemComponent, TryingToSleepEvent>(OnTrySleeping); // Frontier
     }
 
     private void AddInsertVerb(EntityUid uid, PseudoItemComponent component, GetVerbsEvent<InnateVerb> args)
@@ -96,6 +103,10 @@ public sealed class PseudoItemSystem : EntitySystem
 
         RemComp<ItemComponent>(uid);
         component.Active = false;
+
+        // Frontier
+        if (component.SleepAction is { Valid: true })
+            _actions.RemoveAction(uid, component.SleepAction);
     }
 
     private void OnGettingPickedUpAttempt(EntityUid uid, PseudoItemComponent component,
@@ -142,6 +153,10 @@ public sealed class PseudoItemSystem : EntitySystem
             return false;
         }
 
+        // Frontier
+        if (HasComp<AllowsSleepInsideComponent>(storageUid))
+            _actions.AddAction(toInsert, ref component.SleepAction, SleepingSystem.SleepActionId, toInsert);
+
         component.Active = true;
         return true;
     }
@@ -170,5 +185,12 @@ public sealed class PseudoItemSystem : EntitySystem
             return;
         // This hopefully shouldn't trigger, but this is a failsafe just in case so we dont bluespace them cats
         args.Cancel();
+    }
+
+    // Frontier
+    private void OnTrySleeping(EntityUid uid, PseudoItemComponent component, TryingToSleepEvent args)
+    {
+        if (!HasComp<SleepingComponent>(uid))
+            _popup.PopupEntity(Loc.GetString("popup-sleep-in-bag", ("entity", uid)), uid);
     }
 }

--- a/Content.Shared/Nyanotrasen/Item/Components/PseudoItemComponent.cs
+++ b/Content.Shared/Nyanotrasen/Item/Components/PseudoItemComponent.cs
@@ -12,4 +12,7 @@ public sealed partial class PseudoItemComponent : Component, ITransferredByCloni
     public int Size = 120;
 
     public bool Active = false;
+
+    [DataField]
+    public EntityUid? SleepAction;
 }

--- a/Resources/Locale/en-US/_NF/actions/sleep.ftl
+++ b/Resources/Locale/en-US/_NF/actions/sleep.ftl
@@ -1,0 +1,1 @@
+popup-sleep-in-bag = {THE($entity)} curls up and falls asleep.

--- a/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
@@ -26,6 +26,7 @@
   # to prevent bag open/honk spam
   - type: UseDelay
     delay: 0.5
+  - type: AllowsSleepInside
 
 - type: entity
   parent: ClothingBackpack


### PR DESCRIPTION
## About the PR
Allows pseudo-item creatures (small cats and vulps) to sleep while being placed inside a bag.

37 added lines, 0 removed

## Why / Balance
Amimir

I need it. Seriously.

## Technical details
Created a new component, AllowsSleepingInside, and added it to the base backpack item. Modified PseudoItemSystem to add/remove the sleep action when a pseudo-item entity gets into/out of a container with that component, and show a popup when it falls asleep.

## Media

https://github.com/new-frontiers-14/frontier-station-14/assets/69920617/2845d58c-bd9a-4821-a99a-55754fa79914

(Note: in the video the popup can show even when the entity is already asleep, I changed the code to prevent that)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None

**Changelog**
:cl:
- add: Scientists have discovered that small creatures can sleep inside bags.
