### PR TITLE
Helix (Update)

### DIFF
--- a/Resources/Maps/_NF/Shuttles/helix.yml
+++ b/Resources/Maps/_NF/Shuttles/helix.yml
@@ -3,14 +3,14 @@ meta:
   postmapinit: false
 tilemap:
   0: Space
-  27: FloorDark
-  32: FloorDarkMono
-  62: FloorMetalDiamond
-  96: FloorTechMaint
-  100: FloorWhite
-  101: FloorWhiteDiagonal
-  112: Lattice
-  113: Plating
+  28: FloorDark
+  33: FloorDarkMono
+  63: FloorMetalDiamond
+  97: FloorTechMaint
+  101: FloorWhite
+  102: FloorWhiteDiagonal
+  113: Lattice
+  114: Plating
 entities:
 - proto: ""
   entities:
@@ -23,19 +23,19 @@ entities:
     - chunks:
         -1,-1:
           ind: -1,-1
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAZAAAAAABcQAAAAAA
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAZQAAAAABcgAAAAAA
           version: 6
         -1,0:
           ind: -1,0
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAZAAAAAADcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcQAAAAAAZAAAAAADZAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAZAAAAAADZAAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAZAAAAAADcQAAAAAAZAAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcQAAAAAAZAAAAAABZAAAAAAAZAAAAAABZAAAAAAAcQAAAAAAZAAAAAADZAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcQAAAAAAZAAAAAAAZAAAAAACZAAAAAACZAAAAAADcQAAAAAAZAAAAAACZQAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcQAAAAAAZAAAAAADZAAAAAACZAAAAAABZAAAAAAAZAAAAAADZAAAAAADZQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAZAAAAAADcQAAAAAAcQAAAAAAZAAAAAABZQAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAZAAAAAADZAAAAAADZAAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAZQAAAAADcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcgAAAAAAZQAAAAADZQAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAZQAAAAADZQAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAZQAAAAADcgAAAAAAZQAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcgAAAAAAZQAAAAABZQAAAAAAZQAAAAABZQAAAAAAcgAAAAAAZQAAAAADZQAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcgAAAAAAZQAAAAAAZQAAAAACZQAAAAACZQAAAAADcgAAAAAAZQAAAAACZgAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcgAAAAAAZQAAAAADZQAAAAACZQAAAAABZQAAAAAAZQAAAAADZQAAAAADZgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAZQAAAAADcgAAAAAAcgAAAAAAZQAAAAABZgAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAZQAAAAADZQAAAAADZQAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
           version: 6
         0,-1:
           ind: 0,-1
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcAAAAAAAAAAAAAAAcAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZAAAAAADcQAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcQAAAAAAZAAAAAADcQAAAAAAZAAAAAADcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcgAAAAAAcQAAAAAAAAAAAAAAcQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZQAAAAADcgAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcgAAAAAAZQAAAAADcgAAAAAAZQAAAAADcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
           version: 6
         0,0:
           ind: 0,0
-          tiles: ZAAAAAABcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAZAAAAAABcQAAAAAAZAAAAAACcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZAAAAAADcQAAAAAAZAAAAAADZAAAAAADZAAAAAACcQAAAAAAZAAAAAAAZAAAAAABZAAAAAAAcQAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZAAAAAAAcQAAAAAAZAAAAAABZAAAAAADZAAAAAADcQAAAAAAZAAAAAACZAAAAAAAZAAAAAACcQAAAAAAcQAAAAAAcQAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZAAAAAACcQAAAAAAZAAAAAAAZAAAAAABZAAAAAABcQAAAAAAZAAAAAAAcQAAAAAAZAAAAAABcQAAAAAAGwAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAZAAAAAABZAAAAAABZAAAAAABZAAAAAADZAAAAAACcQAAAAAAZAAAAAACZAAAAAABZAAAAAABZAAAAAACGwAAAAADPgAAAAAAPgAAAAAAPgAAAAAAcQAAAAAAcAAAAAAAZAAAAAACcQAAAAAAZAAAAAACZAAAAAADcQAAAAAAcQAAAAAAZAAAAAAAZQAAAAACZAAAAAACcQAAAAAAGwAAAAABYAAAAAAAYAAAAAAAYAAAAAAAcQAAAAAAcAAAAAAAZAAAAAADcQAAAAAAZAAAAAABZAAAAAADZAAAAAACcQAAAAAAZAAAAAACZQAAAAACZAAAAAACcQAAAAAAGwAAAAACYAAAAAAAYAAAAAAAYAAAAAAAcQAAAAAAcAAAAAAAZQAAAAAAZQAAAAAAZQAAAAACZQAAAAAAZQAAAAABZQAAAAACZQAAAAADZQAAAAADZAAAAAABZAAAAAACGwAAAAABYAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAZAAAAAACcQAAAAAAZAAAAAAAZAAAAAAAZAAAAAAAcQAAAAAAZAAAAAADZAAAAAADZAAAAAACZAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAIAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAYAAAAAAAYAAAAAAAcQAAAAAAGwAAAAAAGwAAAAADGwAAAAAAcQAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAIAAAAAACGwAAAAACGwAAAAACGwAAAAACcQAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAYAAAAAAAYAAAAAAAcQAAAAAAGwAAAAADGwAAAAACGwAAAAABcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          tiles: ZQAAAAABcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAZQAAAAABcgAAAAAAZQAAAAACcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZQAAAAADcgAAAAAAZQAAAAADZQAAAAADZQAAAAACcgAAAAAAZQAAAAAAZQAAAAABZQAAAAAAcgAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZQAAAAAAcgAAAAAAZQAAAAABZQAAAAADZQAAAAADcgAAAAAAZQAAAAACZQAAAAAAZQAAAAACcgAAAAAAcgAAAAAAcgAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZQAAAAACcgAAAAAAZQAAAAAAZQAAAAABZQAAAAABcgAAAAAAZQAAAAAAcgAAAAAAZQAAAAABcgAAAAAAHAAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAZQAAAAABZQAAAAABZQAAAAABZQAAAAADZQAAAAACcgAAAAAAZQAAAAACZQAAAAABZQAAAAABZQAAAAACHAAAAAADPwAAAAAAPwAAAAAAPwAAAAAAcgAAAAAAcQAAAAAAZQAAAAACcgAAAAAAZQAAAAACZQAAAAADcgAAAAAAcgAAAAAAZQAAAAAAZgAAAAACZQAAAAACcgAAAAAAHAAAAAABYQAAAAAAYQAAAAAAYQAAAAAAcgAAAAAAcQAAAAAAZQAAAAADcgAAAAAAZQAAAAABZQAAAAADZQAAAAACcgAAAAAAZQAAAAACZgAAAAACZQAAAAACcgAAAAAAHAAAAAACYQAAAAAAYQAAAAAAYQAAAAAAcgAAAAAAcQAAAAAAZgAAAAAAZgAAAAAAZgAAAAACZgAAAAAAZgAAAAABZgAAAAACZgAAAAADZgAAAAADZQAAAAABZQAAAAACHAAAAAABYQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAZQAAAAACcgAAAAAAZQAAAAAAZQAAAAAAZQAAAAAAcgAAAAAAZQAAAAADZQAAAAADZQAAAAACZQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAIQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYQAAAAAAYQAAAAAAYQAAAAAAcgAAAAAAHAAAAAAAHAAAAAADHAAAAAAAcgAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYQAAAAAAcgAAAAAAcgAAAAAAIQAAAAACHAAAAAACHAAAAAACHAAAAAACcgAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYQAAAAAAYQAAAAAAYQAAAAAAcgAAAAAAHAAAAAADHAAAAAACHAAAAAABcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
           version: 6
       type: MapGrid
     - type: Broadphase
