### PR TITLE
add 45cal to the Liberation machine

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/ammo.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/ammo.yml
@@ -16,5 +16,6 @@
     MagazineBoxRifle: 15
     MagazineBoxRifleRubber: 15
     MagazineBoxRiflePractice: 15
+    MagazineBoxMagnum: 15
   emaggedInventory:
     WeaponPistolViper: 1


### PR DESCRIPTION


## About the PR
Adds .45 cal magnum to the Liberation vending machine

## Why / Balance
Deckard is in the T2 gun safe, like all weapons you have a chance of it being nonlethal instead of lethal.  However, unlike all the other weapons in the Gunsafe pool,  You aren't able to buy lethal ammo for the Deckard (The T2 magnum weapon). Since the majority of the time you can obtain T2 weapon safes via expedition ships at the Lodge. Not having a way to buy .45, you can be stuck without your t2 weapon on expeditions which leaves you at a huge disadvantage instead. 

## Media

![image](https://github.com/new-frontiers-14/frontier-station-14/assets/150621839/c2cd089f-f6e2-4590-8dcd-d95e2f0773b5)

- [X] I have added screenshots/videos to this PR showcasing its changes in-game.

**Changelog**
add: .45 Magnum is added to the Liberation Station for $222
