### PR TITLE
Prospector (Update)

### DIFF
--- a/Resources/Maps/_NF/Shuttles/prospector.yml
+++ b/Resources/Maps/_NF/Shuttles/prospector.yml
@@ -3,12 +3,12 @@ meta:
   postmapinit: false
 tilemap:
   0: Space
-  27: FloorDark
-  84: FloorSteel
-  92: FloorSteelMono
-  96: FloorTechMaint
-  112: Lattice
-  113: Plating
+  28: FloorDark
+  85: FloorSteel
+  93: FloorSteelMono
+  97: FloorTechMaint
+  113: Lattice
+  114: Plating
 entities:
 - proto: ""
   entities:
@@ -21,19 +21,19 @@ entities:
     - chunks:
         -1,-1:
           ind: -1,-1
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAYAAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcQAAAAAAYAAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcQAAAAAAVAAAAAAAVAAAAAAAVAAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAACcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAADVAAAAAADXAAAAAABVAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAADVAAAAAABXAAAAAABXAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAAAVAAAAAADXAAAAAADXAAAAAAD
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcgAAAAAAYQAAAAAAYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcgAAAAAAYQAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcgAAAAAAVQAAAAAAVQAAAAAAVQAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAVQAAAAACcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAVQAAAAADVQAAAAADXQAAAAABVQAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAVQAAAAADVQAAAAABXQAAAAABXQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAVQAAAAAAVQAAAAADXQAAAAADXQAAAAAD
           version: 6
         0,-1:
           ind: 0,-1
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAYAAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVAAAAAACVAAAAAACcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcgAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYQAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAYQAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVQAAAAACVQAAAAACcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
           version: 6
         0,0:
           ind: 0,0
-          tiles: cQAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGwAAAAACGwAAAAADcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGwAAAAABGwAAAAADcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGwAAAAABGwAAAAACcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          tiles: cgAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHAAAAAACHAAAAAADcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHAAAAAABHAAAAAADcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHAAAAAABHAAAAAACcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
           version: 6
         -1,0:
           ind: -1,0
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAACVAAAAAABcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAACcQAAAAAAGwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcQAAAAAAGwAAAAABGwAAAAABGwAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcQAAAAAAGwAAAAADGwAAAAAAGwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAVQAAAAACVQAAAAABcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAVQAAAAACcgAAAAAAHAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcgAAAAAAHAAAAAABHAAAAAABHAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcgAAAAAAHAAAAAADHAAAAAAAHAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
           version: 6
       type: MapGrid
     - type: Broadphase
@@ -135,21 +135,25 @@ entities:
           -1,-1:
             0: 65535
           0,-1:
-            0: 30583
+            0: 4375
+            1: 26208
           -2,-1:
             0: 61166
           -2,-2:
-            0: 51200
+            1: 51200
           -1,-2:
-            0: 65535
+            1: 1
+            0: 65534
           0,-2:
-            0: 30583
+            0: 30579
+            1: 4
           0,0:
             0: 30583
           0,1:
             0: 7
           -2,0:
-            0: 36078
+            0: 238
+            1: 35840
           -1,0:
             0: 65535
           -1,1:
@@ -170,6 +174,21 @@ entities:
           - 0
           - 0
           - 0
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
         chunkSize: 4
       type: GridAtmosphere
     - type: GasTileOverlay
@@ -177,6 +196,16 @@ entities:
     - id: Prospector
       type: BecomesStation
     - type: SpreaderGrid
+- proto: ActionToggleLight
+  entities:
+  - uid: 164
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 160
+      type: Transform
+    - container: 160
+      type: InstantAction
 - proto: AirAlarm
   entities:
   - uid: 235
@@ -186,13 +215,9 @@ entities:
       type: Transform
     - ShutdownSubscribers:
       - 233
-      - 214
-      - 154
       type: DeviceNetwork
     - devices:
       - 233
-      - 214
-      - 154
       type: DeviceList
   - uid: 236
     components:
@@ -201,22 +226,27 @@ entities:
       parent: 201
       type: Transform
     - ShutdownSubscribers:
-      - 228
       - 213
-      - 153
+      - 227
+      - 228
+      - 215
       type: DeviceNetwork
     - devices:
       - 228
+      - 227
       - 213
-      - 153
+      - 215
       type: DeviceList
 - proto: AirCanister
   entities:
   - uid: 237
     components:
-    - pos: -5.5,-0.5
+    - anchored: True
+      pos: -5.5,-0.5
       parent: 201
       type: Transform
+    - bodyType: Static
+      type: Physics
 - proto: AirlockCargoGlass
   entities:
   - uid: 155
@@ -267,15 +297,6 @@ entities:
       type: Transform
 - proto: AppraisalTool
   entities:
-  - uid: 190
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 182
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
   - uid: 196
     components:
     - pos: 1.3489224,-4.3157334
@@ -308,47 +329,129 @@ entities:
     - pos: -6.5,0.5
       parent: 201
       type: Transform
-- proto: BlastDoorOpen
-  entities:
-  - uid: 8
-    components:
-    - pos: 0.5,-0.5
-      parent: 201
-      type: Transform
-    - links:
-      - 172
-      type: DeviceLinkSink
-  - uid: 9
-    components:
-    - pos: 0.5,-1.5
-      parent: 201
-      type: Transform
-    - links:
-      - 172
-      type: DeviceLinkSink
-  - uid: 10
-    components:
-    - pos: 0.5,-2.5
-      parent: 201
-      type: Transform
-    - links:
-      - 172
-      type: DeviceLinkSink
-  - uid: 25
+  - uid: 114
     components:
     - pos: -6.5,-2.5
       parent: 201
       type: Transform
-    - links:
-      - 172
-      type: DeviceLinkSink
-  - uid: 170
+- proto: AtmosFixBlockerMarker
+  entities:
+  - uid: 149
     components:
-    - pos: -4.5,-2.5
+    - pos: -5.5,-4.5
+      parent: 201
+      type: Transform
+  - uid: 183
+    components:
+    - pos: -4.5,-4.5
+      parent: 201
+      type: Transform
+  - uid: 184
+    components:
+    - pos: -4.5,-5.5
+      parent: 201
+      type: Transform
+  - uid: 185
+    components:
+    - pos: -3.5,-7.5
+      parent: 201
+      type: Transform
+  - uid: 186
+    components:
+    - pos: 2.5,-7.5
+      parent: 201
+      type: Transform
+  - uid: 187
+    components:
+    - pos: 2.5,-2.5
+      parent: 201
+      type: Transform
+  - uid: 188
+    components:
+    - pos: 2.5,-1.5
+      parent: 201
+      type: Transform
+  - uid: 189
+    components:
+    - pos: 2.5,-0.5
+      parent: 201
+      type: Transform
+  - uid: 190
+    components:
+    - pos: 1.5,-2.5
+      parent: 201
+      type: Transform
+  - uid: 191
+    components:
+    - pos: 1.5,-1.5
+      parent: 201
+      type: Transform
+  - uid: 192
+    components:
+    - pos: 1.5,-0.5
+      parent: 201
+      type: Transform
+  - uid: 193
+    components:
+    - pos: -4.5,3.5
+      parent: 201
+      type: Transform
+  - uid: 194
+    components:
+    - pos: -4.5,2.5
+      parent: 201
+      type: Transform
+  - uid: 195
+    components:
+    - pos: -5.5,2.5
+      parent: 201
+      type: Transform
+- proto: BlastDoor
+  entities:
+  - uid: 9
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,-2.5
       parent: 201
       type: Transform
     - links:
-      - 172
+      - 103
+      type: DeviceLinkSink
+  - uid: 10
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -4.5,-2.5
+      parent: 201
+      type: Transform
+    - links:
+      - 83
+      type: DeviceLinkSink
+  - uid: 25
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -6.5,-2.5
+      parent: 201
+      type: Transform
+    - links:
+      - 83
+      type: DeviceLinkSink
+  - uid: 171
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,-0.5
+      parent: 201
+      type: Transform
+    - links:
+      - 103
+      type: DeviceLinkSink
+  - uid: 172
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,-1.5
+      parent: 201
+      type: Transform
+    - links:
+      - 103
       type: DeviceLinkSink
 - proto: CableApcExtension
   entities:
@@ -402,114 +505,64 @@ entities:
     - pos: -2.5,2.5
       parent: 201
       type: Transform
-  - uid: 103
-    components:
-    - pos: -2.5,3.5
-      parent: 201
-      type: Transform
   - uid: 104
     components:
-    - pos: -1.5,3.5
+    - pos: -1.5,-1.5
       parent: 201
       type: Transform
   - uid: 105
     components:
-    - pos: -0.5,3.5
+    - pos: -0.5,-1.5
       parent: 201
       type: Transform
   - uid: 106
     components:
-    - pos: 0.5,3.5
+    - pos: -3.5,-1.5
       parent: 201
       type: Transform
   - uid: 107
     components:
-    - pos: 1.5,3.5
+    - pos: -4.5,-1.5
       parent: 201
       type: Transform
   - uid: 108
     components:
-    - pos: 1.5,2.5
+    - pos: 1.5,-5.5
       parent: 201
       type: Transform
   - uid: 109
     components:
-    - pos: 1.5,1.5
+    - pos: 0.5,-5.5
       parent: 201
       type: Transform
   - uid: 110
     components:
-    - pos: -1.5,-0.5
+    - pos: -0.5,-5.5
       parent: 201
       type: Transform
   - uid: 111
     components:
-    - pos: -0.5,-0.5
+    - pos: -1.5,-5.5
       parent: 201
       type: Transform
   - uid: 112
     components:
-    - pos: -0.5,-1.5
+    - pos: -1.5,2.5
       parent: 201
       type: Transform
   - uid: 113
     components:
-    - pos: -0.5,-2.5
+    - pos: -0.5,2.5
       parent: 201
       type: Transform
-  - uid: 114
+  - uid: 168
     components:
-    - pos: -0.5,-3.5
+    - pos: -3.5,0.5
       parent: 201
       type: Transform
-  - uid: 115
+  - uid: 210
     components:
-    - pos: -0.5,-4.5
-      parent: 201
-      type: Transform
-  - uid: 116
-    components:
-    - pos: -0.5,-5.5
-      parent: 201
-      type: Transform
-  - uid: 117
-    components:
-    - pos: 0.5,-5.5
-      parent: 201
-      type: Transform
-  - uid: 118
-    components:
-    - pos: 1.5,-5.5
-      parent: 201
-      type: Transform
-  - uid: 119
-    components:
-    - pos: -3.5,-0.5
-      parent: 201
-      type: Transform
-  - uid: 120
-    components:
-    - pos: -4.5,-0.5
-      parent: 201
-      type: Transform
-  - uid: 121
-    components:
-    - pos: -5.5,-0.5
-      parent: 201
-      type: Transform
-  - uid: 122
-    components:
-    - pos: -5.5,-1.5
-      parent: 201
-      type: Transform
-  - uid: 123
-    components:
-    - pos: -5.5,-2.5
-      parent: 201
-      type: Transform
-  - uid: 124
-    components:
-    - pos: -5.5,0.5
+    - pos: -4.5,0.5
       parent: 201
       type: Transform
 - proto: CableHV
@@ -585,39 +638,6 @@ entities:
       pos: 0.5,2.5
       parent: 201
       type: Transform
-- proto: ClothingBeltUtilityFilled
-  entities:
-  - uid: 184
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 182
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
-- proto: ClothingMaskGasExplorer
-  entities:
-  - uid: 195
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 182
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
-- proto: ClothingNeckCloakCap
-  entities:
-  - uid: 192
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 182
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
 - proto: ClothingNeckCloakMiner
   entities:
   - uid: 148