@@ -272,81 +272,95 @@ entities:
       data:
         tiles:
           -1,-1:
-            0: 61184
+            0: 256
+            1: 60928
           -1,0:
-            0: 65534
+            0: 16
+            1: 65518
           0,-1:
-            0: 63232
+            1: 13056
+            0: 50176
           0,0:
-            0: 65535
+            1: 65535
           -3,1:
             0: 2184
           -2,0:
-            0: 64512
+            1: 63488
+            0: 1024
           -2,1:
-            0: 65535
+            1: 65535
           -2,2:
-            0: 142
+            0: 130
+            1: 12
           -1,1:
-            0: 65535
+            1: 65535
           -1,2:
-            0: 52991
+            1: 35071
+            0: 17920
           -1,3:
-            0: 136
+            1: 136
           1,-1:
-            0: 65280
+            0: 4352
+            1: 60928
           2,-1:
-            0: 14080
+            1: 13056
+            0: 1024
           0,1:
-            0: 65535
+            1: 65535
           0,2:
-            0: 65535
+            1: 65535
           0,3:
-            0: 3327
+            1: 255
+            0: 3072
           1,0:
-            0: 65535
+            1: 65535
           1,1:
-            0: 65535
+            1: 65535
           1,2:
-            0: 65023
-            1: 512
+            1: 65535
           1,3:
-            0: 511
+            1: 255
+            0: 256
           2,0:
-            0: 65395
+            1: 65331
+            0: 64
           2,1:
-            0: 65535
+            1: 65535
           2,2:
-            0: 5119
+            1: 127
+            0: 4992
           3,0:
-            0: 61696
+            0: 256
+            1: 61440
           3,1:
-            0: 65535
+            1: 63351
+            0: 2184
           3,2:
-            0: 23
+            1: 21
+            0: 2
           4,1:
-            0: 273
+            1: 273
         uniqueMixes:
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
         - volume: 2500
           temperature: 293.15
           moles:
           - 21.824879
           - 82.10312
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-        - volume: 2500
-          temperature: 293.14996
-          moles:
-          - 21.6852
-          - 81.57766
           - 0
           - 0
           - 0
@@ -364,6 +378,96 @@ entities:
     - id: Helix
       type: BecomesStation
     - type: SpreaderGrid
+- proto: AirAlarm
+  entities:
+  - uid: 560
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 1.5,9.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 102
+      type: DeviceNetwork
+    - devices:
+      - 102
+      type: DeviceList
+  - uid: 561
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 5.5,9.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 550
+      - 106
+      - 541
+      - 207
+      - 209
+      - 537
+      - 160
+      - 35
+      - 551
+      - 545
+      - 540
+      - 208
+      - 536
+      - 211
+      type: DeviceNetwork
+    - devices:
+      - 211
+      - 536
+      - 208
+      - 540
+      - 545
+      - 551
+      - 35
+      - 160
+      - 537
+      - 209
+      - 207
+      - 541
+      - 106
+      - 550
+      type: DeviceList
+  - uid: 562
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -4.5,3.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 213
+      - 529
+      type: DeviceNetwork
+    - devices:
+      - 213
+      - 529
+      type: DeviceList
+  - uid: 563
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 11.5,3.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 239
+      - 171
+      type: DeviceNetwork
+    - devices:
+      - 239
+      - 171
+      type: DeviceList
+- proto: AirCanister
+  entities:
+  - uid: 121
+    components:
+    - anchored: True
+      pos: 0.5,11.5
+      parent: 1
+      type: Transform
+    - bodyType: Static
+      type: Physics
 - proto: AirlockChemistry
   entities:
   - uid: 2
@@ -503,6 +607,158 @@ entities:
     - pos: 8.5,-1.5
       parent: 1
       type: Transform
