### PR TITLE
Forensic In Vends

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/sec.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/sec.yml
@@ -17,6 +17,8 @@
     Stunbaton: 10
     WeaponDisabler: 10
     CrowbarRed: 10 # Frontier
+    ForensicScanner: 3 # Frontier
+    BoxForensicPad: 3 # Frontier
     TrackingImplanter: 5 # Frontier
 #    MindShieldImplanter: 5 # Frontier
   # security officers need to follow a diet regimen!

--- a/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/bountyvend.yml
+++ b/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/bountyvend.yml
@@ -9,6 +9,8 @@
     Zipties: 20
     Flash: 15
     ClothingEyesGlassesSunglasses: 12
+    ForensicScanner: 3
+    BoxForensicPad: 3
 #Bounty hunter
     ClothingUniformJumpsuitBH: 3
     ClothingUniformJumpskirtBH: 3


### PR DESCRIPTION
## About the PR
Added ForensicScanner and BoxForensicPad to SecTech and BountyVend inventory to allow the use of scanners for all security and private mercs.

## Why / Balance
Was missing.

## Technical details
.yml

## Media
- [X] this PR does not require an ingame showcase

## Breaking changes
N/A

**Changelog**
:cl: dvir01
- add: Added ForensicScanner & BoxForensicPad to SecTech & BountyVend
