### PR TITLE
ICR Chisel Update

### DIFF
--- a/Resources/Maps/_NF/Shuttles/chisel.yml
+++ b/Resources/Maps/_NF/Shuttles/chisel.yml
@@ -3,15 +3,15 @@ meta:
   postmapinit: false
 tilemap:
   0: Space
-  71: FloorRGlass
-  72: FloorReinforced
-  84: FloorSteel
-  89: FloorSteelDirty
-  92: FloorSteelMono
-  93: FloorSteelOffset
-  96: FloorTechMaint
-  112: Lattice
-  113: Plating
+  72: FloorRGlass
+  73: FloorReinforced
+  85: FloorSteel
+  90: FloorSteelDirty
+  93: FloorSteelMono
+  94: FloorSteelOffset
+  97: FloorTechMaint
+  113: Lattice
+  114: Plating
 entities:
 - proto: ""
   entities:
@@ -25,19 +25,19 @@ entities:
     - chunks:
         0,0:
           ind: 0,0
-          tiles: YAAAAAAAYAAAAAAAcQAAAAAAXQAAAAAAXQAAAAAAXQAAAAAAXAAAAAAARwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAYAAAAAAAcQAAAAAAXQAAAAAAXQAAAAAAXQAAAAAAXAAAAAAARwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXQAAAAAAYAAAAAAAcQAAAAAAXQAAAAAAXQAAAAAAXQAAAAAAXAAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAASAAAAAAASAAAAAAAcQAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAcQAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          tiles: YQAAAAAAYQAAAAAAcgAAAAAAXgAAAAAAXgAAAAAAXgAAAAAAXQAAAAAASAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYQAAAAAAYQAAAAAAcgAAAAAAXgAAAAAAXgAAAAAAXgAAAAAAXQAAAAAASAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXgAAAAAAYQAAAAAAcgAAAAAAXgAAAAAAXgAAAAAAXgAAAAAAXQAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAASQAAAAAASQAAAAAAcgAAAAAAXQAAAAAAXQAAAAAAXQAAAAAAcgAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
           version: 6
         -1,0:
           ind: -1,0
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAASAAAAAAAXQAAAAAAXQAAAAAAXQAAAAAAXQAAAAAAXQAAAAAAXQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAASAAAAAAAcQAAAAAAXQAAAAAAXQAAAAAAXQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAXAAAAAAAVAAAAAAAVAAAAAAAcQAAAAAAXQAAAAAAXQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARwAAAAAAXAAAAAAAVAAAAAAAVAAAAAAAVAAAAAAAcQAAAAAASAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARwAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAcQAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAARwAAAAAARwAAAAAARwAAAAAAcQAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAASQAAAAAAXgAAAAAAXgAAAAAAXgAAAAAAXgAAAAAAXgAAAAAAXgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcgAAAAAASQAAAAAAcgAAAAAAXgAAAAAAXgAAAAAAXgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAXQAAAAAAVQAAAAAAVQAAAAAAcgAAAAAAXgAAAAAAXgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAASAAAAAAAXQAAAAAAVQAAAAAAVQAAAAAAVQAAAAAAcgAAAAAASQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAASAAAAAAAXQAAAAAAXQAAAAAAXQAAAAAAXQAAAAAAcgAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAASAAAAAAASAAAAAAASAAAAAAAcgAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
           version: 6
         0,-1:
           ind: 0,-1
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAASAAAAAAAYAAAAAAAcQAAAAAAcAAAAAAAcQAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAASAAAAAAAYAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAASAAAAAAAYAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXQAAAAAAYAAAAAAAcQAAAAAASAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXQAAAAAAYAAAAAAAcQAAAAAAYAAAAAAAYAAAAAAAYAAAAAAAYAAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXQAAAAAAYAAAAAAASAAAAAAAXQAAAAAAXQAAAAAAXQAAAAAAYAAAAAAARwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAASQAAAAAAYQAAAAAAcgAAAAAAcQAAAAAAcgAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAASQAAAAAAYQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAASQAAAAAAYQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXgAAAAAAYQAAAAAAcgAAAAAASQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXgAAAAAAYQAAAAAAcgAAAAAAYQAAAAAAYQAAAAAAYQAAAAAAYQAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXgAAAAAAYQAAAAAASQAAAAAAXgAAAAAAXgAAAAAAXgAAAAAAYQAAAAAASAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
           version: 6
         -1,-1:
           ind: -1,-1
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcQAAAAAAcQAAAAAASAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAASAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAYAAAAAAAYAAAAAAAYAAAAAAAcQAAAAAASAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAWQAAAAAAXQAAAAAAXQAAAAAAXQAAAAAAXQAAAAAAXQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAASAAAAAAAXQAAAAAAXQAAAAAAXQAAAAAAXQAAAAAAXQAAAAAAXQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAASAAAAAAAXQAAAAAAXQAAAAAAXQAAAAAAXQAAAAAAXQAAAAAAXQAAAAAA
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcgAAAAAAcgAAAAAASQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAASQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAYQAAAAAAYQAAAAAAYQAAAAAAcgAAAAAASQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAWgAAAAAAXgAAAAAAXgAAAAAAXgAAAAAAXgAAAAAAXgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAASQAAAAAAXgAAAAAAXgAAAAAAXgAAAAAAXgAAAAAAXgAAAAAAXgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAASQAAAAAAXgAAAAAAXgAAAAAAXgAAAAAAXgAAAAAAXgAAAAAAXgAAAAAA
           version: 6
       type: MapGrid
     - type: Broadphase