+- proto: AtmosFixBlockerMarker
+  entities:
+  - uid: 135
+    components:
+    - pos: -8.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 136
+    components:
+    - pos: -8.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 432
+    components:
+    - pos: 11.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 436
+    components:
+    - pos: -8.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 495
+    components:
+    - pos: -5.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 503
+    components:
+    - pos: -3.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 504
+    components:
+    - pos: -3.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 505
+    components:
+    - pos: 2.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 506
+    components:
+    - pos: 2.5,-0.5
+      parent: 1
+      type: Transform
+  - uid: 507
+    components:
+    - pos: 3.5,-0.5
+      parent: 1
+      type: Transform
+  - uid: 509
+    components:
+    - pos: 4.5,-0.5
+      parent: 1
+      type: Transform
+  - uid: 510
+    components:
+    - pos: 4.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 511
+    components:
+    - pos: 10.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 512
+    components:
+    - pos: 10.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 513
+    components:
+    - pos: 12.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 514
+    components:
+    - pos: 15.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 515
+    components:
+    - pos: 15.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 516
+    components:
+    - pos: 15.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 517
+    components:
+    - pos: 13.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 518
+    components:
+    - pos: 9.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 519
+    components:
+    - pos: 8.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 520
+    components:
+    - pos: 8.5,11.5
+      parent: 1
+      type: Transform
+  - uid: 521
+    components:
+    - pos: 4.5,14.5
+      parent: 1
+      type: Transform
+  - uid: 522
+    components:
+    - pos: 3.5,14.5
+      parent: 1
+      type: Transform
+  - uid: 523
+    components:
+    - pos: 2.5,14.5
+      parent: 1
+      type: Transform
+  - uid: 524
+    components:
+    - pos: -1.5,11.5
+      parent: 1
+      type: Transform
+  - uid: 525
+    components:
+    - pos: -1.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 526
+    components:
+    - pos: -2.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 527
+    components:
+    - pos: -4.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 528
+    components:
+    - pos: -6.5,8.5
+      parent: 1
+      type: Transform
 - proto: Beaker
   entities:
   - uid: 26
@@ -538,33 +794,12 @@ entities:
   entities:
   - uid: 31
     components:
-    - pos: 12.578991,4.6547847
+    - pos: 11.558722,4.631956
       parent: 1
       type: Transform
   - uid: 32
     components:
     - pos: 12.344845,4.713321
-      parent: 1
-      type: Transform
-- proto: BoxBeaker
-  entities:
-  - uid: 33
-    components:
-    - pos: 4.5120697,4.656429
-      parent: 1
-      type: Transform
-- proto: BoxMouthSwab
-  entities:
-  - uid: 34
-    components:
-    - pos: 0.30763578,8.693682
-      parent: 1
-      type: Transform
-- proto: BoxNitrileGloves
-  entities:
-  - uid: 35
-    components:
-    - pos: 11.767725,4.5306177
       parent: 1
       type: Transform
 - proto: CableApcExtension
@@ -597,21 +832,6 @@ entities:
   - uid: 41
     components:
     - pos: 2.5,11.5
-      parent: 1
-      type: Transform
-  - uid: 42
-    components:
-    - pos: 1.5,11.5
-      parent: 1
-      type: Transform
-  - uid: 43
-    components:
-    - pos: 0.5,11.5
-      parent: 1
-      type: Transform
-  - uid: 44
-    components:
-    - pos: 0.5,10.5
       parent: 1
       type: Transform
   - uid: 45
@@ -736,22 +956,17 @@ entities:
       type: Transform
   - uid: 69
     components:
-    - pos: 11.5,4.5
+    - pos: 10.5,5.5
       parent: 1
       type: Transform
   - uid: 70
     components:
-    - pos: 12.5,4.5
+    - pos: 11.5,5.5
       parent: 1
       type: Transform
   - uid: 71
     components:
-    - pos: 13.5,4.5
-      parent: 1
-      type: Transform
-  - uid: 72
-    components:
-    - pos: 14.5,4.5
+    - pos: 12.5,5.5
       parent: 1
       type: Transform
   - uid: 73
@@ -806,47 +1021,17 @@ entities:
       type: Transform
   - uid: 83
     components:
-    - pos: -4.5,4.5
+    - pos: -3.5,5.5
       parent: 1
       type: Transform
   - uid: 84
     components:
-    - pos: -5.5,4.5
+    - pos: -4.5,5.5
       parent: 1
       type: Transform
   - uid: 85
     components:
-    - pos: -6.5,4.5
-      parent: 1
-      type: Transform
-  - uid: 86
-    components:
-    - pos: -6.5,5.5
-      parent: 1
-      type: Transform
-  - uid: 87
-    components:
-    - pos: -6.5,6.5
-      parent: 1
-      type: Transform
-  - uid: 88
-    components:
-    - pos: 14.5,5.5
-      parent: 1
-      type: Transform
-  - uid: 89
-    components:
-    - pos: 14.5,6.5
-      parent: 1
-      type: Transform
-  - uid: 90
-    components:
-    - pos: 6.5,3.5
-      parent: 1
-      type: Transform
-  - uid: 91
-    components:
-    - pos: 6.5,2.5
+    - pos: -5.5,5.5
       parent: 1
       type: Transform
   - uid: 92
@@ -864,11 +1049,6 @@ entities:
     - pos: 6.5,-0.5
       parent: 1
       type: Transform
-  - uid: 95
-    components:
-    - pos: 6.5,-1.5
-      parent: 1
-      type: Transform
   - uid: 96
     components:
     - pos: 7.5,1.5
@@ -879,32 +1059,7 @@ entities:
     - pos: 8.5,1.5
       parent: 1
       type: Transform
-  - uid: 98
-    components:
-    - pos: 8.5,0.5
-      parent: 1
-      type: Transform
-  - uid: 99
-    components:
-    - pos: 8.5,-0.5
-      parent: 1
-      type: Transform
-  - uid: 100
-    components:
-    - pos: 8.5,-1.5
-      parent: 1
-      type: Transform
   - uid: 101
-    components:
-    - pos: 0.5,3.5
-      parent: 1
-      type: Transform
-  - uid: 102
-    components:
-    - pos: 0.5,2.5
-      parent: 1
-      type: Transform
-  - uid: 103
     components:
     - pos: 0.5,1.5
       parent: 1
