### PR TITLE
Re-add sparrow.yml

### DIFF
--- a/Resources/Prototypes/_NF/Shipyard/sparrow.yml
+++ b/Resources/Prototypes/_NF/Shipyard/sparrow.yml
@@ -1,0 +1,38 @@
+# Author Info
+# GitHub: ???
+# Discord: ???
+
+# Maintainer Info
+# GitHub: ???
+# Discord: ???
+
+# Shuttle Notes:
+#
+- type: vessel
+  id: Sparrow
+  name: NR Sparrow
+  description: A small research and engineering vessel.
+  price: 37000 # +4800 from 15% markup
+  category: Small
+  group: Civilian
+  shuttlePath: /Maps/_NF/Shuttles/sparrow.yml
+
+- type: gameMap
+  id: Sparrow
+  mapName: 'NR Sparrow'
+  mapPath: /Maps/_NF/Shuttles/sparrow.yml
+  minPlayers: 0
+  stations:
+    Sparrow:
+      stationProto: StandardFrontierVessel
+      components:
+        - type: StationNameSetup
+          mapNameTemplate: 'Sparrow {1}'
+          nameGenerator:
+            !type:NanotrasenNameGenerator
+            prefixCreator: '14'
+        - type: StationJobs
+          overflowJobs: []
+          availableJobs:
+            StationEngineer: [ 0, 0 ]
+            Scientist: [ 0, 0 ]


### PR DESCRIPTION
## About the PR
Re-adds sparrow.yml from #955, which was reworked to be in line with updated mapping guidelines by ErhardSteinhauer. Solves #1012 issue. I'm not sure why after the upstream merge this file vanished and I couldn't find any info why. I would like it back. Also easy pr for first pr.

## Why / Balance
I like this ship a lot.

## Technical details
A separate sparrow.yml already exists in Maps/_NF/Shuttles, that is the grid. This sparrow.yml is for Prototypes/_NF/shipyard which gives the shuttle a price and ID so it can be listed and purchased by players in-game.

- [X] this PR does not require an ingame showcase

**Changelog**
:cl:
- add: Added sparrow.yml, which re-lists the vessel in the shipyard again.