### PR TITLE
Mining drill back to sci tech

### DIFF
--- a/Resources/Maps/_NF/Shuttles/gourd.yml
+++ b/Resources/Maps/_NF/Shuttles/gourd.yml
@@ -10283,18 +10283,6 @@ entities:
     - type: Transform
       pos: 0.92998254,5.462837
       parent: 1
-- proto: MiningDrill
-  entities:
-  - uid: 1316
-    components:
-    - type: Transform
-      pos: 8.467209,-3.6639047
-      parent: 1
-  - uid: 1317
-    components:
-    - type: Transform
-      pos: 8.529709,-3.3435922
-      parent: 1
 - proto: Multitool
   entities:
   - uid: 68

--- a/Resources/Maps/_NF/Shuttles/rosebudmkii.yml
+++ b/Resources/Maps/_NF/Shuttles/rosebudmkii.yml
@@ -7155,14 +7155,6 @@ entities:
     - type: Transform
       pos: -8.642134,3.4433465
       parent: 1
-- proto: MiningDrill
-  entities:
-  - uid: 322
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 11.16817,4.674234
-      parent: 1
 - proto: Morgue
   entities:
   - uid: 175

--- a/Resources/Prototypes/Catalog/Fills/Lockers/cargo.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/cargo.yml
@@ -25,7 +25,7 @@
 #      - id: Flare # Frontier
 #        amount: 3 # Frontier
       - id: BoxFlare # Frontier
-      - id: MiningDrill # Frontier
+      - id: Pickaxe # Frontier
       - id: WeaponProtoKineticAccelerator # Frontier
 
 - type: entity

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/salvage.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/salvage.yml
@@ -5,8 +5,8 @@
     WeaponProtoKineticAccelerator: 3
     WeaponCrusher: 3
     WeaponCrusherDagger: 5
-    MiningDrill: 3
-    Pickaxe: 8
+#    MiningDrill: 3
+    Pickaxe: 10
     OreBag: 6
     Floodlight: 10
     RadioHandheld: 5


### PR DESCRIPTION
## About the PR
Restore the drill to sci, removed from lockers and venders.

## Why / Balance
The mining drill is crazy fast now and is an an upgrade to the pickaxe.

## Technical details
.yml

## Media
N/A

## Breaking changes
N.A

**Changelog**
:cl: dvir01
- tweak: Mining drill has been moved back to sci tech, ask someone to print you some.