@@ -337,35 +337,45 @@ entities:
           0,0:
             0: 65535
           0,1:
-            0: 2047
+            1: 2035
+            0: 12
           1,0:
-            0: 65535
+            0: 32767
+            1: 32768
           -2,0:
             0: 61166
           -1,0:
             0: 65535
           -1,1:
-            0: 3839
+            0: 55
+            1: 3784
           0,-2:
-            0: 65280
+            0: 63232
+            1: 2048
           0,-1:
             0: 65535
           1,-2:
-            0: 29440
+            0: 12544
+            1: 16896
           1,-1:
-            0: 65535
+            0: 65527
+            1: 8
           -1,-2:
-            0: 65280
+            1: 256
+            0: 65024
           -1,-1:
             0: 65535
           1,1:
-            0: 55
+            0: 3
+            1: 52
           -2,1:
-            0: 238
+            0: 206
+            1: 32
           -2,-1:
             0: 61164
           -2,-2:
-            0: 49152
+            1: 16384
+            0: 32768
         uniqueMixes:
         - volume: 2500
           temperature: 293.15
@@ -382,33 +392,27 @@ entities:
           - 0
           - 0
           - 0
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
         chunkSize: 4
       type: GridAtmosphere
     - type: GasTileOverlay
     - type: RadiationGridResistance
 - proto: AirAlarm
   entities:
-  - uid: 321
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -1.5,-3.5
-      parent: 1
-      type: Transform
-    - ShutdownSubscribers:
-      - 316
-      - 317
-      - 318
-      - 319
-      type: DeviceNetwork
-    - devices:
-      - 316
-      - 317
-      - 318
-      - 319
-      type: DeviceList
-    - enabled: False
-      type: AccessReader
-    - type: Emagged
   - uid: 322
     components:
     - rot: 1.5707963267948966 rad
@@ -416,14 +420,12 @@ entities:
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 315
       - 304
-      - 319
+      - 315
       type: DeviceNetwork
     - devices:
       - 315
       - 304
-      - 319
       type: DeviceList
     - enabled: False
       type: AccessReader
@@ -435,25 +437,30 @@ entities:
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 301
-      - 305
-      - 318
+      - 316
+      - 190
+      - 187
+      - 317
       type: DeviceNetwork
     - devices:
-      - 301
-      - 305
-      - 318
+      - 187
+      - 316
+      - 190
+      - 317
       type: DeviceList
     - enabled: False
       type: AccessReader
     - type: Emagged
 - proto: AirCanister
   entities:
-  - uid: 102
+  - uid: 188
     components:
-    - pos: -5.5,2.5
+    - anchored: True
+      pos: -2.5,4.5
       parent: 1
       type: Transform
+    - bodyType: Static
+      type: Physics
 - proto: AirlockCargoGlass
   entities:
   - uid: 122
@@ -494,7 +501,7 @@ entities:
       pos: -6.5,-0.5
       parent: 1
       type: Transform
