### PR TITLE
Fix improper SizeAttribute scaling

### DIFF
--- a/Content.Server/_NF/SizeAttribute/SizeAttributeSystem.cs
+++ b/Content.Server/_NF/SizeAttribute/SizeAttributeSystem.cs
@@ -71,6 +71,9 @@ namespace Content.Server.SizeAttribute
             {
                 foreach (var (id, fixture) in manager.Fixtures)
                 {
+                    if (!fixture.Hard || fixture.Density <= 1f)
+                        continue; // This will skip the flammable fixture and any other fixture that is not supposed to contribute to mass
+
                     switch (fixture.Shape)
                     {
                         case PhysShapeCircle circle:

--- a/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
@@ -45,7 +45,7 @@
   - type: SizeAttributeWhitelist
     tall: true
     tallscale: 1.2
-    tallDensity: 220
+    tallDensity: 200 # less than oni - 220
   - type: MeleeWeapon
     soundHit:
       path: /Audio/Weapons/slash.ogg


### PR DESCRIPTION
## About the PR
Fixes tall lizards, tall cats and small vulps being twice as heavy as others of the same size, and thus incomparably stronger

Also makes tall lizards slightly less heavy compared to oni (reduces their density by roughly 10%)

## Why / Balance
*SCREAMS*

## Technical details
Every mob has two fixtures: the main one used for collisions, and an auxillary one used for flammability. The second one normally has a density of 1, and thus contributes little to nothing to the mass. SizeAttribute, however, used to change the density of ALL fixtures, thus making the flammable fixture have mass AND DOUBLING THE FINAL MASS OF THE MOB.

## Media
https://cdn.discordapp.com/attachments/1127687656084611214/1201800015753007134/weeee-2024-01-30_10.55.29.mp4?ex=65cb227c&is=65b8ad7c&hm=730dbbe0f2217b6d376ccbec0f4c64543ae268f1f76cc95e8c7c59ffa93befe0&

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
N/A

**Changelog**
:cl:
- fix: NanoTrasen cloning facilities no longer cause tall lizards, small vulpkanin, and tall felinids to have their body weight doubled.