### PR TITLE
Skipper (Update)

### DIFF
--- a/Resources/Maps/_NF/Shuttles/skipper.yml
+++ b/Resources/Maps/_NF/Shuttles/skipper.yml
@@ -3,16 +3,16 @@ meta:
   postmapinit: false
 tilemap:
   0: Space
-  27: FloorDark
-  31: FloorDarkMini
-  42: FloorFreezer
-  46: FloorGrassDark
-  84: FloorSteel
-  92: FloorSteelMono
-  96: FloorTechMaint
-  100: FloorWhite
-  112: Lattice
-  113: Plating
+  28: FloorDark
+  32: FloorDarkMini
+  43: FloorFreezer
+  47: FloorGrassDark
+  85: FloorSteel
+  93: FloorSteelMono
+  97: FloorTechMaint
+  101: FloorWhite
+  113: Lattice
+  114: Plating
 entities:
 - proto: ""
   entities:
@@ -25,19 +25,19 @@ entities:
     - chunks:
         0,0:
           ind: 0,0
-          tiles: HwAAAAADZAAAAAAAXAAAAAACVAAAAAABVAAAAAACcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHwAAAAABcQAAAAAAZAAAAAADcQAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHwAAAAAAZAAAAAADZAAAAAABZAAAAAAAcQAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHwAAAAACZAAAAAAAZAAAAAABZAAAAAABcQAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAYAAAAAAAYAAAAAAAcQAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHwAAAAACGwAAAAADGwAAAAACcQAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHwAAAAABGwAAAAAAcQAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHwAAAAADGwAAAAAAcQAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          tiles: IAAAAAADZQAAAAAAXQAAAAACVQAAAAABVQAAAAACcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAABcgAAAAAAZQAAAAADcgAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAZQAAAAADZQAAAAABZQAAAAAAcgAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAACZQAAAAAAZQAAAAABZQAAAAABcgAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAYQAAAAAAYQAAAAAAcgAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAACHAAAAAADHAAAAAACcgAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAABHAAAAAAAcgAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAADHAAAAAAAcgAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcgAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
           version: 6
         -1,0:
           ind: -1,0
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAKgAAAAAAKgAAAAAAKgAAAAAAKgAAAAAAHwAAAAAAHwAAAAABHwAAAAAAHwAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAKgAAAAAAcQAAAAAAHwAAAAACHwAAAAACHwAAAAAAHwAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcQAAAAAAZAAAAAAAZAAAAAADZAAAAAADHwAAAAADHwAAAAADHwAAAAADHwAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcQAAAAAAZAAAAAABZAAAAAAAZAAAAAABHwAAAAACHwAAAAACHwAAAAAAHwAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcQAAAAAAYAAAAAAAYAAAAAAAcQAAAAAALgAAAAAALgAAAAAALgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcQAAAAAAGwAAAAADGwAAAAABHwAAAAAAHwAAAAABHwAAAAAAHwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcQAAAAAAGwAAAAAAHwAAAAACHwAAAAADHwAAAAADHwAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcQAAAAAAGwAAAAACHwAAAAADHwAAAAABHwAAAAADHwAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcQAAAAAAcQAAAAAAGwAAAAADGwAAAAABGwAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAKwAAAAAAKwAAAAAAKwAAAAAAKwAAAAAAIAAAAAAAIAAAAAABIAAAAAAAIAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAKwAAAAAAcgAAAAAAIAAAAAACIAAAAAACIAAAAAAAIAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcgAAAAAAZQAAAAAAZQAAAAADZQAAAAADIAAAAAADIAAAAAADIAAAAAADIAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcgAAAAAAZQAAAAABZQAAAAAAZQAAAAABIAAAAAACIAAAAAACIAAAAAAAIAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcgAAAAAAYQAAAAAAYQAAAAAAcgAAAAAALwAAAAAALwAAAAAALwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcgAAAAAAHAAAAAADHAAAAAABIAAAAAAAIAAAAAABIAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcgAAAAAAHAAAAAAAIAAAAAACIAAAAAADIAAAAAADIAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcgAAAAAAHAAAAAACIAAAAAADIAAAAAABIAAAAAADIAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcgAAAAAAcgAAAAAAHAAAAAADHAAAAAABHAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
           version: 6
         -1,-1:
           ind: -1,-1
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAGwAAAAADGwAAAAAAGwAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAKgAAAAAAKgAAAAAAKgAAAAAAcQAAAAAAGwAAAAADGwAAAAADGwAAAAABGwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAKgAAAAAAKgAAAAAAKgAAAAAAcQAAAAAAZAAAAAADZAAAAAACZAAAAAACZAAAAAAD
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAHAAAAAADHAAAAAAAHAAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAKwAAAAAAKwAAAAAAKwAAAAAAcgAAAAAAHAAAAAADHAAAAAADHAAAAAABHAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAKwAAAAAAKwAAAAAAKwAAAAAAcgAAAAAAZQAAAAADZQAAAAACZQAAAAACZQAAAAAD
           version: 6
         0,-1:
           ind: 0,-1
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGwAAAAACGwAAAAAAXAAAAAABVAAAAAADVAAAAAABcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZAAAAAAAcQAAAAAAXAAAAAADcQAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHAAAAAACHAAAAAAAXQAAAAABVQAAAAADVQAAAAABcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZQAAAAAAcgAAAAAAXQAAAAADcgAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
           version: 6
       type: MapGrid
     - type: Broadphase
