### PR TITLE
Esquire (Update)

### DIFF
--- a/.github/mapchecker/whitelist.yml
+++ b/.github/mapchecker/whitelist.yml
@@ -16,10 +16,6 @@ Lodge:
 
 # TECHNICAL DEBT BELOW. These ones were added to this list to ensure other PR's would not break upon merging. It is
 # the intention for this list to become empty in separate PR's.
-Esquire:
-  - ToyFigurineSecurity
-  - AirlockSecurity
-  - SignSec
 Bison:
   - WallPlastitanium
   - WallPlastitaniumDiagonal

--- a/Resources/Maps/_NF/Shuttles/esquire.yml
+++ b/Resources/Maps/_NF/Shuttles/esquire.yml
@@ -4,15 +4,15 @@ meta:
 tilemap:
   0: Space
   12: FloorBar
-  26: FloorDark
-  32: FloorDarkOffset
-  59: FloorLino
-  88: FloorSteelDirty
-  95: FloorTechMaint
-  109: FloorWood
-  110: FloorWoodTile
-  111: Lattice
-  112: Plating
+  28: FloorDark
+  34: FloorDarkOffset
+  61: FloorLino
+  90: FloorSteelDirty
+  97: FloorTechMaint
+  111: FloorWood
+  112: FloorWoodTile
+  113: Lattice
+  114: Plating
 entities:
 - proto: ""
   entities:
@@ -25,19 +25,19 @@ entities:
     - chunks:
         0,0:
           ind: 0,0
-          tiles: OwAAAAAAOwAAAAAAcAAAAAAADAAAAAAADAAAAAABDAAAAAAADAAAAAACDAAAAAACDAAAAAABcAAAAAAAbwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOwAAAAAAOwAAAAAAcAAAAAAADAAAAAADDAAAAAABDAAAAAADDAAAAAAADAAAAAAAcAAAAAAAbwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOwAAAAAAOwAAAAAAcAAAAAAADAAAAAAADAAAAAACDAAAAAADDAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOwAAAAAAOwAAAAAAcAAAAAAADAAAAAACDAAAAAABDAAAAAACDAAAAAABcAAAAAAAbwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOwAAAAAAOwAAAAAAcAAAAAAAcAAAAAAAXwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAbwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXwAAAAAAcAAAAAAAcAAAAAAAGgAAAAADGgAAAAACGgAAAAABcAAAAAAAbwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGgAAAAABGgAAAAACGgAAAAADGgAAAAADGgAAAAABGgAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGgAAAAADGgAAAAAAGgAAAAACGgAAAAAAGgAAAAADcAAAAAAAbwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGgAAAAABGgAAAAADGgAAAAADGgAAAAADcAAAAAAAbwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAbwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          tiles: PQAAAAAAPQAAAAAAcgAAAAAADAAAAAAADAAAAAABDAAAAAAADAAAAAACDAAAAAACDAAAAAABcgAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPQAAAAAAPQAAAAAAcgAAAAAADAAAAAADDAAAAAABDAAAAAADDAAAAAAADAAAAAAAcgAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPQAAAAAAPQAAAAAAcgAAAAAADAAAAAAADAAAAAACDAAAAAADDAAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPQAAAAAAPQAAAAAAcgAAAAAADAAAAAACDAAAAAABDAAAAAACDAAAAAABcgAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPQAAAAAAPQAAAAAAcgAAAAAAcgAAAAAAYQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYQAAAAAAcgAAAAAAcgAAAAAAHAAAAAADHAAAAAACHAAAAAABcgAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHAAAAAABHAAAAAACHAAAAAADHAAAAAADHAAAAAABHAAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHAAAAAADHAAAAAAAHAAAAAACHAAAAAAAHAAAAAADcgAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHAAAAAABHAAAAAADHAAAAAADHAAAAAADcgAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
           version: 6
         0,-1:
           ind: 0,-1
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAXwAAAAAAcAAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAIAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAbwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAWAAAAAAAWAAAAAAAWAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAbgAAAAABbgAAAAAAbQAAAAACbQAAAAACbQAAAAABcAAAAAAAWAAAAAAAWAAAAAAAWAAAAAAAWAAAAAAAXwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAbgAAAAABbgAAAAACbQAAAAACbQAAAAAAbQAAAAADcAAAAAAAXwAAAAAAWAAAAAAAWAAAAAAAWAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAbgAAAAAAbgAAAAACbQAAAAABbQAAAAADbQAAAAAAXwAAAAAAWAAAAAAAWAAAAAAAWAAAAAAAWAAAAAAAXwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAbgAAAAAAbgAAAAABcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAWAAAAAAAWAAAAAAAWAAAAAAAWAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOwAAAAAAcAAAAAAAcAAAAAAADAAAAAABDAAAAAAAcAAAAAAAXwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAYQAAAAAAcgAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIgAAAAAAIgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAWgAAAAAAWgAAAAAAWgAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAABcAAAAAAAbwAAAAACbwAAAAACbwAAAAABcgAAAAAAWgAAAAAAWgAAAAAAWgAAAAAAWgAAAAAAYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAABcAAAAAACbwAAAAACbwAAAAAAbwAAAAADcgAAAAAAYQAAAAAAWgAAAAAAWgAAAAAAWgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAACbwAAAAABbwAAAAADbwAAAAAAYQAAAAAAWgAAAAAAWgAAAAAAWgAAAAAAWgAAAAAAYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAABcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAWgAAAAAAWgAAAAAAWgAAAAAAWgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPQAAAAAAcgAAAAAAcgAAAAAADAAAAAABDAAAAAAAcgAAAAAAYQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
           version: 6
         -1,0:
           ind: -1,0
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAbwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAOwAAAAAAOwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAbwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAOwAAAAAAOwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAOwAAAAAAOwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAbwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAOwAAAAAAOwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAbwAAAAAAcAAAAAAAcAAAAAAAXwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAOwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAbwAAAAAAcAAAAAAAbQAAAAADbQAAAAADbQAAAAACcAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAbQAAAAABbQAAAAACbQAAAAABXwAAAAAAGgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAbwAAAAAAcAAAAAAAcAAAAAAAbQAAAAADcAAAAAAAGgAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAbwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAGgAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAbwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAPQAAAAAAPQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAPQAAAAAAPQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAPQAAAAAAPQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAPQAAAAAAPQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcgAAAAAAcgAAAAAAYQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAPQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcgAAAAAAbwAAAAADbwAAAAADbwAAAAACcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAbwAAAAABbwAAAAACbwAAAAABYQAAAAAAHAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcgAAAAAAcgAAAAAAbwAAAAADcgAAAAAAHAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAHAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
           version: 6
         -1,-1:
           ind: -1,-1
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAcAAAAAAAXwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAbwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAXwAAAAAAXwAAAAAAXwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAXwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAbQAAAAAAbQAAAAABbQAAAAAAbgAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAXwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAbQAAAAABbQAAAAACbQAAAAAAbgAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAXwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAXwAAAAAAbQAAAAAAbQAAAAACbQAAAAAAbgAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAXwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAbgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAA
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcgAAAAAAYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAIgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcgAAAAAAYQAAAAAAYQAAAAAAYQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAYQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAbwAAAAAAbwAAAAABbwAAAAAAcAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAYQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAbwAAAAABbwAAAAACbwAAAAAAcAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAYQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAYQAAAAAAbwAAAAAAbwAAAAACbwAAAAAAcAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAYQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAA
           version: 6
       type: MapGrid
     - type: Broadphase