-    - secondsUntilStateChange: -6034.745
+    - secondsUntilStateChange: -7573.943
       state: Opening
       type: Door
   - uid: 48
@@ -568,6 +575,138 @@ entities:
       pos: 0.5,3.5
       parent: 1
       type: Transform
+- proto: AtmosFixBlockerMarker
+  entities:
+  - uid: 216
+    components:
+    - pos: -5.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 217
+    components:
+    - pos: -3.5,-5.5
+      parent: 1
+      type: Transform
+  - uid: 218
+    components:
+    - pos: 3.5,-5.5
+      parent: 1
+      type: Transform
+  - uid: 219
+    components:
+    - pos: 5.5,-5.5
+      parent: 1
+      type: Transform
+  - uid: 220
+    components:
+    - pos: 6.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 226
+    components:
+    - pos: 7.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 227
+    components:
+    - pos: 7.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 238
+    components:
+    - pos: 6.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 241
+    components:
+    - pos: 5.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 250
+    components:
+    - pos: 4.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 251
+    components:
+    - pos: 3.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 260
+    components:
+    - pos: 2.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 265
+    components:
+    - pos: 1.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 266
+    components:
+    - pos: 0.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 270
+    components:
+    - pos: -0.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 272
+    components:
+    - pos: -1.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 273
+    components:
+    - pos: -2.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 278
+    components:
+    - pos: -1.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 290
+    components:
+    - pos: -0.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 301
+    components:
+    - pos: 0.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 305
+    components:
+    - pos: 1.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 307
+    components:
+    - pos: 2.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 321
+    components:
+    - pos: 1.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 326
+    components:
+    - pos: 0.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 327
+    components:
+    - pos: -0.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 328
+    components:
+    - pos: -6.5,5.5
+      parent: 1
+      type: Transform
 - proto: BlastDoor
   entities:
   - uid: 61
@@ -590,16 +729,92 @@ entities:
       - 52
       - 60
       type: DeviceLinkSink
+  - uid: 183
+    components:
+    - pos: 1.5,-3.5
+      parent: 1
+      type: Transform
+    - links:
+      - 189
+      type: DeviceLinkSink
+  - uid: 185
+    components:
+    - pos: 1.5,-5.5
+      parent: 1
+      type: Transform
+    - links:
+      - 189
+      type: DeviceLinkSink
+  - uid: 186
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 1.5,3.5
+      parent: 1
+      type: Transform
+    - links:
+      - 52
+      - 60
+      type: DeviceLinkSink
 - proto: CableApcExtension
   entities:
+  - uid: 31
+    components:
+    - pos: 3.5,-0.5
+      parent: 1
+      type: Transform
+  - uid: 33
+    components:
+    - pos: 0.5,-0.5
+      parent: 1
+      type: Transform
+  - uid: 39
+    components:
+    - pos: -0.5,-0.5
+      parent: 1
+      type: Transform
   - uid: 63
     components:
     - pos: 3.5,-3.5
       parent: 1
       type: Transform
+  - uid: 102
+    components:
+    - pos: -1.5,-0.5
+      parent: 1
+      type: Transform
   - uid: 136
     components:
-    - pos: 3.5,-4.5
+    - pos: -2.5,-0.5
+      parent: 1
+      type: Transform
+  - uid: 140
+    components:
+    - pos: -3.5,-0.5
+      parent: 1
+      type: Transform
+  - uid: 147
+    components:
+    - pos: 2.5,-0.5
+      parent: 1
+      type: Transform
+  - uid: 153
+    components:
+    - pos: 0.5,-2.5
+      parent: 1
+      type: Transform
+  - uid: 154
+    components:
+    - pos: 0.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 155
+    components:
+    - pos: -4.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 157
+    components:
+    - pos: 0.5,0.5
       parent: 1
       type: Transform
   - uid: 177
@@ -609,32 +824,27 @@ entities:
       type: Transform
   - uid: 178
     components:
-    - pos: 3.5,0.5
+    - pos: 0.5,1.5
       parent: 1
       type: Transform
   - uid: 179
     components:
-    - pos: 4.5,0.5
+    - pos: 0.5,2.5
       parent: 1
       type: Transform
   - uid: 180
     components:
-    - pos: 5.5,0.5
+    - pos: -3.5,-2.5
       parent: 1
       type: Transform
   - uid: 181
     components:
-    - pos: 6.5,0.5
+    - pos: 0.5,3.5
       parent: 1
       type: Transform
   - uid: 182
     components:
-    - pos: 6.5,1.5
-      parent: 1
-      type: Transform
-  - uid: 183
-    components:
-    - pos: 6.5,2.5
+    - pos: 0.5,4.5
       parent: 1
       type: Transform
   - uid: 184
@@ -642,89 +852,49 @@ entities:
     - pos: 5.5,2.5
       parent: 1
       type: Transform
-  - uid: 185
-    components:
-    - pos: 4.5,2.5
-      parent: 1
-      type: Transform
-  - uid: 186
-    components:
-    - pos: 3.5,2.5
-      parent: 1
-      type: Transform
-  - uid: 187
-    components:
-    - pos: 1.5,0.5
-      parent: 1
-      type: Transform
-  - uid: 188
-    components:
-    - pos: 0.5,0.5
-      parent: 1
-      type: Transform
-  - uid: 189
-    components:
-    - pos: -0.5,0.5
-      parent: 1
-      type: Transform
-  - uid: 190
-    components:
-    - pos: -1.5,0.5
-      parent: 1
-      type: Transform
-  - uid: 191
-    components:
-    - pos: -2.5,0.5
-      parent: 1
-      type: Transform
-  - uid: 192
-    components:
-    - pos: -3.5,0.5
-      parent: 1
-      type: Transform
   - uid: 193
     components:
-    - pos: -4.5,0.5
+    - pos: -3.5,-1.5
       parent: 1
       type: Transform
   - uid: 194
     components:
-    - pos: -5.5,0.5
+    - pos: -4.5,0.5
       parent: 1
       type: Transform
   - uid: 195
     components:
-    - pos: -6.5,0.5
+    - pos: 0.5,-1.5
       parent: 1
       type: Transform
   - uid: 196
     components:
-    - pos: 1.5,1.5
+    - pos: -4.5,-0.5
       parent: 1
       type: Transform
   - uid: 197
     components:
-    - pos: 1.5,2.5
+    - pos: 5.5,0.5
       parent: 1
       type: Transform
   - uid: 198
     components:
-    - pos: 1.5,3.5
+    - pos: 3.5,-2.5
       parent: 1
       type: Transform
   - uid: 199
     components:
-    - pos: 1.5,4.5
+    - pos: 3.5,-1.5
       parent: 1
       type: Transform
   - uid: 200
     components:
-    - pos: 0.5,3.5
+    - pos: 5.5,1.5
       parent: 1
       type: Transform
   - uid: 201
     components:
-    - pos: -0.5,3.5
+    - pos: 5.5,-0.5
       parent: 1
       type: Transform
   - uid: 202
@@ -734,82 +904,7 @@ entities:
       type: Transform
   - uid: 203
     components:
-    - pos: 1.5,-1.5
-      parent: 1
-      type: Transform
-  - uid: 204
-    components:
-    - pos: 1.5,-2.5
-      parent: 1
-      type: Transform
-  - uid: 205
-    components:
-    - pos: 1.5,-3.5
-      parent: 1
-      type: Transform
-  - uid: 206
-    components:
-    - pos: 1.5,-4.5
-      parent: 1
-      type: Transform
-  - uid: 207
-    components:
-    - pos: 1.5,-5.5
-      parent: 1
-      type: Transform
-  - uid: 208
-    components:
-    - pos: 0.5,-3.5
-      parent: 1
-      type: Transform
-  - uid: 209
-    components:
-    - pos: -0.5,-3.5
-      parent: 1
-      type: Transform
-  - uid: 210
-    components:
-    - pos: 0.5,-5.5
-      parent: 1
-      type: Transform
-  - uid: 211
-    components:
-    - pos: -0.5,-5.5
-      parent: 1
-      type: Transform
-  - uid: 212
-    components:
-    - pos: -3.5,-0.5
-      parent: 1
-      type: Transform
-  - uid: 213
-    components:
-    - pos: -3.5,-1.5
-      parent: 1
-      type: Transform
-  - uid: 216
-    components:
-    - pos: 3.5,-5.5
-      parent: 1
-      type: Transform
-  - uid: 217
-    components:
-    - pos: -4.5,-1.5
-      parent: 1
-      type: Transform
-  - uid: 218
-    components:
-    - pos: -5.5,-1.5
-      parent: 1
-      type: Transform
-  - uid: 219
-    components:
-    - pos: -6.5,-1.5
-      parent: 1
-      type: Transform
-  - uid: 220
-    components:
-    - pos: -6.5,-0.5
+    - pos: 4.5,-0.5
       parent: 1
       type: Transform
   - uid: 221
