### PR TITLE
YML Cleanup

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -685,7 +685,7 @@
 
 - type: entity
   id: ComputerCargoOrders
-  parent: BaseStructureComputer
+  parent: [BaseStructureUnanchorable, BaseStructureIndestructible, BaseStructureComputer] # Frontier
   name: cargo request computer
   description: Used to order supplies and approve requests.
   placement:
@@ -745,13 +745,6 @@
   - type: GuideHelp
     guides:
     - Cargo
-  - type: Anchorable # Frontier
-    delay: 999999
-  - type: Destructible  # Frontier
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 0
 
 - type: entity
   id: ComputerCargoBounty

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -138,7 +138,7 @@
     noRot: false
 
 - type: entity
-  parent: VendingMachine
+  parent: [BaseStructureUnanchorable, VendingMachine] # Frontier
   id: VendingMachineAmmo
   name: Liberation Station
   description: An overwhelming amount of ancient patriotism washes over you just by looking at the machine.
@@ -197,7 +197,7 @@
     - Bartender
 
 - type: entity
-  parent: VendingMachine
+  parent: [BaseStructureUnanchorable, VendingMachine] # Frontier
   id: VendingMachineCart
   name: PTech
   description: PTech vending! Providing a ROBUST selection of PDAs, cartridges, and anything else a dull paper pusher needs!
@@ -1788,7 +1788,7 @@
       map: ["enum.WiresVisualLayers.MaintenancePanel"]
 
 - type: entity
-  parent: VendingMachine
+  parent: [BaseStructureUnanchorable, VendingMachine] # Frontier
   id: VendingMachineSyndieDrobe
   name: SyndieDrobe
   description: Wardrobe machine encoded by the syndicate, contains elite outfits for various operations.
@@ -1886,7 +1886,7 @@
       map: ["enum.WiresVisualLayers.MaintenancePanel"]
 
 - type: entity
-  parent: VendingMachine
+  parent: [BaseStructureUnanchorable, VendingMachine] # Frontier
   id: VendingMachineCentDrobe
   name: CentDrobe
   description: A one-of-a-kind vending machine for all your centcom aesthetic needs!

--- a/Resources/Prototypes/Entities/Structures/cargo_telepad.yml
+++ b/Resources/Prototypes/Entities/Structures/cargo_telepad.yml
@@ -1,6 +1,6 @@
 ﻿- type: entity
   id: CargoTelepad
-  parent: BaseMachinePowered
+  parent: [BaseStructureUnanchorable, BaseStructureIndestructible, BaseMachinePowered] # Frontier
   name: cargo telepad
   description: Beam in the pizzas and dig in.
   components:
@@ -47,10 +47,3 @@
     board: CargoTelepadMachineCircuitboard
   - type: Appearance
   - type: CollideOnAnchor
-  - type: Destructible # Frontier
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 0
-  - type: Anchorable # Frontier
-    delay: 999999

--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers.yml
@@ -72,18 +72,11 @@
   - type: ContainerContainer
     containers:
       ShipyardConsole-targetId: !type:ContainerSlot {}
-  - type: Anchorable
-    delay: 999999
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 0
 
 # Custom console
 - type: entity
   id: BaseMothershipComputer
-  parent: ComputerShipyard
+  parent: [BaseStructureUnanchorable, BaseStructureIndestructible, ComputerShipyard]
   name: mothership console
   description: Used on motherships to purchase and sell ships without returning to a station.
   components:
@@ -98,16 +91,10 @@
 # Hardcoded consoles
 - type: entity
   id: ComputerShipyardSecurity
-  parent: ComputerShipyard
+  parent: [BaseStructureUnanchorable, BaseStructureIndestructible, ComputerShipyard]
   name: security shipyard console
   description: Used to enlist into Nanotrasen Security Forces
   components:
-  - type: ActivatableUI
-    key: enum.ShipyardConsoleUiKey.Security
-  - type: UserInterface
-    interfaces:
-    - key: enum.ShipyardConsoleUiKey.Security
-      type: ShipyardConsoleBoundUserInterface
   - type: Sprite
     sprite: _NF/Structures/Machines/computers.rsi
     layers:
@@ -119,10 +106,16 @@
       state: shipyard_security
     - map: ["computerLayerKeys"]
       state: telesci_key
+  - type: ActivatableUI
+    key: enum.ShipyardConsoleUiKey.Security
+  - type: UserInterface
+    interfaces:
+    - key: enum.ShipyardConsoleUiKey.Security
+      type: ShipyardConsoleBoundUserInterface
 
 - type: entity
   id: ComputerShipyardBlackMarket
-  parent: ComputerShipyard
+  parent: [BaseStructureUnanchorable, BaseStructureDestructible, ComputerShipyard]
   name: black market shipyard console
   description: Used to buy ships not available through other means. Has a sticker that says SALES TAX 30%
   components:
@@ -143,18 +136,10 @@
       state: shipyard_blackmarket
     - map: ["computerLayerKeys"]
       state: blackmarket_key
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 300
-      behaviors:
-        - !type:DoActsBehavior
-          acts: ["Destruction"]
 
 - type: entity
   id: ComputerShipyardExpedition