@@ -154,55 +154,84 @@ entities:
           0,1:
             0: 65535
           0,2:
-            0: 255
+            0: 127
+            1: 128
           1,0:
             0: 65535
           1,1:
-            0: 30719
+            0: 14207
+            1: 16512
           1,2:
-            0: 19
+            0: 1
+            1: 18
           2,0:
-            0: 4407
+            0: 275
+            1: 4132
           0,-2:
-            0: 65535
+            0: 65527
+            1: 8
           1,-2:
-            0: 65523
+            1: 3
+            0: 65520
           1,-1:
             0: 65535
           2,-2:
-            0: 30576
+            0: 30512
+            1: 64
           2,-1:
             0: 30583
           -3,0:
-            0: 140
-          -2,0:
-            0: 65535
-          -2,1:
-            0: 52463
-          -2,2:
+            1: 132
             0: 8
+          -2,0:
+            0: 61439
+            1: 4096
+          -2,1:
+            1: 16417
+            0: 36046
+          -2,2:
+            1: 8
           -1,1:
             0: 65535
           -1,2:
-            0: 255
+            0: 207
+            1: 48
           -3,-2:
-            0: 52416
+            1: 64
+            0: 52352
           -3,-1:
             0: 52428
           -2,-2:
-            0: 65528
+            0: 65520
+            1: 8
           -2,-1:
             0: 65535
           -1,-2:
-            0: 65535
+            1: 3
+            0: 65532
           2,1:
-            0: 1
+            1: 1
         uniqueMixes:
         - volume: 2500
           temperature: 293.15
           moles:
           - 21.824879
           - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 0
+          - 0
           - 0
           - 0
           - 0
@@ -249,14 +278,14 @@ entities:
     - pos: -8.5,-0.5
       parent: 1
       type: Transform
-- proto: AirlockBrigLocked
-  entities:
-  - uid: 255
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 6.5,-3.5
-      parent: 1
-      type: Transform
+    - ShutdownSubscribers:
+      - 423
+      - 336
+      type: DeviceNetwork
+    - devices:
+      - 423
+      - 336
+      type: DeviceList
 - proto: AirlockCommand
   entities:
   - uid: 46
@@ -331,14 +360,24 @@ entities:
       pos: -4.5,4.5
       parent: 1
       type: Transform
-- proto: AirlockSecurity
+- proto: AirlockMercenaryGlass
   entities:
-  - uid: 184
+  - uid: 11
     components:
-    - rot: 1.5707963267948966 rad
-      pos: 5.5,-2.5
+    - pos: 5.5,-2.5
       parent: 1
       type: Transform
+- proto: AirlockMercenaryLocked
+  entities:
+  - uid: 586
+    components:
+    - pos: 6.5,-3.5
+      parent: 1
+      type: Transform
+    - links:
+      - 485
+      - 499
+      type: DeviceLinkSink
 - proto: APCBasic
   entities:
   - uid: 439
@@ -377,6 +416,138 @@ entities:
   - uid: 297
     components:
     - pos: 10.5,-2.5
+      parent: 1
+      type: Transform
+- proto: AtmosFixBlockerMarker
+  entities:
+  - uid: 500
+    components:
+    - pos: -9.5,-6.5
+      parent: 1
+      type: Transform
+  - uid: 502
+    components:
+    - pos: -4.5,-7.5
+      parent: 1
+      type: Transform
+  - uid: 504
+    components:
+    - pos: -3.5,-7.5
+      parent: 1
+      type: Transform
+  - uid: 512
+    components:
+    - pos: -2.5,-7.5
+      parent: 1
+      type: Transform
+  - uid: 513
+    components:
+    - pos: 3.5,-7.5
+      parent: 1
+      type: Transform
+  - uid: 522
+    components:
+    - pos: 4.5,-7.5
+      parent: 1
+      type: Transform
+  - uid: 530
+    components:
+    - pos: 5.5,-7.5
+      parent: 1
+      type: Transform
+  - uid: 531
+    components:
+    - pos: 10.5,-6.5
+      parent: 1
+      type: Transform
+  - uid: 534
+    components:
+    - pos: 10.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 539
+    components:
+    - pos: 9.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 540
+    components:
+    - pos: 8.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 541
+    components:
+    - pos: 8.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 542
+    components:
+    - pos: 7.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 551
+    components:
+    - pos: 6.5,7.5
+      parent: 1
+      type: Transform
+  - uid: 552
+    components:
+    - pos: 5.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 558
+    components:
+    - pos: 4.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 561
+    components:
+    - pos: 3.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 563
+    components:
+    - pos: -2.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 564
+    components:
+    - pos: -3.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 565
+    components:
+    - pos: -4.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 569
+    components:
+    - pos: -5.5,7.5
+      parent: 1
+      type: Transform
+  - uid: 570
+    components:
+    - pos: -6.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 578
+    components:
+    - pos: -7.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 579
+    components:
+    - pos: -7.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 583
+    components:
+    - pos: -8.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 585
+    components:
+    - pos: -9.5,0.5
       parent: 1
       type: Transform
 - proto: Bed
@@ -486,72 +657,59 @@ entities:
     - pos: 1.5,5.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
-  - uid: 132
+  - uid: 24
     components:
-    - pos: 5.5,-6.5
+    - pos: -3.5,6.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
+  - uid: 35
+    components:
+    - pos: -0.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 37
+    components:
+    - pos: 0.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 67
+    components:
+    - pos: 0.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 76
+    components:
+    - pos: 8.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 78
+    components:
+    - pos: -5.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 124
+    components:
+    - pos: -1.5,6.5
+      parent: 1
+      type: Transform
   - uid: 133
     components:
-    - pos: 4.5,-6.5
+    - pos: 8.5,-2.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 150
     components:
     - pos: 0.5,-4.5
       parent: 1
       type: Transform
-  - uid: 216
+  - uid: 171
     components:
-    - pos: 2.5,-6.5
+    - pos: -5.5,-5.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
-  - uid: 281
+  - uid: 182
     components:
-    - pos: -1.5,-6.5
-      parent: 1
-      type: Transform
-    - enabled: True
-      type: AmbientSound
-  - uid: 282
-    components:
-    - pos: -4.5,-6.5
-      parent: 1
-      type: Transform
-    - enabled: True
-      type: AmbientSound
-  - uid: 320
-    components:
-    - pos: 3.5,-6.5
-      parent: 1
-      type: Transform
-    - enabled: True
-      type: AmbientSound
-  - uid: 485
-    components:
-    - pos: -1.5,4.5
-      parent: 1
-      type: Transform
-    - enabled: True
-      type: AmbientSound
-  - uid: 486
-    components:
-    - pos: -1.5,5.5
-      parent: 1
-      type: Transform
-    - enabled: True
-      type: AmbientSound
-  - uid: 487
-    components:
-    - pos: -2.5,5.5
+    - pos: -4.5,-5.5
       parent: 1
       type: Transform
   - uid: 488
