### PR TITLE
Cargo Cleanup

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_armory.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_armory.yml
@@ -18,15 +18,15 @@
   # category: Armory
   # group: market
 
-- type: cargoProduct
-  id: TrackingImplant
-  icon:
-    sprite: Objects/Specific/Medical/implanter.rsi
-    state: implanter0
-  product: CrateTrackingImplants
-  cost: 1000
-  category: Armory
-  group: market
+# - type: cargoProduct
+  # id: TrackingImplant
+  # icon:
+    # sprite: Objects/Specific/Medical/implanter.rsi
+    # state: implanter0
+  # product: CrateTrackingImplants
+  # cost: 1000
+  # category: Armory
+  # group: market
 
 # - type: cargoProduct
   # id: ArmoryLaser
@@ -48,12 +48,12 @@
 #  category: Armory
 #  group: market
 
-- type: cargoProduct
-  id: TrainingBombs
-  icon:
-    sprite: Structures/Machines/bomb.rsi
-    state: training-bomb
-  product: CrateTrainingBombs
-  cost: 3000
-  category: Armory
-  group: market
+# - type: cargoProduct
+  # id: TrainingBombs
+  # icon:
+    # sprite: Structures/Machines/bomb.rsi
+    # state: training-bomb
+  # product: CrateTrainingBombs
+  # cost: 3000
+  # category: Armory
+  # group: market

--- a/Resources/Prototypes/Catalog/Cargo/cargo_fun.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_fun.yml
@@ -58,15 +58,15 @@
   # category: Fun
   # group: market
 
-- type: cargoProduct
-  id: FunArtSupplies
-  icon:
-    sprite: Objects/Fun/crayons.rsi
-    state: box
-  product: CrateFunArtSupplies
-  cost: 500
-  category: Fun
-  group: market
+# - type: cargoProduct
+  # id: FunArtSupplies
+  # icon:
+    # sprite: Objects/Fun/crayons.rsi
+    # state: box
+  # product: CrateFunArtSupplies
+  # cost: 500
+  # category: Fun
+  # group: market
 
 - type: cargoProduct
   id: FunParty
@@ -78,35 +78,35 @@
   category: Fun
   group: market
 
-- type: cargoProduct
-  id: CrateFunWaterGuns
-  icon:
-    sprite: Objects/Weapons/Guns/Pistols/water_pistol.rsi
-    state: display
-  product: CrateFunWaterGuns
-  cost: 1100
-  category: Fun
-  group: market
+# - type: cargoProduct
+  # id: CrateFunWaterGuns
+  # icon:
+    # sprite: Objects/Weapons/Guns/Pistols/water_pistol.rsi
+    # state: display
+  # product: CrateFunWaterGuns
+  # cost: 1100
+  # category: Fun
+  # group: market
 
-- type: cargoProduct
-  id: FunPlushies
-  icon:
-    sprite: Objects/Fun/toys.rsi
-    state: plushie_h
-  product: CrateFunPlushie
-  cost: 1000
-  category: Fun
-  group: market
+# - type: cargoProduct
+  # id: FunPlushies
+  # icon:
+    # sprite: Objects/Fun/toys.rsi
+    # state: plushie_h
+  # product: CrateFunPlushie
+  # cost: 1000
+  # category: Fun
+  # group: market
 
-- type: cargoProduct
-  id: FunBoardGames
-  icon:
-    sprite: Objects/Fun/dice.rsi
-    state: d6_6
-  product: CrateFunBoardGames
-  cost: 1500
-  category: Fun
-  group: market
+# - type: cargoProduct
+  # id: FunBoardGames
+  # icon:
+    # sprite: Objects/Fun/dice.rsi
+    # state: d6_6
+  # product: CrateFunBoardGames
+  # cost: 1500
+  # category: Fun
+  # group: market
 
 - type: cargoProduct
   id: FunATV
@@ -118,82 +118,82 @@
   category: Fun
   group: market
 