@@ -917,11 +1072,6 @@ entities:
   - uid: 105
     components:
     - pos: 0.5,-0.5
-      parent: 1
-      type: Transform
-  - uid: 106
-    components:
-    - pos: 0.5,-1.5
       parent: 1
       type: Transform
   - uid: 107
@@ -937,21 +1087,6 @@ entities:
   - uid: 109
     components:
     - pos: -1.5,1.5
-      parent: 1
-      type: Transform
-  - uid: 110
-    components:
-    - pos: -1.5,0.5
-      parent: 1
-      type: Transform
-  - uid: 111
-    components:
-    - pos: -1.5,-0.5
-      parent: 1
-      type: Transform
-  - uid: 112
-    components:
-    - pos: -1.5,-1.5
       parent: 1
       type: Transform
   - uid: 113
@@ -981,41 +1116,41 @@ entities:
       type: Transform
 - proto: CableHV
   entities:
+  - uid: 43
+    components:
+    - pos: 2.5,10.5
+      parent: 1
+      type: Transform
   - uid: 118
-    components:
-    - pos: 0.5,12.5
-      parent: 1
-      type: Transform
-  - uid: 119
-    components:
-    - pos: 1.5,12.5
-      parent: 1
-      type: Transform
-  - uid: 120
     components:
     - pos: 2.5,12.5
       parent: 1
       type: Transform
-  - uid: 121
-    components:
-    - pos: 0.5,10.5
-      parent: 1
-      type: Transform
-  - uid: 122
-    components:
-    - pos: 0.5,11.5
-      parent: 1
-      type: Transform
   - uid: 123
+    components:
+    - pos: 1.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 138
+    components:
+    - pos: 2.5,11.5
+      parent: 1
+      type: Transform
+  - uid: 303
     components:
     - pos: 0.5,12.5
       parent: 1
       type: Transform
 - proto: CableMV
   entities:
-  - uid: 124
+  - uid: 99
     components:
-    - pos: 2.5,12.5
+    - pos: 4.5,7.5
+      parent: 1
+      type: Transform
+  - uid: 122
+    components:
+    - pos: 2.5,11.5
       parent: 1
       type: Transform
   - uid: 125
@@ -1043,16 +1178,6 @@ entities:
     - pos: 4.5,9.5
       parent: 1
       type: Transform
-  - uid: 130
-    components:
-    - pos: 4.5,8.5
-      parent: 1
-      type: Transform
-  - uid: 131
-    components:
-    - pos: 4.5,7.5
-      parent: 1
-      type: Transform
   - uid: 132
     components:
     - pos: 4.5,6.5
@@ -1068,27 +1193,27 @@ entities:
     - pos: 4.5,4.5
       parent: 1
       type: Transform
-  - uid: 135
-    components:
-    - pos: 4.5,3.5
-      parent: 1
-      type: Transform
-  - uid: 136
-    components:
-    - pos: 5.5,3.5
-      parent: 1
-      type: Transform
   - uid: 137
     components:
     - pos: 5.5,4.5
       parent: 1
       type: Transform
+  - uid: 431
+    components:
+    - pos: 2.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 542
+    components:
+    - pos: 4.5,8.5
+      parent: 1
+      type: Transform
 - proto: CableTerminal
   entities:
-  - uid: 138
+  - uid: 146
     components:
     - rot: 1.5707963267948966 rad
-      pos: 0.5,12.5
+      pos: 1.5,12.5
       parent: 1
       type: Transform
 - proto: Catwalk
@@ -1097,18 +1222,6 @@ entities:
     components:
     - rot: 3.141592653589793 rad
       pos: 2.5,11.5
-      parent: 1
-      type: Transform
-  - uid: 140
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 1.5,11.5
-      parent: 1
-      type: Transform
-  - uid: 141
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 0.5,11.5
       parent: 1
       type: Transform
 - proto: Chair
@@ -1135,14 +1248,6 @@ entities:
     components:
     - rot: -1.5707963267948966 rad
       pos: 0.5,5.5
-      parent: 1
-      type: Transform
-- proto: ChairFolding
-  entities:
-  - uid: 146
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 0.5,11.5
       parent: 1
       type: Transform
 - proto: ChairOfficeLight
@@ -1192,110 +1297,6 @@ entities:
     - pos: 11.5,6.5
       parent: 1
       type: Transform
-- proto: ClothingBeltMedicalFilled
-  entities:
-  - uid: 155
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 154
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
-- proto: ClothingEyesHudMedical
-  entities:
-  - uid: 163
-    components:
-    - pos: 7.532101,8.5749855
-      parent: 1
-      type: Transform
-  - uid: 503
-    components:
-    - pos: 6.411058,8.514711
-      parent: 1
-      type: Transform
-  - uid: 504
-    components:
-    - pos: 0.588331,8.538559
-      parent: 1
-      type: Transform
-  - uid: 505
-    components:
-    - pos: 3.094012,5.605332
-      parent: 1
-      type: Transform
-- proto: ClothingHandsGlovesNitrile
-  entities:
-  - uid: 164
-    components:
-    - pos: 0.57105017,8.576609
-      parent: 1
-      type: Transform
-- proto: ClothingHeadHatSurgcapPurple
-  entities:
-  - uid: 165
-    components:
-    - pos: 11.504311,4.5452514
-      parent: 1
-      type: Transform
-- proto: ClothingHeadHelmetVoidParamed
-  entities:
-  - uid: 156
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 154
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
-  - uid: 166
-    components:
-    - pos: 7.6064925,8.527011
-      parent: 1
-      type: Transform
-- proto: ClothingNeckMantleCap
-  entities:
-  - uid: 157
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 154
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
-- proto: ClothingNeckStethoscope
-  entities:
-  - uid: 167
-    components:
-    - pos: -4.509046,7.6246953
-      parent: 1
-      type: Transform
-- proto: ClothingOuterHardsuitVoidParamed
-  entities:
-  - uid: 158
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 154
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
-  - uid: 168
-    components:
-    - pos: 7.2552733,8.556279
-      parent: 1
-      type: Transform
-- proto: ClothingOuterWinterChem
-  entities:
-  - uid: 169
-    components:
-    - pos: 3.9942956,1.5917455
-      parent: 1
-      type: Transform
 - proto: ComputerCloningConsole
   entities:
   - uid: 170
