### PR TITLE
Weapon Racks (Update)

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/base_pka.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/base_pka.yml
@@ -47,7 +47,3 @@
     - Belt
   - type: UseDelay
     delay: 1
-  - type: Tag # Frontier
-    tags: # Frontier
-    - WeaponRanged # Frontier
-    - WeaponLongarms # Frontier

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/base_staff.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/base_staff.yml
@@ -20,6 +20,4 @@
   - type: Tag
     tags:
     - WizardStaff
-    - WeaponRanged # Frontier
-    - WeaponLongarms # Frontier
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/base_wand.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/base_wand.yml
@@ -25,5 +25,3 @@
   - type: Tag
     tags:
     - WizardWand
-    - WeaponRanged # Frontier
-    - WeaponShortArms # Frontier

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/watergun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/watergun.yml
@@ -51,8 +51,6 @@
       Plastic: 150
   - type: Tag # Frontier
     tags: # Frontier
-    - WeaponRanged # Frontier
-    - WeaponShortArms # Frontier
     - Sidearm # Frontier
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -30,10 +30,6 @@
   - type: Appearance
   - type: StaticPrice
     price: 500
-  - type: Tag # Frontier
-    tags: # Frontier
-    - WeaponRanged # Frontier
-    - WeaponLongarms # Frontier
 
 - type: entity
   id: BaseWeaponPowerCell
@@ -82,8 +78,6 @@
     - 0,1,0,1
   - type: Tag
     tags:
-    - WeaponRanged # Frontier
-    - WeaponShortArms # Frontier
     - Sidearm
   - type: Clothing
     sprite: Objects/Weapons/Guns/Battery/taser.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Bow/bow.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Bow/bow.yml
@@ -44,10 +44,6 @@
       projectiles: !type:ContainerSlot
   - type: ContainerAmmoProvider
     container: aprojectiles
-  - type: Tag # Frontier
-    tags: # Frontier
-    - WeaponRanged # Frontier
-    - WeaponLongarms # Frontier
 
 - type: entity
   id: BowImprovised

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/HMGs/hmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/HMGs/hmgs.yml
@@ -19,10 +19,6 @@
       path: /Audio/Weapons/Guns/Empty/lmg_empty.ogg
   - type: StaticPrice
     price: 500
-  - type: Tag # Frontier
-    tags: # Frontier
-    - WeaponRanged # Frontier
-    - WeaponLongarms # Frontier
   # No chamber because HMG may want its own
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
@@ -60,10 +60,6 @@
     price: 500
   - type: UseDelay
     delay: 1
-  - type: Tag # Frontier
-    tags: # Frontier
-    - WeaponRanged # Frontier
-    - WeaponLongarms # Frontier
 
 - type: entity
   name: L6 SAW

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
@@ -19,10 +19,6 @@
     containers:
       ballistic-ammo: !type:Container
         ents: []
-  - type: Tag # Frontier
-    tags: # Frontier
-    - WeaponRanged # Frontier
-    - WeaponLongarms # Frontier
 
 - type: entity
   name: china lake
@@ -266,8 +262,6 @@
             False: { state: base-unshaded-off }
     - type: Tag # Frontier
       tags: # Frontier
-      - WeaponRanged # Frontier
-      - WeaponShortArms # Frontier
       - Sidearm # Frontier
 
 # Admeme

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -19,8 +19,6 @@
   - type: Tag
     tags:
     - Sidearm
-    - WeaponRanged # Frontier
-    - WeaponShortArms # Frontier
   - type: Clothing
     sprite: Objects/Weapons/Guns/Pistols/viper.rsi
     quickEquip: false

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
@@ -15,8 +15,6 @@
   - type: Tag
     tags:
     - Sidearm
-    - WeaponRanged # Frontier
-    - WeaponShortArms # Frontier
   - type: Clothing
     sprite: Objects/Weapons/Guns/Revolvers/deckard.rsi
     quickEquip: false

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -49,10 +49,6 @@
       gun_chamber: !type:ContainerSlot
   - type: StaticPrice
     price: 500
