### PR TITLE
Removes syndicate turret box from Caduceus

### DIFF
--- a/Resources/Maps/_NF/Shuttles/caduceus.yml
+++ b/Resources/Maps/_NF/Shuttles/caduceus.yml
@@ -8793,7 +8793,7 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -7.5,2.5
       parent: 1
-- proto: ToolboxElectricalTurretFilled
+- proto: ToolboxElectricalFilled
   entities:
   - uid: 1405
     components:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Removes a syndicate turret toolbox from the Caduceus.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Duh.

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl: MagnusCrowe
- remove: Removed syndicate turret box from Caduceus.