@@ -1319,16 +1320,16 @@ entities:
       pos: 7.5,4.5
       parent: 1
       type: Transform
-- proto: ComputerShuttle
+- proto: ComputerTabletopShuttle
   entities:
   - uid: 173
     components:
     - pos: 5.5,12.5
       parent: 1
       type: Transform
-- proto: ComputerStationRecords
+- proto: ComputerTabletopStationRecords
   entities:
-  - uid: 171
+  - uid: 227
     components:
     - rot: -1.5707963267948966 rad
       pos: 6.5,11.5
@@ -1384,6 +1385,58 @@ entities:
       pos: -2.5,2.5
       parent: 1
       type: Transform
+- proto: EmergencyLight
+  entities:
+  - uid: 553
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 4.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 554
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -1.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 555
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 8.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 556
+    components:
+    - pos: 7.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 557
+    components:
+    - pos: -0.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 558
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 2.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 559
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 6.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 564
+    components:
+    - pos: 12.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 565
+    components:
+    - pos: -5.5,6.5
+      parent: 1
+      type: Transform
 - proto: EmergencyRollerBed
   entities:
   - uid: 180
@@ -1427,6 +1480,21 @@ entities:
       type: Transform
 - proto: FirelockGlass
   entities:
+  - uid: 72
+    components:
+    - pos: -2.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 86
+    components:
+    - pos: 9.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 87
+    components:
+    - pos: 9.5,7.5
+      parent: 1
+      type: Transform
   - uid: 187
     components:
     - pos: 4.5,9.5
@@ -1477,6 +1545,21 @@ entities:
     - pos: 0.5,3.5
       parent: 1
       type: Transform
+  - uid: 566
+    components:
+    - pos: 3.5,11.5
+      parent: 1
+      type: Transform
+- proto: FloorDrain
+  entities:
+  - uid: 89
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 12.5,5.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
 - proto: FoodGumball
   entities:
   - uid: 197
@@ -1484,248 +1567,817 @@ entities:
     - pos: 3.5949607,5.5785956
       parent: 1
       type: Transform
-  - uid: 198
-    components:
-    - pos: 3.4193509,5.490791
-      parent: 1
-      type: Transform
-- proto: FoodLollipop
-  entities:
-  - uid: 199
-    components:
-    - pos: 2.4681318,5.5054255
-      parent: 1
-      type: Transform
 - proto: GasPassiveVent
   entities:
-  - uid: 200
+  - uid: 218
     components:
     - rot: 1.5707963267948966 rad
-      pos: -1.5,11.5
+      pos: -1.5,10.5
       parent: 1
       type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
 - proto: GasPipeBend
   entities:
-  - uid: 201
+  - uid: 95
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -1.5,7.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 131
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -1.5,6.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 219
     components:
     - pos: 10.5,7.5
       parent: 1
       type: Transform
-  - uid: 202
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -0.5,7.5
-      parent: 1
-      type: Transform
-  - uid: 203
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -4.5,6.5
-      parent: 1
-      type: Transform
-- proto: GasPipeStraight
-  entities:
-  - uid: 204
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -0.5,11.5
-      parent: 1
-      type: Transform
-  - uid: 205
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 0.5,11.5
-      parent: 1
-      type: Transform
-  - uid: 206
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 1.5,11.5
-      parent: 1
-      type: Transform
-  - uid: 207
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 2.5,11.5
-      parent: 1
-      type: Transform
-  - uid: 208
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 3.5,11.5
-      parent: 1
-      type: Transform
-  - uid: 209
-    components:
-    - pos: 4.5,10.5
-      parent: 1
-      type: Transform
-  - uid: 210
-    components:
-    - pos: 4.5,9.5
-      parent: 1
-      type: Transform
-  - uid: 211
-    components:
-    - pos: 4.5,8.5
-      parent: 1
-      type: Transform
-  - uid: 212
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 5.5,7.5
-      parent: 1
-      type: Transform
-  - uid: 213
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 6.5,7.5
-      parent: 1
-      type: Transform
-  - uid: 214
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 9.5,7.5
-      parent: 1
-      type: Transform
-  - uid: 215
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 7.5,6.5
-      parent: 1
-      type: Transform
-  - uid: 216
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 7.5,5.5
-      parent: 1
-      type: Transform
-  - uid: 217
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 8.5,7.5
-      parent: 1
-      type: Transform
-  - uid: 218
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 223
     components:
     - rot: 3.141592653589793 rad
       pos: 10.5,6.5
       parent: 1
       type: Transform
-  - uid: 219
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+- proto: GasPipeFourway
+  entities:
+  - uid: 158
     components:
-    - rot: 1.5707963267948966 rad
-      pos: 2.5,7.5
+    - pos: 6.5,7.5
       parent: 1
       type: Transform
-  - uid: 220
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 203
     components:
-    - rot: 1.5707963267948966 rad
-      pos: 1.5,7.5
+    - pos: -1.5,4.5
       parent: 1
       type: Transform
-  - uid: 221
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 206
     components:
-    - rot: 1.5707963267948966 rad
-      pos: 0.5,7.5
+    - pos: 2.5,4.5
       parent: 1
       type: Transform
-  - uid: 222
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 233
     components:
-    - rot: 3.141592653589793 rad
-      pos: -0.5,5.5
+    - pos: 8.5,4.5
       parent: 1
       type: Transform
-  - uid: 223
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 304
     components:
-    - rot: 1.5707963267948966 rad
-      pos: -1.5,6.5
+    - pos: 2.5,10.5
       parent: 1
       type: Transform