@@ -837,24 +932,9 @@ entities:
     - pos: -3.5,3.5
       parent: 1
       type: Transform
-  - uid: 226
-    components:
-    - pos: 1.5,5.5
-      parent: 1
-      type: Transform
-  - uid: 227
-    components:
-    - pos: 2.5,5.5
-      parent: 1
-      type: Transform
   - uid: 237
     components:
     - pos: 5.5,3.5
-      parent: 1
-      type: Transform
-  - uid: 238
-    components:
-    - pos: 5.5,5.5
       parent: 1
       type: Transform
   - uid: 239
@@ -862,49 +942,9 @@ entities:
     - pos: 4.5,-3.5
       parent: 1
       type: Transform
-  - uid: 241
-    components:
-    - pos: 5.5,4.5
-      parent: 1
-      type: Transform
   - uid: 249
     components:
     - pos: 5.5,-3.5
-      parent: 1
-      type: Transform
-  - uid: 250
-    components:
-    - pos: 6.5,-3.5
-      parent: 1
-      type: Transform
-  - uid: 251
-    components:
-    - pos: 4.5,-2.5
-      parent: 1
-      type: Transform
-  - uid: 260
-    components:
-    - pos: 7.5,-3.5
-      parent: 1
-      type: Transform
-  - uid: 265
-    components:
-    - pos: 3.5,-0.5
-      parent: 1
-      type: Transform
-  - uid: 266
-    components:
-    - pos: 3.5,-1.5
-      parent: 1
-      type: Transform
-  - uid: 272
-    components:
-    - pos: 4.5,-1.5
-      parent: 1
-      type: Transform
-  - uid: 273
-    components:
-    - pos: 4.5,-2.5
       parent: 1
       type: Transform
   - uid: 275
@@ -924,11 +964,6 @@ entities:
       type: Transform
 - proto: CableHV
   entities:
-  - uid: 39
-    components:
-    - pos: 5.5,-1.5
-      parent: 1
-      type: Transform
   - uid: 165
     components:
     - pos: 5.5,-1.5
@@ -1140,38 +1175,16 @@ entities:
       pos: -4.5,3.5
       parent: 1
       type: Transform
-- proto: ClothingBeltUtilityEngineering
+- proto: ComputerTabletopShuttle
   entities:
-  - uid: 157
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 153
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
-- proto: ClothingOuterHardsuitEngineering
-  entities:
-  - uid: 154
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 153
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
-- proto: ComputerShuttle
-  entities:
-  - uid: 140
+  - uid: 191
     components:
     - pos: -4.5,4.5
       parent: 1
       type: Transform
-- proto: ComputerStationRecords
+- proto: ComputerTabletopStationRecords
   entities:
-  - uid: 147
+  - uid: 192
     components:
     - pos: -3.5,4.5
       parent: 1
@@ -1312,17 +1325,6 @@ entities:
     - pos: 3.2484512,3.5189266
       parent: 1
       type: Transform
-- proto: DrinkFlask
-  entities:
-  - uid: 155
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 153
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
 - proto: DrinkMugBlue
   entities:
   - uid: 263
@@ -1394,19 +1396,11 @@ entities:
     - pos: -4.5,1.5
       parent: 1
       type: Transform
-    - ShutdownSubscribers:
-      - 323
-      - 321
-      type: DeviceNetwork
   - uid: 319
     components:
     - pos: 2.5,-0.5
       parent: 1
       type: Transform
-    - ShutdownSubscribers:
-      - 321
-      - 322
-      type: DeviceNetwork
 - proto: FoodBoxPizzaFilled
   entities:
   - uid: 152