-- type: cargoProduct
-  id: FunSadTromboneImplants
-  icon:
-    sprite: Objects/Specific/Medical/implanter.rsi
-    state: implanter0
-  product: CrateFunSadTromboneImplants
-  cost: 1000
-  category: Fun
-  group: market
+# - type: cargoProduct
+  # id: FunSadTromboneImplants
+  # icon:
+    # sprite: Objects/Specific/Medical/implanter.rsi
+    # state: implanter0
+  # product: CrateFunSadTromboneImplants
+  # cost: 1000
+  # category: Fun
+  # group: market
 
-- type: cargoProduct
-  id: FunLightImplants
-  icon:
-    sprite: Objects/Specific/Medical/implanter.rsi
-    state: implanter0
-  product: CrateFunLightImplants
-  cost: 1000
-  category: Fun
-  group: market
+# - type: cargoProduct
+  # id: FunLightImplants
+  # icon:
+    # sprite: Objects/Specific/Medical/implanter.rsi
+    # state: implanter0
+  # product: CrateFunLightImplants
+  # cost: 1000
+  # category: Fun
+  # group: market
 
-- type: cargoProduct
-  id: FunBoxing
-  icon:
-    sprite: Clothing/Hands/Gloves/Boxing/boxingred.rsi
-    state: icon
-  product: CrateFunBoxing
-  cost: 500
-  category: Fun
-  group: market
+# - type: cargoProduct
+  # id: FunBoxing
+  # icon:
+    # sprite: Clothing/Hands/Gloves/Boxing/boxingred.rsi
+    # state: icon
+  # product: CrateFunBoxing
+  # cost: 500
+  # category: Fun
+  # group: market
 
-- type: cargoProduct
-  id: FunPirate
-  icon:
-    sprite: Structures/Storage/Crates/piratechest.rsi
-    state: crate_icon
-  product: CrateFunPirate
-  cost: 400
-  category: Fun
-  group: market
+# - type: cargoProduct
+  # id: FunPirate
+  # icon:
+    # sprite: Structures/Storage/Crates/piratechest.rsi
+    # state: crate_icon
+  # product: CrateFunPirate
+  # cost: 400
+  # category: Fun
+  # group: market
 
-- type: cargoProduct
-  id: FunToyBox
-  icon:
-    sprite: Structures/Storage/Crates/toybox.rsi
-    state: crate_icon
-  product: CrateFunToyBox
-  cost: 1400
-  category: Fun
-  group: market
+# - type: cargoProduct
+  # id: FunToyBox
+  # icon:
+    # sprite: Structures/Storage/Crates/toybox.rsi
+    # state: crate_icon
+  # product: CrateFunToyBox
+  # cost: 1400
+  # category: Fun
+  # group: market
 
-- type: cargoProduct
-  id: FunBikeHornImplants
-  icon:
-    sprite: Objects/Specific/Medical/implanter.rsi
-    state: implanter0
-  product: CrateFunBikeHornImplants
-  cost: 1000
-  category: Fun
-  group: market
+# - type: cargoProduct
+  # id: FunBikeHornImplants
+  # icon:
+    # sprite: Objects/Specific/Medical/implanter.rsi
+    # state: implanter0
+  # product: CrateFunBikeHornImplants
+  # cost: 1000
+  # category: Fun
+  # group: market
 
-- type: cargoProduct
-  id: FunMysteryFigurines
-  icon:
-    sprite: Objects/Fun/figurines.rsi
-    state: fig_box
-  product: CrateFunMysteryFigurines
-  cost: 4000
-  category: Fun
-  group: market
+# - type: cargoProduct
+  # id: FunMysteryFigurines
+  # icon:
+    # sprite: Objects/Fun/figurines.rsi
+    # state: fig_box
+  # product: CrateFunMysteryFigurines
+  # cost: 4000
+  # category: Fun
+  # group: market
   