-  parent: ComputerShipyard
+  parent: [BaseStructureUnanchorable, BaseStructureIndestructible, ComputerShipyard]
   name: expedition shipyard console
   description: Used to buy ships outfitted for planetary expeditions
   components:
@@ -178,7 +163,7 @@
 
 - type: entity
   id: ComputerShipyardScrap
-  parent: ComputerShipyard
+  parent: [BaseStructureUnanchorable, BaseStructureIndestructible, ComputerShipyard]
   name: scrapyard console
   description: Used to purchase and sell "shuttles"
   components:
@@ -203,7 +188,7 @@
 - type: entity
   name: cargo sale computer
   suffix: Normal
-  parent: BaseStructureComputer
+  parent: [BaseStructureUnanchorable, BaseStructureIndestructible, BaseStructureComputer]
   id: ComputerPalletConsoleNFNormalMarket
   description: Used to sell goods loaded onto cargo pallets
   placement:
@@ -262,15 +247,8 @@
     interfaces:
     - key: enum.CargoPalletConsoleUiKey.Sale
       type: CargoPalletConsoleBoundUserInterface
-  - type: Anchorable
-    delay: 999999
   - type: MarketModifier
     mod: 1.00
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 0
 
 - type: entity
   parent: ComputerPalletConsoleNFNormalMarket

--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers.yml
@@ -63,6 +63,7 @@
         components:
         - IdCard
   - type: ActivatableUI
+    singleUser: true
     key: enum.ShipyardConsoleUiKey.Shipyard
   - type: UserInterface
     interfaces:

--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/cryo_sleep_pod.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/cryo_sleep_pod.yml
@@ -1,6 +1,6 @@
 - type: entity
   id: MachineCryoSleepPod
-  parent: BaseMachine
+  parent: [BaseStructureUnanchorable, BaseStructureIndestructible, BaseMachine]
   name: cryo sleep chamber
   description: cold pillow guaranteed
   components:
@@ -9,8 +9,6 @@
     sprite: _NF/Structures/cryopod.rsi
     layers:
     - state: closed
-  - type: Anchorable
-    delay: 999999
   - type: Physics
     bodyType: Static
   - type: Fixtures
@@ -31,8 +29,3 @@
   - type: ContainerContainer
     containers:
       body_container: !type:ContainerSlot
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 0

--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/m_emp.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/m_emp.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ BaseMachinePowered, ConstructibleMachine ]
+  parent: [BaseStructureUnanchorable, BaseStructureIndestructible, BaseMachinePowered, ConstructibleMachine]
   id: M_Emp
   name: M_EMP Generator
   description: Mobile EMP generator.

--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/vending_machines.yml
@@ -1,11 +1,9 @@
 - type: entity
-  parent: VendingMachine
+  parent: [BaseStructureUnanchorable, VendingMachine]
   id: VendingMachineCuddlyCritterVend
   name: CuddlyCritterVend
   description: Step into the world of wonder and warmth with Cuddly Critters Vending Machine, a haven for plushie and toy enthusiasts alike.
   components:
-  - type: Anchorable
-    delay: 999999
   - type: VendingMachine
     pack: CuddlyCritterVendInventory
     offState: off
@@ -32,13 +30,11 @@
     mod: 15
 
 - type: entity
-  parent: VendingMachine
+  parent: [BaseStructureUnanchorable, VendingMachine]
   id: VendingMachineAstroVend
   name: AstroVend
   description: Essential gear for the space-men on the go
   components:
-  - type: Anchorable
-    delay: 999999
   - type: VendingMachine
     pack: AstroVendInventory
     offState: off
@@ -63,13 +59,11 @@
     color: "#4b93ad"
 
 - type: entity
-  parent: VendingMachine
+  parent: [BaseStructureUnanchorable, VendingMachine]
   id: VendingMachineCircuitVend
   name: CircuitVend
   description: Essential tech for the space-men on the go
   components:
-  - type: Anchorable
-    delay: 999999
   - type: VendingMachine
     pack: CircuitVendInventory
     offState: off
@@ -97,7 +91,7 @@
     mod: 25
 
 - type: entity
-  parent: VendingMachine
+  parent: [BaseStructureUnanchorable, VendingMachine]
   id: VendingMachineSyndieContraband
   name: ContraVend
   description: Wanted across multiple sectors!
@@ -115,9 +109,6 @@
     ejectDelay: 3
   - type: Advertise
     pack: SyndieDrobeAds
-  - type: Speech
-  - type: Anchorable
-    delay: 999999
   - type: Sprite
     sprite: Structures/Machines/VendingMachines/syndicateArmor.rsi
     layers:
@@ -139,13 +130,11 @@
     mod: 50
 
 - type: entity
-  parent: VendingMachine
+  parent: [BaseStructureUnanchorable, VendingMachine]
   id: VendingMachineBountyVend
   name: BountyVend
   description: Essential gear for the space-men on the go
   components:
-  - type: Anchorable
-    delay: 999999
   - type: VendingMachine
     pack: BountyVendInventory
     offState: off
@@ -236,13 +225,11 @@
       color: "#ff033e"
 
 - type: entity
-  parent: VendingMachine
+  parent: [BaseStructureUnanchorable, VendingMachine]
   id: VendingMachineAutoTuneVend
   name: AutoTune
   description: feeling BASSed? time to TUNE into AutoVend! Take NOTES and let your audience TREBLE
   components:
-  - type: Anchorable
-    delay: 999999
   - type: VendingMachine
     pack: AutoTuneVendInventory
     offState: off

--- a/Resources/Prototypes/_NF/Entities/Structures/Shuttles/thrusters.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Shuttles/thrusters.yml
@@ -1,6 +1,6 @@
 - type: entity
   id: ThrusterSecurity
-  parent: Thruster
+  parent: [BaseStructureUnanchorable, Thruster]
   suffix: Security
   components:
   - type: Sprite
@@ -56,7 +56,7 @@
 
 - type: entity
   id: DebugThrusterSecurity
-  parent: DebugThruster
+  parent: [BaseStructureUnanchorable, DebugThruster]
   name: thruster
   suffix: DEBUG, Security
   components:
@@ -116,7 +116,7 @@
 
 - type: entity
   id: GyroscopeSecurity
-  parent: Gyroscope
+  parent: [BaseStructureUnanchorable, Gyroscope]
   suffix: Security
   components:
   - type: Sprite
@@ -158,7 +158,7 @@
 
 - type: entity
   id: DebugGyroscopeSecurity
-  parent: DebugGyroscope
+  parent: [BaseStructureUnanchorable, DebugGyroscope]
   name: gyroscope
   suffix: DEBUG, Security
   components:

--- a/Resources/Prototypes/_NF/Entities/Structures/atms.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/atms.yml
@@ -1,11 +1,18 @@
 - type: entity
-  name: bank atm
-  parent: BaseStructureComputer
-  id: ComputerBankATM
-  description: Used to deposit and withdraw funds from a personal bank account
+  id: ComputerBankATMBase
+  abstract: true
   placement:
     mode: SnapgridCenter
   components:
+  - type: GenericVisualizer
+    visuals:
+      enum.ComputerVisuals.Powered:
+        computerLayerScreen:
+          True: { visible: true, shader: unshaded }
+          False: { visible: false }
+        computerLayerKeys:
+          True: { visible: true, shader: unshaded }
+          False: { visible: true, shader: shaded }
   - type: MeleeSound
     soundGroups:
       Brute:
@@ -16,25 +23,8 @@
     powerLoad: 200
   - type: ExtensionCableReceiver
   - type: ActivatableUIRequiresPower
-  - type: Sprite
-    netsync: false
-    noRot: true
-    sprite: _NF/Structures/atm.rsi
-    layers:
-    - map: ["computerLayerBody"]
-      state: icon
-    - map: ["computerLayerScreen"]
-      state: unshaded
-  - type: Appearance
-  - type: GenericVisualizer
-    visuals:
-      enum.ComputerVisuals.Powered:
-        computerLayerScreen:
-          True: { visible: true, shader: unshaded }
-          False: { visible: false }
-        computerLayerKeys:
-          True: { visible: true, shader: unshaded }
-          False: { visible: true, shader: shaded }
+  - type: ActivatableUI
+    singleUser: true
   - type: LitOnPowered
   - type: PointLight
     radius: 1.5
@@ -48,6 +38,22 @@
   - type: EmitSoundOnUIOpen
     sound:
       collection: Keyboard
+  - type: Appearance
+  - type: Anchorable
+    delay: 999999
+  - type: Damageable
+    damageContainer: Inorganic
+    damageModifierSet: Metallic
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 0
+
+- type: entity
+  id: ComputerBankATMDeposit
+  abstract: true
+  components:
   - type: BankATM
     bank-ATM-cashSlot:
       name: bank-ATM-cashSlot
@@ -68,35 +74,49 @@
   - type: ContainerContainer
     containers:
       bank-ATM-cashSlot: !type:ContainerSlot {}
-  - type: Anchorable
-    delay: 999999
-  - type: Damageable
-    damageContainer: Inorganic
-    damageModifierSet: Metallic
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 0
-        
+
+- type: entity
+  name: withdraw-only bank atm
+  id: ComputerBankATMWithdraw
+  abstract: true
+  components:
+  - type: BankATM
+    bank-ATM-cashSlot:
+      name: bank-ATM-cashSlot
+      insertSound: /Audio/Machines/scanning.ogg
+      ejectSound: /Audio/Machines/tray_eject.ogg
+      ejectOnBreak: true
+      swap: false
+      locked: true
+  - type: ActivatableUI
+    key: enum.BankATMMenuUiKey.ATM
+  - type: UserInterface
+    interfaces:
+      - key: enum.BankATMMenuUiKey.ATM
+        type: WithdrawBankATMMenuBoundUserInterface
+
+- type: entity
+  name: bank atm
+  parent: [ComputerBankATMBase, BaseStructureComputer, ComputerBankATMDeposit]
+  id: ComputerBankATM
+  description: Used to deposit and withdraw funds from a personal bank account
+  components:
+  - type: Sprite
+    netsync: false
+    noRot: true
+    sprite: _NF/Structures/atm.rsi
+    layers:
+    - map: ["computerLayerBody"]
+      state: icon
+    - map: ["computerLayerScreen"]
+      state: unshaded
+
 - type: entity
   name: black market atm
