### PR TITLE
Disable artifexium artifacts activation

### DIFF
--- a/Resources/Prototypes/Reagents/chemicals.yml
+++ b/Resources/Prototypes/Reagents/chemicals.yml
@@ -72,14 +72,14 @@
         damage:
           types:
             Caustic: 2
-  reactiveEffects:
-    Acidic:
-      methods: [ Touch ]
-      effects:
-      - !type:ActivateArtifact
-        conditions:
-        - !type:ReagentThreshold
-          min: 5
+  # reactiveEffects: # Frontier - Removed till a rework
+    # Acidic:
+      # methods: [ Touch ]
+      # effects:
+      # - !type:ActivateArtifact
+        # conditions:
+        # - !type:ReagentThreshold
+          # min: 5
 
 - type: reagent
   id: Benzene


### PR DESCRIPTION
## About the PR
Disable artifexium artifacts activation till we can rework it into a balanced systems that isnt "spray" for free points.

## Why / Balance
The spray to get points has made artifacts research useless, there is no point in even trying to gain points without grabbing 50 arti on a space rock and spray it, 

## Technical details
.yml edit

## Media
N/A

## Breaking changes
N/A

**Changelog**
:cl: dvir01
- tweak: Artifexium no longer activate artifacts till a rework to make it less spray to win.
