### PR TITLE
Added Cyborg Charging Station & Cell Charger Machine Boards to Frontier CircuitVend

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -517,7 +517,7 @@
         Steel: 30
         Plastic: 30
     - type: StaticPrice
-      price: 15
+      price: 25
 
 - type: entity
   id: BorgChargerCircuitboard
@@ -539,7 +539,7 @@
         Steel: 30
         Plastic: 30
     - type: StaticPrice
-      price: 15
+      price: 25
 
 - type: entity
   id: WeaponCapacitorRechargerCircuitboard

--- a/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/circuitvend.yml
+++ b/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/circuitvend.yml
@@ -19,3 +19,5 @@
     UniformPrinterMachineCircuitboard: 4
     HydroponicsTrayMachineCircuitboard: 16
     TelecomServerCircuitboard: 6
+    BorgChargerCircuitboard: 8
+    CellRechargerCircuitboard: 8


### PR DESCRIPTION
## About the PR
I added two products to the CirctuitVend on Frontier Station, the Cyborg Recharging Station Machine Board and the Cell Recharger Machine Board

This is my first PR for anything ever, please be merciful.

## Why / Balance
Being a Cyborg on Frontier is difficult. 

To be even moderately useful to station crew, you need specialized modules. You can only get them from scientists who've researched them and have the available materials and machines to make them, who are usually off-station, but leaving the station and working with crew on ships without a charger (especially with your default battery) is very difficult.

Running out of power and hunting around for a charger and juggling power cells is not fun or good gameplay, and right now outside of autoclaving the boards, there's no reliable source beyond the single charger in Frontier maint tunnels. 

It's as if there was a single food vending machine in all of frontier hidden in a corner, and someone had to hand-feed you anything you brought off the station. 

These boards will add an easier way for cyborgs to work with the station crew, live their life, and get where they need to be without having to constantly fret about power levels.

## Technical details
Nothing complicated. Upped the price a little (They're still worth less than their mats when sold, no worries there) and added their entries to the vendor list.

## Media
![image](https://github.com/new-frontiers-14/frontier-station-14/assets/1471082/22e108e2-1e00-416f-8bb7-849c3b41fc80)

- [X ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
Shouldn't cause any problems, nothing fragile has been changed. 

**Changelog**
8 Cyborg Recharging Station Machine Boards and 8 Cell Recharger Machine Boards now available at Frontier Station's CirctuitVend. For the adventurous cyborg.
