### PR TITLE
Sparrow (Update)

### DIFF
--- a/Resources/Maps/_NF/Shuttles/sparrow.yml
+++ b/Resources/Maps/_NF/Shuttles/sparrow.yml
@@ -3,13 +3,14 @@ meta:
   postmapinit: false
 tilemap:
   0: Space
-  27: FloorDark
-  31: FloorDarkMini
-  32: FloorDarkMono
-  84: FloorSteel
-  96: FloorTechMaint
-  112: Lattice
-  113: Plating
+  28: FloorDark
+  32: FloorDarkMini
+  33: FloorDarkMono
+  37: FloorDarkPlastic
+  85: FloorSteel
+  97: FloorTechMaint
+  113: Lattice
+  114: Plating
 entities:
 - proto: ""
   entities:
@@ -22,19 +23,19 @@ entities:
     - chunks:
         0,0:
           ind: 0,0
-          tiles: HwAAAAADVAAAAAAAIAAAAAACcQAAAAAAcQAAAAAAcQAAAAAAIAAAAAABcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHwAAAAADVAAAAAADcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAGwAAAAADcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHwAAAAABVAAAAAABcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHwAAAAADVAAAAAABcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVAAAAAADVAAAAAACcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAACcQAAAAAAcQAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGwAAAAAAGwAAAAABcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGwAAAAABGwAAAAABcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGwAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          tiles: IAAAAAADVQAAAAAAIQAAAAACJQAAAAAAJQAAAAAAJQAAAAAAJQAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAADVQAAAAADcgAAAAAAJQAAAAAAJQAAAAAAJQAAAAAAJQAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAABVQAAAAABcgAAAAAAJQAAAAAAJQAAAAAAJQAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAADVQAAAAABcgAAAAAAJQAAAAAAJQAAAAAAJQAAAAAAcgAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVQAAAAADVQAAAAACcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIQAAAAACcgAAAAAAcgAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHAAAAAAAHAAAAAABcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHAAAAAABHAAAAAABcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHAAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcgAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
           version: 6
         -1,0:
           ind: -1,0
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAGwAAAAACcQAAAAAAGwAAAAAAcQAAAAAAIAAAAAACVAAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAGwAAAAACIAAAAAAAGwAAAAADIAAAAAADcQAAAAAAVAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAGwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAGwAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAHAAAAAACcgAAAAAAHAAAAAAAcgAAAAAAIQAAAAACVQAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAHAAAAAACIQAAAAAAHAAAAAADIQAAAAADcgAAAAAAVQAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAVQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAVQAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAVQAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAHAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAHAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
           version: 6
         -1,-1:
           ind: -1,-1
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAGwAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcAAAAAAAcAAAAAAAcQAAAAAAGwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAGwAAAAADGwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAGwAAAAACYAAAAAAAYAAAAAAAYAAAAAAAcQAAAAAAVAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAGwAAAAADcQAAAAAAGwAAAAADcQAAAAAAcQAAAAAAVAAAAAAB
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAHAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcQAAAAAAcQAAAAAAcgAAAAAAHAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAHAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAHAAAAAACYQAAAAAAYQAAAAAAYQAAAAAAcgAAAAAAVQAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAHAAAAAADcgAAAAAAHAAAAAADcgAAAAAAcgAAAAAAVQAAAAAB
           version: 6
         0,-1:
           ind: 0,-1
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAGwAAAAACcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAGwAAAAACcQAAAAAAcAAAAAAAcAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAGwAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAGwAAAAACcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVAAAAAAAVAAAAAADcQAAAAAAYAAAAAAAYAAAAAAAYAAAAAAAGwAAAAABcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHwAAAAACVAAAAAABcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAIAAAAAABcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAHAAAAAACcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAHAAAAAACcgAAAAAAcQAAAAAAcQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAHAAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAHAAAAAACcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVQAAAAAAVQAAAAADcgAAAAAAYQAAAAAAYQAAAAAAYQAAAAAAJQAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAACVQAAAAABcgAAAAAAJQAAAAAAJQAAAAAAJQAAAAAAJQAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
           version: 6
       type: MapGrid
     - type: Broadphase
@@ -55,11 +56,6 @@ entities:
     - chunkCollection:
         version: 2
         nodes:
-        - node:
-            color: '#EFB34196'
-            id: Box
-          decals:
-            65: 4,2
         - node:
             color: '#D381C996'
             id: BoxGreyscale
@@ -207,12 +203,6 @@ entities:
             34: 0,2
             35: 0,3
         - node:
-            color: '#EFB34196'
-            id: StandClear
-          decals:
-            62: 4,2
-            73: 4,4
-        - node:
             color: '#D381C996'
             id: StandClearGreyscale
           decals:
@@ -227,25 +217,35 @@ entities:
           -1,0:
             0: 65535
           -1,-1:
-            0: 65535
+            1: 3
+            0: 65532
           0,-1:
-            0: 65535
+            0: 65527
+            1: 8
           0,1:
-            0: 30719
+            0: 30591
+            1: 128
           0,2:
-            0: 119
+            0: 55
+            1: 64
           1,0:
-            0: 65535
+            0: 32767
+            1: 32768
           1,1:
-            0: 63
+            0: 7
+            1: 56
           -2,0:
-            0: 61166
+            0: 52974
+            1: 8192
           -2,1:
-            0: 142
+            1: 130
+            0: 12
           -1,1:
-            0: 52479
+            0: 52431
+            1: 48
           -1,2:
-            0: 204
+            0: 140
+            1: 64
           -2,-1:
             0: 61166
           -1,-2:
@@ -253,13 +253,29 @@ entities:
           0,-2:
             0: 28672
           1,-1:
-            0: 65535
+            1: 1
+            0: 65534
         uniqueMixes:
         - volume: 2500
           temperature: 293.15
           moles:
           - 21.824879
           - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 0
+          - 0
           - 0
           - 0
           - 0
@@ -279,37 +295,19 @@ entities:
     - type: SpreaderGrid
 - proto: AirAlarm
   entities:
-  - uid: 104
+  - uid: 76
     components:
-    - name: air alarm (engineering room)
-      type: MetaData
-    - pos: 3.5,2.5
+    - rot: -1.5707963267948966 rad
+      pos: 6.5,2.5
       parent: 174
       type: Transform
     - ShutdownSubscribers:
-      - 326
-      - 163
-      - 290
-      - 292
+      - 266
+      - 243
       type: DeviceNetwork
     - devices:
-      - 326
-      - 163
-      - 290
-      - 292
-      type: DeviceList
-  - uid: 360
-    components:
-    - name: air alarm (mixing chamber)
-      type: MetaData
-    - pos: 6.5,2.5
-      parent: 174
-      type: Transform
-    - ShutdownSubscribers:
-      - 258
-      type: DeviceNetwork
-    - devices:
-      - 258
+      - 266
+      - 243
       type: DeviceList
   - uid: 361
     components:
@@ -317,14 +315,10 @@ entities:
       parent: 174
       type: Transform
     - ShutdownSubscribers:
-      - 339
-      - 343
-      - 291
+      - 186
       type: DeviceNetwork
     - devices:
-      - 339
-      - 343
-      - 291
+      - 186
       type: DeviceList
   - uid: 362
     components:
@@ -334,47 +328,29 @@ entities:
     - ShutdownSubscribers:
       - 359
       - 358
-      - 294
+      - 237
+      - 250
+      - 221
+      - 122
       type: DeviceNetwork
     - devices:
-      - 359
+      - 122
+      - 221
+      - 250
+      - 237
       - 358
-      - 294
-      type: DeviceList
-  - uid: 363
-    components:
-    - pos: -0.5,5.5
-      parent: 174
-      type: Transform
-    - ShutdownSubscribers:
-      - 349
-      - 350
-      - 291
-      - 290
-      - 294
-      type: DeviceNetwork
-    - devices:
-      - 349
-      - 350
-      - 291
-      - 290
-      - 294
+      - 359
       type: DeviceList
 - proto: AirCanister
   entities:
-  - uid: 201
+  - uid: 307
     components:
-    - pos: 6.5,-0.5
+    - anchored: True
+      pos: 3.5,-1.5
       parent: 174
       type: Transform
-- proto: AirlockAtmosphericsGlass
-  entities:
-  - uid: 261
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 4.5,2.5
-      parent: 174
-      type: Transform
+    - bodyType: Static
+      type: Physics
 - proto: AirlockCommandGlass
   entities:
   - uid: 264
@@ -431,13 +407,13 @@ entities:
       type: Transform
 - proto: AirSensor
   entities:
-  - uid: 258
+  - uid: 186
     components:
-    - pos: 4.5,3.5
+    - pos: -4.5,3.5
       parent: 174
       type: Transform
     - ShutdownSubscribers:
-      - 360
+      - 361
       type: DeviceNetwork
 - proto: APCBasic
   entities:
@@ -470,11 +446,93 @@ entities:
     - pos: -3.5,2.5
       parent: 174
       type: Transform
+- proto: AtmosFixBlockerMarker
+  entities:
+  - uid: 109
+    components:
+    - pos: 2.5,9.5
+      parent: 174
+      type: Transform
+  - uid: 110
+    components:
+    - pos: -1.5,9.5
+      parent: 174
+      type: Transform
+  - uid: 312
+    components:
+    - pos: -3.5,-3.5
+      parent: 174
+      type: Transform
+  - uid: 314
+    components:
+    - pos: -2.5,-3.5
+      parent: 174
+      type: Transform
+  - uid: 315
+    components:
+    - pos: 3.5,-3.5
+      parent: 174
+      type: Transform
+  - uid: 316
+    components:
+    - pos: 4.5,-3.5
+      parent: 174
+      type: Transform
+  - uid: 320
+    components:
+    - pos: 7.5,3.5
+      parent: 174
+      type: Transform
+  - uid: 321
+    components:
+    - pos: 7.5,4.5
+      parent: 174
+      type: Transform
+  - uid: 322
+    components:
+    - pos: 5.5,5.5
+      parent: 174
+      type: Transform
+  - uid: 325
+    components:
+    - pos: 4.5,5.5
+      parent: 174
+      type: Transform
+  - uid: 326
+    components:
+    - pos: 3.5,5.5
+      parent: 174
+      type: Transform
+  - uid: 327
+    components:
+    - pos: -2.5,5.5
+      parent: 174
+      type: Transform
+  - uid: 328
+    components:
+    - pos: -3.5,5.5
+      parent: 174
+      type: Transform
+  - uid: 329
+    components:
+    - pos: -4.5,5.5
+      parent: 174
+      type: Transform
+  - uid: 330
+    components:
+    - pos: -6.5,4.5
+      parent: 174
+      type: Transform
+  - uid: 331
+    components:
+    - pos: -6.5,3.5
+      parent: 174
+      type: Transform
 - proto: Autolathe
   entities:
-  - uid: 152
+  - uid: 67
     components:
-    - pos: 1.5,4.5
+    - pos: 3.5,3.5
       parent: 174
       type: Transform
 - proto: BlastDoorOpen
@@ -496,25 +554,127 @@ entities:
       - 252
       - 251
       type: DeviceLinkSink
-  - uid: 76
+- proto: BoxFolderBlue
+  entities:
+  - uid: 177
     components:
-    - pos: 4.5,4.5
+    - rot: 1.5707963267948966 rad
+      pos: -0.3575886,1.7827138
       parent: 174
       type: Transform
-    - state: Closed
-      type: Door
-    - enabled: True
-      type: Occluder
-    - canCollide: True
-      type: Physics
-    - airBlocked: True
-      type: Airtight
-    - links:
-      - 102
-      - 253
-      type: DeviceLinkSink
+- proto: BoxFolderClipboard
+  entities:
+  - uid: 178
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -0.6544636,1.9389638
+      parent: 174
+      type: Transform
+- proto: BoxFolderRed
+  entities:
+  - uid: 296
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -0.6544636,1.5327138
+      parent: 174
+      type: Transform
 - proto: CableApcExtension
   entities:
+  - uid: 103
+    components:
+    - pos: -5.5,1.5
+      parent: 174
+      type: Transform
+  - uid: 104
+    components:
+    - pos: -3.5,-0.5
+      parent: 174
+      type: Transform
+  - uid: 125
+    components:
+    - pos: 4.5,2.5
+      parent: 174
+      type: Transform
+  - uid: 128
+    components:
+    - pos: 5.5,2.5
+      parent: 174
+      type: Transform
+  - uid: 138
+    components:
+    - pos: 6.5,2.5
+      parent: 174
+      type: Transform
+  - uid: 141
+    components:
+    - pos: -3.5,0.5
+      parent: 174
+      type: Transform
+  - uid: 150
+    components:
+    - pos: -2.5,0.5
+      parent: 174
+      type: Transform
+  - uid: 151
+    components:
+    - pos: -1.5,0.5
+      parent: 174
+      type: Transform
+  - uid: 152
+    components:
+    - pos: -0.5,-3.5
+      parent: 174
+      type: Transform
+  - uid: 153
+    components:
+    - pos: -0.5,-2.5
+      parent: 174
+      type: Transform
+  - uid: 154
+    components:
+    - pos: -0.5,-1.5
+      parent: 174
+      type: Transform
+  - uid: 155
+    components:
+    - pos: -0.5,-0.5
+      parent: 174
+      type: Transform
+  - uid: 164
+    components:
+    - pos: 3.5,2.5
+      parent: 174
+      type: Transform
+  - uid: 166
+    components:
+    - pos: 0.5,4.5
+      parent: 174
+      type: Transform
+  - uid: 168
+    components:
+    - pos: -4.5,-1.5
+      parent: 174
+      type: Transform
+  - uid: 170
+    components:
+    - pos: 0.5,5.5
+      parent: 174
+      type: Transform
+  - uid: 180
+    components:
+    - pos: -0.5,0.5
+      parent: 174
+      type: Transform
+  - uid: 185
+    components:
+    - pos: -3.5,1.5
+      parent: 174
+      type: Transform
+  - uid: 193
+    components:
+    - pos: 4.5,-0.5
+      parent: 174
+      type: Transform
   - uid: 205
     components:
     - pos: -1.5,2.5