@@ -559,20 +717,6 @@ entities:
     - pos: -2.5,6.5
       parent: 1
       type: Transform
-  - uid: 489
-    components:
-    - pos: -1.5,5.5
-      parent: 1
-      type: Transform
-    - enabled: True
-      type: AmbientSound
-  - uid: 490
-    components:
-    - pos: -0.5,5.5
-      parent: 1
-      type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 491
     components:
     - pos: -3.5,5.5
@@ -608,36 +752,9 @@ entities:
     - pos: 3.5,7.5
       parent: 1
       type: Transform
-  - uid: 498
-    components:
-    - pos: 3.5,6.5
-      parent: 1
-      type: Transform
-  - uid: 499
-    components:
-    - pos: 4.5,7.5
-      parent: 1
-      type: Transform
-  - uid: 500
-    components:
-    - pos: -1.5,4.5
-      parent: 1
-      type: Transform
-    - enabled: True
-      type: AmbientSound
-  - uid: 501
-    components:
-    - pos: -1.5,3.5
-      parent: 1
-      type: Transform
   - uid: 503
     components:
     - pos: 0.5,2.5
-      parent: 1
-      type: Transform
-  - uid: 504
-    components:
-    - pos: -0.5,2.5
       parent: 1
       type: Transform
   - uid: 505
@@ -645,8 +762,6 @@ entities:
     - pos: -4.5,-3.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 506
     components:
     - pos: -3.5,-3.5
@@ -677,16 +792,6 @@ entities:
     - pos: 1.5,-3.5
       parent: 1
       type: Transform
-  - uid: 512
-    components:
-    - pos: 1.5,-2.5
-      parent: 1
-      type: Transform
-  - uid: 513
-    components:
-    - pos: 1.5,-4.5
-      parent: 1
-      type: Transform
   - uid: 514
     components:
     - pos: 2.5,-3.5
@@ -699,12 +804,12 @@ entities:
       type: Transform
   - uid: 516
     components:
-    - pos: 3.5,-2.5
+    - pos: 4.5,-3.5
       parent: 1
       type: Transform
   - uid: 517
     components:
-    - pos: 4.5,-2.5
+    - pos: 4.5,-4.5
       parent: 1
       type: Transform
   - uid: 518
@@ -712,116 +817,64 @@ entities:
     - pos: -4.5,-3.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 519
     components:
     - pos: -5.5,-3.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 520
     components:
     - pos: -6.5,-3.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 521
     components:
     - pos: -7.5,-3.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
-  - uid: 522
-    components:
-    - pos: -7.5,-4.5
-      parent: 1
-      type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 523
     components:
     - pos: -7.5,-2.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 524
     components:
     - pos: -7.5,-1.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 525
     components:
     - pos: -7.5,-0.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 526
     components:
     - pos: -6.5,-0.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 527
     components:
     - pos: -6.5,0.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 528
     components:
     - pos: -6.5,1.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 529
     components:
     - pos: -5.5,1.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
-  - uid: 530
-    components:
-    - pos: -5.5,2.5
-      parent: 1
-      type: Transform
-    - enabled: True
-      type: AmbientSound
-  - uid: 531
-    components:
-    - pos: -5.5,3.5
-      parent: 1
-      type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 532
     components:
     - pos: -4.5,1.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 533
     components:
     - pos: -3.5,1.5
-      parent: 1
-      type: Transform
-    - enabled: True
-      type: AmbientSound
-  - uid: 534
-    components:
-    - pos: -7.5,-5.5
       parent: 1
       type: Transform
   - uid: 535
@@ -829,8 +882,6 @@ entities:
     - pos: 7.5,-0.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 536
     components:
     - pos: 7.5,-1.5
@@ -846,33 +897,11 @@ entities:
     - pos: 7.5,-2.5
       parent: 1
       type: Transform
-  - uid: 539
-    components:
-    - pos: 7.5,-3.5
-      parent: 1
-      type: Transform
-  - uid: 540
-    components:
-    - pos: 7.5,-4.5
-      parent: 1
-      type: Transform
-  - uid: 541
-    components:
-    - pos: 7.5,-5.5
-      parent: 1
-      type: Transform
-  - uid: 542
-    components:
-    - pos: 7.5,-4.5
-      parent: 1
-      type: Transform
   - uid: 543
     components:
     - pos: 7.5,-0.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 544
     components:
     - pos: 7.5,0.5
@@ -908,30 +937,6 @@ entities:
     - pos: 6.5,2.5
       parent: 1
       type: Transform
-  - uid: 551
-    components:
-    - pos: 8.5,-3.5
-      parent: 1
-      type: Transform
-  - uid: 552
-    components:
-    - pos: 9.5,-3.5
-      parent: 1
-      type: Transform
-  - uid: 578
-    components:
-    - pos: -1.5,5.5
-      parent: 1
-      type: Transform
-    - enabled: True
-      type: AmbientSound
-  - uid: 579
-    components:
-    - pos: -1.5,4.5
-      parent: 1
-      type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 580
     components:
     - pos: 1.5,4.5
@@ -947,158 +952,31 @@ entities:
     - pos: 1.5,2.5
       parent: 1
       type: Transform
-  - uid: 594
+  - uid: 591
     components:
-    - pos: 5.5,7.5
+    - pos: 4.5,-5.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
+  - uid: 592
+    components:
+    - pos: 4.5,-6.5
+      parent: 1
+      type: Transform
   - uid: 595
     components:
     - pos: -2.5,7.5
       parent: 1
       type: Transform
-  - uid: 596
-    components:
-    - pos: -3.5,7.5
-      parent: 1
-      type: Transform
-    - enabled: True
-      type: AmbientSound
-  - uid: 597
-    components:
-    - pos: -4.5,7.5
-      parent: 1
-      type: Transform
-    - enabled: True
-      type: AmbientSound
-  - uid: 599
-    components:
-    - pos: -4.5,-4.5
-      parent: 1
-      type: Transform
-    - enabled: True
-      type: AmbientSound
-  - uid: 600
-    components:
-    - pos: -4.5,-5.5
-      parent: 1
-      type: Transform
-    - enabled: True
-      type: AmbientSound
-  - uid: 602
-    components:
-    - pos: -2.5,-6.5
-      parent: 1
-      type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 603
     components:
     - pos: -4.5,-3.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
-  - uid: 604
-    components:
-    - pos: -4.5,-4.5
-      parent: 1
-      type: Transform
-    - enabled: True
-      type: AmbientSound
-  - uid: 605
-    components:
-    - pos: -3.5,-6.5
-      parent: 1
-      type: Transform
-    - enabled: True
-      type: AmbientSound
-  - uid: 608
-    components:
-    - pos: 7.5,-6.5
-      parent: 1
-      type: Transform
-    - enabled: True
-      type: AmbientSound
-  - uid: 609
-    components:
-    - pos: 6.5,-6.5
-      parent: 1
-      type: Transform
-    - enabled: True
-      type: AmbientSound
-  - uid: 610
-    components:
-    - pos: 5.5,-6.5
-      parent: 1
-      type: Transform
-    - enabled: True
-      type: AmbientSound
-  - uid: 611
-    components:
-    - pos: 4.5,-6.5
-      parent: 1
-      type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 622
     components:
     - pos: 0.5,-5.5
       parent: 1
       type: Transform
