### PR TITLE
Tall trait tweak

### DIFF
--- a/Content.Server/_NF/SizeAttribute/SizeAttributeSystem.cs
+++ b/Content.Server/_NF/SizeAttribute/SizeAttributeSystem.cs
@@ -26,12 +26,12 @@ namespace Content.Server.SizeAttribute
 
             if (whitelist.Tall && component.Tall)
             {
-                Scale(uid, component, whitelist.TallScale, whitelist.TallDensity);
+                Scale(uid, component, whitelist.TallScale, whitelist.TallDensity, whitelist.TallCosmeticOnly);
                 PseudoItem(uid, component, whitelist.TallPseudoItem);
             }
             else if (whitelist.Short && component.Short)
             {
-                Scale(uid, component, whitelist.ShortScale, whitelist.ShortDensity);
+                Scale(uid, component, whitelist.ShortScale, whitelist.ShortDensity, whitelist.ShortCosmeticOnly);
                 PseudoItem(uid, component, whitelist.ShortPseudoItem);
             }
         }
@@ -54,7 +54,7 @@ namespace Content.Server.SizeAttribute
             }
         }
 
-        private void Scale(EntityUid uid, SizeAttributeComponent component, float scale, float density)
+        private void Scale(EntityUid uid, SizeAttributeComponent component, float scale, float density, bool cosmeticOnly)
         {
             if (scale <= 0f && density <= 0f)
                 return;
@@ -67,7 +67,7 @@ namespace Content.Server.SizeAttribute
 
             _appearance.SetData(uid, ScaleVisuals.Scale, oldScale * scale, appearanceComponent);
 
-            if (_entityManager.TryGetComponent(uid, out FixturesComponent? manager))
+            if (!cosmeticOnly && _entityManager.TryGetComponent(uid, out FixturesComponent? manager))
             {
                 foreach (var (id, fixture) in manager.Fixtures)
                 {

--- a/Content.Server/_NF/SizeAttribute/SizeAttributeWhitelistComponent.cs
+++ b/Content.Server/_NF/SizeAttribute/SizeAttributeWhitelistComponent.cs
@@ -18,6 +18,9 @@ namespace Content.Server.SizeAttribute
         [DataField("shortPseudoItem")]
         public bool ShortPseudoItem = false;
 
+        [DataField("shortCosmeticOnly")]
+        public bool ShortCosmeticOnly = false;
+
         // Tall
         [DataField("tall")]
         public bool Tall = false;
@@ -30,5 +33,8 @@ namespace Content.Server.SizeAttribute
 
         [DataField("tallPseudoItem")]
         public bool TallPseudoItem = false;
+
+        [DataField("tallCosmeticOnly")]
+        public bool TallCosmeticOnly = false;
     }
 }

--- a/Content.Server/_NF/SizeAttribute/SizeAttributeWhitelistComponent.cs
+++ b/Content.Server/_NF/SizeAttribute/SizeAttributeWhitelistComponent.cs
@@ -19,7 +19,7 @@ namespace Content.Server.SizeAttribute
         public bool ShortPseudoItem = false;
 
         [DataField("shortCosmeticOnly")]
-        public bool ShortCosmeticOnly = false;
+        public bool ShortCosmeticOnly = true;
 
         // Tall
         [DataField("tall")]
@@ -35,6 +35,6 @@ namespace Content.Server.SizeAttribute
         public bool TallPseudoItem = false;
 
         [DataField("tallCosmeticOnly")]
-        public bool TallCosmeticOnly = false;
+        public bool TallCosmeticOnly = true;
     }
 }

--- a/Resources/Prototypes/DeltaV/Entities/Mobs/Species/vulpkanin.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Mobs/Species/vulpkanin.yml
@@ -23,11 +23,6 @@
   - type: VulpLanguageSpeaker
   - type: VulpLangaugeListener
   - type: VulpGiveTranslator
-  - type: SizeAttributeWhitelist
-    short: true
-    shortscale: 0.8
-    shortDensity: 140
-    shortPseudoItem: true
   - type: Speech
     speechSounds: Vulpkanin
     speechVerb: Vulpkanin
@@ -114,6 +109,12 @@
     damage:
       types:
         Heat: 1.5 # Rip Fur
+  - type: SizeAttributeWhitelist # Frontier
+    short: true
+    shortscale: 0.8
+    shortDensity: 140
+    shortPseudoItem: true
+    shortCosmeticOnly: false
 
 - type: entity
   save: false

--- a/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
@@ -45,7 +45,7 @@
   - type: SizeAttributeWhitelist
     tall: true
     tallscale: 1.2
-    tallDensity: 200 # less than oni - 220
+    tallCosmeticOnly: true
   - type: MeleeWeapon
     soundHit:
       path: /Audio/Weapons/slash.ogg

--- a/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
@@ -42,10 +42,6 @@
   - type: Damageable
     damageContainer: Biological
     damageModifierSet: Scale
-  - type: SizeAttributeWhitelist
-    tall: true
-    tallscale: 1.2
-    tallCosmeticOnly: true
   - type: MeleeWeapon
     soundHit:
       path: /Audio/Weapons/slash.ogg
@@ -66,6 +62,9 @@
     heatDamage:
       types:
         Heat : 0.1 #per second, scales with temperature & other constants
+  - type: SizeAttributeWhitelist # Frontier
+    tall: true
+    tallscale: 1.2
 
 - type: entity
   parent: BaseSpeciesDummy

--- a/Resources/Prototypes/_Nyano/Entities/Mobs/Species/felinid.yml
+++ b/Resources/Prototypes/_Nyano/Entities/Mobs/Species/felinid.yml
@@ -46,7 +46,7 @@
   - type: SizeAttributeWhitelist
     tall: true
     tallscale: 1
-    tallDensity: 185
+    tallCosmeticOnly: true
   - type: Vocal
     wilhelm: "/Audio/Nyanotrasen/Voice/Felinid/cat_wilhelm.ogg"
     sounds:

--- a/Resources/Prototypes/_Nyano/Entities/Mobs/Species/felinid.yml
+++ b/Resources/Prototypes/_Nyano/Entities/Mobs/Species/felinid.yml
@@ -43,10 +43,6 @@
         Blunt: 1
   - type: Stamina
   - type: PseudoItem
-  - type: SizeAttributeWhitelist
-    tall: true
-    tallscale: 1
-    tallCosmeticOnly: true
   - type: Vocal
     wilhelm: "/Audio/Nyanotrasen/Voice/Felinid/cat_wilhelm.ogg"
     sounds:
@@ -57,7 +53,10 @@
   - type: NpcFactionMember
     factions:
     - NanoTrasen
-    - Felinid
+    - Felinid # Frontier
+  - type: SizeAttributeWhitelist # Frontier
+    tall: true
+    tallscale: 1
 
 - type: entity
   save: false


### PR DESCRIPTION
## About the PR
Makes the tall trait cosmetic-only for lizards and cats

And adds the ability to mark the tall/small traits as cosmetic-only in SizeAttributeWhitelistComponent

## Why / Balance
@dvir001 

## Technical details
*Screams*

12 changed lines

## Media
- [X] this PR does not require an ingame showcase

## Breaking changes
N/A

**Changelog**
:cl: 
- tweak: The tall trait no longer makes cats and lizards heavier.