@@ -523,16 +683,6 @@ entities:
   - uid: 206
     components:
     - pos: -0.5,2.5
-      parent: 174
-      type: Transform
-  - uid: 207
-    components:
-    - pos: -0.5,3.5
-      parent: 174
-      type: Transform
-  - uid: 208
-    components:
-    - pos: -0.5,4.5
       parent: 174
       type: Transform
   - uid: 209
@@ -555,59 +705,9 @@ entities:
     - pos: 1.5,4.5
       parent: 174
       type: Transform
-  - uid: 213
-    components:
-    - pos: 1.5,5.5
-      parent: 174
-      type: Transform
   - uid: 214
     components:
-    - pos: 1.5,6.5
-      parent: 174
-      type: Transform
-  - uid: 215
-    components:
-    - pos: 1.5,7.5
-      parent: 174
-      type: Transform
-  - uid: 216
-    components:
     - pos: 0.5,7.5
-      parent: 174
-      type: Transform
-  - uid: 217
-    components:
-    - pos: -0.5,7.5
-      parent: 174
-      type: Transform
-  - uid: 218
-    components:
-    - pos: -0.5,1.5
-      parent: 174
-      type: Transform
-  - uid: 219
-    components:
-    - pos: -0.5,0.5
-      parent: 174
-      type: Transform
-  - uid: 220
-    components:
-    - pos: -0.5,-0.5
-      parent: 174
-      type: Transform
-  - uid: 221
-    components:
-    - pos: -0.5,-1.5
-      parent: 174
-      type: Transform
-  - uid: 222
-    components:
-    - pos: -0.5,-2.5
-      parent: 174
-      type: Transform
-  - uid: 223
-    components:
-    - pos: -0.5,-3.5
       parent: 174
       type: Transform
   - uid: 224
@@ -640,188 +740,83 @@ entities:
     - pos: 1.5,1.5
       parent: 174
       type: Transform
-  - uid: 230
-    components:
-    - pos: -2.5,2.5
-      parent: 174
-      type: Transform
-  - uid: 231
-    components:
-    - pos: -3.5,2.5
-      parent: 174
-      type: Transform
-  - uid: 232
-    components:
-    - pos: -4.5,2.5
-      parent: 174
-      type: Transform
-  - uid: 233
-    components:
-    - pos: -4.5,1.5
-      parent: 174
-      type: Transform
-  - uid: 234
-    components:
-    - pos: -4.5,0.5
-      parent: 174
-      type: Transform
-  - uid: 235
-    components:
-    - pos: -4.5,-0.5
-      parent: 174
-      type: Transform
   - uid: 236
     components:
-    - pos: -4.5,-1.5
-      parent: 174
-      type: Transform
-  - uid: 237
-    components:
-    - pos: -3.5,-1.5
+    - pos: 0.5,6.5
       parent: 174
       type: Transform
   - uid: 238
     components:
-    - pos: -2.5,-1.5
+    - pos: 0.5,8.5
       parent: 174
       type: Transform
-  - uid: 239
+  - uid: 254
     components:
-    - pos: 3.5,2.5
+    - pos: -0.5,1.5
       parent: 174
       type: Transform
-  - uid: 240
-    components:
-    - pos: 4.5,2.5
-      parent: 174
-      type: Transform
-  - uid: 241
-    components:
-    - pos: 5.5,2.5
-      parent: 174
-      type: Transform
-  - uid: 242
-    components:
-    - pos: 6.5,2.5
-      parent: 174
-      type: Transform
-  - uid: 243
-    components:
-    - pos: 5.5,1.5
-      parent: 174
-      type: Transform
-  - uid: 244
-    components:
-    - pos: 5.5,0.5
-      parent: 174
-      type: Transform
-  - uid: 245
-    components:
-    - pos: 6.5,-0.5
-      parent: 174
-      type: Transform
-  - uid: 246
+  - uid: 256
     components:
     - pos: 4.5,0.5
       parent: 174
       type: Transform
-  - uid: 247
-    components:
-    - pos: 3.5,0.5
-      parent: 174
-      type: Transform
-  - uid: 248
-    components:
-    - pos: 2.5,0.5
-      parent: 174
-      type: Transform
-  - uid: 249
-    components:
-    - pos: 6.5,0.5
-      parent: 174
-      type: Transform
-  - uid: 250
-    components:
-    - pos: 6.5,-1.5
-      parent: 174
-      type: Transform
-- proto: CableHV
-  entities:
-  - uid: 177
-    components:
-    - pos: 3.5,-1.5
-      parent: 174
-      type: Transform
-  - uid: 178
+  - uid: 257
     components:
     - pos: 4.5,-1.5
       parent: 174
       type: Transform
-  - uid: 179
+  - uid: 299
+    components:
+    - pos: -3.5,-1.5
+      parent: 174
+      type: Transform
+  - uid: 303
+    components:
+    - pos: -4.5,1.5
+      parent: 174
+      type: Transform
+  - uid: 308
+    components:
+    - pos: 4.5,1.5
+      parent: 174
+      type: Transform
+- proto: CableHV
+  entities:
+  - uid: 92
     components:
     - pos: 5.5,-1.5
       parent: 174
       type: Transform
-  - uid: 180
-    components:
-    - pos: 5.5,-2.5
-      parent: 174
-      type: Transform
-  - uid: 320
-    components:
-    - pos: 6.5,-2.5
-      parent: 174
-      type: Transform
-  - uid: 321
-    components:
-    - pos: 7.5,-2.5
-      parent: 174
-      type: Transform
-- proto: CableMV
-  entities:
-  - uid: 125
-    components:
-    - pos: 7.5,-2.5
-      parent: 174
-      type: Transform
-  - uid: 181
-    components:
-    - pos: 5.5,-2.5
-      parent: 174
-      type: Transform
-  - uid: 182
-    components:
-    - pos: 6.5,-2.5
-      parent: 174
-      type: Transform
-  - uid: 183
+  - uid: 159
     components:
     - pos: 6.5,-1.5
       parent: 174
       type: Transform
-  - uid: 184
+  - uid: 162
     components:
-    - pos: 6.5,-0.5
+    - pos: 4.5,-1.5
       parent: 174
       type: Transform
-  - uid: 185
+  - uid: 199
     components:
-    - pos: 6.5,0.5
+    - pos: 6.5,-2.5
       parent: 174
       type: Transform
-  - uid: 186
-    components:
-    - pos: 5.5,0.5
-      parent: 174
-      type: Transform
-  - uid: 187
+- proto: CableMV
+  entities:
+  - uid: 173
     components:
     - pos: 4.5,0.5
       parent: 174
       type: Transform
-  - uid: 188
+  - uid: 175
     components:
     - pos: 3.5,0.5
+      parent: 174
+      type: Transform
+  - uid: 188
+    components:
+    - pos: 5.5,0.5
       parent: 174
       type: Transform
   - uid: 189