@@ -625,88 +645,16 @@ entities:
     - pos: 1.5,1.5000001
       parent: 201
       type: Transform
-- proto: ClothingOuterHardsuitSpatio
+- proto: ComputerTabletopShuttle
   entities:
-  - uid: 183
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 182
-      type: Transform
-    - group:
-      - hoverMessage: ""
-        contextText: verb-examine-group-other
-        icon: /Textures/Interface/examine-star.png
-        components:
-        - Armor
-        - ClothingSpeedModifier
-        entries:
-        - message: >-
-            It provides the following protection:
-
-            - [color=yellow]Blunt[/color] damage reduced by [color=lightblue]10%[/color].
-
-            - [color=yellow]Slash[/color] damage reduced by [color=lightblue]10%[/color].
-
-            - [color=yellow]Piercing[/color] damage reduced by [color=lightblue]5%[/color].
-
-            - [color=yellow]Heat[/color] damage reduced by [color=lightblue]10%[/color].
-
-            - [color=yellow]Radiation[/color] damage reduced by [color=lightblue]50%[/color].
-
-            - [color=yellow]Caustic[/color] damage reduced by [color=lightblue]10%[/color].
-          priority: 0
-          component: Armor
-        - message: >-
-            This decreases your running speed by [color=yellow]20%[/color].
-
-            This decreases your walking speed by [color=yellow]10%[/color].
-          priority: 0
-          component: ClothingSpeedModifier
-        title: null
-      type: GroupExamine
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
-- proto: ClothingOuterWinterMiner
-  entities:
-  - uid: 149
-    components:
-    - pos: 1.5,1.5000001
-      parent: 201
-      type: Transform
-- proto: ClothingShoesBootsMag
-  entities:
-  - uid: 185
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 182
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
-- proto: CombatKnife
-  entities:
-  - uid: 187
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 182
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
-- proto: ComputerShuttle
-  entities:
-  - uid: 125
+  - uid: 220
     components:
     - pos: 0.5,3.5
       parent: 201
       type: Transform
-- proto: ComputerStationRecords
+- proto: ComputerTabletopStationRecords
   entities:
-  - uid: 126
+  - uid: 221
     components:
     - rot: -1.5707963267948966 rad
       pos: 1.5,2.5
@@ -748,7 +696,7 @@ entities:
       parent: 201
       type: Transform
     - links:
-      - 168
+      - 179
       type: DeviceLinkSink
   - uid: 19
     components:
@@ -757,7 +705,7 @@ entities:
       parent: 201
       type: Transform
     - links:
-      - 168
+      - 179
       type: DeviceLinkSink
   - uid: 20
     components:
@@ -766,7 +714,7 @@ entities:
       parent: 201
       type: Transform
     - links:
-      - 168
+      - 179
       type: DeviceLinkSink
   - uid: 144
     components:
@@ -775,7 +723,7 @@ entities:
       parent: 201
       type: Transform
     - links:
-      - 168
+      - 179
       type: DeviceLinkSink
 - proto: DefibrillatorCabinetFilled
   entities:
@@ -823,36 +771,30 @@ entities:
     - pos: -2.5,1.5
       parent: 201
       type: Transform
-    - ShutdownSubscribers:
-      - 236
-      type: DeviceNetwork
   - uid: 154
     components:
     - pos: -2.5,-3.5
       parent: 201
       type: Transform
-    - ShutdownSubscribers:
-      - 235
-      type: DeviceNetwork
 - proto: GasPassiveVent
   entities:
-  - uid: 234
+  - uid: 123
     components:
     - rot: 1.5707963267948966 rad
-      pos: -4.5,-5.5
+      pos: -4.5,-4.5
       parent: 201
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
 - proto: GasPipeBend
   entities:
-  - uid: 179
+  - uid: 118
     components:
     - rot: 3.141592653589793 rad
-      pos: -2.5,-4.5
+      pos: -2.5,-5.5
       parent: 201
       type: Transform