-  - uid: 623
-    components:
-    - pos: 0.5,-6.5
-      parent: 1
-      type: Transform
-  - uid: 624
-    components:
-    - pos: -0.5,-6.5
-      parent: 1
-      type: Transform
-  - uid: 625
-    components:
-    - pos: 1.5,-6.5
-      parent: 1
-      type: Transform
-  - uid: 626
-    components:
-    - pos: -6.5,-5.5
-      parent: 1
-      type: Transform
-  - uid: 628
-    components:
-    - pos: -5.5,-5.5
-      parent: 1
-      type: Transform
-  - uid: 635
-    components:
-    - pos: -2.5,8.5
-      parent: 1
-      type: Transform
-    - enabled: True
-      type: AmbientSound
-  - uid: 636
-    components:
-    - pos: -2.5,9.5
-      parent: 1
-      type: Transform
-    - enabled: True
-      type: AmbientSound
-  - uid: 637
-    components:
-    - pos: 3.5,8.5
-      parent: 1
-      type: Transform
-  - uid: 638
-    components:
-    - pos: 3.5,9.5
-      parent: 1
-      type: Transform
-    - enabled: True
-      type: AmbientSound
 - proto: CableApcStack10
   entities:
   - uid: 568
@@ -1107,13 +985,20 @@ entities:
       pos: -5.516655,3.5164235
       parent: 1
       type: Transform
-- proto: CableHV
+- proto: Cablecuffs
   entities:
-  - uid: 124
+  - uid: 431
     components:
-    - pos: -8.5,-1.5
+    - pos: 9.318908,-1.3494799
       parent: 1
       type: Transform
+  - uid: 487
+    components:
+    - pos: 9.553283,-1.5526049
+      parent: 1
+      type: Transform
+- proto: CableHV
+  entities:
   - uid: 174
     components:
     - pos: -8.5,-4.5
@@ -1134,16 +1019,9 @@ entities:
     - pos: -7.5,-4.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 236
     components:
     - pos: -6.5,-5.5
-      parent: 1
-      type: Transform
-  - uid: 237
-    components:
-    - pos: -5.5,-5.5
       parent: 1
       type: Transform
   - uid: 238
@@ -1153,6 +1031,36 @@ entities:
       type: Transform
 - proto: CableMV
   entities:
+  - uid: 185
+    components:
+    - pos: -2.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 193
+    components:
+    - pos: -0.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 194
+    components:
+    - pos: -1.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 216
+    components:
+    - pos: 1.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 232
+    components:
+    - pos: 0.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 237
+    components:
+    - pos: -2.5,6.5
+      parent: 1
+      type: Transform
   - uid: 442
     components:
     - pos: -8.5,-2.5
@@ -1163,92 +1071,66 @@ entities:
     - pos: -7.5,-2.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 444
     components:
     - pos: -6.5,-2.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 445
     components:
     - pos: -5.5,-2.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 446
     components:
     - pos: -5.5,-3.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 447
     components:
     - pos: -4.5,-3.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 448
     components:
     - pos: -5.5,-2.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 449
     components:
     - pos: -5.5,-1.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 450
     components:
     - pos: -5.5,-0.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 451
     components:
     - pos: -5.5,0.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 452
     components:
     - pos: -4.5,0.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 453
     components:
     - pos: -4.5,1.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 454
     components:
     - pos: -4.5,2.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 455
     components:
     - pos: -4.5,3.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 456
     components:
     - pos: -4.5,4.5
@@ -1264,25 +1146,6 @@ entities:
     - pos: -3.5,5.5
       parent: 1
       type: Transform
-  - uid: 459
-    components:
-    - pos: -2.5,5.5
-      parent: 1
-      type: Transform
-  - uid: 460
-    components:
-    - pos: -1.5,5.5
-      parent: 1
-      type: Transform
-    - enabled: True
-      type: AmbientSound
-  - uid: 461
-    components:
-    - pos: -1.5,4.5
-      parent: 1
-      type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 462
     components:
     - pos: -4.5,-2.5
@@ -1363,67 +1226,29 @@ entities:
     - pos: 7.5,-0.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 478
     components:
     - pos: 7.5,-0.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 479
     components:
     - pos: 7.5,-0.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 480
     components:
     - pos: -4.5,-3.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 481
     components:
     - pos: -4.5,-3.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
-  - uid: 482
-    components:
-    - pos: -1.5,4.5
-      parent: 1
-      type: Transform
-    - enabled: True
-      type: AmbientSound
-  - uid: 483
-    components:
-    - pos: -1.5,4.5
-      parent: 1
-      type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 484
     components:
     - pos: -4.5,-3.5
-      parent: 1
-      type: Transform
-    - enabled: True
-      type: AmbientSound
-  - uid: 502
-    components:
-    - pos: -0.5,5.5
-      parent: 1
-      type: Transform
-    - enabled: True
-      type: AmbientSound
-  - uid: 583
-    components:
-    - pos: 0.5,5.5
       parent: 1
       type: Transform
   - uid: 584
@@ -1431,67 +1256,16 @@ entities:
     - pos: 1.5,5.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
-  - uid: 585
-    components:
-    - pos: -1.5,5.5
-      parent: 1
-      type: Transform
-    - enabled: True
-      type: AmbientSound
-  - uid: 586
-    components:
-    - pos: -0.5,5.5
-      parent: 1
-      type: Transform
-    - enabled: True
-      type: AmbientSound
-  - uid: 587
-    components:
-    - pos: 0.5,5.5
-      parent: 1
-      type: Transform
   - uid: 588
     components:
     - pos: 1.5,5.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 589
     components:
     - pos: 1.5,5.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
-  - uid: 590
-    components:
-    - pos: 0.5,5.5
-      parent: 1
-      type: Transform
-  - uid: 591
-    components:
-    - pos: -0.5,5.5
-      parent: 1
-      type: Transform
-    - enabled: True
-      type: AmbientSound
-  - uid: 592
-    components:
-    - pos: -0.5,5.5
-      parent: 1
-      type: Transform
-    - enabled: True
-      type: AmbientSound
-  - uid: 593
-    components:
-    - pos: -1.5,5.5
-      parent: 1
-      type: Transform
-    - enabled: True
-      type: AmbientSound
 - proto: CableTerminal
   entities:
   - uid: 138
@@ -1753,13 +1527,6 @@ entities:
     - pos: 0.86970043,3.740715
       parent: 1
       type: Transform
-- proto: ClothingShoesBootsLaceup
-  entities:
-  - uid: 78
-    components:
-    - pos: 2.4480429,6.262601
-      parent: 1
-      type: Transform
 - proto: ClothingUniformJumpskirtCaptain
   entities:
   - uid: 616
@@ -1782,32 +1549,6 @@ entities:
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
-- proto: ClothingUniformJumpsuitLawyerBlack
-  entities:
-  - uid: 171
-    components:
-    - pos: 2.2511678,6.703226
-      parent: 1
-      type: Transform
-- proto: ClothingUniformJumpsuitLawyerBlue
-  entities:
-  - uid: 24
-    components:
-    - pos: 2.326168,6.459476
-      parent: 1
-      type: Transform
-- proto: ClothingUniformJumpsuitPrisoner
-  entities:
-  - uid: 77
-    components:
-    - pos: 9.2412615,-1.1839774
-      parent: 1
-      type: Transform
-  - uid: 298
-    components:
-    - pos: 9.549633,-1.2568827
-      parent: 1
-      type: Transform
 - proto: ComfyChair
   entities:
   - uid: 338
