### PR TITLE
Shuttle Secret Door Recipe

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Structures/Doors/secret_door.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Doors/secret_door.yml
@@ -79,3 +79,31 @@
     node: UraniumSecretDoorNode
     containers:
     - battery-container
+
+#shuttle secret door
+- type: entity
+  id: ShuttleSecretDoorAssembly
+  name: secret shuttle door assembly
+  parent: BaseSecretDoorAssembly
+  components:
+  - type: Sprite
+    sprite: _NF/Structures/Doors/secret_door_shuttle.rsi
+    state: assembly
+  - type: Construction
+    graph: ShuttleSecretDoorGraph
+    node: assembly
+  placement:
+    mode: SnapgridCenter
+
+- type: entity
+  id: ShuttleSecretDoor
+  name: shuttle wall
+  parent: BaseSecretDoor
+  components:
+  - type: Sprite
+    sprite: _NF/Structures/Doors/secret_door_shuttle.rsi
+  - type: Construction
+    graph: ShuttleSecretDoorGraph
+    node: ShuttleSecretDoorNode
+    containers:
+    - battery-container

--- a/Resources/Prototypes/_NF/Recipes/Construction/Graphs/structures/secretdoor.yml
+++ b/Resources/Prototypes/_NF/Recipes/Construction/Graphs/structures/secretdoor.yml
@@ -249,3 +249,85 @@
       steps:
       - tool: Prying
         doAfter: 5
+
+- type: constructionGraph
+  id: ShuttleSecretDoorGraph
+  start: start
+  graph:
+  - node: start
+    edges:
+    - to: assembly
+      completed:
+      - !type:SetAnchor
+        value: false
+      steps:
+      - material: Silver
+        amount: 4
+        doAfter: 4
+      - material: MetalRod
+        amount: 4
+        doAfter: 4
+  - node: assembly
+    entity: ShuttleSecretDoorAssembly
+    actions:
+    - !type:SnapToGrid {}
+    - !type:SetAnchor {}
+    edges:
+    - to: wired
+      conditions:
+      - !type:EntityAnchored {}
+      steps:
+      - material: Cable
+        amount: 4
+        doAfter: 2.5
+    - to: start
+      conditions:
+      - !type:EntityAnchored
+        anchored: false
+      completed:
+      - !type:SpawnPrototype
+        prototype: SheetUranium1
+        amount: 4
+      - !type:DeleteEntity {}
+      steps:
+      - tool: Welding
+        doAfter: 3
+  - node: wired
+    entity: ShuttleSecretDoorAssembly
+    edges:
+    - to: electronics
+      steps:
+      - component: PowerCell
+        name: power cell
+        store: battery-container
+        icon:
+          sprite: Objects/Power/power_cells.rsi
+          state: small
+        doAfter: 1
+    - to: assembly
+      completed:
+      - !type:GivePrototype
+        prototype: CableApcStack1
+        amount: 4
+      steps:
+      - tool: Cutting
+        doAfter: 2
+  - node: electronics
+    entity: ShuttleSecretDoorAssembly
+    edges:
+    - to: ShuttleSecretDoorNode
+      steps:
+      - tool: Screwing
+        doAfter: 2
+  - node: ShuttleSecretDoorNode
+    entity: ShuttleSecretDoor
+    edges:
+    - to: wired
+      conditions:
+      - !type:EntityAnchored {}
+      - !type:DoorWelded {}
+      completed:
+      - !type:EmptyAllContainers {}
+      steps:
+      - tool: Prying
+        doAfter: 5

--- a/Resources/Prototypes/_NF/Recipes/Construction/structures.yml
+++ b/Resources/Prototypes/_NF/Recipes/Construction/structures.yml
@@ -48,3 +48,20 @@
     state: closed
   conditions:
     - !type:TileNotBlocked
+
+- type: construction
+  name: shuttle secret door
+  id: ShuttleSecretDoorConstruction
+  graph: ShuttleSecretDoorGraph
+  startNode: start
+  targetNode: ShuttleSecretDoorNode
+  category: construction-category-structures
+  description: A secret door for the wall.
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canBuildInImpassable: false
+  icon:
+    sprite: _NF/Structures/Doors/secret_door_shuttle.rsi
+    state: closed
+  conditions:
+    - !type:TileNotBlocked


### PR DESCRIPTION
## About the PR
Added construction recipe for shuttle secret door that I forgot to add.

## Why / Balance
Fixes.

## Media
- [X] This PR does not require an ingame showcase

**Changelog**
:cl: erhardsteinhauer
- tweak: Shuttle Secret doors are actually constructible now.