@@ -844,14 +839,9 @@ entities:
     - pos: 1.5,0.5
       parent: 174
       type: Transform
-  - uid: 193
-    components:
-    - pos: 0.5,0.5
-      parent: 174
-      type: Transform
   - uid: 194
     components:
-    - pos: 2.5,-0.5
+    - pos: 6.5,-1.5
       parent: 174
       type: Transform
   - uid: 195
@@ -874,17 +864,32 @@ entities:
     - pos: -1.5,2.5
       parent: 174
       type: Transform
-  - uid: 199
+  - uid: 201
     components:
-    - pos: -1.5,-0.5
+    - pos: 6.5,0.5
+      parent: 174
+      type: Transform
+  - uid: 202
+    components:
+    - pos: 6.5,-2.5
+      parent: 174
+      type: Transform
+  - uid: 208
+    components:
+    - pos: 6.5,-0.5
+      parent: 174
+      type: Transform
+  - uid: 235
+    components:
+    - pos: 0.5,0.5
       parent: 174
       type: Transform
 - proto: CableTerminal
   entities:
-  - uid: 176
+  - uid: 207
     components:
     - rot: 1.5707963267948966 rad
-      pos: 4.5,-1.5
+      pos: 5.5,-1.5
       parent: 174
       type: Transform
 - proto: Catwalk
@@ -913,21 +918,6 @@ entities:
       pos: -2.5,-0.5
       parent: 174
       type: Transform
-  - uid: 170
-    components:
-    - pos: 4.5,-0.5
-      parent: 174
-      type: Transform
-  - uid: 171
-    components:
-    - pos: 4.5,0.5
-      parent: 174
-      type: Transform
-  - uid: 172
-    components:
-    - pos: 4.5,1.5
-      parent: 174
-      type: Transform
 - proto: ChairOfficeDark
   entities:
   - uid: 260
@@ -946,41 +936,23 @@ entities:
       type: Transform
 - proto: CircuitImprinter
   entities:
-  - uid: 157
+  - uid: 282
     components:
-    - pos: -5.5,-1.5
+    - pos: 5.5,3.5
       parent: 174
       type: Transform
 - proto: ClosetRadiationSuitFilled
   entities:
-  - uid: 200
+  - uid: 156
     components:
-    - pos: -3.5,-1.5
+    - pos: -5.5,-1.5
       parent: 174
       type: Transform
-    - air:
-        volume: 200
-        immutable: False
-        temperature: 293.1496
-        moles:
-        - 1.7459903
-        - 6.568249
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-      type: EntityStorage
 - proto: ClothingBeltUtilityEngineering
   entities:
-  - uid: 283
+  - uid: 310
     components:
-    - pos: -0.48324507,2.5954952
+    - pos: 3.4476445,1.7475064
       parent: 174
       type: Transform
 - proto: ComputerAnalysisConsole
@@ -993,10 +965,10 @@ entities:
       type: Transform
 - proto: ComputerFrame
   entities:
-  - uid: 280
+  - uid: 181
     components:
     - rot: -1.5707963267948966 rad
-      pos: 1.5,7.5
+      pos: 1.5,1.5
       parent: 174
       type: Transform
 - proto: ComputerResearchAndDevelopment
@@ -1007,27 +979,19 @@ entities:
       pos: -5.5,-0.5
       parent: 174
       type: Transform
-- proto: ComputerShuttle
+- proto: ComputerTabletopShuttle
   entities:
-  - uid: 278
+  - uid: 279
     components:
     - pos: 0.5,8.5
       parent: 174
       type: Transform
-- proto: ComputerStationRecords
+- proto: ComputerTabletopStationRecords
   entities:
-  - uid: 279
+  - uid: 184
     components:
     - rot: 1.5707963267948966 rad
-      pos: -0.5,7.5
-      parent: 174
-      type: Transform
-- proto: CrowbarRed
-  entities:
-  - uid: 276
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 1.5825404,1.599323
+      pos: -0.5,6.5
       parent: 174
       type: Transform
 - proto: DefibrillatorCabinetFilled
@@ -1040,16 +1004,16 @@ entities:
       type: Transform
 - proto: EmergencyLight
   entities:
+  - uid: 273
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 3.5,-1.5
+      parent: 174
+      type: Transform
   - uid: 366
     components:
     - rot: 1.5707963267948966 rad
       pos: -0.5,2.5
-      parent: 174
-      type: Transform
-  - uid: 367
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 3.5,-1.5
       parent: 174
       type: Transform
   - uid: 368
@@ -1073,74 +1037,53 @@ entities:
       type: Transform
 - proto: FaxMachineShip
   entities:
-  - uid: 282
+  - uid: 157
     components:
-    - pos: -0.5,6.5
+    - pos: -0.5,7.5
       parent: 174
       type: Transform
 - proto: FirelockGlass
   entities:
+  - uid: 165
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 1.5,-2.5
+      parent: 174
+      type: Transform
+  - uid: 176
+    components:
+    - pos: -3.5,2.5
+      parent: 174
+      type: Transform
+  - uid: 261
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -0.5,-2.5
+      parent: 174
+      type: Transform
   - uid: 290
     components:
     - rot: 1.5707963267948966 rad
       pos: 2.5,0.5
       parent: 174
       type: Transform
-    - ShutdownSubscribers:
-      - 363
-      - 104
-      type: DeviceNetwork
   - uid: 291
     components:
     - rot: 1.5707963267948966 rad
       pos: -1.5,0.5
       parent: 174
       type: Transform
-    - ShutdownSubscribers:
-      - 361
-      - 363
-      type: DeviceNetwork
-  - uid: 292
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 4.5,2.5
-      parent: 174
-      type: Transform
-    - ShutdownSubscribers:
-      - 104
-      type: DeviceNetwork
   - uid: 294
     components:
     - rot: 1.5707963267948966 rad
       pos: 0.5,5.5
       parent: 174
       type: Transform
-    - ShutdownSubscribers:
-      - 363
-      - 362
-      type: DeviceNetwork
 - proto: GasAnalyzer
   entities:
-  - uid: 274
+  - uid: 302
     components:
-    - pos: 1.3922963,1.5846891
-      parent: 174
-      type: Transform
-- proto: GasMixer
-  entities:
-  - uid: 153
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 5.5,0.5
-      parent: 174
-      type: Transform
-    - color: '#03FCD3FF'
-      type: AtmosPipeColor
-- proto: GasOutletInjector
-  entities:
-  - uid: 257
-    components:
-    - pos: 5.5,3.5
+    - pos: 3.6195195,1.6693814
       parent: 174
       type: Transform
 - proto: GasPassiveVent
@@ -1150,32 +1093,42 @@ entities:
     - pos: -4.5,3.5
       parent: 174
       type: Transform
-  - uid: 92
-    components:
-    - pos: 3.5,3.5
-      parent: 174
-      type: Transform
   - uid: 93
     components:
     - pos: -2.5,3.5
       parent: 174
       type: Transform
-  - uid: 305
+  - uid: 287
     components:
-    - pos: 4.5,5.5
+    - rot: 3.141592653589793 rad
+      pos: 4.5,-3.5
       parent: 174
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
 - proto: GasPipeBend
   entities:
+  - uid: 218
+    components:
+    - pos: 4.5,1.5
+      parent: 174
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 269
+    components:
+    - pos: 5.5,0.5
+      parent: 174
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
   - uid: 356
     components:
     - rot: 1.5707963267948966 rad
       pos: -0.5,4.5
       parent: 174
       type: Transform
-    - color: '#03FCD3FF'
+    - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 357
     components:
@@ -1183,15 +1136,7 @@ entities:
       pos: 0.5,4.5
       parent: 174
       type: Transform
-    - color: '#03FCD3FF'
-      type: AtmosPipeColor
-  - uid: 364
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 4.5,0.5
-      parent: 174
-      type: Transform
-    - color: '#990000FF'
+    - color: '#0055CCFF'
       type: AtmosPipeColor
 - proto: GasPipeStraight
   entities:
@@ -1205,18 +1150,6 @@ entities:
     components:
     - rot: 3.141592653589793 rad
       pos: -2.5,2.5
-      parent: 174
-      type: Transform
-  - uid: 109
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 3.5,2.5
-      parent: 174
-      type: Transform
-  - uid: 110
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 5.5,2.5
       parent: 174
       type: Transform
   - uid: 113
@@ -1243,156 +1176,130 @@ entities:
       pos: -2.5,-0.5
       parent: 174
       type: Transform
-  - uid: 259
+  - uid: 119
     components:
-    - pos: 3.5,1.5
+    - rot: 3.141592653589793 rad
+      pos: -0.5,2.5
       parent: 174
       type: Transform
-  - uid: 306
-    components:
-    - pos: 4.5,4.5
-      parent: 174
-      type: Transform
-    - color: '#990000FF'
+    - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 307
-    components:
-    - pos: 4.5,3.5
-      parent: 174
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 308
-    components:
-    - pos: 4.5,2.5
-      parent: 174
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 309
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 3.5,0.5
-      parent: 174
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 328
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 2.5,0.5
-      parent: 174
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 330
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 3.5,-0.5
-      parent: 174
-      type: Transform
-    - color: '#03FCD3FF'
-      type: AtmosPipeColor
-  - uid: 331
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 2.5,-0.5
-      parent: 174
-      type: Transform
-    - color: '#03FCD3FF'
-      type: AtmosPipeColor
-  - uid: 332
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 1.5,-0.5
-      parent: 174
-      type: Transform
-    - color: '#03FCD3FF'
-      type: AtmosPipeColor
-  - uid: 333
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 0.5,-0.5
-      parent: 174
-      type: Transform
-    - color: '#03FCD3FF'
-      type: AtmosPipeColor
-  - uid: 334
-    components:
-    - pos: -0.5,0.5
-      parent: 174
-      type: Transform
-    - color: '#03FCD3FF'
-      type: AtmosPipeColor
-  - uid: 335
-    components:
-    - pos: -0.5,1.5
-      parent: 174
-      type: Transform
-    - color: '#03FCD3FF'
-      type: AtmosPipeColor
-  - uid: 337
-    components:
-    - pos: -0.5,3.5
-      parent: 174
-      type: Transform
-    - color: '#03FCD3FF'
-      type: AtmosPipeColor
-  - uid: 338
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -2.5,0.5
-      parent: 174
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 341
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -1.5,-0.5
-      parent: 174
-      type: Transform
-    - color: '#03FCD3FF'
-      type: AtmosPipeColor
-  - uid: 342
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -2.5,-0.5
-      parent: 174
-      type: Transform
-    - color: '#03FCD3FF'
-      type: AtmosPipeColor
-  - uid: 344
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -1.5,0.5
-      parent: 174
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 345
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -0.5,0.5
-      parent: 174
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 346
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 0.5,0.5
-      parent: 174
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 351
+  - uid: 124
     components:
     - rot: 3.141592653589793 rad
       pos: 1.5,2.5
       parent: 174
       type: Transform
     - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 200
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -0.5,1.5
+      parent: 174
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 213
+    components:
+    - pos: 4.5,-1.5
+      parent: 174
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 215
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -2.5,1.5
+      parent: 174
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 216
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -1.5,1.5
+      parent: 174
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 217
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -0.5,1.5
+      parent: 174
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 222
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 2.5,1.5
+      parent: 174
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 230
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 1.5,0.5
+      parent: 174
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 231
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 2.5,0.5
+      parent: 174
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 233
+    components:
+    - pos: 4.5,-2.5
+      parent: 174
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 234
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -2.5,0.5
+      parent: 174
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 240
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 3.5,1.5
+      parent: 174
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 241
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 3.5,1.5
+      parent: 174
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 242
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -1.5,0.5
+      parent: 174
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 337
+    components:
+    - pos: -0.5,3.5
+      parent: 174
+      type: Transform
+    - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 352
     components:
@@ -1424,65 +1331,56 @@ entities:
       pos: 0.5,5.5
       parent: 174
       type: Transform
-    - color: '#03FCD3FF'
+    - color: '#0055CCFF'
       type: AtmosPipeColor
 - proto: GasPipeTJunction
   entities:
-  - uid: 162
+  - uid: 123
     components:
     - rot: 3.141592653589793 rad
-      pos: 5.5,-0.5
-      parent: 174
-      type: Transform
-    - color: '#03FCD3FF'
-      type: AtmosPipeColor
-  - uid: 327
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 1.5,0.5
-      parent: 174
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 336
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -0.5,2.5
-      parent: 174
-      type: Transform
-    - color: '#03FCD3FF'
-      type: AtmosPipeColor
-  - uid: 340
-    components:
-    - rot: 3.141592653589793 rad
-      pos: -0.5,-0.5
-      parent: 174
-      type: Transform
-    - color: '#03FCD3FF'
-      type: AtmosPipeColor
-  - uid: 347
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 4.5,-0.5
-      parent: 174
-      type: Transform
-    - color: '#03FCD3FF'
-      type: AtmosPipeColor
-  - uid: 348
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 4.5,1.5
-      parent: 174
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 365
-    components:
-    - rot: -1.5707963267948966 rad
       pos: 1.5,1.5
       parent: 174
       type: Transform
     - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 172
+    components:
+    - pos: 0.5,0.5
+      parent: 174
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 219
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 4.5,0.5
+      parent: 174
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 220
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -0.5,0.5
+      parent: 174
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 223
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,1.5
+      parent: 174
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 286
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 3.5,0.5
+      parent: 174
+      type: Transform
+    - color: '#0055CCFF'
       type: AtmosPipeColor
 - proto: GasPort
   entities:
@@ -1498,34 +1396,16 @@ entities:
       pos: -2.5,-1.5
       parent: 174
       type: Transform
-  - uid: 150
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 6.5,0.5
-      parent: 174
-      type: Transform
-  - uid: 151
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 6.5,-0.5
-      parent: 174
-      type: Transform
-    - color: '#03FCD3FF'
-      type: AtmosPipeColor
-  - uid: 169
+  - uid: 179
     components:
     - rot: 3.141592653589793 rad