@@ -313,49 +313,55 @@ entities:
       data:
         tiles:
           0,0:
+            0: 65535
+          -1,0:
+            0: 65535
+          -1,-1:
+            1: 15
+            0: 65520
+          0,-1:
+            1: 3
+            0: 65520
+          0,1:
             0: 30719
             1: 34816
-          -1,0:
-            0: 61439
-            2: 4096
-          -1,-1:
-            0: 65535
-          0,-1:
-            0: 65523
-          0,1:
-            0: 65531
-            1: 4
           0,2:
-            0: 127
+            0: 3
+            1: 124
           1,0:
-            0: 13107
+            0: 4403
+            1: 8704
           1,1:
-            0: 275
+            1: 275
           -3,0:
-            0: 34952
+            0: 136
+            1: 34816
           -3,1:
-            0: 8
+            1: 8
           -2,0:
-            0: 63487
-            3: 2048
+            0: 65535
           -2,1:
-            0: 61435
-            2: 4
+            1: 8977
+            0: 52462
           -2,2:
-            0: 206
+            1: 198
+            0: 8
           -1,1:
             0: 65535
           -1,2:
-            0: 255
+            0: 239
+            1: 16
           -3,-1:
-            0: 34952
+            1: 8
+            0: 34944
           -2,-1:
-            0: 63992
-            1: 1536
+            0: 65520
+            1: 8
           -1,-2:
-            0: 57344
+            1: 57344
           1,-1:
-            0: 13106
+            0: 13104
+            1: 2
         uniqueMixes:
         - volume: 2500
           temperature: 293.15
@@ -373,40 +379,10 @@ entities:
           - 0
           - 0
         - volume: 2500
-          temperature: 293.14996
+          temperature: 293.15
           moles:
-          - 20.078888
-          - 75.53487
           - 0
           - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-        - volume: 2500
-          temperature: 293.14996
-          moles:
-          - 21.824879
-          - 82.10312
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-        - volume: 2500
-          temperature: 293.14993
-          moles:
-          - 21.824879
-          - 82.10312
           - 0
           - 0
           - 0
@@ -424,6 +400,36 @@ entities:
     - id: Skipper
       type: BecomesStation
     - type: SpreaderGrid
+- proto: AirAlarm
+  entities:
+  - uid: 95
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -3.5,4.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 96
+      - 73
+      - 186
+      - 183
+      type: DeviceNetwork
+    - devices:
+      - 96
+      - 73
+      - 186
+      - 183
+      type: DeviceList
+- proto: AirCanister
+  entities:
+  - uid: 400
+    components:
+    - anchored: True
+      pos: 3.5,2.5
+      parent: 1
+      type: Transform
+    - bodyType: Static
+      type: Physics
 - proto: AirlockExternalGlass
   entities:
   - uid: 2