-  - uid: 224
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 538
+    components:
+    - pos: 0.5,7.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 543
+    components:
+    - pos: 3.5,7.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+- proto: GasPipeStraight
+  entities:
+  - uid: 42
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -4.5,4.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 44
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -2.5,4.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 88
     components:
     - rot: 1.5707963267948966 rad
       pos: -2.5,6.5
       parent: 1
       type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 90
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 3.5,10.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 91
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 1.5,7.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 98
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 2.5,7.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 103
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -0.5,7.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 110
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 4.5,10.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 111
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 5.5,10.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 112
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 2.5,8.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 155
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 3.5,3.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 156
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 3.5,2.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 157
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 3.5,4.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 159
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 3.5,5.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 162
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 8.5,7.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 164
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 7.5,7.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 167
+    components:
+    - pos: 6.5,6.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 168
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 2.5,9.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 169
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 3.5,4.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 198
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -4.5,6.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 199
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 4.5,4.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 200
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 5.5,4.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 201
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 6.5,4.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 202
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 7.5,4.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 204
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 0.5,4.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 205
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 1.5,4.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 210
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 2.5,2.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 212
+    components:
+    - pos: 8.5,3.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 214
+    components:
+    - pos: 2.5,5.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 215
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 2.5,11.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 216
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 3.5,11.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 217
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 0.5,10.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 220
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 9.5,7.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 221
+    components:
+    - pos: 2.5,3.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 222
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 9.5,4.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 224
+    components:
+    - pos: 2.5,7.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
   - uid: 225
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -0.5,10.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 226
     components:
     - rot: 1.5707963267948966 rad
       pos: -3.5,6.5
       parent: 1
       type: Transform
-- proto: GasPipeTJunction
-  entities:
-  - uid: 226
-    components:
-    - pos: 7.5,7.5
-      parent: 1
-      type: Transform
-  - uid: 227
-    components:
-    - pos: 4.5,11.5
-      parent: 1
-      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
   - uid: 228
     components:
-    - rot: 3.141592653589793 rad
-      pos: 4.5,7.5
+    - pos: -1.5,3.5
       parent: 1
       type: Transform
-  - uid: 229
-    components:
-    - pos: 3.5,7.5
-      parent: 1
-      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
   - uid: 230
     components:
     - rot: -1.5707963267948966 rad
-      pos: -0.5,6.5
+      pos: 11.5,4.5
       parent: 1
       type: Transform
-- proto: GasVentScrubber
-  entities:
+    - color: '#990000FF'
+      type: AtmosPipeColor
   - uid: 231
     components:
-    - rot: 3.141592653589793 rad
-      pos: -4.5,5.5
+    - rot: -1.5707963267948966 rad
+      pos: 10.5,4.5
       parent: 1
       type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
   - uid: 232
     components:
-    - rot: 3.141592653589793 rad
+    - rot: -1.5707963267948966 rad
       pos: -0.5,4.5
       parent: 1
       type: Transform
-  - uid: 233
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 237
     components:
-    - rot: 3.141592653589793 rad
-      pos: 7.5,4.5
+    - rot: -1.5707963267948966 rad
+      pos: -3.5,4.5
       parent: 1
       type: Transform
-  - uid: 234
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 295
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 11.5,6.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 323
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 4.5,8.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 396
     components:
     - rot: 3.141592653589793 rad
       pos: 3.5,6.5
       parent: 1
       type: Transform
-  - uid: 235
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 530
     components:
-    - rot: 3.141592653589793 rad
-      pos: 10.5,5.5
+    - pos: 0.5,4.5
       parent: 1
       type: Transform
-  - uid: 236
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 531
+    components:
+    - pos: 0.5,5.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 532
+    components:
+    - pos: 0.5,3.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 533
+    components:
+    - pos: 6.5,3.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 534
+    components:
+    - pos: 6.5,4.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 535
+    components:
+    - pos: 6.5,5.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 539
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 5.5,7.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 544
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 2.5,3.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 547
+    components:
+    - pos: 4.5,10.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 548
+    components:
+    - pos: 4.5,9.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 549
     components:
     - rot: -1.5707963267948966 rad
       pos: 5.5,11.5
       parent: 1
       type: Transform
-- proto: GravityGeneratorMini
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 552
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,6.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+- proto: GasPipeTJunction
+  entities:
+  - uid: 130
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 4.5,7.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 229
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 2.5,6.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 546
+    components:
+    - pos: 4.5,11.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+- proto: GasPort
+  entities:
+  - uid: 141
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 0.5,11.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+- proto: GasPressurePump
+  entities:
+  - uid: 119
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 1.5,10.5
+      parent: 1
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 140
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 1.5,11.5
+      parent: 1
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+- proto: GasVentPump
   entities:
   - uid: 239
     components:
-    - pos: 2.5,10.5
+    - rot: -1.5707963267948966 rad
+      pos: 12.5,6.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 563
+      type: DeviceNetwork
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 529
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -5.5,6.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 562
+      type: DeviceNetwork
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 536
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,2.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 561
+      type: DeviceNetwork
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 537
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 6.5,2.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 561
+      type: DeviceNetwork
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 540
+    components:
+    - pos: 0.5,8.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 561
+      type: DeviceNetwork
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 541
+    components:
+    - pos: 6.5,8.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 561
+      type: DeviceNetwork
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 545
+    components:
+    - pos: 3.5,8.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 561
+      type: DeviceNetwork
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 550
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 6.5,11.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 561
+      type: DeviceNetwork
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+- proto: GasVentScrubber
+  entities:
+  - uid: 35
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 2.5,1.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 561
+      type: DeviceNetwork
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 102
+    components:
+    - pos: 2.5,11.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 560
+      type: DeviceNetwork
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 106
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 6.5,10.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 561
+      type: DeviceNetwork
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 160
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 3.5,1.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 561
+      type: DeviceNetwork
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 171
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 12.5,4.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 563
+      type: DeviceNetwork
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 207
+    components:
+    - pos: 8.5,5.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 561
+      type: DeviceNetwork
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 208
+    components:
+    - pos: -1.5,5.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 561
+      type: DeviceNetwork
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 209
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 8.5,2.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 561
+      type: DeviceNetwork
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 211
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -1.5,2.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 561
+      type: DeviceNetwork
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 213
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -5.5,4.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 562
+      type: DeviceNetwork
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 551
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 3.5,6.5
+      parent: 1
+      type: Transform
+    - ShutdownSubscribers:
+      - 561
+      type: DeviceNetwork
+    - color: '#990000FF'
+      type: AtmosPipeColor
+- proto: GravityGeneratorMini
+  entities:
+  - uid: 100
+    components:
+    - pos: 0.5,10.5
       parent: 1
       type: Transform
 - proto: Grille