@@ -1425,13 +1419,21 @@ entities:
       type: AtmosPipeColor
 - proto: GasPipeBend
   entities:
+  - uid: 209
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -2.5,3.5
+      parent: 1
+      type: Transform
+    - color: '#0000CCFF'
+      type: AtmosPipeColor
   - uid: 279
     components:
     - rot: 3.141592653589793 rad
       pos: -4.5,-0.5
       parent: 1
       type: Transform
-    - color: '#03FCD3FF'
+    - color: '#0000CCFF'
       type: AtmosPipeColor
   - uid: 285
     components:
@@ -1451,13 +1453,28 @@ entities:
       type: AtmosPipeColor
 - proto: GasPipeStraight
   entities:
+  - uid: 8
+    components:
+    - pos: -4.5,2.5
+      parent: 1
+      type: Transform
+    - color: '#0000CCFF'
+      type: AtmosPipeColor
+  - uid: 156
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -3.5,3.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
   - uid: 280
     components:
     - rot: 3.141592653589793 rad
       pos: -4.5,1.5
       parent: 1
       type: Transform
-    - color: '#03FCD3FF'
+    - color: '#0000CCFF'
       type: AtmosPipeColor
   - uid: 281
     components:
@@ -1465,7 +1482,7 @@ entities:
       pos: -4.5,0.5
       parent: 1
       type: Transform
-    - color: '#03FCD3FF'
+    - color: '#0000CCFF'
       type: AtmosPipeColor
   - uid: 282
     components:
@@ -1473,7 +1490,7 @@ entities:
       pos: -3.5,-0.5
       parent: 1
       type: Transform
-    - color: '#03FCD3FF'
+    - color: '#0000CCFF'
       type: AtmosPipeColor
   - uid: 283
     components:
@@ -1481,7 +1498,7 @@ entities:
       pos: -2.5,-0.5
       parent: 1
       type: Transform
-    - color: '#03FCD3FF'
+    - color: '#0000CCFF'
       type: AtmosPipeColor
   - uid: 284
     components:
@@ -1489,7 +1506,7 @@ entities:
       pos: -1.5,-0.5
       parent: 1
       type: Transform
-    - color: '#03FCD3FF'
+    - color: '#0000CCFF'
       type: AtmosPipeColor
   - uid: 286
     components:
@@ -1497,7 +1514,7 @@ entities:
       pos: 0.5,-0.5
       parent: 1
       type: Transform
-    - color: '#03FCD3FF'
+    - color: '#0000CCFF'
       type: AtmosPipeColor
   - uid: 287
     components:
@@ -1505,7 +1522,7 @@ entities:
       pos: 1.5,-0.5
       parent: 1
       type: Transform
-    - color: '#03FCD3FF'
+    - color: '#0000CCFF'
       type: AtmosPipeColor
   - uid: 288
     components:
@@ -1513,7 +1530,7 @@ entities:
       pos: 2.5,-0.5
       parent: 1
       type: Transform
-    - color: '#03FCD3FF'
+    - color: '#0000CCFF'
       type: AtmosPipeColor
   - uid: 289
     components:
@@ -1521,14 +1538,8 @@ entities:
       pos: 3.5,-0.5
       parent: 1
       type: Transform
-    - color: '#03FCD3FF'
+    - color: '#0000CCFF'
       type: AtmosPipeColor
-  - uid: 290
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 3.5,0.5
-      parent: 1
-      type: Transform
   - uid: 292
     components:
     - rot: -1.5707963267948966 rad
@@ -1601,14 +1612,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 307
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 0.5,2.5
-      parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
   - uid: 308
     components:
     - rot: 3.141592653589793 rad
@@ -1659,13 +1662,13 @@ entities:
       type: AtmosPipeColor
 - proto: GasPipeTJunction
   entities:
-  - uid: 278
+  - uid: 210
     components:
-    - rot: -1.5707963267948966 rad
-      pos: -4.5,2.5
+    - rot: 1.5707963267948966 rad
+      pos: -4.5,3.5
       parent: 1
       type: Transform
-    - color: '#03FCD3FF'
+    - color: '#0000CCFF'
       type: AtmosPipeColor
   - uid: 291
     components:
@@ -1673,7 +1676,7 @@ entities:
       pos: -0.5,-0.5
       parent: 1
       type: Transform
