### PR TITLE
Chief engineer's hardsuit 95% radiation protection

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -342,7 +342,7 @@
         Slash: 0.8
         Piercing: 0.8
         Heat: 0.4
-        Radiation: 0.0
+        Radiation: 0.05 # Frontier - 0<0.05 ClothingOuterSuitRad
         Caustic: 0.7
   - type: ClothingSpeedModifier
     walkModifier: 0.75


### PR DESCRIPTION
## About the PR
Chief engineer's suit no longer has 100% protection

## Why / Balance
Balance, no one should have 100% protection

## Technical details
.yml

## Media
N/A

## Breaking changes
N/A


**Changelog**
:cl: dvir01
- tweak: CE suit 100<95% rad protection.