@@ -2012,33 +2664,11 @@ entities:
       type: Transform
 - proto: Gyroscope
   entities:
-  - uid: 295
+  - uid: 404
     components:
-    - pos: 1.5,10.5
+    - pos: 4.5,12.5
       parent: 1
       type: Transform
-- proto: HandheldCrewMonitor
-  entities:
-  - uid: 159
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 154
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
-- proto: HandheldHealthAnalyzer
-  entities:
-  - uid: 160
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 154
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
 - proto: HospitalCurtains
   entities:
   - uid: 296
@@ -2056,17 +2686,6 @@ entities:
     - pos: -5.5,4.5
       parent: 1
       type: Transform
-- proto: Hypospray
-  entities:
-  - uid: 161
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 154
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
 - proto: KitchenReagentGrinder
   entities:
   - uid: 299
@@ -2091,61 +2710,23 @@ entities:
     - pos: 2.68707,5.581429
       parent: 1
       type: Transform
-- proto: LockerCaptain
+- proto: LockerChemistryFilled
+  entities:
+  - uid: 163
+    components:
+    - pos: 2.5,3.5
+      parent: 1
+      type: Transform
+- proto: LockerChiefMedicalOfficerFilled
   entities:
   - uid: 154
     components:
     - pos: 5.5,10.5
       parent: 1
       type: Transform
-    - air:
-        volume: 200
-        immutable: False
-        temperature: 293.1496
-        moles:
-        - 1.8856695
-        - 7.0937095
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-      type: EntityStorage
-    - containers:
-        entity_storage: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 158
-          - 157
-          - 160
-          - 162
-          - 161
-          - 155
-          - 159
-          - 156
-        paper_label: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
-      type: ContainerContainer
-- proto: LockerChemistryFilled
+- proto: LockerMedical
   entities:
-  - uid: 303
-    components:
-    - pos: 2.5,2.5
-      parent: 1
-      type: Transform
-    - locked: False
-      type: Lock
-- proto: LockerChiefMedicalOfficerFilled
-  entities:
-  - uid: 304
+  - uid: 161
     components:
     - pos: 11.5,7.5
       parent: 1
@@ -2233,39 +2814,46 @@ entities:
     - pos: 3.286086,8.547117
       parent: 1
       type: Transform
-- proto: OxygenTankFilled
-  entities:
-  - uid: 162
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 154
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
 - proto: PortableGeneratorPacman
   entities:
-  - uid: 237
+  - uid: 124
     components:
-    - pos: 0.5,12.5
+    - anchored: True
+      pos: 1.5,12.5
       parent: 1
       type: Transform
     - storage:
-        Plasma: 1500
+        Plasma: 3000
       type: MaterialStorage
-    - type: InsertingMaterialStorage
+    - bodyType: Static
+      type: Physics
+    - endTime: 0
+      type: InsertingMaterialStorage
   - uid: 238
     components:
-    - pos: 0.5,10.5
+    - anchored: True
+      pos: 0.5,12.5
       parent: 1
       type: Transform
     - storage:
-        Plasma: 1500
+        Plasma: 3000
       type: MaterialStorage
-    - type: InsertingMaterialStorage
+    - bodyType: Static
+      type: Physics
+    - endTime: 0
+      type: InsertingMaterialStorage
 - proto: PowerCellRecharger
   entities:
+  - uid: 33
+    components:
+    - pos: 7.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 34
+    components:
+    - pos: -4.5,7.5
+      parent: 1
+      type: Transform
   - uid: 401
     components:
     - pos: 6.5,10.5
@@ -2313,16 +2901,14 @@ entities:
       type: Transform
     - powerLoad: 0
       type: ApcPowerReceiver
-  - uid: 323
+- proto: PoweredlightLED
+  entities:
+  - uid: 236
     components:
     - rot: 3.141592653589793 rad
       pos: 1.5,10.5
       parent: 1
       type: Transform
-    - powerLoad: 0
-      type: ApcPowerReceiver
-- proto: PoweredlightLED
-  entities:
   - uid: 324
     components:
     - rot: 3.141592653589793 rad
@@ -2355,22 +2941,6 @@ entities:
       type: Transform
     - powerLoad: 0
       type: ApcPowerReceiver
-  - uid: 328
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 2.5,-1.5
-      parent: 1
-      type: Transform
-    - powerLoad: 0
-      type: ApcPowerReceiver
-  - uid: 329
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 4.5,-1.5
-      parent: 1
-      type: Transform
-    - powerLoad: 0
-      type: ApcPowerReceiver
   - uid: 330
     components:
     - pos: 3.5,8.5
@@ -2386,13 +2956,40 @@ entities:
       type: Transform
     - powerLoad: 0
       type: ApcPowerReceiver
-- proto: SheetPlasma
-  entities:
-  - uid: 495
+  - uid: 569
     components:
-    - pos: 0.4716878,11.43344
+    - rot: 1.5707963267948966 rad
+      pos: -1.5,1.5
       parent: 1
       type: Transform
