### PR TITLE
Fix instant glass throwing

### DIFF
--- a/Content.Server/Hands/Systems/HandsSystem.cs
+++ b/Content.Server/Hands/Systems/HandsSystem.cs
@@ -165,7 +165,7 @@ namespace Content.Server.Hands.Systems
             if (playerSession == null)
                 return false;
 
-            if (playerSession.AttachedEntity is not { Valid: true } player ||
+            if (playerSession.AttachedEntity is not {Valid: true} player ||
                 !Exists(player) ||
                 ContainerSystem.IsEntityInContainer(player) ||
                 !TryComp(player, out HandsComponent? hands) ||

--- a/Content.Shared/Hands/Components/HandsComponent.cs
+++ b/Content.Shared/Hands/Components/HandsComponent.cs
@@ -57,6 +57,12 @@ public sealed partial class HandsComponent : Component
     ///     Used by the client.
     /// </summary>
     public readonly Dictionary<HandLocation, HashSet<string>> RevealedLayers = new();
+
+    // Frontier
+    /// <summary>
+    ///     The moment in time until which another item cannot be thrown.
+    /// </summary>
+    public TimeSpan NextThrowAfter;
 }
 
 [Serializable, NetSerializable]


### PR DESCRIPTION
## About the PR
Limits the amount of throws per second per entity to 4 (using in-game time, so less when time is diliated). If an entity tries to throw an item more than once per 250 milliseconds, it gets timed it for 0.67 sec each time it tries to make another throw

## Why / Balance
Shitters

## Technical details
Added a new field to HandsComponent, and added a check to HandsSystem.HandleThrowItem.

## Media
- [X] this PR does not require an ingame showcase

## Breaking changes
None

**Changelog**
:cl:
- fix: The number of items an entity can throw every second has been limited to 4.