@@ -507,6 +513,198 @@ entities:
   - uid: 15
     components:
     - pos: -0.5,-2.5
+      parent: 1
+      type: Transform
+- proto: AtmosFixBlockerMarker
+  entities:
+  - uid: 192
+    components:
+    - pos: -4.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 193
+    components:
+    - pos: -3.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 194
+    components:
+    - pos: -2.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 223
+    components:
+    - pos: -1.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 233
+    components:
+    - pos: -0.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 236
+    components:
+    - pos: 0.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 237
+    components:
+    - pos: 1.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 241
+    components:
+    - pos: -2.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 242
+    components:
+    - pos: -1.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 243
+    components:
+    - pos: -0.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 262
+    components:
+    - pos: -8.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 294
+    components:
+    - pos: 5.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 295
+    components:
+    - pos: 5.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 297
+    components:
+    - pos: 5.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 299
+    components:
+    - pos: 5.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 364
+    components:
+    - pos: 4.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 371
+    components:
+    - pos: 4.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 373
+    components:
+    - pos: 4.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 374
+    components:
+    - pos: 3.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 375
+    components:
+    - pos: 3.5,7.5
+      parent: 1
+      type: Transform
+  - uid: 376
+    components:
+    - pos: 3.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 377
+    components:
+    - pos: 2.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 378
+    components:
+    - pos: 2.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 379
+    components:
+    - pos: 1.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 380
+    components:
+    - pos: 0.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 381
+    components:
+    - pos: -3.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 382
+    components:
+    - pos: -4.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 383
+    components:
+    - pos: -5.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 384
+    components:
+    - pos: -5.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 385
+    components:
+    - pos: -6.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 386
+    components:
+    - pos: -6.5,7.5
+      parent: 1
+      type: Transform
+  - uid: 387
+    components:
+    - pos: -6.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 388
+    components:
+    - pos: -7.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 389
+    components:
+    - pos: -7.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 390
+    components:
+    - pos: -7.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 391
+    components:
+    - pos: -8.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 392
+    components:
+    - pos: -8.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 393
+    components:
+    - pos: -8.5,2.5
       parent: 1
       type: Transform
 - proto: BarSign
@@ -796,14 +994,14 @@ entities:
       type: Transform
 - proto: CableApcExtension
   entities:
+  - uid: 44
+    components:
+    - pos: 2.5,5.5
+      parent: 1
+      type: Transform
   - uid: 49
     components:
     - pos: 1.5,3.5
-      parent: 1
-      type: Transform
-  - uid: 50
-    components:
-    - pos: -4.5,3.5
       parent: 1
       type: Transform
   - uid: 51
@@ -814,11 +1012,6 @@ entities:
   - uid: 52
     components:
     - pos: 2.5,4.5
-      parent: 1
-      type: Transform
-  - uid: 53
-    components:
-    - pos: 1.5,4.5
       parent: 1
       type: Transform
   - uid: 54
@@ -891,11 +1084,6 @@ entities:
     - pos: -5.5,3.5
       parent: 1
       type: Transform
-  - uid: 68
-    components:
-    - pos: 2.5,3.5
-      parent: 1
-      type: Transform
   - uid: 69
     components:
     - pos: 2.5,2.5
@@ -903,7 +1091,7 @@ entities:
       type: Transform
   - uid: 70
     components:
-    - pos: 3.5,2.5
+    - pos: -6.5,2.5
       parent: 1
       type: Transform
   - uid: 71
@@ -911,19 +1099,9 @@ entities:
     - pos: -5.5,2.5
       parent: 1
       type: Transform
-  - uid: 72
-    components:
-    - pos: -6.5,2.5
-      parent: 1
-      type: Transform
-  - uid: 73
-    components:
-    - pos: -6.5,3.5
-      parent: 1
-      type: Transform
   - uid: 74
     components:
-    - pos: 3.5,3.5
+    - pos: 2.5,3.5
       parent: 1
       type: Transform
   - uid: 75
@@ -954,31 +1132,6 @@ entities:
   - uid: 80
     components:
     - pos: -7.5,-1.5
-      parent: 1
-      type: Transform
-  - uid: 81
-    components:
-    - pos: -7.5,-2.5
-      parent: 1
-      type: Transform
-  - uid: 82
-    components:
-    - pos: -8.5,-1.5
-      parent: 1
-      type: Transform
-  - uid: 83
-    components:
-    - pos: -8.5,-0.5
-      parent: 1
-      type: Transform
-  - uid: 84
-    components:
-    - pos: -8.5,0.5
-      parent: 1
-      type: Transform
-  - uid: 85
-    components:
-    - pos: -6.5,-2.5
       parent: 1
       type: Transform
   - uid: 86
@@ -1026,21 +1179,6 @@ entities:
     - pos: -1.5,6.5
       parent: 1
       type: Transform
-  - uid: 95
-    components:
-    - pos: -1.5,5.5
-      parent: 1
-      type: Transform
-  - uid: 96
-    components:
-    - pos: -1.5,3.5
-      parent: 1
-      type: Transform
-  - uid: 97
-    components:
-    - pos: -1.5,2.5
-      parent: 1
-      type: Transform
   - uid: 98
     components:
     - pos: -1.5,1.5
@@ -1059,16 +1197,6 @@ entities:
   - uid: 101
     components:
     - pos: -1.5,-1.5
-      parent: 1
-      type: Transform
-  - uid: 102
-    components:
-    - pos: -0.5,-1.5
-      parent: 1
-      type: Transform
-  - uid: 103
-    components:
-    - pos: -2.5,-1.5
       parent: 1
       type: Transform
   - uid: 104
@@ -1113,11 +1241,6 @@ entities:
       type: Transform
 - proto: CableHV
   entities:
-  - uid: 112
-    components:
-    - pos: -3.5,8.5
-      parent: 1
-      type: Transform
   - uid: 113
     components:
     - pos: -2.5,8.5
@@ -1133,11 +1256,6 @@ entities:
     - pos: -0.5,8.5
       parent: 1
       type: Transform
-  - uid: 116
-    components:
-    - pos: 0.5,8.5
-      parent: 1
-      type: Transform
   - uid: 117
     components:
     - pos: -1.5,7.5
@@ -1146,11 +1264,6 @@ entities:
   - uid: 118
     components:
     - pos: -1.5,6.5
-      parent: 1
-      type: Transform
-  - uid: 119
-    components:
-    - pos: -5.5,6.5
       parent: 1
       type: Transform
   - uid: 120
@@ -1166,31 +1279,6 @@ entities:
   - uid: 122
     components:
     - pos: -2.5,6.5
-      parent: 1
-      type: Transform
-  - uid: 123
-    components:
-    - pos: -0.5,6.5
-      parent: 1
-      type: Transform
-  - uid: 124
-    components:
-    - pos: 0.5,6.5
-      parent: 1
-      type: Transform
-  - uid: 125
-    components:
-    - pos: 1.5,6.5
-      parent: 1
-      type: Transform
-  - uid: 126
-    components:
-    - pos: 2.5,6.5
-      parent: 1
-      type: Transform
-  - uid: 127
-    components:
-    - pos: -1.5,5.5
       parent: 1
       type: Transform
   - uid: 128
@@ -1282,58 +1370,32 @@ entities:
       type: Transform
 - proto: ChairFolding
   entities:
-  - uid: 145
+  - uid: 119
     components:
     - rot: 3.141592653589793 rad
-      pos: -7.5,-0.5
+      pos: -6.5,-0.5
       parent: 1
       type: Transform
 - proto: ClosetChefFilled
   entities:
-  - uid: 146
+  - uid: 405
     components:
-    - pos: 3.5,2.5
+    - pos: -1.2326875,8.501068
       parent: 1
       type: Transform