-- type: cargoProduct
-  id: FunDartsSet
-  icon:
-    sprite: Objects/Fun/Darts/dart_red.rsi
-    state: icon
-  product: CrateFunDartsSet
-  cost: 900
-  category: Fun
-  group: market
+# - type: cargoProduct
+  # id: FunDartsSet
+  # icon:
+    # sprite: Objects/Fun/Darts/dart_red.rsi
+    # state: icon
+  # product: CrateFunDartsSet
+  # cost: 900
+  # category: Fun
+  # group: market

--- a/Resources/Prototypes/Catalog/Cargo/cargo_medical.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_medical.yml
@@ -98,15 +98,15 @@
   category: Medical
   group: market
 
-- type: cargoProduct
-  id: MedicalMindShieldImplants
-  icon:
-    sprite: Objects/Specific/Medical/implanter.rsi
-    state: implanter0
-  product: CrateMindShieldImplants
-  cost: 3000
-  category: Medical
-  group: market
+# - type: cargoProduct
+  # id: MedicalMindShieldImplants
+  # icon:
+    # sprite: Objects/Specific/Medical/implanter.rsi
+    # state: implanter0
+  # product: CrateMindShieldImplants
+  # cost: 3000
+  # category: Medical
+  # group: market
 
 - type: cargoProduct
   id: ChemistryP

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/medical.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/medical.yml
@@ -7,4 +7,7 @@
     Bloodpack: 15
     EpinephrineChemistryBottle: 9
     Syringe: 9
-    MedicalTrackingImplanter: 20
+    MedicalTrackingImplanter: 20 # Frontier
+    SadTromboneImplanter: 10 # Frontier
+    BikeHornImplanter: 10 # Frontier
+    LightImplanter: 10 # Frontier

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/sec.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/sec.yml
@@ -17,6 +17,8 @@
     Stunbaton: 10
     WeaponDisabler: 10
     CrowbarRed: 10 # Frontier
+    CrateTrackingImplants: 5 # Frontier
+#    CrateMindShieldImplants: 5 # Frontier
   # security officers need to follow a diet regimen!
   contrabandInventory:
     FoodDonutHomer: 3 # Frontier - No more then 3

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/sec.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/sec.yml
@@ -17,8 +17,8 @@
     Stunbaton: 10
     WeaponDisabler: 10
     CrowbarRed: 10 # Frontier
-    CrateTrackingImplants: 5 # Frontier
-#    CrateMindShieldImplants: 5 # Frontier
+    TrackingImplanter: 5 # Frontier
+#    MindShieldImplanter: 5 # Frontier
   # security officers need to follow a diet regimen!
   contrabandInventory:
     FoodDonutHomer: 3 # Frontier - No more then 3

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/theater.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/theater.yml
@@ -25,6 +25,7 @@
     ClothingOuterSuitChicken: 2
     ClothingHeadHatChickenhead: 2
     ClothingOuterSuitMonkey: 2
+    ClothingHeadHatAnimalMonkey: 2
     ClothingHeadHatPumpkin: 2
     ClothingHeadHatShrineMaidenWig: 2
     ClothingOuterSuitShrineMaiden: 2
@@ -44,6 +45,26 @@
     ClothingHeadHatHairflower: 1
     ClothingHeadHatGladiator: 1
     ClothingUniformJumpsuitGladiator: 1
+    ClothingUniformJumpskirtPerformer: 2
+    ClothingShoesBootsPerformer: 2
+    ClothingNeckCloakMoth: 2
+    ClothingMaskClown: 2
+    ClothingMaskMime: 2
+    ClothingShoesClown: 2
+    ClothingUniformJumpskirtJanimaid: 2
+    ClothingHeadBandRed: 1
+    ClothingHeadHatPirate: 1
+    ClothingOuterCoatPirate: 1
+    ClothingUniformJumpsuitPirate: 1
+    ClothingEyesEyepatch: 2
+    ClothingShoesBootsLaceup: 2
+    FoamCutlass: 2
+    ClothingHandsGlovesBoxingRed: 2
+    ClothingHandsGlovesBoxingBlue: 2
+    ClothingHandsGlovesBoxingYellow: 2
+    ClothingHandsGlovesBoxingGreen: 2
+    UniformShortsRed: 4
+    UniformShortsRedWithTop: 4
     RubberStampClown: 1
     RubberStampMime: 1
   emaggedInventory:

--- a/Resources/Prototypes/Entities/Objects/Vehicles/buckleable.yml
+++ b/Resources/Prototypes/Entities/Objects/Vehicles/buckleable.yml
@@ -82,7 +82,7 @@
           params:
             volume: -3
   - type: StaticPrice
-    price: 750 # Grand Theft Auto.
+    price: 200 # Grand Theft Auto. # Frontier 750<200
 
 - type: entity
   id: VehicleJanicart

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/watergun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/watergun.yml
@@ -45,7 +45,7 @@
   - type: ExaminableSolution
     solution: chamber
   - type: StaticPrice
-    price: 100
+    price: 30 # Frontier 100<30
   - type: PhysicalComposition
     materialComposition:
       Plastic: 150

--- a/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/cuddlycritter.yml
+++ b/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/cuddlycritter.yml
@@ -6,6 +6,8 @@
     PlushieLizard: 3
     PlushieSpaceLizard: 3
     PlushieVox: 3
+    PlushieRouny: 3
+    PlushieMoth: 3
     PlushieMoff: 3
     PlushieMoffsician: 3
     PlushieMoffbar: 3
@@ -18,18 +20,41 @@
     PlushieSlime: 3
     PlushieSnake: 3
     PlushieCarp: 3
+    PlushieAtmosian: 3
+    PlushieXeno: 3
     PlasticBanana: 3
-    BeachBall: 2
-    Basketball: 2
-    Football: 2
-    ToyHammer: 2
-    WhoopieCushion: 2
+    BeachBall: 3
+    Basketball: 3
+    Football: 3
+    ToyHammer: 3
+    WhoopieCushion: 3
+    MrChips: 1
+    MrDips: 1
+    RevolverCapGun: 2
+    VehicleUnicycleFolded: 2
+    ClothingHeadHatMagician: 2
     ClownRecorder: 1
     PonderingOrb: 1
+    CrayonBox: 10
     CrayonRainbow: 5
+    WeaponWaterPistol: 8
+    WeaponWaterBlaster: 4
+    TargetDarts: 1
+    BoxDarts: 2
+    ChessBoard: 2
+    BackgammonBoard: 2
+    ParchisBoard: 1
+    CheckerBoard: 1
+    ShipBattlemap: 1
+    SnowBattlemap: 1
+    SandBattlemap: 1
+    MoonBattlemap: 1
+    GrassBattlemap: 1
+    DiceBag: 6
     PrizeBall: 10
   contrabandInventory:
     PlushieLamp: 3
+    CrazyGlue: 1
   emaggedInventory:
     PlushieJester: 3
     PlushieNuke: 3

--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/vending_machines.yml
@@ -29,7 +29,7 @@
     energy: 1.6
     color: "#4b93ad"
   - type: MarketModifier
-    mod: 10
+    mod: 15
 
 - type: entity
   parent: VendingMachine


### PR DESCRIPTION
## About the PR
Removing crates from cargo for cleanup.
All implants moved to vending
Most "Fun" crates items moved to vending
Removed TrainingBomb from cargo
Removed MindShield from cargo

## Why / Balance
Cargo depo cleanup

## Technical details
.yml

## Media
- [X] this PR does not require an ingame showcase

## Breaking changes
N/A

**Changelog**
:cl: dvir01
- tweak: Cargo has moved some of the crates items to vending machines, Implant to medical, cloth to theater, toys to cuddly critter.