### PR TITLE
fix(ui): Fix dock labels misbehave with UI scaling

### DIFF
--- a/Content.Client/Shuttles/UI/RadarControl.cs
+++ b/Content.Client/Shuttles/UI/RadarControl.cs
@@ -396,7 +396,7 @@ public sealed class RadarControl : MapGridControl
                     shown.Add(ent);
                     label.Visible = true;
                     label.Text = state.Name;
-                    LayoutContainer.SetPosition(label, ScalePosition(uiPosition));
+                    LayoutContainer.SetPosition(label, ScalePosition(uiPosition) / UIScale);
                 }
             }
         }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
`RadarControl.DrawDocks` now scales the dock label position by the user's UI scale. Previously, using a different UI scale would result in the dock labels "drifting" and being very misaligned. Image attached.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Fixes a visual error. Issue discussed on Discord bugs-feedback channel.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Divides the the label's scaled `uiPosition` by `UIScale`. The error appears to be a typo/oversight that was not caught due to use of 100% UI scale. 

See the correct scaling done here (ignore the vector offset, which is used only for grid labels): https://github.com/new-frontiers-14/frontier-station-14/blob/f1d81417323294b204bcf0a1e2a2982d58cab7fb/Content.Client/Shuttles/UI/RadarControl.cs#L277-L279

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

This screenshot demonstrates the erroneous scaling. *Users with `100%` UI scale do not experience this effect.* This PR fixes the shown behavior, so that it works regardless of UI scale.

![Screenshot_20240211_212544](https://github.com/new-frontiers-14/frontier-station-14/assets/44628275/4862c155-4822-4a9e-a0ce-72d338cf2e90)

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
N/A

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
Does not affect gameplay, so no player changelog is needed.
<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