-    - air:
-        volume: 200
-        immutable: False
-        temperature: 293.1496
-        moles:
-        - 1.7459903
-        - 6.568249
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-      type: EntityStorage
-- proto: ClosetWallEmergencyFilledRandom
-  entities:
-  - uid: 34
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -4.5,-0.5
-      parent: 1
-      type: Transform
-- proto: ComputerShuttle
+- proto: ComputerTabletopShuttle
   entities:
   - uid: 148
     components:
-    - pos: -7.5,0.5
+    - pos: -6.5,0.5
       parent: 1
       type: Transform
-- proto: ComputerStationRecords
+- proto: ComputerTabletopStationRecords
   entities:
-  - uid: 371
+  - uid: 116
     components:
-    - rot: 3.141592653589793 rad
-      pos: -7.5,-1.5
+    - rot: 1.5707963267948966 rad
+      pos: -7.5,-0.5
       parent: 1
       type: Transform
 - proto: ComputerWallmountWithdrawBankATM
@@ -1383,6 +1445,13 @@ entities:
       type: Fixtures
     - isPlaceable: True
       type: PlaceableSurface
+- proto: DeskBell
+  entities:
+  - uid: 402
+    components:
+    - pos: 0.5366521,-0.43652472
+      parent: 1
+      type: Transform
 - proto: ExtinguisherCabinetFilled
   entities:
   - uid: 152
@@ -1392,9 +1461,9 @@ entities:
       type: Transform
 - proto: FaxMachineShip
   entities:
-  - uid: 153
+  - uid: 147
     components:
-    - pos: -6.5,0.5
+    - pos: -7.5,0.5
       parent: 1
       type: Transform
 - proto: FirelockGlass
@@ -1474,10 +1543,10 @@ entities:
       type: Transform
 - proto: FloorDrain
   entities:
-  - uid: 167
+  - uid: 123
     components:
     - rot: 3.141592653589793 rad
-      pos: -5.5,-0.5
+      pos: -6.5,-0.5
       parent: 1
       type: Transform
     - fixtures: {}
@@ -1494,6 +1563,20 @@ entities:
     - pos: -2.3013163,2.5161572
       parent: 1
       type: Transform
+- proto: FoodCondimentSqueezeBottleKetchup
+  entities:
+  - uid: 403
+    components:
+    - pos: -2.9143553,-0.32714972
+      parent: 1
+      type: Transform
+- proto: FoodCondimentSqueezeBottleMustard
+  entities:
+  - uid: 404
+    components:
+    - pos: -2.6487303,-0.34277472
+      parent: 1
+      type: Transform
 - proto: FoodContainerEgg
   entities:
   - uid: 170
@@ -1503,122 +1586,398 @@ entities:
       type: Transform
 - proto: GasPassiveVent
   entities:
-  - uid: 172
+  - uid: 191
     components:
     - rot: 1.5707963267948966 rad
-      pos: -7.5,5.5
+      pos: -8.5,3.5
       parent: 1
       type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
 - proto: GasPipeBend
   entities:
-  - uid: 173
+  - uid: 124
     components:
-    - rot: 1.5707963267948966 rad
-      pos: -6.5,0.5
+    - pos: 1.5,6.5
       parent: 1
       type: Transform
-  - uid: 174
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 172
+    components:
+    - pos: -1.5,0.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 177
     components:
     - rot: -1.5707963267948966 rad
-      pos: -1.5,0.5
+      pos: -5.5,-0.5
       parent: 1
       type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 179
+    components:
+    - pos: -3.5,3.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 185
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -4.5,6.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 395
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -5.5,2.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
 - proto: GasPipeStraight
   entities:
-  - uid: 175
+  - uid: 50
+    components:
+    - pos: 1.5,3.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 68
+    components:
+    - pos: -4.5,5.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 72
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -0.5,2.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 81
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -3.5,6.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 82
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -2.5,6.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 84
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 0.5,2.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 97
+    components:
+    - pos: -1.5,7.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 103
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 0.5,6.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 112
+    components:
+    - pos: 1.5,5.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 125
+    components:
+    - pos: 1.5,4.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 151
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -6.5,3.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 167
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -4.5,4.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 171
     components:
     - rot: 1.5707963267948966 rad
       pos: -4.5,0.5
       parent: 1
       type: Transform