-      pos: 3.5,-0.5
+      pos: 3.5,-1.5
       parent: 174
       type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
 - proto: GasPressurePump
   entities:
-  - uid: 103
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 5.5,1.5
-      parent: 174
-      type: Transform
   - uid: 105
     components:
     - pos: -4.5,1.5
@@ -1537,39 +1417,54 @@ entities:
       pos: -2.5,1.5
       parent: 174
       type: Transform
+  - uid: 169
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 3.5,-0.5
+      parent: 174
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 232
+    components:
+    - pos: 4.5,-0.5
+      parent: 174
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
 - proto: GasVentPump
   entities:
-  - uid: 163
+  - uid: 122
     components:
-    - pos: 4.5,0.5
+    - rot: 3.141592653589793 rad
+      pos: 0.5,-0.5
       parent: 174
       type: Transform
     - ShutdownSubscribers:
-      - 104
+      - 362
       type: DeviceNetwork
-    - color: '#03FCD3FF'
+    - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 343
+  - uid: 237
     components:
     - rot: 1.5707963267948966 rad
-      pos: -3.5,-0.5
+      pos: -3.5,0.5
       parent: 174
       type: Transform
     - ShutdownSubscribers:
-      - 361
+      - 362
       type: DeviceNetwork
-    - color: '#03FCD3FF'
+    - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 350
+  - uid: 243
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 0.5,2.5
+    - pos: 3.5,2.5
       parent: 174
       type: Transform
     - ShutdownSubscribers:
-      - 363
+      - 76
       type: DeviceNetwork
-    - color: '#03FCD3FF'
+    - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 358
     components:
@@ -1579,40 +1474,39 @@ entities:
     - ShutdownSubscribers:
       - 362
       type: DeviceNetwork
-    - color: '#03FCD3FF'
+    - color: '#0055CCFF'
       type: AtmosPipeColor
 - proto: GasVentScrubber
   entities:
-  - uid: 326
+  - uid: 221
     components:
-    - rot: 1.5707963267948966 rad
-      pos: 3.5,1.5
+    - pos: 0.5,2.5
       parent: 174
       type: Transform
     - ShutdownSubscribers:
-      - 104
+      - 362
       type: DeviceNetwork
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 339
+  - uid: 250
     components:
     - rot: 1.5707963267948966 rad
-      pos: -3.5,0.5
+      pos: -3.5,1.5
       parent: 174
       type: Transform
     - ShutdownSubscribers:
-      - 361
+      - 362
       type: DeviceNetwork
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 349
+  - uid: 266
     components:
-    - rot: 1.5707963267948966 rad
-      pos: 0.5,1.5
+    - rot: 3.141592653589793 rad
+      pos: 5.5,-0.5
       parent: 174
       type: Transform
     - ShutdownSubscribers:
-      - 363
+      - 76
       type: DeviceNetwork
     - color: '#990000FF'
       type: AtmosPipeColor
@@ -1626,18 +1520,11 @@ entities:
       type: DeviceNetwork
     - color: '#990000FF'
       type: AtmosPipeColor
-- proto: GasVolumePump
-  entities:
-  - uid: 329
-    components:
-    - pos: 3.5,0.5
-      parent: 174
-      type: Transform
 - proto: GravityGeneratorMini
   entities:
-  - uid: 128
+  - uid: 89
     components:
-    - pos: 6.5,-2.5
+    - pos: 6.5,-0.5
       parent: 174
       type: Transform
 - proto: Grille
@@ -1776,30 +1663,6 @@ entities:
       pos: -2.5,4.5
       parent: 174
       type: Transform
-  - uid: 138
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 3.5,2.5
-      parent: 174
-      type: Transform
-  - uid: 139
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 5.5,2.5
-      parent: 174
-      type: Transform
-  - uid: 140
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 3.5,4.5
-      parent: 174
-      type: Transform
-  - uid: 141
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 5.5,4.5
-      parent: 174
-      type: Transform
   - uid: 143
     components:
     - pos: -2.5,-2.5
@@ -1835,27 +1698,27 @@ entities:
     - pos: -6.5,1.5
       parent: 174
       type: Transform
+  - uid: 246
+    components:
+    - pos: 3.5,4.5
+      parent: 174
+      type: Transform
+  - uid: 247
+    components:
+    - pos: 5.5,4.5
+      parent: 174
+      type: Transform
+  - uid: 275
+    components:
+    - pos: 4.5,4.5
+      parent: 174
+      type: Transform
 - proto: Gyroscope
   entities:
-  - uid: 123
+  - uid: 182
     components:
-    - rot: 3.141592653589793 rad
-      pos: 7.5,3.5
-      parent: 174
-      type: Transform
-- proto: HolofanProjector
-  entities:
-  - uid: 168
-    components:
-    - pos: -0.42904305,2.6791677
-      parent: 174
-      type: Transform
-- proto: IntercomEngineering
-  entities:
-  - uid: 287
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 5.5,-2.5
+    - rot: -1.5707963267948966 rad
+      pos: 1.5,7.5
       parent: 174
       type: Transform
 - proto: IntercomScience
@@ -1871,81 +1734,20 @@ entities:
       pos: -4.5,-2.5
       parent: 174
       type: Transform
-- proto: LockerCaptainFilled
+- proto: LockerResearchDirectorFilled
   entities:
-  - uid: 167
+  - uid: 253
     components:
     - pos: 1.5,6.5
       parent: 174
       type: Transform
-    - air:
-        volume: 200
-        immutable: False
-        temperature: 293.1495
-        moles:
-        - 1.606311
-        - 6.042789
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-      type: EntityStorage
-- proto: LockerEngineerFilled
-  entities:
-  - uid: 166
-    components:
-    - pos: 6.5,1.5
-      parent: 174
-      type: Transform
-    - air:
-        volume: 200
-        immutable: False
-        temperature: 293.1496
-        moles:
-        - 1.7459903
-        - 6.568249
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-      type: EntityStorage
 - proto: LockerScienceFilled
   entities:
-  - uid: 159
+  - uid: 245
     components:
     - pos: -5.5,1.5
       parent: 174
       type: Transform
-    - air:
-        volume: 200
-        immutable: False
-        temperature: 293.1496
-        moles:
-        - 1.7459903
-        - 6.568249
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-      type: EntityStorage
 - proto: MachineArtifactAnalyzer
   entities:
   - uid: 158
@@ -1954,46 +1756,25 @@ entities:
       pos: -3.5,3.5
       parent: 174
       type: Transform
-- proto: NitrousOxideCanister
+- proto: MachineFrame
   entities:
-  - uid: 173
+  - uid: 248
     components:
-    - pos: 6.5,0.5
+    - rot: -1.5707963267948966 rad
+      pos: 1.5,2.5
       parent: 174
       type: Transform
-- proto: PaperOffice
+- proto: PaperBin10
   entities:
-  - uid: 314
+  - uid: 292
     components:
-    - pos: 1.2864163,1.6446724
-      parent: 174
-      type: Transform
-  - uid: 315
-    components:
-    - pos: 1.4327569,1.5422331
-      parent: 174
-      type: Transform
-  - uid: 316
-    components:
-    - pos: 1.604184,1.6446724
+    - rot: 3.141592653589793 rad
+      pos: -0.5,2.5
       parent: 174
       type: Transform
 - proto: PortableGeneratorPacman
   entities:
-  - uid: 119
-    components:
-    - anchored: True
-      pos: 3.5,-1.5
-      parent: 174
-      type: Transform
-    - storage:
-        Plasma: 1500
-      type: MaterialStorage
-    - bodyType: Static
-      type: Physics
-    - type: InsertingMaterialStorage
-    - type: ItemCooldown
-  - uid: 122
+  - uid: 163
     components:
     - anchored: True
       pos: 4.5,-1.5
@@ -2004,52 +1785,41 @@ entities:
       type: MaterialStorage
     - bodyType: Static
       type: Physics
-    - type: InsertingMaterialStorage
-    - type: ItemCooldown
-- proto: PortableScrubber
-  entities:
-  - uid: 175
+    - endTime: 0
+      type: InsertingMaterialStorage
+  - uid: 274
     components:
-    - pos: 6.5,-1.5
+    - anchored: True
+      pos: 5.5,-1.5
       parent: 174
       type: Transform
+    - storage:
+        Plasma: 3000
+      type: MaterialStorage
+    - bodyType: Static
+      type: Physics
+    - endTime: 0
+      type: InsertingMaterialStorage
 - proto: PowerCellRecharger
   entities:
-  - uid: 256
+  - uid: 244
     components:
-    - pos: 1.5,3.5
+    - rot: 3.141592653589793 rad
+      pos: 3.5,2.5
       parent: 174
       type: Transform
 - proto: Poweredlight
   entities:
-  - uid: 296
+  - uid: 239
     components:
-    - rot: 3.141592653589793 rad
-      pos: 5.5,-1.5
+    - rot: -1.5707963267948966 rad
+      pos: -2.5,5.5
       parent: 174
       type: Transform
-    - powerLoad: 0
-      type: ApcPowerReceiver
   - uid: 297
     components:
     - rot: -1.5707963267948966 rad
       pos: 1.5,2.5
-      parent: 174
-      type: Transform
-    - powerLoad: 0
-      type: ApcPowerReceiver
-  - uid: 298
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -6.5,3.5
-      parent: 174
-      type: Transform
-    - powerLoad: 0
-      type: ApcPowerReceiver
-  - uid: 299
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 7.5,3.5
       parent: 174
       type: Transform
     - powerLoad: 0
@@ -2070,22 +1840,6 @@ entities:
       type: Transform
     - powerLoad: 0
       type: ApcPowerReceiver
-  - uid: 302
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -2.5,5.5
-      parent: 174
-      type: Transform
-    - powerLoad: 0
-      type: ApcPowerReceiver
-  - uid: 303
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 3.5,5.5
-      parent: 174
-      type: Transform
-    - powerLoad: 0
-      type: ApcPowerReceiver
   - uid: 311
     components:
     - rot: 3.141592653589793 rad
@@ -2096,6 +1850,12 @@ entities:
       type: ApcPowerReceiver
 - proto: PoweredlightLED
   entities:
+  - uid: 270
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 5.5,-1.5
+      parent: 174
+      type: Transform
   - uid: 295
     components:
     - rot: 3.141592653589793 rad
@@ -2106,9 +1866,9 @@ entities:
       type: ApcPowerReceiver
 - proto: Protolathe
   entities:
-  - uid: 164
+  - uid: 283
     components:
-    - pos: 1.5,2.5
+    - pos: 4.5,3.5
       parent: 174
       type: Transform
 - proto: ReinforcedPlasmaWindow
@@ -2123,16 +1883,6 @@ entities:
     - pos: -2.5,4.5
       parent: 174
       type: Transform
-  - uid: 66
-    components:
-    - pos: 3.5,4.5
-      parent: 174
-      type: Transform
-  - uid: 67
-    components:
-    - pos: 5.5,4.5
-      parent: 174
-      type: Transform
   - uid: 87
     components:
     - pos: -2.5,2.5
@@ -2141,16 +1891,6 @@ entities:
   - uid: 88
     components:
     - pos: -4.5,2.5
-      parent: 174
-      type: Transform
-  - uid: 89
-    components:
-    - pos: 3.5,2.5
-      parent: 174
-      type: Transform
-  - uid: 90
-    components:
-    - pos: 5.5,2.5
       parent: 174
       type: Transform
 - proto: ReinforcedWindow
@@ -2184,18 +1924,9 @@ entities:
       type: Transform
 - proto: SheetPlasma
   entities:
-  - uid: 202
+  - uid: 167
     components:
-    - pos: -0.4936617,2.6247969
-      parent: 174
-      type: Transform
-    - count: 15
-      type: Stack
-    - size: 15
-      type: Item
-  - uid: 325
-    components:
-    - pos: 4.4886045,-0.70675695
+    - pos: 3.491716,1.719785
       parent: 174
       type: Transform
 - proto: ShuttleWindow
@@ -2320,21 +2051,23 @@ entities:
     - pos: -6.5,-1.5
       parent: 174
       type: Transform
-- proto: SignalButton
-  entities:
   - uid: 102
     components:
-    - rot: 1.5707963267948966 rad
-      pos: 2.5,3.5
+    - pos: 4.5,4.5
       parent: 174
       type: Transform
-    - state: True
-      type: SignalSwitch
-    - linkedPorts:
-        76:
-        - Pressed: Toggle
-      type: DeviceLinkSource
-    - type: ItemCooldown
+  - uid: 204
+    components:
+    - pos: 5.5,4.5
+      parent: 174
+      type: Transform
+  - uid: 276
+    components:
+    - pos: 3.5,4.5
+      parent: 174
+      type: Transform
+- proto: SignalButton
+  entities:
   - uid: 251
     components:
     - rot: -1.5707963267948966 rad
@@ -2355,15 +2088,6 @@ entities:
       type: Transform
     - linkedPorts:
         75:
-        - Pressed: Toggle
-      type: DeviceLinkSource
-  - uid: 253
-    components:
-    - pos: 6.5,2.5
-      parent: 174
-      type: Transform
-    - linkedPorts:
-        76:
         - Pressed: Toggle
       type: DeviceLinkSource
 - proto: SignEngineering
@@ -2396,23 +2120,13 @@ entities:
       type: Transform
 - proto: SMESBasic
   entities:
-  - uid: 124
+  - uid: 90
     components:
-    - pos: 5.5,-1.5
+    - pos: 6.5,-1.5
       parent: 174
       type: Transform
 - proto: SpawnPointLatejoin
   entities:
-  - uid: 310
-    components:
-    - pos: 0.5,0.5
-      parent: 174
-      type: Transform
-  - uid: 312
-    components:
-    - pos: 0.5,1.5
-      parent: 174
-      type: Transform
   - uid: 313
     components:
     - pos: 0.5,2.5