-  parent: BaseStructureComputer
+  parent: [ComputerBankATMBase, BaseStructureComputer, ComputerBankATMWithdraw]
   id: ComputerBlackMarketBankATM
   description: Has some sketchy looking modifications and a sticker that says DEPOSIT FEE 30%
-  placement:
-    mode: SnapgridCenter
   components:
-  - type: MeleeSound
-    soundGroups:
-      Brute:
-        path:
-          "/Audio/Effects/glass_hit.ogg"
-  - type: Computer
-  - type: ApcPowerReceiver
-    powerLoad: 200
-  - type: ExtensionCableReceiver
-  - type: ActivatableUIRequiresPower
   - type: Sprite
     netsync: false
     noRot: true
@@ -106,54 +126,12 @@
       state: icon
     - map: ["computerLayerScreen"]
       state: unshaded
-  - type: Appearance
-  - type: GenericVisualizer
-    visuals:
-      enum.ComputerVisuals.Powered:
-        computerLayerScreen:
-          True: { visible: true, shader: unshaded }
-          False: { visible: false }
-        computerLayerKeys:
-          True: { visible: true, shader: unshaded }
-          False: { visible: true, shader: shaded }
-  - type: LitOnPowered
-  - type: PointLight
-    radius: 1.5
-    energy: 1.6
-    color: "#b89f25"
-    enabled: false
-    mask: /Textures/Effects/LightMasks/cone.png
-    autoRot: true
-    offset: "0, 0.4" # shine from the top, not bottom of the computer
-    castShadows: false
-  - type: EmitSoundOnUIOpen
-    sound:
-      collection: Keyboard
-  - type: BankATM
-    bank-ATM-cashSlot:
-      name: bank-ATM-cashSlot
-      insertSound: /Audio/Machines/scanning.ogg
-      ejectSound: /Audio/Machines/tray_eject.ogg
-      ejectOnBreak: true
-      swap: false
-      whitelist:
-        components:
-          - Currency
   - type: ActivatableUI
     key: enum.BankATMMenuUiKey.BlackMarket
   - type: UserInterface
     interfaces:
       - key: enum.BankATMMenuUiKey.BlackMarket
         type: BankATMMenuBoundUserInterface
-  - type: ItemSlots
-  - type: ContainerContainer
-    containers:
-      bank-ATM-cashSlot: !type:ContainerSlot {}
-  - type: Anchorable
-    delay: 999999
-  - type: Damageable
-    damageContainer: Inorganic
-    damageModifierSet: Metallic
   - type: Destructible
     thresholds:
     - trigger:
@@ -167,23 +145,10 @@
         acts: ["Destruction"]
 
 - type: entity
-  name: withdraw-only bank atm
-  parent: BaseStructureComputer
+  parent: [ComputerBankATMBase, BaseStructureComputer, ComputerBankATMWithdraw]
   id: ComputerWithdrawBankATM
   description: Used to withdraw funds from a personal bank account. Unable to deposit.
-  placement:
-    mode: SnapgridCenter
   components:
-  - type: MeleeSound
-    soundGroups:
-      Brute:
-        path:
-          "/Audio/Effects/glass_hit.ogg"
-  - type: Computer
-  - type: ApcPowerReceiver
-    powerLoad: 200
-  - type: ExtensionCableReceiver
-  - type: ActivatableUIRequiresPower
   - type: Sprite
     netsync: false
     noRot: true
@@ -193,45 +158,6 @@
       state: icon
     - map: ["computerLayerScreen"]
       state: unshaded
-  - type: Appearance
-  - type: GenericVisualizer
-    visuals:
-      enum.ComputerVisuals.Powered:
-        computerLayerScreen:
-          True: { visible: true, shader: unshaded }
-          False: { visible: false }
-        computerLayerKeys:
-          True: { visible: true, shader: unshaded }
-          False: { visible: true, shader: shaded }
-  - type: LitOnPowered
-  - type: PointLight
-    radius: 1.5
-    energy: 1.6
-    color: "#b89f25"
-    enabled: false
-    mask: /Textures/Effects/LightMasks/cone.png
-    autoRot: true
-    offset: "0, 0.4" # shine from the top, not bottom of the computer
-    castShadows: false
-  - type: EmitSoundOnUIOpen
-    sound:
-      collection: Keyboard
-  - type: BankATM
-    bank-ATM-cashSlot:
-      name: bank-ATM-cashSlot
-      insertSound: /Audio/Machines/scanning.ogg
-      ejectSound: /Audio/Machines/tray_eject.ogg
-      ejectOnBreak: true
-      swap: false
-      locked: true
-  - type: ActivatableUI
-    key: enum.BankATMMenuUiKey.ATM
-  - type: UserInterface
-    interfaces:
-      - key: enum.BankATMMenuUiKey.ATM
-        type: WithdrawBankATMMenuBoundUserInterface
-  - type: Anchorable
-    delay: 999999
   - type: Destructible
     thresholds:
     - trigger:
@@ -245,29 +171,14 @@
         acts: ["Destruction"]
 
 - type: entity
-  name: wallmount bank atm
-  parent: BaseStructureComputer
+  suffix: Wallmount
+  parent: [ComputerBankATMBase, BaseStructureComputer, ComputerBankATMDeposit]
   id: ComputerWallmountBankATM
   description: Used to deposit and withdraw funds from a personal bank account, it now comes in a more compact design!