-  - uid: 176
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -3.5,0.5
-      parent: 1
-      type: Transform
-  - uid: 177
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 173
     components:
     - rot: 1.5707963267948966 rad
       pos: -2.5,0.5
       parent: 1
       type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 175
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -5.5,1.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 176
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -6.5,-0.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
   - uid: 178
-    components:
-    - pos: -5.5,1.5
-      parent: 1
-      type: Transform
-  - uid: 179
-    components:
-    - pos: -5.5,2.5
-      parent: 1
-      type: Transform
-  - uid: 180
-    components:
-    - pos: -5.5,3.5
-      parent: 1
-      type: Transform
-  - uid: 181
-    components:
-    - pos: -5.5,4.5
-      parent: 1
-      type: Transform
-  - uid: 182
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -4.5,5.5
-      parent: 1
-      type: Transform
-  - uid: 183
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -3.5,5.5
-      parent: 1
-      type: Transform
-  - uid: 184
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -2.5,5.5
-      parent: 1
-      type: Transform
-  - uid: 185
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -6.5,5.5
-      parent: 1
-      type: Transform
-- proto: GasPipeTJunction
-  entities:
-  - uid: 186
     components:
     - rot: 3.141592653589793 rad
       pos: -5.5,0.5
       parent: 1
       type: Transform
-  - uid: 187
-    components:
-    - pos: -5.5,5.5
-      parent: 1
-      type: Transform
-- proto: GasVentScrubber
-  entities:
-  - uid: 188
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 181
     components:
     - rot: 3.141592653589793 rad
-      pos: -6.5,-0.5
+      pos: -3.5,1.5
       parent: 1
       type: Transform
-  - uid: 189
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 182
     components:
-    - pos: -1.5,1.5
+    - rot: 1.5707963267948966 rad
+      pos: -5.5,0.5
       parent: 1
       type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 184
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -0.5,6.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 187
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -3.5,2.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
   - uid: 190
     components:
+    - rot: 1.5707963267948966 rad
+      pos: -7.5,3.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 396
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -2.5,2.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 397
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -3.5,2.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 398
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -4.5,2.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+- proto: GasPipeTJunction
+  entities:
+  - uid: 34
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 1.5,2.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 53
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -1.5,2.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 83
+    components:
     - rot: -1.5707963267948966 rad
+      pos: -1.5,6.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 174
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -4.5,3.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 180
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -3.5,0.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+- proto: GasPort
+  entities:
+  - uid: 127
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 3.5,2.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+- proto: GasPressurePump
+  entities:
+  - uid: 85
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 2.5,2.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 153
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -5.5,3.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+- proto: GasVentPump
+  entities:
+  - uid: 102
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -1.5,6.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 394
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -7.5,-0.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 399
+    components:
+    - pos: -1.5,3.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+- proto: GasVentScrubber
+  entities:
+  - uid: 73
+    components:
+    - rot: 3.141592653589793 rad
       pos: -1.5,5.5
       parent: 1
       type: Transform
+    - ShutdownSubscribers:
+      - 95
+      type: DeviceNetwork
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 96
+    components:
+    - pos: -1.5,8.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 95
+      type: DeviceNetwork
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 183
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -1.5,-0.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 95
+      type: DeviceNetwork
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 186
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -6.5,0.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 95
+      type: DeviceNetwork
+    - color: '#990000FF'
+      type: AtmosPipeColor
 - proto: GravityGeneratorMini
   entities:
   - uid: 195
@@ -1872,36 +2231,18 @@ entities:
       type: Transform
 - proto: LockerBotanistFilled
   entities:
-  - uid: 44
+  - uid: 188
     components:
-    - pos: -1.5,8.5
+    - pos: -1.7795625,8.501068
       parent: 1
       type: Transform
 - proto: LockerFreezer
   entities:
-  - uid: 242
+  - uid: 189
     components:
-    - pos: -6.5,-1.5
+    - pos: -7.5,-1.5
       parent: 1
       type: Transform
-    - air:
-        volume: 200
-        immutable: False
-        temperature: 293.1496
-        moles:
-        - 1.7459903
-        - 6.568249
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-      type: EntityStorage
 - proto: OilJarCorn
   entities:
   - uid: 225
@@ -1936,8 +2277,7 @@ entities:
       type: MaterialStorage
     - bodyType: Static
       type: Physics
-    - endTime: 0
-      type: InsertingMaterialStorage
+    - type: InsertingMaterialStorage
   - uid: 46
     components:
     - anchored: True
@@ -1949,8 +2289,7 @@ entities:
       type: MaterialStorage
     - bodyType: Static
       type: Physics
-    - endTime: 0
-      type: InsertingMaterialStorage
+    - type: InsertingMaterialStorage
 - proto: Poweredlight
   entities:
   - uid: 244
@@ -2414,19 +2753,9 @@ entities:
       type: Transform
 - proto: SpawnPointLatejoin
   entities:
-  - uid: 297
-    components:
-    - pos: -2.5,0.5
-      parent: 1
-      type: Transform
   - uid: 298
     components:
     - pos: -1.5,0.5
-      parent: 1
-      type: Transform
-  - uid: 299
-    components:
-    - pos: -0.5,0.5
       parent: 1
       type: Transform
 - proto: StairStage
@@ -2477,8 +2806,30 @@ entities:
       pos: -6.5,4.5
       parent: 1
       type: Transform
+- proto: SuitStorageWallmountEVAAlternate
+  entities:
+  - uid: 145
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -4.5,-0.5
+      parent: 1
+      type: Transform
+    - canCollide: False
+      type: Physics
 - proto: Table
   entities:
+  - uid: 126
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -7.5,-0.5
+      parent: 1
+      type: Transform
+  - uid: 146
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -7.5,0.5
+      parent: 1
+      type: Transform
   - uid: 305
     components:
     - rot: 1.5707963267948966 rad
@@ -2894,6 +3245,13 @@ entities:
   - uid: 370
     components:
     - pos: -1.5,4.5
+      parent: 1
+      type: Transform
+- proto: Wrench
+  entities:
+  - uid: 401
+    components:
+    - pos: -1.5558069,7.538511
       parent: 1
       type: Transform
 ...

--- a/Resources/Prototypes/_NF/Shipyard/skipper.yml
+++ b/Resources/Prototypes/_NF/Shipyard/skipper.yml
@@ -1,16 +1,26 @@
+# Author Info
+# GitHub: ???
+# Discord: ???
+
+# Maintainer Info
+# GitHub: ???
+# Discord: ???
+
+# Shuttle Notes:
+#
 - type: vessel
   id: Skipper
   name: NC Skipper
   description: A small service ship with a full service kitchen and hydroponics garden
-  price: 32650
+  price: 29715
   category: Small
   group: Civilian
-  shuttlePath: /Maps/Shuttles/skipper.yml
+  shuttlePath: /Maps/_NF/Shuttles/skipper.yml
 
 - type: gameMap
   id: Skipper
   mapName: 'NC Skipper'
-  mapPath: /Maps/Shuttles/skipper.yml
+  mapPath: /Maps/_NF/Shuttles/skipper.yml
   minPlayers: 0
   stations:
     Skipper:


### PR DESCRIPTION
## About the PR
Updating NC Skipper to current mapping standards:
- Wiring rework.
- Atmos rework.
- Replaced consoles with tabletop variants.
- Added Vacuum Markers to exposed to space tiles.
- Moved ship.yml to Maps/_NF/Shuttles/

## Why / Balance
New mapping standards.

## Media
![2024-1-29_23 21 34](https://github.com/new-frontiers-14/frontier-station-14/assets/65374927/52d41d07-f2e3-4d9b-8f2d-a63d025246df)
- [X] I have added screenshots/videos to this PR showcasing its changes ingame.

**Changelog**
:cl: erhardsteinhauer
- tweak: Updated NC Skipper to current mapping standards.