@@ -1815,32 +1556,32 @@ entities:
     - pos: 2.5,-2.5
       parent: 1
       type: Transform
-- proto: ComputerCriminalRecords
-  entities:
-  - uid: 331
-    components:
-    - pos: 7.5,-1.5
-      parent: 1
-      type: Transform
-- proto: ComputerRadar
-  entities:
-  - uid: 194
-    components:
-    - pos: 0.5,8.5
-      parent: 1
-      type: Transform
-- proto: ComputerShuttle
-  entities:
-  - uid: 193
-    components:
-    - pos: -0.5,8.5
-      parent: 1
-      type: Transform
 - proto: ComputerStationRecords
   entities:
   - uid: 210
     components:
     - pos: 2.5,8.5
+      parent: 1
+      type: Transform
+- proto: ComputerTabletopCriminalRecords
+  entities:
+  - uid: 587
+    components:
+    - pos: 7.5,-1.5
+      parent: 1
+      type: Transform
+- proto: ComputerTabletopRadar
+  entities:
+  - uid: 433
+    components:
+    - pos: 0.5,8.5
+      parent: 1
+      type: Transform
+- proto: ComputerTabletopShuttle
+  entities:
+  - uid: 281
+    components:
+    - pos: -0.5,8.5
       parent: 1
       type: Transform
 - proto: DonkpocketBoxSpawner
@@ -1942,6 +1683,23 @@ entities:
     - pos: 4.5,4.5
       parent: 1
       type: Transform
+- proto: FirelockGlass
+  entities:
+  - uid: 4
+    components:
+    - pos: 6.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 436
+    components:
+    - pos: -1.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 482
+    components:
+    - pos: 6.5,-0.5
+      parent: 1
+      type: Transform
 - proto: Fireplace
   entities:
   - uid: 286
@@ -1988,16 +1746,27 @@ entities:
       type: AtmosPipeColor
 - proto: GasPassiveVent
   entities:
-  - uid: 436
+  - uid: 425
+    components:
+    - pos: 8.5,4.5
+      parent: 1
+      type: Transform
+- proto: GasPipeBend
+  entities:
+  - uid: 320
     components:
     - rot: -1.5707963267948966 rad
-      pos: 8.5,4.5
+      pos: 8.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 334
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 3.5,1.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-- proto: GasPipeBend
-  entities:
   - uid: 341
     components:
     - rot: 3.141592653589793 rad
@@ -2006,8 +1775,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 347
     components:
     - rot: 1.5707963267948966 rad
@@ -2016,8 +1783,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 353
     components:
     - rot: 1.5707963267948966 rad
@@ -2104,8 +1869,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 416
     components:
     - rot: 3.141592653589793 rad
@@ -2114,11 +1877,41 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
+  - uid: 422
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -5.5,-3.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 426
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 6.5,-1.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
 - proto: GasPipeStraight
   entities:
-  - uid: 267
+  - uid: 77
     components:
-    - pos: 5.5,3.5
+    - pos: 3.5,-2.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 132
+    components:
+    - pos: 3.5,-1.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 298
+    components:
+    - pos: 5.5,4.5
       parent: 1
       type: Transform
     - color: '#990000FF'
@@ -2130,15 +1923,28 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
-  - uid: 321
+  - uid: 332
     components:
-    - pos: -2.5,-1.5
+    - pos: 3.5,0.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 333
+    components:
+    - pos: 3.5,-0.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 335
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 2.5,-3.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
   - uid: 343
     components:
     - rot: 1.5707963267948966 rad
@@ -2162,8 +1968,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 346
     components:
     - pos: -5.5,-0.5
@@ -2171,8 +1975,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 349
     components:
     - rot: 3.141592653589793 rad
@@ -2181,8 +1983,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 350
     components:
     - rot: 3.141592653589793 rad
@@ -2191,8 +1991,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 351
     components:
     - rot: 3.141592653589793 rad
@@ -2201,8 +1999,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 352
     components:
     - rot: 3.141592653589793 rad
@@ -2373,6 +2169,14 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
+  - uid: 391
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 1.5,-3.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
   - uid: 394
     components:
     - rot: -1.5707963267948966 rad
@@ -2405,8 +2209,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 400
     components:
     - pos: 1.5,6.5
@@ -2421,8 +2223,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 402
     components:
     - pos: 1.5,4.5
@@ -2460,16 +2260,22 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 413
+  - uid: 412
     components:
     - rot: 1.5707963267948966 rad
-      pos: 6.5,4.5
+      pos: 0.5,-3.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
+  - uid: 413
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -0.5,-3.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
   - uid: 414
     components:
     - pos: 5.5,2.5
@@ -2479,7 +2285,8 @@ entities:
       type: AtmosPipeColor
   - uid: 415
     components:
-    - pos: 5.5,1.5
+    - rot: 1.5707963267948966 rad
+      pos: -1.5,-3.5
       parent: 1
       type: Transform
     - color: '#990000FF'
@@ -2491,146 +2298,51 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
+  - uid: 419
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -2.5,-3.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
   - uid: 420
     components:
-    - rot: 3.141592653589793 rad
-      pos: 3.5,-2.5
+    - rot: 1.5707963267948966 rad
+      pos: -3.5,-3.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 422
+  - uid: 421
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 4.5,-1.5
+    - rot: 1.5707963267948966 rad
+      pos: -4.5,-3.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
-  - uid: 423
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 5.5,-1.5
-      parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 424
     components:
-    - rot: 3.141592653589793 rad
-      pos: 3.5,-3.5
-      parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 425
-    components:
     - rot: 1.5707963267948966 rad
-      pos: 2.5,-1.5
+      pos: 7.5,3.5
       parent: 1
       type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
-  - uid: 426
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 1.5,-1.5
-      parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
   - uid: 427
     components:
     - rot: 1.5707963267948966 rad
-      pos: 0.5,-1.5
+      pos: 4.5,1.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 428
     components:
-    - rot: 1.5707963267948966 rad
-      pos: -0.5,-1.5
+    - pos: -5.5,-4.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 429
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -1.5,-1.5
-      parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
-  - uid: 430
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -2.5,-1.5
-      parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
-  - uid: 431
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -3.5,-1.5
-      parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
-  - uid: 432
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -4.5,-1.5
-      parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
-  - uid: 433
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -5.5,-1.5
-      parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
-  - uid: 434
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -6.5,-1.5
-      parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
-  - uid: 435
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 7.5,4.5
-      parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
 - proto: GasPipeTJunction
   entities:
   - uid: 250
@@ -2641,6 +2353,22 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
+  - uid: 321
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 5.5,1.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 331
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 3.5,-3.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
   - uid: 342
     components:
     - rot: 3.141592653589793 rad
@@ -2649,8 +2377,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 348
     components:
     - rot: -1.5707963267948966 rad
@@ -2659,8 +2385,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 354
     components:
     - rot: 3.141592653589793 rad
@@ -2698,16 +2422,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 412
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 5.5,4.5
-      parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 417
     components:
     - pos: 6.5,0.5