-  - type: Tag # Frontier
-    tags: # Frontier
-    - WeaponRanged # Frontier
-    - WeaponLongarms # Frontier
 
 - type: entity
   name: AKMS

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -54,10 +54,6 @@
       gun_chamber: !type:ContainerSlot
   - type: StaticPrice
     price: 500
-  - type: Tag # Frontier
-    tags: # Frontier
-    - WeaponRanged # Frontier
-    - WeaponLongarms # Frontier
 
 - type: entity
   name: Atreides

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -42,10 +42,6 @@
         ents: []
   - type: StaticPrice
     price: 500
-  - type: Tag # Frontier
-    tags: # Frontier
-    - WeaponRanged # Frontier
-    - WeaponLongarms # Frontier
 
 - type: entity
   name: Bulldog
@@ -102,10 +98,6 @@
   - type: Appearance
   - type: StaticPrice
     price: 500
-  - type: Tag # Frontier
-    tags: # Frontier
-    - WeaponRanged # Frontier
-    - WeaponLongarms # Frontier
 
 - type: entity
   name: double-barreled shotgun

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -36,10 +36,6 @@
         ents: []
   - type: StaticPrice
     price: 500
-  - type: Tag # Frontier
-    tags: # Frontier
-    - WeaponRanged # Frontier
-    - WeaponLongarms # Frontier
 
 - type: entity
   name: Kardashev-Mosin

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/flare_gun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/flare_gun.yml
@@ -46,5 +46,4 @@
     price: 150
   - type: Tag # Frontier
     tags: # Frontier
-    - Sidearm
-    - WeaponShortArms # Frontier
+    - Sidearm # Frontier

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/pneumatic_cannon.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/pneumatic_cannon.yml
@@ -65,10 +65,6 @@
       storagebase: !type:Container
         ents: []
       gas_tank: !type:ContainerSlot
-  - type: Tag # Frontier
-    tags: # Frontier
-    - WeaponRanged # Frontier
-    - WeaponLongarms # Frontier
 
 - type: entity
   name: pie cannon
@@ -111,10 +107,6 @@
     containers:
       storagebase: !type:Container
         ents: []
-  - type: Tag # Frontier
-    tags: # Frontier
-    - WeaponRanged # Frontier
-    - WeaponLongarms # Frontier
 
 # shoots bullets instead of throwing them, no other changes
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/armblade.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/armblade.yml
@@ -22,6 +22,3 @@
     qualities:
       - Prying
   - type: Prying
-  - type: Tag # Frontier
-    tags: # Frontier
-    - WeaponMelee # Frontier

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/baseball_bat.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/baseball_bat.yml
@@ -38,7 +38,6 @@
   - type: Tag
     tags:
     - BaseballBat
-    - WeaponMelee # Frontier
 
 - type: entity
   name: knockback stick

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/chainsaw.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/chainsaw.yml
@@ -47,6 +47,3 @@
         maxVol: 300
   - type: UseDelay
     delay: 1
-  - type: Tag # Frontier
-    tags: # Frontier
-    - WeaponMelee # Frontier

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/cult.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/cult.yml
@@ -21,9 +21,6 @@
     slots:
     - back
   - type: DisarmMalus
-  - type: Tag # Frontier
-    tags: # Frontier
-    - WeaponMelee # Frontier
 
 - type: entity
   name: eldritch blade
@@ -48,9 +45,6 @@
     slots:
     - back
   - type: DisarmMalus
-  - type: Tag # Frontier
-    tags: # Frontier
-    - WeaponMelee # Frontier
 
 - type: entity
   name: unholy halberd
@@ -61,7 +55,6 @@
   - type: Tag
     tags:
     - FireAxe
-    - WeaponMelee # Frontier
   - type: Sharp
   - type: Sprite
     sprite: Objects/Weapons/Melee/cult_halberd.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
@@ -7,7 +7,6 @@
   - type: Tag
     tags:
     - FireAxe
-    - WeaponMelee # Frontier
   - type: Sharp
   - type: Sprite
     sprite: Objects/Weapons/Melee/fireaxe.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/gohei.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/gohei.yml
@@ -15,6 +15,3 @@
   - type: Item
     size: Small
     sprite: Objects/Weapons/Melee/gohei.rsi