+  - uid: 570
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 8.5,1.5
+      parent: 1
+      type: Transform
+- proto: SheetPlasma
+  entities:
+  - uid: 567
+    components:
+    - pos: 0.5186641,12.523288
+      parent: 1
+      type: Transform
+    - count: 15
+      type: Stack
+    - size: 15
+      type: Item
+- proto: SheetPlasma1
+  entities:
+  - uid: 568
+    components:
+    - pos: 1.5186641,12.538913
+      parent: 1
+      type: Transform
+    - count: 15
+      type: Stack
+    - size: 15
+      type: Item
 - proto: ShuttleWindow
   entities:
   - uid: 332
@@ -2736,9 +3333,9 @@ entities:
       type: Transform
 - proto: SMESBasic
   entities:
-  - uid: 396
+  - uid: 328
     components:
-    - pos: 1.5,12.5
+    - pos: 2.5,12.5
       parent: 1
       type: Transform
 - proto: SpawnPointChemist
@@ -2750,9 +3347,9 @@ entities:
       type: Transform
 - proto: SpawnPointChiefMedicalOfficer
   entities:
-  - uid: 398
+  - uid: 235
     components:
-    - pos: 10.5,7.5
+    - pos: 5.5,11.5
       parent: 1
       type: Transform
 - proto: SpawnPointLatejoin
@@ -2783,20 +3380,35 @@ entities:
       type: Transform
 - proto: SubstationBasic
   entities:
-  - uid: 404
+  - uid: 120
     components:
-    - pos: 2.5,12.5
+    - pos: 2.5,10.5
       parent: 1
       type: Transform
-- proto: SuitStorageCMO
+- proto: SuitStorageWallmountCMO
   entities:
-  - uid: 405
+  - uid: 329
     components:
-    - pos: 4.5,12.5
+    - rot: 1.5707963267948966 rad
+      pos: 3.5,10.5
       parent: 1
       type: Transform
+    - canCollide: False
+      type: Physics
 - proto: TableReinforced
   entities:
+  - uid: 165
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 6.5,11.5
+      parent: 1
+      type: Transform
+  - uid: 166
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 5.5,12.5
+      parent: 1
+      type: Transform
   - uid: 406
     components:
     - pos: 2.5,5.5
@@ -2830,6 +3442,16 @@ entities:
       type: Transform
 - proto: TableReinforcedGlass
   entities:
+  - uid: 234
+    components:
+    - pos: 2.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 398
+    components:
+    - pos: 2.5,2.5
+      parent: 1
+      type: Transform
   - uid: 412
     components:
     - pos: -4.5,7.5
@@ -2935,22 +3557,6 @@ entities:
       pos: 4.5,-1.5
       parent: 1
       type: Transform
-- proto: UniformScrubsColorPurple
-  entities:
-  - uid: 431
-    components:
-    - pos: 11.343336,4.5013494
-      parent: 1
-      type: Transform
-- proto: VendingMachineChemDrobe
-  entities:
-  - uid: 432
-    components:
-    - flags: SessionSpecific
-      type: MetaData
-    - pos: 2.5,1.5
-      parent: 1
-      type: Transform
 - proto: VendingMachineChemicals
   entities:
   - uid: 433
@@ -2958,15 +3564,6 @@ entities:
     - flags: SessionSpecific
       type: MetaData
     - pos: 4.5,2.5
-      parent: 1
-      type: Transform
-- proto: VendingMachineGeneDrobe
-  entities:
-  - uid: 434
-    components:
-    - flags: SessionSpecific
-      type: MetaData
-    - pos: 10.5,3.5
       parent: 1
       type: Transform
 - proto: VendingMachineMedical
@@ -2980,10 +3577,8 @@ entities:
       type: Transform
 - proto: VendingMachineMediDrobe
   entities:
-  - uid: 436
+  - uid: 405
     components:
-    - flags: SessionSpecific
-      type: MetaData
     - pos: 8.5,8.5
       parent: 1
       type: Transform
@@ -3336,9 +3931,9 @@ entities:
       type: Transform
 - proto: Wrench
   entities:
-  - uid: 506
+  - uid: 434
     components:
-    - pos: 0.56263113,11.531941
+    - pos: 0.89714813,12.641543
       parent: 1
       type: Transform
 ...

--- a/Resources/Prototypes/_NF/Shipyard/helix.yml
+++ b/Resources/Prototypes/_NF/Shipyard/helix.yml
@@ -1,16 +1,26 @@
+# Author Info
+# GitHub: ???
+# Discord: ???
+
+# Maintainer Info
+# GitHub: ???
+# Discord: ???
+
+# Shuttle Notes:
+#
 - type: vessel
   id: Helix
   name: NM Helix
   description: A medium, modular hospital. Standard issue equipped with chem lab, cloning, and treatment ward
-  price: 52400
+  price: 44600 # +5800 from 15% markup
   category: Medium
   group: Civilian
-  shuttlePath: /Maps/Shuttles/helix.yml
+  shuttlePath: /Maps/_NF/Shuttles/helix.yml
 
 - type: gameMap
   id: Helix
   mapName: 'NM Helix'
-  mapPath: /Maps/Shuttles/helix.yml
+  mapPath: /Maps/_NF/Shuttles/helix.yml
   minPlayers: 0
   stations:
     Helix:


### PR DESCRIPTION
## About the PR
Updating NM Helix to current mapping standards:
- Atmos rework.
- Removed some loot.
- Replaced some consoles with tabletop variants.
- Added firelocks.
- Added blast doors to cover conveyor lines output.
- Added Vacuum Markers to exposed to space tiles.
- Moved ship.yml to Maps/_NF/Shuttles/

## Why / Balance
New mapping standards.

## Media
![2024-1-30_16 15 07](https://github.com/new-frontiers-14/frontier-station-14/assets/65374927/4eb16791-76f6-4878-9ca0-c1ecbcf53554)
- [X] I have added screenshots/videos to this PR showcasing its changes ingame.

**Changelog**
:cl: erhardsteinhauer
- tweak: Updated NM Helix to current mapping standards.