@@ -2715,23 +2429,14 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 419
+  - uid: 434
     components:
-    - rot: 3.141592653589793 rad
-      pos: 6.5,-1.5
+    - rot: 1.5707963267948966 rad
+      pos: 5.5,3.5
       parent: 1
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 421
-    components:
-    - pos: 3.5,-1.5
-      parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
 - proto: GasPort
   entities:
   - uid: 312
@@ -2747,6 +2452,23 @@ entities:
       pos: -7.5,-0.5
       parent: 1
       type: Transform
+- proto: GasPressurePump
+  entities:
+  - uid: 299
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 6.5,3.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 429
+    components:
+    - pos: -6.5,-1.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
 - proto: GasVentPump
   entities:
   - uid: 15
@@ -2755,8 +2477,6 @@ entities:
       pos: 1.5,2.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 330
@@ -2764,8 +2484,6 @@ entities:
     - pos: -3.5,6.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 336
@@ -2774,8 +2492,9 @@ entities:
       pos: -4.5,-0.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
+    - ShutdownSubscribers:
+      - 339
+      type: DeviceNetwork
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 337
@@ -2784,8 +2503,6 @@ entities:
       pos: -2.5,-3.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 384
@@ -2794,8 +2511,6 @@ entities:
       pos: 8.5,-2.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 385
@@ -2804,8 +2519,6 @@ entities:
       pos: 5.5,3.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 386
@@ -2813,8 +2526,6 @@ entities:
     - pos: 0.5,7.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
 - proto: GasVentScrubber
@@ -2828,8 +2539,6 @@ entities:
     - ShutdownSubscribers:
       - 14
       type: DeviceNetwork
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 388
@@ -2841,8 +2550,6 @@ entities:
     - ShutdownSubscribers:
       - 14
       type: DeviceNetwork
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 389
@@ -2851,8 +2558,6 @@ entities:
       pos: 3.5,-4.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 390
@@ -2861,18 +2566,6 @@ entities:
       pos: -1.5,2.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 391
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -7.5,-1.5
-      parent: 1
-      type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 392
@@ -2881,8 +2574,6 @@ entities:
       pos: -2.5,6.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 393
@@ -2891,26 +2582,19 @@ entities:
       pos: 3.5,6.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
-- proto: GasVolumePump
-  entities:
-  - uid: 316
+  - uid: 423
     components:
-    - pos: -6.5,-1.5
+    - rot: 3.141592653589793 rad
+      pos: -5.5,-5.5
       parent: 1
       type: Transform
-    - color: '#0055CCFF'
+    - ShutdownSubscribers:
+      - 339
+      type: DeviceNetwork
+    - color: '#990000FF'
       type: AtmosPipeColor
-- proto: GeneratorRTG
-  entities:
-  - uid: 182
-    components:
-    - pos: -6.5,-5.5
-      parent: 1
-      type: Transform
 - proto: GravityGeneratorMini
   entities:
   - uid: 233
@@ -2997,13 +2681,6 @@ entities:
     - pos: -7.5,-4.5
       parent: 1
       type: Transform
-- proto: Handcuffs
-  entities:
-  - uid: 299
-    components:
-    - pos: 9.615258,-1.5100076
-      parent: 1
-      type: Transform
 - proto: HandLabeler
   entities:
   - uid: 627
@@ -3082,15 +2759,13 @@ entities:
           occludes: True
           ent: null
       type: ContainerContainer
-- proto: LockerEvidence
+- proto: LockerMercenary
   entities:
-  - uid: 332
+  - uid: 432
     components:
     - pos: 8.5,-3.5
       parent: 1
       type: Transform
-    - locked: False
-      type: Lock
 - proto: MaintenanceFluffSpawner
   entities:
   - uid: 328
@@ -3098,20 +2773,43 @@ entities:
     - pos: -5.5,3.5
       parent: 1
       type: Transform
+- proto: MedicalTrackingImplanter
+  entities:
+  - uid: 267
+    components:
+    - pos: 8.321192,-1.2869799
+      parent: 1
+      type: Transform
+  - uid: 275
+    components:
+    - pos: 8.493067,-1.5369799
+      parent: 1
+      type: Transform
+  - uid: 486
+    components:
+    - pos: 8.696192,-1.4119799
+      parent: 1
+      type: Transform
 - proto: NitrogenCanister
   entities:
   - uid: 317
     components:
-    - pos: -7.5,-0.5
+    - anchored: True
+      pos: -7.5,-0.5
       parent: 1
       type: Transform
+    - bodyType: Static
+      type: Physics
 - proto: OxygenCanister
   entities:
   - uid: 318
     components:
-    - pos: -6.5,1.5
+    - anchored: True
+      pos: -6.5,1.5
       parent: 1
       type: Transform
+    - bodyType: Static
+      type: Physics
 - proto: PaintingAmogusTriptych
   entities:
   - uid: 295
@@ -3153,16 +2851,30 @@ entities:
     - type: InsideEntityStorage
 - proto: PortableGeneratorPacman
   entities:
-  - uid: 224
+  - uid: 184
     components:
-    - pos: -7.5,-5.5
+    - anchored: True
+      pos: -6.5,-5.5
       parent: 1
       type: Transform
     - storage:
         Plasma: 1500
       type: MaterialStorage
-    - endTime: 0
-      type: InsertingMaterialStorage
+    - bodyType: Static
+      type: Physics
+    - type: InsertingMaterialStorage
+  - uid: 224
+    components:
+    - anchored: True
+      pos: -7.5,-5.5
+      parent: 1
+      type: Transform
+    - storage:
+        Plasma: 1500
+      type: MaterialStorage
+    - bodyType: Static
+      type: Physics
+    - type: InsertingMaterialStorage
 - proto: PosterContrabandDonutCorp
   entities:
   - uid: 263
@@ -3212,15 +2924,13 @@ entities:
     - pos: -0.49874568,4.49925
       parent: 1
       type: Transform
-- proto: PottedPlant28
-  entities:
-  - uid: 4
-    components:
-    - pos: 1.5,8.5
-      parent: 1
-      type: Transform
 - proto: PottedPlantRandom
   entities:
+  - uid: 167
+    components:
+    - pos: 6.5,2.5
+      parent: 1
+      type: Transform
   - uid: 175
     components:
     - pos: 1.5,-1.5
@@ -3231,144 +2941,87 @@ entities:
     - pos: 3.5,-4.5
       parent: 1
       type: Transform
-- proto: PottedPlantRandomPlastic
-  entities:
-  - uid: 67
-    components:
-    - pos: 6.5,3.5
-      parent: 1
-      type: Transform
 - proto: Poweredlight
   entities:
+  - uid: 255
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -0.5,7.5
+      parent: 1
+      type: Transform
+  - uid: 435
+    components:
+    - pos: -3.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 460
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,-6.5
+      parent: 1
+      type: Transform
+  - uid: 461
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 3.5,1.5
+      parent: 1
+      type: Transform
   - uid: 553
     components:
     - pos: -0.5,4.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 554
     components:
     - rot: 3.141592653589793 rad
       pos: 1.5,0.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 555
     components:
     - rot: 3.141592653589793 rad
       pos: -2.5,-4.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 556
     components:
     - rot: 1.5707963267948966 rad
       pos: -8.5,-3.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 557
     components:
     - rot: 3.141592653589793 rad
       pos: 3.5,-4.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