-  placement:
-    mode: SnapgridCenter
   components:
-  - type: MeleeSound
-    soundGroups:
-      Brute:
-        path:
-          "/Audio/Effects/glass_hit.ogg"
-  - type: Computer
-  - type: ApcPowerReceiver
-    powerLoad: 200
-  - type: ExtensionCableReceiver
-  - type: ActivatableUIRequiresPower
-  - type: Transform
-    anchored: true
-  - type: InteractionOutline
   - type: Sprite
     netsync: false
-    noRot: true
+    noRot: false
     sprite: _NF/Structures/wall_atm.rsi
     layers:
       - map: ["computerLayerBody"]
@@ -275,82 +186,19 @@
       - map: ["computerLayerScreen"]
         state: unshaded
   - type: WallMount
-    arc: 360
-  - type: Appearance
-  - type: GenericVisualizer
-    visuals:
-      enum.ComputerVisuals.Powered:
-        computerLayerScreen:
-          True: { visible: true, shader: unshaded }
-          False: { visible: false }
-        computerLayerKeys:
-          True: { visible: true, shader: unshaded }
-          False: { visible: true, shader: shaded }
-  - type: LitOnPowered
-  - type: PointLight
-    radius: 1.5
-    energy: 1.6
-    color: "#b89f25"
-    enabled: false
-    mask: /Textures/Effects/LightMasks/cone.png
-    autoRot: true
-    offset: "0, 0.4" # shine from the top, not bottom of the computer
-    castShadows: false
-  - type: EmitSoundOnUIOpen
-    sound:
-      collection: Keyboard
-  - type: BankATM
-    bank-ATM-cashSlot:
-      name: bank-ATM-cashSlot
-      insertSound: /Audio/Machines/scanning.ogg
-      ejectSound: /Audio/Machines/tray_eject.ogg
-      ejectOnBreak: true
-      swap: false
-      whitelist:
-        components:
-          - Currency
-  - type: ActivatableUI
-    key: enum.BankATMMenuUiKey.ATM
-  - type: UserInterface
-    interfaces:
-      - key: enum.BankATMMenuUiKey.ATM
-        type: BankATMMenuBoundUserInterface
-  - type: ItemSlots
-  - type: ContainerContainer
-    containers:
-      bank-ATM-cashSlot: !type:ContainerSlot {}
-  - type: Anchorable
-    delay: 999999
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 0
+    arc: 360 # TODO: 180
+  - type: Fixtures
+    fixtures: {}
 
 - type: entity
-  name: wallmount withdraw-only bank atm
-  parent: BaseStructureComputer
+  suffix: Wallmount
+  parent: [ComputerBankATMBase, BaseStructureComputer, ComputerBankATMWithdraw]
   id: ComputerWallmountWithdrawBankATM
   description: Used to withdraw funds from a personal bank account. Unable to deposit. It now comes in a more compact design!
-  placement:
-    mode: SnapgridCenter
   components:
-  - type: MeleeSound
-    soundGroups:
-      Brute:
-        path:
-          "/Audio/Effects/glass_hit.ogg"
-  - type: Computer
-  - type: ApcPowerReceiver
-    powerLoad: 200
-  - type: ExtensionCableReceiver
-  - type: ActivatableUIRequiresPower
-  - type: Transform
-    anchored: true
-  - type: InteractionOutline
   - type: Sprite
     netsync: false
-    noRot: true
+    noRot: false
     sprite: _NF/Structures/wall_atm.rsi
     layers:
       - map: ["computerLayerBody"]
@@ -358,76 +206,16 @@
       - map: ["computerLayerScreen"]
         state: unshaded
   - type: WallMount
-    arc: 360
-  - type: Appearance
-  - type: GenericVisualizer
-    visuals:
-      enum.ComputerVisuals.Powered:
-        computerLayerScreen:
-          True: { visible: true, shader: unshaded }
-          False: { visible: false }
-        computerLayerKeys:
-          True: { visible: true, shader: unshaded }
-          False: { visible: true, shader: shaded }
-  - type: LitOnPowered
-  - type: PointLight
-    radius: 1.5
-    energy: 1.6
-    color: "#b89f25"
-    enabled: false
-    mask: /Textures/Effects/LightMasks/cone.png
-    autoRot: true
-    offset: "0, 0.4" # shine from the top, not bottom of the computer
-    castShadows: false
-  - type: EmitSoundOnUIOpen
-    sound:
-      collection: Keyboard
-  - type: BankATM
-    bank-ATM-cashSlot:
-      name: bank-ATM-cashSlot
-      insertSound: /Audio/Machines/scanning.ogg
-      ejectSound: /Audio/Machines/tray_eject.ogg
-      ejectOnBreak: true
-      swap: false
-      locked: true
-  - type: ActivatableUI
-    key: enum.BankATMMenuUiKey.ATM
-  - type: UserInterface
-    interfaces:
-      - key: enum.BankATMMenuUiKey.ATM
-        type: WithdrawBankATMMenuBoundUserInterface
-  - type: Anchorable
-    delay: 999999
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 100
-      behaviors:
-      - !type:PlaySoundBehavior
-        sound:
-          collection: GlassBreak
-      - !type:DoActsBehavior
-        acts: ["Destruction"]
+    arc: 360 # TODO: 180
+  - type: Fixtures
+    fixtures: {}
 
 - type: entity
   name: station administration console
