### PR TITLE
Add a vestine vial to the contravend

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry-vials.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry-vials.yml
@@ -111,3 +111,5 @@
               Quantity: 30
     - type: Tag
       tags: []
+    - type: VendPrice # Frontier
+      price: 15000

--- a/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/contravend.yml
+++ b/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/contravend.yml
@@ -20,3 +20,4 @@
     ClothingShoesChameleonNoSlips: 8
     ClothingBackpackDuffelSyndicateEVABundle: 12
     BoxHoloparasite: 2
+    VestineChemistryVial: 6

--- a/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/contravend.yml
+++ b/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/contravend.yml
@@ -20,4 +20,4 @@
     ClothingShoesChameleonNoSlips: 8
     ClothingBackpackDuffelSyndicateEVABundle: 12
     BoxHoloparasite: 2
-    VestineChemistryVial: 6
+    VestineChemistryVial: 2


### PR DESCRIPTION
## About the PR
Adds a vial of vestine (30u) to the contravend at the cost of 15k spesos per vial.

## Why / Balance
Vestine is a crucial component of syndicate chemicals, and is unobtainable on frontier (unless you raid a syndicate vault, which is nearly impossible most shifts). Adding it to the contravend should open up new opportunities for pirates and other criminals.

Currently the contravend offers 6 vials, the price and count can be a subject for discussion.

## Technical details
3 added yml lines

## Media
- [X] this PR does not require an ingame showcase

## Breaking changes
N/A

**Changelog**
:cl:
- add: The contravend now sells vials of vestine, a precursor to a few powerful chemicals.