-  - uid: 558
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -3.5,0.5
-      parent: 1
-      type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 559
     components:
     - pos: -5.5,3.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 560
     components:
     - pos: -3.5,6.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
-  - uid: 561
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 1.5,6.5
-      parent: 1
-      type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 562
     components:
     - rot: -1.5707963267948966 rad
       pos: 5.5,6.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
-  - uid: 563
-    components:
-    - pos: 5.5,3.5
-      parent: 1
-      type: Transform
-    - enabled: False
-      type: AmbientSound
-  - uid: 564
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 7.5,0.5
-      parent: 1
-      type: Transform
-    - enabled: False
-      type: AmbientSound
-  - uid: 565
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 3.5,-0.5
-      parent: 1
-      type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 566
     components:
     - pos: 8.5,-1.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 567
     components:
     - rot: 3.141592653589793 rad
       pos: 6.5,-5.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
-  - uid: 569
-    components:
-    - pos: 1.5,-6.5
-      parent: 1
-      type: Transform
-    - enabled: False
-      type: AmbientSound
-  - uid: 570
-    components:
-    - pos: -0.5,-6.5
-      parent: 1
-      type: Transform
-    - enabled: False
-      type: AmbientSound
 - proto: Rack
   entities:
   - uid: 69
@@ -3432,13 +3085,6 @@ entities:
     - pos: 6.5,1.5
       parent: 1
       type: Transform
-- proto: RandomVending
-  entities:
-  - uid: 167
-    components:
-    - pos: 8.5,0.5
-      parent: 1
-      type: Transform
 - proto: ReinforcedWindow
   entities:
   - uid: 258
@@ -3455,9 +3101,20 @@ entities:
       type: Transform
 - proto: SheetPlasma
   entities:
-  - uid: 232
+  - uid: 430
     components:
-    - pos: -5.6272902,2.621225
+    - pos: -7.530926,-5.475161
+      parent: 1
+      type: Transform
+    - count: 15
+      type: Stack
+    - size: 15
+      type: Item
+- proto: SheetPlasma1
+  entities:
+  - uid: 501
+    components:
+    - pos: -6.5309267,-5.522036
       parent: 1
       type: Transform
     - count: 15
@@ -3532,13 +3189,28 @@ entities:
       pos: 10.5,-3.5
       parent: 1
       type: Transform
-- proto: SignSec
+- proto: SignalButtonDirectional
   entities:
-  - uid: 276
+  - uid: 485
     components:
-    - pos: 7.5,-3.5
+    - rot: 1.5707963267948966 rad
+      pos: 5.5,-1.5
       parent: 1
       type: Transform
+    - linkedPorts:
+        586:
+        - Pressed: DoorBolt
+      type: DeviceLinkSource
+  - uid: 499
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 7.5,-3.5
+      parent: 1
+      type: Transform
+    - linkedPorts:
+        586:
+        - Pressed: DoorBolt
+      type: DeviceLinkSource
 - proto: SignToolStorage
   entities:
   - uid: 84
@@ -3561,13 +3233,6 @@ entities:
     - pos: -8.5,-4.5
       parent: 1
       type: Transform
-- proto: SpawnMobSlothPaperwork
-  entities:
-  - uid: 335
-    components:
-    - pos: 1.5,7.5
-      parent: 1
-      type: Transform
 - proto: SpawnPointLatejoin
   entities:
   - uid: 617
@@ -3582,18 +3247,18 @@ entities:
     - pos: 1.5,4.5
       parent: 1
       type: Transform
-- proto: SpawnPointPrisonGuard
+- proto: SpawnPointMercenary
   entities:
-  - uid: 619
+  - uid: 483
     components:
     - pos: 9.5,-3.5
       parent: 1
       type: Transform
-- proto: SpawnPointStationEngineer
+- proto: SpawnPointPilot
   entities:
-  - uid: 618
+  - uid: 590
     components:
-    - pos: -3.5,2.5
+    - pos: -0.5,7.5
       parent: 1
       type: Transform
 - proto: SubstationBasic
@@ -3648,11 +3313,33 @@ entities:
       pos: 8.5,-1.5
       parent: 1
       type: Transform
+  - uid: 276
+    components:
+    - pos: 7.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 316
+    components:
+    - pos: 7.5,1.5
+      parent: 1
+      type: Transform
 - proto: TableGlass
   entities:
   - uid: 221
     components:
     - pos: -2.5,-3.5
+      parent: 1
+      type: Transform
+- proto: TableReinforced
+  entities:
+  - uid: 282
+    components:
+    - pos: -0.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 459
+    components:
+    - pos: 0.5,8.5
       parent: 1
       type: Transform
 - proto: TableReinforcedGlass
@@ -3769,32 +3456,11 @@ entities:
     - pos: -2.5,9.5
       parent: 1
       type: Transform
-- proto: ToyFigurineSecurity
-  entities:
-  - uid: 275
-    components:
-    - pos: 9.69197,-1.2933671
-      parent: 1
-      type: Transform
-- proto: TrackingImplanter
-  entities:
-  - uid: 35
-    components:
-    - pos: 8.3591,-1.2683523
-      parent: 1
-      type: Transform
-  - uid: 37
-    components:
-    - pos: 8.471601,-1.3808522
-      parent: 1
-      type: Transform
 - proto: VendingMachineCigs
   entities:
-  - uid: 185
+  - uid: 489
     components:
-    - flags: SessionSpecific
-      type: MetaData
-    - pos: 7.5,1.5
+    - pos: 8.5,0.5
       parent: 1
       type: Transform
 - proto: VendingMachineClothing
@@ -4223,11 +3889,6 @@ entities:
     - pos: -2.5,1.5
       parent: 1
       type: Transform
-  - uid: 11
-    components:
-    - pos: -1.5,5.5
-      parent: 1
-      type: Transform
   - uid: 25
     components:
     - pos: -2.5,3.5
@@ -4445,6 +4106,11 @@ entities:
       pos: 5.5,4.5
       parent: 1
       type: Transform
+  - uid: 490
+    components:
+    - pos: -1.5,5.5
+      parent: 1
+      type: Transform
   - uid: 601
     components:
     - rot: -1.5707963267948966 rad
@@ -4484,19 +4150,9 @@ entities:
       type: Transform
 - proto: WoodDoor
   entities:
-  - uid: 76
+  - uid: 498
     components:
     - pos: 0.5,-0.5
-      parent: 1
-      type: Transform
-    - SecondsUntilStateChange: -3276.3284
-      state: Opening
-      type: Door
-- proto: Wrench
-  entities:
-  - uid: 639
-    components:
-    - pos: -5.5795636,-5.296104
       parent: 1
       type: Transform
 ...

--- a/Resources/Maps/_NF/Shuttles/esquire.yml
+++ b/Resources/Maps/_NF/Shuttles/esquire.yml
@@ -1426,6 +1426,12 @@ entities:
       pos: 4.5,1.5
       parent: 1
       type: Transform
+  - uid: 594
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 8.5,-4.5
+      parent: 1
+      type: Transform
 - proto: ChairOfficeDark
   entities:
   - uid: 80
