### PR TITLE
Nerf pinpointers

### DIFF
--- a/Content.Server/Pinpointer/PinpointerSystem.cs
+++ b/Content.Server/Pinpointer/PinpointerSystem.cs
@@ -160,6 +160,15 @@ public sealed class PinpointerSystem : SharedPinpointerSystem
 
         var dirVec = CalculateDirection(uid, target.Value);
         var oldDist = pinpointer.DistanceToTarget;
+
+        // Frontier: if the pinpointer has a max range and the distance to target is greater than the max range, set the distance to unknown
+        if (pinpointer.MaxRange > 0 && dirVec != null && dirVec.Value.LengthSquared() > pinpointer.MaxRange * pinpointer.MaxRange)
+        {
+            SetDistance(uid, Distance.Unknown, pinpointer);
+            TrySetArrowAngle(uid, Angle.Zero, pinpointer);
+            return;
+        }
+
         if (dirVec != null)
         {
             var angle = dirVec.Value.ToWorldAngle();

--- a/Content.Shared/Pinpointer/PinpointerComponent.cs
+++ b/Content.Shared/Pinpointer/PinpointerComponent.cs
@@ -66,6 +66,14 @@ public sealed partial class PinpointerComponent : Component
     // Frontier - if greater than 0, then the pinpointer stops pointing to the target when it's further than this value
     [DataField("maxRange")]
     public float MaxRange = -1;
+
+    // Frontier - time in seconds to retarget
+    [DataField("retargetDoAfter")]
+    public float RetargetDoAfter = 15f;
+
+    // Frontier - whether this pinpointer can target mobs
+    [DataField("canTargetMobs")]
+    public bool CanTargetMobs = false;
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/Pinpointer/PinpointerComponent.cs
+++ b/Content.Shared/Pinpointer/PinpointerComponent.cs
@@ -62,6 +62,10 @@ public sealed partial class PinpointerComponent : Component
 
     [ViewVariables]
     public bool HasTarget => DistanceToTarget != Distance.Unknown;
+
+    // Frontier - if greater than 0, then the pinpointer stops pointing to the target when it's further than this value
+    [DataField("maxRange")]
+    public float MaxRange = -1;
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/Pinpointer/SharedPinpointerSystem.cs
+++ b/Content.Shared/Pinpointer/SharedPinpointerSystem.cs
@@ -59,6 +59,7 @@ public abstract class SharedPinpointerSystem : EntitySystem
             BreakOnWeightlessMove = true,
             CancelDuplicate = true,
             BreakOnHandChange = true,
+            NeedHand = true,
             BreakOnTargetMove = true
         };
         _doAfter.TryStartDoAfter(daArgs);