-  parent: BaseStructureComputer
+  parent: [ComputerBankATMBase, BaseStructureComputer]
   id: StationAdminBankATM
   description: Used to pay out from the station's bank account
-  placement:
-    mode: SnapgridCenter
   components:
-  - type: MeleeSound
-    soundGroups:
-      Brute:
-        path:
-          "/Audio/Effects/glass_hit.ogg"
-  - type: Computer
-  - type: ApcPowerReceiver
-    powerLoad: 200
-  - type: ExtensionCableReceiver
-  - type: ActivatableUIRequiresPower
   - type: Sprite
     netsync: false
     noRot: true
@@ -441,29 +229,6 @@
       state: id
     - map: ["computerLayerKeys"]
       state: id_key
-  - type: Appearance
-  - type: GenericVisualizer
-    visuals:
-      enum.ComputerVisuals.Powered:
-        computerLayerScreen:
-          True: { visible: true, shader: unshaded }
-          False: { visible: false }
-        computerLayerKeys:
-          True: { visible: true, shader: unshaded }
-          False: { visible: true, shader: shaded }
-  - type: LitOnPowered
-  - type: PointLight
-    radius: 1.5
-    energy: 1.6
-    color: "#b89f25"
-    enabled: false
-    mask: /Textures/Effects/LightMasks/cone.png
-    autoRot: true
-    offset: "0, 0.4" # shine from the top, not bottom of the computer
-    castShadows: false
-  - type: EmitSoundOnUIOpen
-    sound:
-      collection: Keyboard
   - type: StationBankATM
     station-bank-ATM-cashSlot:
       name: station-bank-ATM-cashSlot
@@ -480,14 +245,9 @@
     interfaces:
     - key: enum.BankATMMenuUiKey.ATM
       type: StationBankATMMenuBoundUserInterface
-  - type: AccessReader
-    access: [["HeadOfPersonnel"], ["HeadOfSecurity"]]
   - type: ItemSlots
   - type: ContainerContainer
     containers:
       station-bank-ATM-cashSlot: !type:ContainerSlot {}
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 0
+  - type: AccessReader
+    access: [["HeadOfPersonnel"], ["HeadOfSecurity"]]

--- a/Resources/Prototypes/_NF/Entities/Structures/atms.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/atms.yml
@@ -79,6 +79,7 @@
 - type: entity
   name: bank atm withdraw-only
   id: ComputerBankATMWithdraw
+  description: Used to withdraw funds from a personal bank account. unable to deposit.
   abstract: true
   components:
   - type: BankATM
@@ -99,7 +100,7 @@
 - type: entity
   parent: [ComputerBankATMBase, BaseStructureComputer, ComputerBankATMDeposit]
   id: ComputerBankATM
-  description: Used to deposit and withdraw funds from a personal bank account
+  description: Used to deposit and withdraw funds from a personal bank account.
   components:
   - type: Sprite
     netsync: false
@@ -147,7 +148,6 @@
 - type: entity
   parent: [ComputerBankATMBase, BaseStructureComputer, ComputerBankATMWithdraw]
   id: ComputerWithdrawBankATM
-  description: Used to withdraw funds from a personal bank account. Unable to deposit.
   components:
   - type: Sprite
     netsync: false
@@ -174,7 +174,6 @@
   suffix: Wallmount
   parent: [ComputerBankATMBase, BaseStructureComputer, ComputerBankATMDeposit]
   id: ComputerWallmountBankATM
-  description: Used to deposit and withdraw funds from a personal bank account, it now comes in a more compact design!
   components:
   - type: Sprite
     netsync: false
@@ -194,7 +193,6 @@
   suffix: Wallmount
   parent: [ComputerBankATMBase, BaseStructureComputer, ComputerBankATMWithdraw]
   id: ComputerWallmountWithdrawBankATM
-  description: Used to withdraw funds from a personal bank account. Unable to deposit. It now comes in a more compact design!
   components:
   - type: Sprite
     netsync: false

--- a/Resources/Prototypes/_NF/Entities/Structures/atms.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/atms.yml
@@ -53,6 +53,7 @@
 - type: entity
   name: bank atm
   id: ComputerBankATMDeposit
+  description: Used to deposit and withdraw funds from a personal bank account.
   abstract: true
   components:
   - type: BankATM
@@ -100,7 +101,6 @@
 - type: entity
   parent: [ComputerBankATMBase, BaseStructureComputer, ComputerBankATMDeposit]
   id: ComputerBankATM
-  description: Used to deposit and withdraw funds from a personal bank account.
   components:
   - type: Sprite
     netsync: false

--- a/Resources/Prototypes/_NF/Entities/Structures/atms.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/atms.yml
@@ -51,6 +51,7 @@
         damage: 0
 
 - type: entity
+  name: bank atm
   id: ComputerBankATMDeposit
   abstract: true
   components:
@@ -76,7 +77,7 @@
       bank-ATM-cashSlot: !type:ContainerSlot {}
 
 - type: entity
-  name: withdraw-only bank atm
+  name: bank atm withdraw-only
   id: ComputerBankATMWithdraw
   abstract: true
   components:
@@ -96,7 +97,6 @@
         type: WithdrawBankATMMenuBoundUserInterface
 
 - type: entity
-  name: bank atm
   parent: [ComputerBankATMBase, BaseStructureComputer, ComputerBankATMDeposit]
   id: ComputerBankATM
   description: Used to deposit and withdraw funds from a personal bank account
@@ -112,8 +112,8 @@
       state: unshaded
 
 - type: entity
-  name: black market atm
-  parent: [ComputerBankATMBase, BaseStructureComputer, ComputerBankATMWithdraw]
+  suffix: BlackMarket
+  parent: [ComputerBankATMBase, BaseStructureComputer, ComputerBankATMDeposit]
   id: ComputerBlackMarketBankATM
   description: Has some sketchy looking modifications and a sticker that says DEPOSIT FEE 30%
   components:

--- a/Resources/Prototypes/_NF/Entities/Structures/atms.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/atms.yml
@@ -80,7 +80,7 @@
 - type: entity
   name: bank atm withdraw-only
   id: ComputerBankATMWithdraw
-  description: Used to withdraw funds from a personal bank account. unable to deposit.
+  description: Used to withdraw funds from a personal bank account, unable to deposit.
   abstract: true
   components:
   - type: BankATM

--- a/Resources/Prototypes/_NF/Entities/Structures/atms.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/atms.yml
@@ -103,7 +103,7 @@
       state: unshaded
 
 - type: entity
-  parent: [ComputerBankATMBase, ComputerBankATMWithdraw, BaseStructureUnanchorable, BaseStructureComputer]
+  parent: [ComputerBankATMBase, ComputerBankATMWithdraw, BaseStructureUnanchorable, BaseStructureIndestructible, BaseStructureComputer]
   id: ComputerWithdrawBankATM
   components:
   - type: Sprite
@@ -118,7 +118,7 @@
 
 - type: entity
   suffix: Wallmount
-  parent: [ComputerBankATMBase, ComputerBankATMDeposit, BaseStructureUnanchorable, BaseStructureWallmount, BaseStructureComputer]
+  parent: [ComputerBankATMBase, ComputerBankATMDeposit, BaseStructureUnanchorable, BaseStructureIndestructible, BaseStructureWallmount, BaseStructureComputer]
   id: ComputerWallmountBankATM
   components:
   - type: Sprite
@@ -148,7 +148,7 @@
 
 - type: entity
   suffix: BlackMarket
-  parent: [ComputerBankATMBase, ComputerBankATMDeposit, BaseStructureUnanchorable, BaseStructureComputer]
+  parent: [ComputerBankATMBase, ComputerBankATMDeposit, BaseStructureUnanchorable, BaseStructureDestructible, BaseStructureComputer]
   id: ComputerBlackMarketBankATM
   description: Has some sketchy looking modifications and a sticker that says DEPOSIT FEE 30%
   components:

--- a/Resources/Prototypes/_NF/Entities/Structures/atms.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/atms.yml
@@ -39,16 +39,6 @@
     sound:
       collection: Keyboard
   - type: Appearance
-  - type: Anchorable
-    delay: 999999
-  - type: Damageable
-    damageContainer: Inorganic
-    damageModifierSet: Metallic
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 0
 
 - type: entity
   name: bank atm
@@ -99,7 +89,7 @@
         type: WithdrawBankATMMenuBoundUserInterface
 
 - type: entity
-  parent: [ComputerBankATMBase, BaseStructureComputer, ComputerBankATMDeposit]
+  parent: [ComputerBankATMBase, ComputerBankATMDeposit, BaseStructureUnanchorable, BaseStructureIndestructible, BaseStructureComputer]
   id: ComputerBankATM
   components:
   - type: Sprite
@@ -113,8 +103,52 @@
       state: unshaded
 
 - type: entity
+  parent: [ComputerBankATMBase, ComputerBankATMWithdraw, BaseStructureUnanchorable, BaseStructureComputer]
+  id: ComputerWithdrawBankATM
+  components:
+  - type: Sprite
+    netsync: false
+    noRot: true
+    sprite: _NF/Structures/atm.rsi
+    layers:
+    - map: ["computerLayerBody"]
+      state: icon
+    - map: ["computerLayerScreen"]
+      state: unshaded
+
+- type: entity
+  suffix: Wallmount
+  parent: [ComputerBankATMBase, ComputerBankATMDeposit, BaseStructureUnanchorable, BaseStructureWallmount, BaseStructureComputer]
+  id: ComputerWallmountBankATM
+  components:
+  - type: Sprite
+    netsync: false
+    noRot: false
+    sprite: _NF/Structures/wall_atm.rsi
+    layers:
+      - map: ["computerLayerBody"]
+        state: icon
+      - map: ["computerLayerScreen"]
+        state: unshaded
+
+- type: entity
+  suffix: Wallmount
+  parent: [ComputerBankATMBase, ComputerBankATMWithdraw, BaseStructureUnanchorable, BaseStructureIndestructible, BaseStructureWallmount, BaseStructureComputer]
+  id: ComputerWallmountWithdrawBankATM
+  components:
+  - type: Sprite
+    netsync: false
+    noRot: false
+    sprite: _NF/Structures/wall_atm.rsi
+    layers:
+      - map: ["computerLayerBody"]
+        state: icon
+      - map: ["computerLayerScreen"]
+        state: unshaded
+
+- type: entity
   suffix: BlackMarket