@@ -1549,6 +1555,13 @@ entities:
     - canCollide: False
       type: Physics
     - type: InsideEntityStorage
+- proto: ClothingUniformJumpsuitPrisoner
+  entities:
+  - uid: 593
+    components:
+    - pos: 9.729263,-1.364162
+      parent: 1
+      type: Transform
 - proto: ComfyChair
   entities:
   - uid: 338
@@ -1751,6 +1764,8 @@ entities:
     - pos: 8.5,4.5
       parent: 1
       type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
 - proto: GasPipeBend
   entities:
   - uid: 320
@@ -1759,6 +1774,8 @@ entities:
       pos: 8.5,3.5
       parent: 1
       type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
   - uid: 334
     components:
     - rot: 1.5707963267948966 rad
@@ -2328,6 +2345,8 @@ entities:
       pos: 7.5,3.5
       parent: 1
       type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
   - uid: 427
     components:
     - rot: 1.5707963267948966 rad
@@ -2917,15 +2936,13 @@ entities:
     - pos: -0.5,-0.5
       parent: 1
       type: Transform
-- proto: PottedPlant21
+- proto: PottedPlantRandom
   entities:
   - uid: 83
     components:
-    - pos: -0.49874568,4.49925
+    - pos: -0.5,4.5
       parent: 1
       type: Transform
-- proto: PottedPlantRandom
-  entities:
   - uid: 167
     components:
     - pos: 6.5,2.5
@@ -2939,6 +2956,11 @@ entities:
   - uid: 287
     components:
     - pos: 3.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 596
+    components:
+    - pos: 1.5,8.5
       parent: 1
       type: Transform
 - proto: Poweredlight

--- a/Resources/Maps/_NF/Shuttles/esquire.yml
+++ b/Resources/Maps/_NF/Shuttles/esquire.yml
@@ -1081,11 +1081,6 @@ entities:
     - pos: -5.5,-2.5
       parent: 1
       type: Transform
-  - uid: 446
-    components:
-    - pos: -5.5,-3.5
-      parent: 1
-      type: Transform
   - uid: 447
     components:
     - pos: -4.5,-3.5
@@ -1576,13 +1571,6 @@ entities:
     - pos: 2.5,8.5
       parent: 1
       type: Transform
-- proto: ComputerTabletopCriminalRecords
-  entities:
-  - uid: 587
-    components:
-    - pos: 7.5,-1.5
-      parent: 1
-      type: Transform
 - proto: ComputerTabletopRadar
   entities:
   - uid: 433
@@ -1609,6 +1597,23 @@ entities:
   - uid: 22
     components:
     - pos: 4.729821,2.6469872
+      parent: 1
+      type: Transform
+- proto: DrinkWaterCup
+  entities:
+  - uid: 276
+    components:
+    - pos: 1.4668448,-4.2323036
+      parent: 1
+      type: Transform
+  - uid: 284
+    components:
+    - pos: 1.7002636,-4.4614706
+      parent: 1
+      type: Transform
+  - uid: 446
+    components:
+    - pos: 1.2627636,-4.4510536
       parent: 1
       type: Transform
 - proto: DrinkWhiskeyBottleFull
@@ -1755,7 +1760,7 @@ entities:
     - pos: -6.5,-0.5
       parent: 1
       type: Transform
-    - color: '#0055CCFF'
+    - color: '#03FCD3FF'
       type: AtmosPipeColor
 - proto: GasPassiveVent
   entities:
@@ -1938,7 +1943,7 @@ entities:
     - pos: -6.5,0.5
       parent: 1
       type: Transform
-    - color: '#0055CCFF'
+    - color: '#03FCD3FF'
       type: AtmosPipeColor
   - uid: 332
     components:
@@ -2463,7 +2468,7 @@ entities:
     - pos: -6.5,1.5
       parent: 1
       type: Transform
-    - color: '#0055CCFF'
+    - color: '#03FCD3FF'
       type: AtmosPipeColor
   - uid: 313
     components:
@@ -2471,6 +2476,8 @@ entities:
       pos: -7.5,-0.5
       parent: 1
       type: Transform
+    - color: '#03FCD3FF'
+      type: AtmosPipeColor
 - proto: GasPressurePump
   entities:
   - uid: 299
@@ -3075,13 +3082,6 @@ entities:
     - pos: 1.5,0.5
       parent: 1
       type: Transform
-- proto: RandomFoodSingle
-  entities:
-  - uid: 284
-    components:
-    - pos: 1.5,-4.5
-      parent: 1
-      type: Transform
 - proto: RandomPainting
   entities:
   - uid: 235
@@ -3335,14 +3335,14 @@ entities:
       pos: 8.5,-1.5
       parent: 1
       type: Transform
-  - uid: 276
-    components:
-    - pos: 7.5,-1.5
-      parent: 1
-      type: Transform
   - uid: 316
     components:
     - pos: 7.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 587
+    components:
+    - pos: 7.5,-1.5
       parent: 1
       type: Transform
 - proto: TableGlass

--- a/Resources/Prototypes/_NF/Shipyard/esquire.yml
+++ b/Resources/Prototypes/_NF/Shipyard/esquire.yml
@@ -1,16 +1,26 @@
+# Author Info
+# GitHub: ???
+# Discord: ???
+
+# Maintainer Info
+# GitHub: ???
+# Discord: ???
+
+# Shuttle Notes:
+#
 - type: vessel
   id: Esquire
   name: NT Esquire
   description: A classy mid-sized vessel equipped with a lawyers office and prisoner handling area.
-  price: 42500
+  price: 38500
   category: Medium
   group: Civilian
-  shuttlePath: /Maps/Shuttles/esquire.yml
+  shuttlePath: /Maps/_NF/Shuttles/esquire.yml
 
 - type: gameMap
   id: Esquire
   mapName: 'NT Esquire'
-  mapPath: /Maps/Shuttles/esquire.yml
+  mapPath: /Maps/_NF/Shuttles/esquire.yml
   minPlayers: 0
   stations:
     Esquire:
@@ -25,5 +35,5 @@
           overflowJobs: []
           availableJobs:
             Lawyer: [ 0, 0 ]
-            StationEngineer: [ 0, 0 ]
-            PrisonGuard: [ 0, 0 ]
+            Mercenary: [ 0, 0 ]
+            Pilot: [ 0, 0 ]


### PR DESCRIPTION
## About the PR
Updating NC Skipper to current mapping standards:
- Wiring rework.
- Atmos rework.
- Removed Food Vendomat.
- Removed some loose items.
- Replaced consoles with tabletop variants.
- Replaced security room with mercenary room.
- Enabled Mercenary Job.
- Enabled Pilot Job.
- Removed Station Engineer Job.
- Added Vacuum Markers to exposed to space tiles.
- Moved ship.yml to Maps/_NF/Shuttles/

## Why / Balance
New mapping standards.

## Media
![2024-1-30_02 21 44](https://github.com/new-frontiers-14/frontier-station-14/assets/65374927/33f947d0-99a8-424f-b912-1aefe88c0560)
- [X] I have added screenshots/videos to this PR showcasing its changes ingame.

**Changelog**
:cl: erhardsteinhauer
- tweak: Updated NC Esquire to current mapping standards.