-    - color: '#03FCD3FF'
+    - color: '#0000CCFF'
       type: AtmosPipeColor
   - uid: 198
     components:
@@ -860,15 +802,7 @@ entities:
       pos: -2.5,2.5
       parent: 201
       type: Transform
-    - color: '#03FCD3FF'
-      type: AtmosPipeColor
-  - uid: 229
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -0.5,-5.5
-      parent: 201
-      type: Transform
-    - color: '#990000FF'
+    - color: '#0000CCFF'
       type: AtmosPipeColor
 - proto: GasPipeFourway
   entities:
@@ -877,17 +811,54 @@ entities:
     - pos: -2.5,-0.5
       parent: 201
       type: Transform
-    - color: '#03FCD3FF'
+    - color: '#0000CCFF'
       type: AtmosPipeColor
 - proto: GasPipeStraight
   entities:
+  - uid: 119
+    components:
+    - pos: -2.5,-2.5
+      parent: 201
+      type: Transform
+    - color: '#0000CCFF'
+      type: AtmosPipeColor
+  - uid: 121
+    components:
+    - pos: -2.5,-4.5
+      parent: 201
+      type: Transform
+    - color: '#0000CCFF'
+      type: AtmosPipeColor
+  - uid: 124
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -3.5,-4.5
+      parent: 201
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 125
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -1.5,-4.5
+      parent: 201
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 126
+    components:
+    - pos: -2.5,-3.5
+      parent: 201
+      type: Transform
+    - color: '#0000CCFF'
+      type: AtmosPipeColor
   - uid: 178
     components:
     - rot: 3.141592653589793 rad
       pos: -2.5,1.5
       parent: 201
       type: Transform
-    - color: '#03FCD3FF'
+    - color: '#0000CCFF'
       type: AtmosPipeColor
   - uid: 203
     components:
@@ -895,15 +866,7 @@ entities:
       pos: -4.5,-0.5
       parent: 201
       type: Transform
-    - color: '#03FCD3FF'
-      type: AtmosPipeColor
-  - uid: 210
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -3.5,-0.5
-      parent: 201
-      type: Transform
-    - color: '#03FCD3FF'
+    - color: '#0000CCFF'
       type: AtmosPipeColor
   - uid: 212
     components:
@@ -911,7 +874,7 @@ entities:
       pos: -2.5,0.5
       parent: 201
       type: Transform
-    - color: '#03FCD3FF'
+    - color: '#0000CCFF'
       type: AtmosPipeColor
   - uid: 217
     components:
@@ -935,23 +898,7 @@ entities:
       pos: -2.5,-1.5
       parent: 201
       type: Transform
-    - color: '#03FCD3FF'
-      type: AtmosPipeColor
-  - uid: 220
-    components:
-    - rot: 3.141592653589793 rad
-      pos: -2.5,-2.5
-      parent: 201
-      type: Transform
-    - color: '#03FCD3FF'
-      type: AtmosPipeColor
-  - uid: 221
-    components:
-    - rot: 3.141592653589793 rad
-      pos: -2.5,-3.5
-      parent: 201
-      type: Transform
-    - color: '#03FCD3FF'
+    - color: '#0000CCFF'
       type: AtmosPipeColor
   - uid: 222
     components:
@@ -985,44 +932,20 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 230
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -1.5,-5.5
-      parent: 201
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 231
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -2.5,-5.5
-      parent: 201
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 232
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -3.5,-5.5
-      parent: 201
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
 - proto: GasPipeTJunction
   entities:
+  - uid: 117
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -0.5,-4.5
+      parent: 201
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
   - uid: 216
     components:
     - rot: -1.5707963267948966 rad
       pos: -0.5,-1.5
-      parent: 201
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 226
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -0.5,-4.5
       parent: 201
       type: Transform
     - color: '#990000FF'
@@ -1035,7 +958,25 @@ entities:
       pos: -5.5,-0.5
       parent: 201
       type: Transform
