### PR TITLE
Remove ratking from the mouse event

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -183,11 +183,11 @@
       prob: 0.015
     - id: MobMouse2
       prob: 0.015
-    - id: MobRatServant
-      prob: 0.015
-    specialEntries:
-    - id: SpawnPointGhostRatKing
-      prob: 0.005
+#    - id: MobRatServant
+#      prob: 0.015
+#    specialEntries:
+#    - id: SpawnPointGhostRatKing
+#      prob: 0.005
 
 - type: entity
   id: CockroachMigration


### PR DESCRIPTION
## About the PR
Came back by mistake, spawn on frontier.

## Why / Balance
The rat

## Technical details
.yml

## Media
N/A

## Breaking changes
N/A

**Changelog**
N/A