### PR TITLE
Spider web node broken

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/spider_web.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/spider_web.yml
@@ -7,9 +7,6 @@
     snap:
       - Wall
   components:
-    - type: Construction
-      graph: WebStructures
-      node: spiderweb
     - type: MeleeSound
       soundGroups:
         Brute:
@@ -43,7 +40,7 @@
           layer:
           - MidImpassable
     - type: Damageable
-      damageModifierSet: Web
+      damageModifierSet: Wood
     - type: Destructible
       thresholds:
       - trigger:
@@ -135,7 +132,7 @@
           mask:
           - ItemMask
     - type: Damageable
-      damageModifierSet: Web
+      damageModifierSet: Wood
     - type: Destructible
       thresholds:
       - trigger:


### PR DESCRIPTION
## About the PR
The web has no actual build node, removing it to remove the errors when you spawn it.
Edit web to wood to match upstream having it burn from fire.

## Why / Balance
bug fix.

## Technical details
bug fix.

## Media
N/A

## Breaking changes
N/A

**Changelog**
N/A