-    - color: '#03FCD3FF'
+    - color: '#0000CCFF'
+      type: AtmosPipeColor
+- proto: GasPressurePump
+  entities:
+  - uid: 120
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -3.5,-0.5
+      parent: 201
+      type: Transform
+    - color: '#0000CCFF'
+      type: AtmosPipeColor
+  - uid: 122
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -2.5,-4.5
+      parent: 201
+      type: Transform
+    - color: '#990000FF'
       type: AtmosPipeColor
 - proto: GasVentPump
   entities:
@@ -1048,18 +989,15 @@ entities:
     - ShutdownSubscribers:
       - 236
       type: DeviceNetwork
-    - color: '#03FCD3FF'
+    - color: '#0000CCFF'
       type: AtmosPipeColor
   - uid: 214
     components:
     - rot: -1.5707963267948966 rad
-      pos: -1.5,-4.5
+      pos: -1.5,-5.5
       parent: 201
       type: Transform
-    - ShutdownSubscribers:
-      - 235
-      type: DeviceNetwork
-    - color: '#03FCD3FF'
+    - color: '#0000CCFF'
       type: AtmosPipeColor
   - uid: 215
     components:
@@ -1067,7 +1005,10 @@ entities:
       pos: -1.5,-0.5
       parent: 201
       type: Transform
-    - color: '#03FCD3FF'
+    - ShutdownSubscribers:
+      - 236
+      type: DeviceNetwork
+    - color: '#0000CCFF'
       type: AtmosPipeColor
 - proto: GasVentScrubber
   entities:
@@ -1077,6 +1018,9 @@ entities:
       pos: -1.5,-1.5
       parent: 201
       type: Transform
+    - ShutdownSubscribers:
+      - 236
+      type: DeviceNetwork
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 228
@@ -1240,17 +1184,6 @@ entities:
     - pos: -4.5,2.5
       parent: 201
       type: Transform
-- proto: HandheldGPSBasic
-  entities:
-  - uid: 194
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 182
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
 - proto: IntercomSupply
   entities:
   - uid: 128
@@ -1271,65 +1204,13 @@ entities:
       pos: -6.5,1.5
       parent: 201
       type: Transform
-- proto: JetpackMiniFilled
+- proto: LockerQuarterMasterFilled
   entities:
-  - uid: 191
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 182
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
-- proto: LockerCaptain
-  entities:
-  - uid: 182
+  - uid: 8
     components:
     - pos: -0.5,3.5
       parent: 201
       type: Transform
-    - air:
-        volume: 200
-        immutable: False
-        temperature: 293.1496
-        moles:
-        - 1.8856695
-        - 7.0937095
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-      type: EntityStorage
-    - containers:
-        entity_storage: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 195
-          - 194
-          - 183
-          - 184
-          - 185
-          - 186
-          - 187
-          - 188
-          - 189
-          - 190
-          - 191
-          - 192
-          - 193
-        paper_label: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
-      type: ContainerContainer
 - proto: LockerSalvageSpecialistFilled
   entities:
   - uid: 159
@@ -1344,17 +1225,6 @@ entities:
     - pos: 1.6783751,-4.3457556
       parent: 201
       type: Transform
-- proto: NitrogenTankFilled
-  entities:
-  - uid: 188
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 182
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
 - proto: OreProcessor
   entities:
   - uid: 152
@@ -1364,20 +1234,12 @@ entities:
       type: Transform
 - proto: Pickaxe
   entities:
-  - uid: 160
+  - uid: 182
     components:
-    - pos: 2.2407923,-1.5702498
+    - rot: 1.5707963267948966 rad
+      pos: 2.3781967,-1.4218146
       parent: 201
       type: Transform
-  - uid: 193
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 182
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
 - proto: PlasticFlapsAirtightClear
   entities:
   - uid: 26
@@ -1392,15 +1254,20 @@ entities:
       type: Transform
 - proto: PortableGeneratorPacman
   entities:
-  - uid: 83
+  - uid: 205
     components:
-    - pos: 0.5,-6.5
+    - anchored: True
+      pos: 0.5,-6.5
       parent: 201
       type: Transform
     - storage:
         Plasma: 1500
       type: MaterialStorage
