### PR TITLE
Suit Wallstorage Unit Fix (Maybe)

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Structures/Storage/Closets/suit_storage_wall.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Storage/Closets/suit_storage_wall.yml
@@ -1,19 +1,9 @@
 - type: entity
   id: SuitStorageWallmount
-  parent: [SuitStorageBase, BaseWallLocker]
+  parent: [BaseWallCloset, SuitStorageBase]
   name: suit wallstorage unit
-  placement:
-    mode: SnapgridCenter
   components:
-# Basic function components
-  - type: WallMount
-    arc: 360
-  - type: Transform
-    noRot: false
-# Visual properties
   - type: Sprite
-    drawdepth: WallMountedItems
-    noRot: false
     sprite: _NF/Structures/Storage/suit_storage_wall.rsi
     layers:
     - state: generic
@@ -31,11 +21,11 @@
     stateLocked: locked
     stateUnlocked: unlocked
   - type: EntityStorage
-    isCollidableWhenOpen: true
-    enteringOffset: 0, -0.75
     closeSound:
       path: /Audio/Machines/windoor_open.ogg
     openSound:
       path: /Audio/Machines/windoor_open.ogg
     denySound:
       path: /Audio/Machines/airlock_deny.ogg
+  - type: Fixtures
+    fixtures: {}

--- a/Resources/Prototypes/_NF/Entities/Structures/Storage/Closets/suit_storage_wall.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Storage/Closets/suit_storage_wall.yml
@@ -6,6 +6,8 @@
     mode: SnapgridCenter
   components:
 # Basic function components
+  - type: WallMount
+    arc: 180
   - type: Transform
     noRot: false
 # Visual properties
@@ -28,6 +30,9 @@
     stateDoorClosed: generic_door
     stateLocked: locked
     stateUnlocked: unlocked
+  - type: EntityStorage
+    isCollidableWhenOpen: true
+    enteringOffset: 0, -0.75
     closeSound:
       path: /Audio/Machines/windoor_open.ogg
     openSound:

--- a/Resources/Prototypes/_NF/Entities/Structures/Storage/Closets/suit_storage_wall.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Storage/Closets/suit_storage_wall.yml
@@ -7,7 +7,7 @@
   components:
 # Basic function components
   - type: WallMount
-    arc: 180
+    arc: 360
   - type: Transform
     noRot: false
 # Visual properties


### PR DESCRIPTION
## About the PR
- **The issue:** weird interaction angles for Suit Wallstorage Units.
- **Proposed solution:** explicitly declared the arc for interaction with wallstorage unit as 360.
- **Discussion:** Maybe the problem arises from wall mounts are somewhat broken in general (might be upstream issue) - wall mounted nanomed angles are not consistent. So I explicitly declared the arc for interaction with wallstorage unit as 360. Seems to work: bought about 10 ships with that kind of storage to test the solution and had no problems with accessing the storage from expected angles.
360 might be a bit of overkill, but 180 isn't as reliable as I'd like it to be and you still from time to time can access the storage unit from outside of 180 arc.

## Why / Balance
Bugfix

## Technical details
.yml edits

## Media
- [X] This PR does not require an ingame showcase.

**Changelog**
:cl: erhardsteinhauer
- fix: Fixed interaction angles for Suit Wallstorage Units. Probably.