@@ -2427,7 +2141,7 @@ entities:
       type: Transform
 - proto: SpawnPointStationEngineer
   entities:
-  - uid: 322
+  - uid: 249
     components:
     - pos: 4.5,1.5
       parent: 174
@@ -2439,66 +2153,69 @@ entities:
     - pos: -2.5,-1.5
       parent: 174
       type: Transform
-  - uid: 204
+  - uid: 258
     components:
-    - pos: -4.5,-1.5
+    - pos: -3.5,-1.5
       parent: 174
       type: Transform
-- proto: SubstationWallBasic
+- proto: SubstationBasic
   entities:
-  - uid: 286
+  - uid: 66
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 7.5,-2.5
+    - pos: 6.5,-2.5
+      parent: 174
+      type: Transform
+- proto: SuitStorageEngi
+  entities:
+  - uid: 259
+    components:
+    - pos: -0.5,3.5
       parent: 174
       type: Transform
 - proto: SuitStorageRD
   entities:
-  - uid: 266
+  - uid: 280
+    components:
+    - pos: -0.5,4.5
+      parent: 174
+      type: Transform
+- proto: TableGlass
+  entities:
+  - uid: 171
     components:
     - pos: -0.5,1.5
       parent: 174
       type: Transform
-    - air:
-        volume: 200
-        immutable: False
-        temperature: 293.1496
-        moles:
-        - 1.7459903
-        - 6.568249
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-      type: EntityStorage
-- proto: TableGlass
-  entities:
-  - uid: 154
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 1.5,3.5
-      parent: 174
-      type: Transform
-  - uid: 165
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -0.5,2.5
-      parent: 174
-      type: Transform
-  - uid: 273
+  - uid: 306
     components:
     - rot: 3.141592653589793 rad
-      pos: 1.5,1.5
+      pos: 3.5,2.5
+      parent: 174
+      type: Transform
+  - uid: 309
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 3.5,1.5
+      parent: 174
+      type: Transform
+  - uid: 332
+    components:
+    - pos: -0.5,2.5
       parent: 174
       type: Transform
 - proto: TableReinforced
   entities:
+  - uid: 183
+    components:
+    - pos: 0.5,8.5
+      parent: 174
+      type: Transform
+  - uid: 187
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -0.5,7.5
+      parent: 174
+      type: Transform
   - uid: 281
     components:
     - rot: -1.5707963267948966 rad
@@ -2517,18 +2234,6 @@ entities:
     - pos: -1.5,9.5
       parent: 174
       type: Transform
-  - uid: 269
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 7.5,4.5
-      parent: 174
-      type: Transform
-  - uid: 270
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -6.5,4.5
-      parent: 174
-      type: Transform
   - uid: 271
     components:
     - rot: 3.141592653589793 rad
@@ -2541,36 +2246,44 @@ entities:
       pos: 3.5,-3.5
       parent: 174
       type: Transform
+  - uid: 304
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 7.5,3.5
+      parent: 174
+      type: Transform
+  - uid: 305
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -6.5,3.5
+      parent: 174
+      type: Transform
 - proto: VendingMachineEngiDrobe
   entities:
-  - uid: 275
+  - uid: 298
     components:
-    - pos: 1.5,-0.5
+    - pos: 1.5,4.5
       parent: 174
       type: Transform
 - proto: VendingMachineEngivend
   entities:
-  - uid: 155
+  - uid: 139
     components:
-    - flags: SessionSpecific
-      type: MetaData
-    - pos: -0.5,4.5
+    - pos: 6.5,1.5
       parent: 174
       type: Transform
 - proto: VendingMachineSciDrobe
   entities:
-  - uid: 304
+  - uid: 278
     components:
-    - pos: -0.5,-0.5
+    - pos: 1.5,3.5
       parent: 174
       type: Transform
 - proto: VendingMachineVendomat
   entities:
-  - uid: 156
+  - uid: 140
     components:
-    - flags: SessionSpecific
-      type: MetaData
-    - pos: -0.5,3.5
+    - pos: 6.5,0.5
       parent: 174
       type: Transform
 - proto: WallShuttle
@@ -2774,11 +2487,4 @@ entities:
       type: Transform
     - location: Sparrow
       type: WarpPoint
-- proto: WelderIndustrial
-  entities:
-  - uid: 254
-    components:
-    - pos: -0.4936617,2.6087184
-      parent: 174
-      type: Transform
 ...

--- a/Resources/Prototypes/_NF/Shipyard/sparrow.yml
+++ b/Resources/Prototypes/_NF/Shipyard/sparrow.yml
@@ -35,4 +35,4 @@
           overflowJobs: []
           availableJobs:
             StationEngineer: [ 0, 0 ]
-            Scientist: [ 0, 0 
+            Scientist: [ 0, 0 ]

--- a/Resources/Prototypes/_NF/Shipyard/sparrow.yml
+++ b/Resources/Prototypes/_NF/Shipyard/sparrow.yml
@@ -1,16 +1,26 @@
+# Author Info
+# GitHub: ???
+# Discord: ???
+
+# Maintainer Info
+# GitHub: ???
+# Discord: ???
+
+# Shuttle Notes:
+#
 - type: vessel
   id: Sparrow
   name: NR Sparrow
   description: A small research and engineering vessel.
-  price: 45875
+  price: 37000 # +4800 from 15% markup
   category: Small
   group: Civilian
-  shuttlePath: /Maps/Shuttles/sparrow.yml
+  shuttlePath: /Maps/_NF/Shuttles/sparrow.yml
 
 - type: gameMap
   id: Sparrow
   mapName: 'NR Sparrow'
-  mapPath: /Maps/Shuttles/sparrow.yml
+  mapPath: /Maps/_NF/Shuttles/sparrow.yml
   minPlayers: 0
   stations:
     Sparrow:
@@ -25,5 +35,4 @@
           overflowJobs: []
           availableJobs:
             StationEngineer: [ 0, 0 ]
-            Scientist: [ 0, 0 ]
-            Borg: [ 0, 0 ]
+            Scientist: [ 0, 0 


### PR DESCRIPTION
## About the PR
Updating NR Sparrow to current mapping standards:
- Wiring rework.
- Atmos rework.
- Replaced some consoles with tabletop variants.
- Scrapped the atmosia, replaced it with engineering room.
- Added Vacuum Markers to exposed to space tiles.
- Moved ship.yml to Maps/_NF/Shuttles/
- Updated mapchecker whitelist.

## Why / Balance
New mapping standards, never ever seen atmosia used on this ship (might be wrong, don't have any statistics to support this claim).

## Media
![2024-1-30_18 02 58](https://github.com/new-frontiers-14/frontier-station-14/assets/65374927/4956f5a0-e4b0-42d1-883e-9c4b4507c18a)
- [X] I have added screenshots/videos to this PR showcasing its changes ingame.

**Changelog**
:cl: erhardsteinhauer
- tweak: Updated (and slightly reworked) NR Sparrow to current mapping standards.