-    - type: InsertingMaterialStorage
+    - bodyType: Static
+      type: Physics
+    - endTime: 0
+      type: InsertingMaterialStorage
+    - type: ItemCooldown
 - proto: PottedPlantRandomPlastic
   entities:
   - uid: 167
@@ -1425,13 +1292,6 @@ entities:
       type: Transform
     - powerLoad: 0
       type: ApcPowerReceiver
-  - uid: 164
-    components:
-    - pos: -4.5,-4.5
-      parent: 201
-      type: Transform
-    - powerLoad: 0
-      type: ApcPowerReceiver
   - uid: 165
     components:
     - rot: 3.141592653589793 rad
@@ -1440,14 +1300,11 @@ entities:
       type: Transform
     - powerLoad: 0
       type: ApcPowerReceiver
-  - uid: 166
+  - uid: 170
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 0.5,-6.5
+    - pos: -1.5,-4.5
       parent: 201
       type: Transform
-    - powerLoad: 0
-      type: ApcPowerReceiver
 - proto: PoweredlightSodium
   entities:
   - uid: 162
@@ -1572,29 +1429,42 @@ entities:
     - pos: -4.5,-0.5
       parent: 201
       type: Transform
-- proto: SignalButton
+- proto: SheetPlasma
   entities:
-  - uid: 171
+  - uid: 166
+    components:
+    - pos: 0.4796412,-5.530752
+      parent: 201
+      type: Transform
+    - count: 15
+      type: Stack
+    - size: 15
+      type: Item
+- proto: SignalButtonDirectional
+  entities:
+  - uid: 83
     components:
     - rot: 3.141592653589793 rad
       pos: -3.5,-3.5
       parent: 201
       type: Transform
-  - uid: 172
+    - linkedPorts:
+        10:
+        - Pressed: Toggle
+        25:
+        - Pressed: Toggle
+      type: DeviceLinkSource
+  - uid: 103
     components:
     - pos: -1.5,0.5
       parent: 201
       type: Transform
     - linkedPorts:
-        8:
+        171:
+        - Pressed: Toggle
+        172:
         - Pressed: Toggle
         9:
-        - Pressed: Toggle
-        10:
-        - Pressed: Toggle
-        170:
-        - Pressed: Toggle
-        25:
         - Pressed: Toggle
       type: DeviceLinkSource
 - proto: SignMinerDock
@@ -1670,6 +1540,18 @@ entities:
       type: Transform
 - proto: TableReinforced
   entities:
+  - uid: 115
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 1.5,2.5
+      parent: 201
+      type: Transform
+  - uid: 116
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 0.5,3.5
+      parent: 201
+      type: Transform
   - uid: 127
     components:
     - rot: -1.5707963267948966 rad
@@ -1709,9 +1591,28 @@ entities:
       type: Transform
 - proto: TwoWayLever
   entities:
-  - uid: 168
+  - uid: 169
     components:
-    - pos: -3.5,-0.5
+    - pos: 2.5,-0.5
+      parent: 201
+      type: Transform
+    - linkedPorts:
+        16:
+        - Left: Forward
+        - Right: Reverse
+        - Middle: Off
+        15:
+        - Left: Forward
+        - Right: Reverse
+        - Middle: Off
+        14:
+        - Left: Forward
+        - Right: Reverse
+        - Middle: Off
+      type: DeviceLinkSource
+  - uid: 179
+    components:
+    - pos: -2.5,-0.5
       parent: 201
       type: Transform
     - linkedPorts:
@@ -1728,25 +1629,6 @@ entities:
         - Right: Reverse
         - Middle: Off
         20:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-      type: DeviceLinkSource
-  - uid: 169
-    components:
-    - pos: 2.5,-0.5
-      parent: 201
-      type: Transform
-    - linkedPorts:
-        16:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        15:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        14:
         - Left: Forward
         - Right: Reverse
         - Middle: Off