-  - type: Tag # Frontier
-    tags: # Frontier
-    - WeaponMelee # Frontier

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
@@ -13,9 +13,6 @@
     radius: 4
   - type: StaticPrice
     price: 255
-  - type: Tag # Frontier
-    tags: # Frontier
-    - WeaponMelee # Frontier
 
 - type: entity
   parent: BaseWeaponCrusher
@@ -24,7 +21,6 @@
   - type: Tag
     tags:
       - Pickaxe
-      - WeaponMelee # Frontier
   - type: Sprite
     sprite: Objects/Weapons/Melee/crusher.rsi
     state: icon
@@ -116,7 +112,6 @@
   - type: Tag
     tags:
       - Pickaxe
-      - WeaponMelee # Frontier
   - type: StaticPrice
     price: 285
   - type: Clothing

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/needle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/needle.yml
@@ -15,6 +15,3 @@
   - type: Item
     size: Tiny
   - type: BalloonPopper
-  - type: Tag # Frontier
-    tags: # Frontier
-    - WeaponMelee # Frontier

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/pickaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/pickaxe.yml
@@ -7,7 +7,6 @@
   - type: Tag
     tags:
     - Pickaxe
-    - WeaponMelee # Frontier
   - type: Sprite
     sprite: Objects/Weapons/Melee/pickaxe.rsi
     state: pickaxe
@@ -56,7 +55,6 @@
   - type: Tag
     tags:
       - Pickaxe
-      - WeaponMelee # Frontier
   - type: Sprite
     sprite: Objects/Tools/handdrill.rsi
     state: handdrill

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/sledgehammer.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/sledgehammer.yml
@@ -20,6 +20,3 @@
         Structural: 10
   - type: Item
     size: Large
-  - type: Tag # Frontier
-    tags: # Frontier
-    - WeaponMelee # Frontier

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/spear.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/spear.yml
@@ -11,7 +11,6 @@
   - type: Tag
     tags:
     - Spear
-    - WeaponMelee # Frontier
   - type: Fixtures
     fixtures:
       fix1:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/stunprod.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/stunprod.yml
@@ -67,6 +67,3 @@
   - type: Construction
     graph: makeshiftstunprod
     node: msstunprod
-  - type: Tag # Frontier
-    tags: # Frontier
-    - WeaponMelee # Frontier

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
@@ -26,7 +26,6 @@
   - type: Tag
     tags:
     - CaptainSabre
-    - WeaponMelee # Frontier
   - type: DisarmMalus
   - type: Clothing
     quickEquip: false
@@ -44,7 +43,6 @@
   - type: Tag
     tags:
     - Katana
-    - WeaponMelee # Frontier
   - type: Sprite
     sprite: Objects/Weapons/Melee/katana.rsi
     state: icon
@@ -106,7 +104,6 @@
   - type: Tag
     tags:
     - Machete
-    - WeaponMelee # Frontier
   - type: Sprite
     sprite: Objects/Weapons/Melee/machete.rsi
     state: icon
@@ -153,9 +150,6 @@
     - back
     - suitStorage
   - type: DisarmMalus
-  - type: Tag # Frontier
-    tags: # Frontier
-    - WeaponMelee # Frontier
 
 - type: entity
   name: cutlass
@@ -167,7 +161,6 @@
   - type: Tag
     tags:
     - Machete
-    - WeaponMelee # Frontier
   - type: Sprite
     sprite: Objects/Weapons/Melee/cutlass.rsi
     state: icon

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/white_cane.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/white_cane.yml
@@ -24,7 +24,3 @@
         Blunt: 3
   - type: UseDelay
     delay: 1
-  - type: Tag # Frontier
-    tags: # Frontier
-    - WeaponMelee # Frontier
-

--- a/Resources/Prototypes/Entities/Objects/Weapons/security.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/security.yml
@@ -82,9 +82,6 @@
   - type: GuideHelp
     guides:
     - Security
-  - type: Tag # Frontier
-    tags: # Frontier
-    - WeaponMelee # Frontier
 
 - type: entity
   name: truncheon
@@ -116,9 +113,6 @@
   - type: GuideHelp
     guides:
     - Security