-    - color: '#03FCD3FF'
+    - color: '#0000CCFF'
       type: AtmosPipeColor
   - uid: 294
     components:
@@ -1692,16 +1695,43 @@ entities:
       type: AtmosPipeColor
 - proto: GasPort
   entities:
-  - uid: 270
+  - uid: 212
     components:
-    - rot: 1.5707963267948966 rad
-      pos: -5.5,2.5
+    - pos: -2.5,4.5
       parent: 1
       type: Transform
-    - color: '#03FCD3FF'
+    - color: '#0000CCFF'
+      type: AtmosPipeColor
+- proto: GasPressurePump
+  entities:
+  - uid: 204
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -3.5,3.5
+      parent: 1
+      type: Transform
+    - color: '#0000CCFF'
+      type: AtmosPipeColor
+  - uid: 208
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,2.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
       type: AtmosPipeColor
 - proto: GasVentPump
   entities:
+  - uid: 190
+    components:
+    - pos: -4.5,4.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 323
+      type: DeviceNetwork
+    - color: '#0000CCFF'
+      type: AtmosPipeColor
   - uid: 304
     components:
     - rot: -1.5707963267948966 rad
@@ -1711,17 +1741,7 @@ entities:
     - ShutdownSubscribers:
       - 322
       type: DeviceNetwork
-    - color: '#03FCD3FF'
-      type: AtmosPipeColor
-  - uid: 305
-    components:
-    - pos: -4.5,3.5
-      parent: 1
-      type: Transform
-    - ShutdownSubscribers:
-      - 323
-      type: DeviceNetwork
-    - color: '#03FCD3FF'
+    - color: '#0000CCFF'
       type: AtmosPipeColor
   - uid: 317
     components:
@@ -1729,15 +1749,15 @@ entities:
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 321
+      - 323
       type: DeviceNetwork
-    - color: '#03FCD3FF'
+    - color: '#0000CCFF'
       type: AtmosPipeColor
 - proto: GasVentScrubber
   entities:
-  - uid: 301
+  - uid: 187
     components:
-    - pos: -3.5,3.5
+    - pos: -3.5,4.5
       parent: 1
       type: Transform
     - ShutdownSubscribers:
@@ -1762,7 +1782,7 @@ entities:
       parent: 1
       type: Transform
     - ShutdownSubscribers:
-      - 321
+      - 323
       type: DeviceNetwork
     - color: '#990000FF'
       type: AtmosPipeColor
@@ -1831,61 +1851,13 @@ entities:
       pos: 6.5,2.5
       parent: 1
       type: Transform
-- proto: JetpackBlueFilled
+- proto: LockerQuarterMasterFilled
   entities:
-  - uid: 8
+  - uid: 211
     components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 153
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
-- proto: LockerCaptain
-  entities:
-  - uid: 153
-    components:
-    - pos: -2.5,4.5
+    - pos: -5.5,2.5
       parent: 1
       type: Transform
-    - locked: False
-      type: Lock
-    - air:
-        volume: 200
-        immutable: False
-        temperature: 147.92499
-        moles:
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-      type: EntityStorage
-    - containers:
-        entity_storage: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 8
-          - 31
-          - 33
-          - 156
-          - 154
-          - 155
-          - 157
-        paper_label: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
-      type: ContainerContainer
 - proto: LockerSalvageSpecialistFilled
   entities:
   - uid: 146
@@ -1900,17 +1872,6 @@ entities:
     - pos: -3.5,0.5
       parent: 1
       type: Transform
-- proto: NitrogenTankFilled
-  entities:
-  - uid: 31
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 153
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
 - proto: OreProcessor
   entities:
   - uid: 247
@@ -1926,17 +1887,6 @@ entities:
       pos: -5.5,3.5
       parent: 1
       type: Transform
-- proto: PenCap
-  entities:
-  - uid: 156
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 153
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
 - proto: PlasticFlapsAirtightClear
   entities:
   - uid: 55
@@ -2125,6 +2075,8 @@ entities:
         - Pressed: Toggle
         62:
         - Pressed: Toggle
+        186:
+        - Pressed: Toggle
       type: DeviceLinkSource
   - uid: 60
     components:
@@ -2136,6 +2088,22 @@ entities:
         61:
         - Pressed: Toggle
         62:
+        - Pressed: Toggle
+        186:
+        - Pressed: Toggle
+      type: DeviceLinkSource
+- proto: SignalButtonDirectional
+  entities:
+  - uid: 189
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 2.5,-2.5
+      parent: 1
+      type: Transform
+    - linkedPorts:
+        183:
+        - Pressed: Toggle
+        185:
         - Pressed: Toggle
       type: DeviceLinkSource
 - proto: SMESBasic
@@ -2161,6 +2129,20 @@ entities:
       pos: 4.5,1.5
       parent: 1
       type: Transform
+- proto: SpawnPointPilot
+  entities:
+  - uid: 207
+    components:
+    - pos: -4.5,3.5
+      parent: 1
+      type: Transform
+- proto: SpawnPointSalvageSpecialist
+  entities:
+  - uid: 213
+    components:
+    - pos: -1.5,0.5
+      parent: 1
+      type: Transform
 - proto: SubstationBasic
   entities:
   - uid: 254
@@ -2173,6 +2155,14 @@ entities:
   - uid: 166
     components:
     - pos: 5.5,-1.5
+      parent: 1
+      type: Transform
+- proto: SuitStorageWallmountQuartermaster
+  entities:
+  - uid: 329
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -2.5,2.5
       parent: 1
       type: Transform
 - proto: Table
@@ -2212,6 +2202,16 @@ entities:
   - uid: 144
     components:
     - pos: -5.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 205
+    components:
+    - pos: -3.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 206
+    components:
+    - pos: -4.5,4.5
       parent: 1
       type: Transform
 - proto: Thruster
@@ -2638,19 +2638,7 @@ entities:
   entities:
   - uid: 151
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 6.495593,1.2318751
+    - pos: 6.380465,1.3807236
       parent: 1
       type: Transform
-- proto: YellowOxygenTankFilled
-  entities:
-  - uid: 33
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 153
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
 ...

--- a/Resources/Prototypes/_NF/Shipyard/chisel.yml
+++ b/Resources/Prototypes/_NF/Shipyard/chisel.yml
@@ -1,3 +1,13 @@
+# Author Info
+# GitHub: Blackszedows (https://github.com/Blackszedows)
+# Discord: ???
+
+# Maintainer Info
+# GitHub: erhardsteinhauer
+# Discord: erhardsteinhauer
+
+# Shuttle Notes:
+# 
 - type: vessel
   id: Chisel
   name: ICR Chisel
@@ -5,12 +15,12 @@
   price: 31340
   category: Small
   group: Civilian
-  shuttlePath: /Maps/Shuttles/chisel.yml
+  shuttlePath: /Maps/_NF/Shuttles/chisel.yml
 
 - type: gameMap
   id: Chisel
   mapName: 'ICR Chisel'
-  mapPath: /Maps/Shuttles/chisel.yml
+  mapPath: /Maps/_NF/Shuttles/chisel.yml
   minPlayers: 0
   stations:
     Chisel:
@@ -25,3 +35,4 @@
           overflowJobs: []
           availableJobs:
             SalvageSpecialist: [ 0, 0 ]
+            Pilot: [ 0, 0 ]


### PR DESCRIPTION
## About the PR
Updating ICR Chisel to current mapping standards:
- Wiring rework.
- Atmos rework (initial atmos setup was introduced in this PR: https://github.com/new-frontiers-14/frontier-station-14/pull/708).
- Added blastdoors and linked control button to the southern conveyor line.
- Replaced custom filled captain's locker with QM's Locker and QM's Suit Wallstorage Unit.
- Replaced consoles with tabletop variants.
- Added Vacuum Markers to exposed to space tiles.
- Enabled Pilot Job.
- Moved ship.yml to Maps/_NF/Shuttles/

## Why / Balance
New mapping standards.

## Media
![2024-1-24_11 24 10](https://github.com/new-frontiers-14/frontier-station-14/assets/65374927/8689f5b0-fc1c-4882-8240-b570198c316c)
- [X] I have added screenshots/videos to this PR showcasing its changes ingame.

**Changelog**
:cl: erhardsteinhauer
- tweak: Updated ICR Chisel to current mapping standards.