@@ -1898,23 +1780,19 @@ entities:
       type: Transform
 - proto: WeaponCrusherGlaive
   entities:
-  - uid: 205
+  - uid: 160
     components:
-    - rot: 1.5707963267948966 rad
-      pos: 2.2446246,-1.5375146
+    - pos: 2.5188217,-1.4061896
       parent: 201
       type: Transform
-- proto: WeaponProtoKineticAccelerator
-  entities:
-  - uid: 186
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 182
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
+    - toggleActionEntity: 164
+      type: UnpoweredFlashlight
+    - type: ActionsContainer
+    - containers:
+        actions: !type:Container
+          ents:
+          - 164
+      type: ContainerContainer
 - proto: Window
   entities:
   - uid: 55
@@ -1932,18 +1810,7 @@ entities:
   entities:
   - uid: 241
     components:
-    - pos: 0.5,-5.5
+    - pos: 0.4483912,-5.452627
       parent: 201
       type: Transform
-- proto: YellowOxygenTankFilled
-  entities:
-  - uid: 189
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 182
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
 ...

--- a/Resources/Maps/_NF/Shuttles/prospector.yml
+++ b/Resources/Maps/_NF/Shuttles/prospector.yml
@@ -1265,8 +1265,7 @@ entities:
       type: MaterialStorage
     - bodyType: Static
       type: Physics
-    - endTime: 0
-      type: InsertingMaterialStorage
+    - type: InsertingMaterialStorage
     - type: ItemCooldown
 - proto: PottedPlantRandomPlastic
   entities:
@@ -1519,16 +1518,18 @@ entities:
     - pos: -1.5,-6.5
       parent: 201
       type: Transform
+- proto: SuitStorageQuartermaster
+  entities:
+  - uid: 202
+    components:
+    - pos: -1.5,3.5
+      parent: 201
+      type: Transform
 - proto: SuitStorageSalv
   entities:
   - uid: 146
     components:
     - pos: 0.5,-4.5
-      parent: 201
-      type: Transform
-  - uid: 202
-    components:
-    - pos: -1.5,3.5
       parent: 201
       type: Transform
 - proto: Table

--- a/Resources/Prototypes/_NF/Shipyard/prospector.yml
+++ b/Resources/Prototypes/_NF/Shipyard/prospector.yml
@@ -1,3 +1,13 @@
+# Author Info
+# GitHub: ???
+# Discord: ???
+
+# Maintainer Info
+# GitHub: ???
+# Discord: ???
+
+# Shuttle Notes:
+#
 - type: vessel
   id: Prospector
   name: NC Prospector
@@ -5,12 +15,12 @@
   price: 23000
   category: Small
   group: Civilian
-  shuttlePath: /Maps/Shuttles/prospector.yml
+  shuttlePath: /Maps/_NF/Shuttles/prospector.yml
 
 - type: gameMap
   id: Prospector
   mapName: 'NC Prospector'
-  mapPath: /Maps/Shuttles/prospector.yml
+  mapPath: /Maps/_NF/Shuttles/prospector.yml
   minPlayers: 0
   stations:
     Prospector:


### PR DESCRIPTION
## About the PR
Updating NC Prospector to current mapping standards:
- Wiring rework.
- Atmos rework (initial atmos setup was introduced in this PR: https://github.com/new-frontiers-14/frontier-station-14/pull/708).
- Replaced custom filled captain's locker with QM's Locker.
- Replaced consoles with tabletop variants.
- Added Vacuum Markers to exposed to space tiles.
- Moved ship.yml to Maps/_NF/Shuttles/

## Why / Balance
New mapping standards.

## Media
![2024-1-28_15 09 31](https://github.com/new-frontiers-14/frontier-station-14/assets/65374927/b0fc12c2-9bd4-4e50-873e-a9e603457dc9)
- [X] I have added screenshots/videos to this PR showcasing its changes ingame.

**Changelog**
:cl: erhardsteinhauer
- tweak: Updated NC Prospector to current mapping standards.