-  - type: Tag # Frontier
-    tags: # Frontier
-    - WeaponMelee # Frontier
 
 - type: entity
   name: flash

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Bow/crossbow.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Bow/crossbow.yml
@@ -8,10 +8,6 @@
   description: The original rooty tooty point and shooty.
   abstract: true
   components:
-  - type: Tag
-    tags:
-    - WeaponRanged
-    - WeaponLongarms
   - type: Sprite
     sprite: _NF/Objects/Weapons/Guns/Bow/crossbow.rsi
   - type: Item

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Melee/sword.yml
@@ -22,9 +22,6 @@
     spread: 90
   - type: Item
     sprite: _NF/Objects/Weapons/Melee/armingsword.rsi
-  - type: Tag
-    tags:
-    - WeaponMelee
   - type: DisarmMalus
   - type: Clothing
     quickEquip: false

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Melee/wooden_stake.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Melee/wooden_stake.yml
@@ -7,7 +7,6 @@
   - type: Tag
     tags:
     - Spear
-    - WeaponMeleeStake
     - Wooden
   - type: Sprite
     sprite: _NF/Objects/Weapons/Melee/wooden_stake.rsi

--- a/Resources/Prototypes/_NF/Entities/Structures/Furniture/Armory/gun_racks_base.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Furniture/Armory/gun_racks_base.yml
@@ -76,36 +76,36 @@
       weapon1_slot:
         name: stored weapon
         whitelist:
-          tags:
-            - WeaponLongarms
+          components:
+            - Gun
         insertOnInteract: false
         priority: 8
       weapon2_slot:
         name: stored weapon
         whitelist:
-          tags:
-            - WeaponLongarms
+          components:
+            - Gun
         insertOnInteract: false
         priority: 7
       weapon3_slot:
         name: stored weapon
         whitelist:
-          tags:
-            - WeaponLongarms
+          components:
+            - Gun
         insertOnInteract: false
         priority: 6
       weapon4_slot:
         name: stored weapon
         whitelist:
-          tags:
-            - WeaponLongarms
+          components:
+            - Gun
         insertOnInteract: false
         priority: 5
       weapon5_slot:
         name: stored weapon
         whitelist:
-          tags:
-            - WeaponLongarms
+          components:
+            - Gun
         insertOnInteract: false
         priority: 4
   - type: ItemMapper
@@ -113,28 +113,28 @@
       weapon_generic_gun1:
         minCount: 1
         whitelist:
-          tags:
-            - WeaponLongarms
+          components:
+            - Gun
       weapon_generic_gun2:
         minCount: 2
         whitelist:
-          tags:
-            - WeaponLongarms
+          components:
+            - Gun
       weapon_generic_gun3:
         minCount: 3
         whitelist:
-          tags:
-            - WeaponLongarms
+          components:
+            - Gun
       weapon_generic_gun4:
         minCount: 4
         whitelist:
-          tags:
-            - WeaponLongarms
+          components:
+            - Gun
       weapon_generic_gun5:
         minCount: 5
         whitelist:
-          tags:
-            - WeaponLongarms
+          components:
+            - Gun
     sprite: _NF/Structures/Furniture/Armory/gun_racks.rsi
   - type: ContainerContainer
     containers:

--- a/Resources/Prototypes/_NF/Entities/Structures/Furniture/Armory/melee_weaapon_racks_base.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Furniture/Armory/melee_weaapon_racks_base.yml
@@ -34,36 +34,36 @@
       weapon1_slot:
         name: stored weapon
         whitelist:
-          tags:
-            - WeaponMelee
+          components:
+            - MeleeWeapon
         insertOnInteract: false
         priority: 8
       weapon2_slot:
         name: stored weapon
         whitelist:
-          tags:
-            - WeaponMelee
+          components:
+            - MeleeWeapon
         insertOnInteract: false
         priority: 7
       weapon3_slot:
         name: stored weapon
         whitelist:
-          tags:
-            - WeaponMelee
+          components:
+            - MeleeWeapon
         insertOnInteract: false
         priority: 6
       weapon4_slot:
         name: stored weapon
         whitelist:
-          tags:
-            - WeaponMelee
+          components:
+            - MeleeWeapon
         insertOnInteract: false
         priority: 5
       weapon5_slot:
         name: stored weapon
         whitelist:
-          tags:
-            - WeaponMelee
+          components:
+            - MeleeWeapon
         insertOnInteract: false
         priority: 4
   - type: ItemMapper
@@ -71,28 +71,28 @@
       weapon_generic_melee1:
         minCount: 1
         whitelist:
-          tags:
-            - WeaponMelee
+          components:
+            - MeleeWeapon
       weapon_generic_melee2:
         minCount: 2
         whitelist:
-          tags:
-            - WeaponMelee
+          components:
+            - MeleeWeapon
       weapon_generic_melee3:
         minCount: 3
         whitelist:
-          tags:
-            - WeaponMelee
+          components:
+            - MeleeWeapon
       weapon_generic_melee4:
         minCount: 4
         whitelist:
-          tags:
-            - WeaponMelee
+          components:
+            - MeleeWeapon
       weapon_generic_melee5:
         minCount: 5
         whitelist:
-          tags:
-            - WeaponMelee
+          components:
+            - MeleeWeapon
     sprite: _NF/Structures/Furniture/Armory/melee_weapon_racks.rsi
   - type: Construction
     graph: WeaponRackConstructionGraph

--- a/Resources/Prototypes/_NF/Entities/Structures/Furniture/Armory/pistol_racks_base.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Furniture/Armory/pistol_racks_base.yml
@@ -81,7 +81,6 @@
         name: stored weapon
         whitelist:
           tags:
-            - WeaponShortArms
             - Sidearm
         insertOnInteract: false
         priority: 8
@@ -89,7 +88,6 @@
         name: stored weapon
         whitelist:
           tags:
-            - WeaponShortArms
             - Sidearm
         insertOnInteract: false
         priority: 7
@@ -97,7 +95,6 @@
         name: stored weapon
         whitelist:
           tags:
-            - WeaponShortArms
             - Sidearm
         insertOnInteract: false
         priority: 6
@@ -105,7 +102,6 @@
         name: stored weapon
         whitelist:
           tags:
-            - WeaponShortArms
             - Sidearm
         insertOnInteract: false
         priority: 5
@@ -115,25 +111,21 @@
         minCount: 1
         whitelist:
           tags:
-            - WeaponShortArms
             - Sidearm
       weapon_generic_pistol2:
         minCount: 2
         whitelist:
           tags:
-            - WeaponShortArms
             - Sidearm
       weapon_generic_pistol3:
         minCount: 3
         whitelist:
           tags:
-            - WeaponShortArms
             - Sidearm
       weapon_generic_pistol4:
         minCount: 4
         whitelist:
           tags:
-            - WeaponShortArms
             - Sidearm
     sprite: _NF/Structures/Furniture/Armory/pistol_racks.rsi
   - type: InteractionOutline

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -1197,15 +1197,3 @@
 
 - type: Tag # Frontier
   id: MothFood #Frontier
-
-- type: Tag # Frontier
-  id: WeaponRanged # Frontier
-
-- type: Tag # Frontier
-  id: WeaponLongarms # Frontier
-
-- type: Tag # Frontier
-  id: WeaponShortArms # Frontier
-
-- type: Tag # Frontier
-  id: WeaponMelee # Frontier


### PR DESCRIPTION
## About the PR
Slots in weapon racks now use components to filter out the items that can go in them rather than tags.

## Why / Balance
Less tags to maintain, should make weapon racks compatible with any guns/melee weapons without the need to add tags to make it work.

## Technical details
This change however brings side effects with it: some weapons can be stored both in gun racks and in melee weapon racks (crusher glaive/axe, musket for example), pistols can be stored in gun racks (but long arms can't be stored in pistol racks), some tools can be stored in melee weapon racks.

## Media
- [X] This PR does not require an ingame showcase

## Breaking changes
Removed the tags I've added previously: `WeaponRanged`, `WeaponLongarms`, `WeaponShortArms` and `WeaponMelee`.

**Changelog**
:cl: erhardsteinhauer
- tweak: Changed how whitelisting works for weapon racks. Also to put/retrieve weapon from rack use Alt+Click.