@@ -66,6 +67,9 @@ public abstract class SharedPinpointerSystem : EntitySystem
 
     private void OnPinpointerDoAfter(EntityUid uid, PinpointerComponent component, PinpointerDoAfterEvent args)
     {
+        if (args.Cancelled)
+            return;
+
         component.Target = args.Target;
         _adminLogger.Add(LogType.Action, LogImpact.Low, $"{ToPrettyString(args.User):player} set target of {ToPrettyString(uid):pinpointer} to {ToPrettyString(component.Target):target}");
         if (component.UpdateTargetName)

--- a/Content.Shared/Pinpointer/SharedPinpointerSystem.cs
+++ b/Content.Shared/Pinpointer/SharedPinpointerSystem.cs
@@ -1,15 +1,20 @@
 using Content.Shared.Administration.Logs;
 using Content.Shared.Database;
+using Content.Shared.DoAfter;
 using Content.Shared.Emag.Systems;
 using Content.Shared.Examine;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
+using Content.Shared.Mobs.Components;
+using Robust.Shared.Serialization;
 
 namespace Content.Shared.Pinpointer;
 
 public abstract class SharedPinpointerSystem : EntitySystem
 {
     [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
+    [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
+    [Dependency] private readonly IEntityManager _endMan = default!;
 
     public override void Initialize()
     {
@@ -17,6 +22,8 @@ public abstract class SharedPinpointerSystem : EntitySystem
         SubscribeLocalEvent<PinpointerComponent, GotEmaggedEvent>(OnEmagged);
         SubscribeLocalEvent<PinpointerComponent, AfterInteractEvent>(OnAfterInteract);
         SubscribeLocalEvent<PinpointerComponent, ExaminedEvent>(OnExamined);
+        // Frontier
+        SubscribeLocalEvent<PinpointerComponent, PinpointerDoAfterEvent>(OnPinpointerDoAfter);
     }
 
     /// <summary>
@@ -30,10 +37,37 @@ public abstract class SharedPinpointerSystem : EntitySystem
         if (!component.CanRetarget || component.IsActive)
             return;
 
+        // Frontier: disallow pinpointing mobs
+        if (!component.CanTargetMobs && HasComp<MobStateComponent>(args.Target))
+            return;
+
         // TODO add doafter once the freeze is lifted
         args.Handled = true;
+
+        // Frontier: the below was made into a do-after, see OnPinpointerDoAfter.
+        // component.Target = args.Target;
+        // _adminLogger.Add(LogType.Action, LogImpact.Low, $"{ToPrettyString(args.User):player} set target of {ToPrettyString(uid):pinpointer} to {ToPrettyString(component.Target.Value):target}");
+        // if (component.UpdateTargetName)
+        //     component.TargetName = component.Target == null ? null : Identity.Name(component.Target.Value, EntityManager);
+
+        // Frontier: do-after
+        var daArgs = new DoAfterArgs(_endMan, args.User, TimeSpan.FromSeconds(component.RetargetDoAfter),
+            new PinpointerDoAfterEvent(), uid, args.Target, uid)
+        {
+            BreakOnUserMove = true,
+            BreakOnDamage = true,
+            BreakOnWeightlessMove = true,
+            CancelDuplicate = true,
+            BreakOnHandChange = true,
+            BreakOnTargetMove = true
+        };
+        _doAfter.TryStartDoAfter(daArgs);
+    }
+
+    private void OnPinpointerDoAfter(EntityUid uid, PinpointerComponent component, PinpointerDoAfterEvent args)
+    {
         component.Target = args.Target;
-        _adminLogger.Add(LogType.Action, LogImpact.Low, $"{ToPrettyString(args.User):player} set target of {ToPrettyString(uid):pinpointer} to {ToPrettyString(component.Target.Value):target}");
+        _adminLogger.Add(LogType.Action, LogImpact.Low, $"{ToPrettyString(args.User):player} set target of {ToPrettyString(uid):pinpointer} to {ToPrettyString(component.Target):target}");
         if (component.UpdateTargetName)
             component.TargetName = component.Target == null ? null : Identity.Name(component.Target.Value, EntityManager);
     }
@@ -140,4 +174,10 @@ public abstract class SharedPinpointerSystem : EntitySystem
         args.Handled = true;
         component.CanRetarget = true;
     }
+}
+
+// Frontier - do-after
+[Serializable, NetSerializable]
+public sealed partial class PinpointerDoAfterEvent : SimpleDoAfterEvent
+{
 }

--- a/Resources/Prototypes/Entities/Objects/Devices/pinpointer.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pinpointer.yml
@@ -68,7 +68,6 @@
   description: A handheld tracking device that locks onto any physical entity while off. Keep upright to retain accuracy.
   id: PinpointerUniversal
   parent: PinpointerBase
-  suffix: 128m # Frontier
   components:
   - type: Icon
     state: pinpointer-way
@@ -88,17 +87,6 @@
       visible: false
   - type: StaticPrice # Frontier
     price: 150
-
-# Frontier
-- type: entity
-  id: PinpointerUniversalNoRange
-  parent: PinpointerUniversal
-  suffix: no range, DO NOT MAP
-  components:
-  - type: Pinpointer
-    updateTargetName: true
-    canRetarget: true
-    maxRange: -1
 
 - type: entity
   parent: PinpointerBase

--- a/Resources/Prototypes/Entities/Objects/Devices/pinpointer.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pinpointer.yml
@@ -68,12 +68,14 @@
   description: A handheld tracking device that locks onto any physical entity while off. Keep upright to retain accuracy.
   id: PinpointerUniversal
   parent: PinpointerBase
+  suffix: 128m # Frontier
   components:
   - type: Icon
     state: pinpointer-way
   - type: Pinpointer
     updateTargetName: true
     canRetarget: true
+    maxRange: 128 # frontier
   - type: Sprite
     noRot: True
     sprite: Objects/Devices/pinpointer.rsi
@@ -86,6 +88,17 @@
       visible: false
   - type: StaticPrice # Frontier
     price: 150
+
+# Frontier
+- type: entity
+  id: PinpointerUniversalNoRange
+  parent: PinpointerUniversal
+  suffix: no range, DO NOT MAP
+  components:
+  - type: Pinpointer
+    updateTargetName: true
+    canRetarget: true
+    maxRange: -1
 
 - type: entity
   parent: PinpointerBase

--- a/Resources/Prototypes/Entities/Objects/Devices/pinpointer.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pinpointer.yml
@@ -74,7 +74,6 @@
   - type: Pinpointer
     updateTargetName: true
     canRetarget: true
-    maxRange: 128 # frontier
   - type: Sprite
     noRot: True
     sprite: Objects/Devices/pinpointer.rsi

--- a/Resources/Prototypes/_NF/Entities/Objects/Devices/pinpointer.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Devices/pinpointer.yml
@@ -1,7 +1,9 @@
 - type: entity
-  id: PinpointerUniversalNoRange
+  id: PinpointerUniversalDebug
   parent: PinpointerUniversal
   suffix: DEBUG, DO NOT MAP
   components:
   - type: Pinpointer
     maxRange: -1
+    retargetDoAfter: 0
+    canTargetMobs: true

--- a/Resources/Prototypes/_NF/Entities/Objects/Devices/pinpointer.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Devices/pinpointer.yml
@@ -1,0 +1,7 @@
+- type: entity
+  id: PinpointerUniversalNoRange
+  parent: PinpointerUniversal
+  suffix: DEBUG, DO NOT MAP
+  components:
+  - type: Pinpointer
+    maxRange: -1


### PR DESCRIPTION
## About the PR
#description is outdated - see the comments

Adds a maximum range to pinpointers, which for normal pinpointers is 128m. When the target entity is more than 128m away, you can observe the same effect as when the tracked entity disappears - the arrow gets "stuck", and if you toggle the pinpointer off and on, it will show a question mark. It will retain this state until the target is in the range again, or until you reconfigure it.

The maximum distance is configurable, and there's also a new [unlimited] variant meant for admemes.

## Why / Balance
Powergamers such as prosmasher use pinpointers to permamently track people and ships. Security can pinpoint *potential* criminals even before they commit anything bad, and criminals can pinpoint security to know if they're being chased. In both cases there's NO COUNTERPLAY to that: once you're pinpointed, your location is forever known.

## Technical details
Added a new if statement to PinpointerSystem.UpdateDirectionToTarget; added a new field to PinpointerComponent and mentioned it in yml.

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None

**Changelog**
:cl:
- tweak: Pinpointers now take time to change their target, throughout which it must stand absolutely still, and can no longer be used to pinpoint people.