-  parent: [ComputerBankATMBase, BaseStructureComputer, ComputerBankATMDeposit]
+  parent: [ComputerBankATMBase, ComputerBankATMDeposit, BaseStructureUnanchorable, BaseStructureComputer]
   id: ComputerBlackMarketBankATM
   description: Has some sketchy looking modifications and a sticker that says DEPOSIT FEE 30%
   components:
@@ -133,84 +167,10 @@
     interfaces:
       - key: enum.BankATMMenuUiKey.BlackMarket
         type: BankATMMenuBoundUserInterface
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 100
-      behaviors:
-      - !type:PlaySoundBehavior
-        sound:
-          collection: GlassBreak
-      - !type:DoActsBehavior
-        acts: ["Destruction"]
-
-- type: entity
-  parent: [ComputerBankATMBase, BaseStructureComputer, ComputerBankATMWithdraw]
-  id: ComputerWithdrawBankATM
-  components:
-  - type: Sprite
-    netsync: false
-    noRot: true
-    sprite: _NF/Structures/atm.rsi
-    layers:
-    - map: ["computerLayerBody"]
-      state: icon
-    - map: ["computerLayerScreen"]
-      state: unshaded
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 100
-      behaviors:
-      - !type:PlaySoundBehavior
-        sound:
-          collection: GlassBreak
-      - !type:DoActsBehavior
-        acts: ["Destruction"]
-
-- type: entity
-  suffix: Wallmount
-  parent: [ComputerBankATMBase, BaseStructureComputer, ComputerBankATMDeposit]
-  id: ComputerWallmountBankATM
-  components:
-  - type: Sprite
-    netsync: false
-    noRot: false
-    sprite: _NF/Structures/wall_atm.rsi
-    layers:
-      - map: ["computerLayerBody"]
-        state: icon
-      - map: ["computerLayerScreen"]
-        state: unshaded
-  - type: WallMount
-    arc: 360 # TODO: 180
-  - type: Fixtures
-    fixtures: {}
-
-- type: entity
-  suffix: Wallmount
-  parent: [ComputerBankATMBase, BaseStructureComputer, ComputerBankATMWithdraw]
-  id: ComputerWallmountWithdrawBankATM
-  components:
-  - type: Sprite
-    netsync: false
-    noRot: false
-    sprite: _NF/Structures/wall_atm.rsi
-    layers:
-      - map: ["computerLayerBody"]
-        state: icon
-      - map: ["computerLayerScreen"]
-        state: unshaded
-  - type: WallMount
-    arc: 360 # TODO: 180
-  - type: Fixtures
-    fixtures: {}
 
 - type: entity
   name: station administration console
-  parent: [ComputerBankATMBase, BaseStructureComputer]
+  parent: [ComputerBankATMBase, BaseStructureUnanchorable, BaseStructureIndestructible, BaseStructureComputer]
   id: StationAdminBankATM
   description: Used to pay out from the station's bank account
   components:

--- a/Resources/Prototypes/_NF/Entities/Structures/base_structure.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/base_structure.yml
@@ -1,0 +1,28 @@
+- type: entity
+  id: BaseStructureUnanchorable
+  abstract: true
+  components:
+  - type: Anchorable
+    delay: 999999
+
+- type: entity
+  id: BaseStructureIndestructible
+  abstract: true
+  components:
+  - type: Damageable
+    damageContainer: Inorganic
+    damageModifierSet: Metallic
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 0
+
+- type: entity
+  id: BaseStructureWallmount
+  abstract: true
+  components:
+  - type: WallMount
+    arc: 360 # TODO: 180 after ATM fixes
+  - type: Fixtures
+    fixtures: {}

--- a/Resources/Prototypes/_NF/Entities/Structures/base_structure.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/base_structure.yml
@@ -6,6 +6,22 @@
     delay: 999999
 
 - type: entity
+  id: BaseStructureDestructible
+  abstract: true
+  components:
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 100
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          collection: GlassBreak
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+
+- type: entity
   id: BaseStructureIndestructible
   abstract: true
   components:

--- a/Resources/Prototypes/_NF/Entities/Structures/base_structure.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/base_structure.yml
@@ -38,7 +38,12 @@
   id: BaseStructureWallmount
   abstract: true
   components:
+  - type: Sprite
+    drawdepth: WallMountedItems
+    snapCardinals: false
   - type: WallMount
-    arc: 360 # TODO: 180 after ATM fixes
+    arc: 180
+  - type: Transform
+    noRot: false
   - type: Fixtures
     fixtures: {}


### PR DESCRIPTION
## About the PR
Cleanup for all yml we edited.
Removed the no ROT from wall-mount ATM.
Made ATM & Shipyards single user to block people from stealing your money.
Used multi perents so we dont need to add lines into comps anymore.

## Why / Balance
Needed cleanup and bug fix.

## Technical details
.yml

## Media
N/A

## Breaking changes
ATM That were placed sideways will now be sideways. we will need to fix it later to make cash not glitch into walls.
Keep in mind this isnt a new bug, its just that only now we can tell its an issue.

**Changelog**
N/A
