### PR TITLE
Remove maxcap explosions

### DIFF
--- a/Content.Server/Atmos/EntitySystems/GasTankSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/GasTankSystem.cs
@@ -312,7 +312,8 @@ namespace Content.Server.Atmos.EntitySystems
                     range = GasTankComponent.MaxExplosionRange;
                 }
 
-                _explosions.TriggerExplosive(owner, radius: range);
+                // Frontier - 1984
+                // _explosions.TriggerExplosive(owner, radius: range);
 
                 return;
             }


### PR DESCRIPTION

## About the PR
Removes maxcap

## Why / Balance
Powergaming

## Technical details
Commented out the explosion line

## Media
- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None

**Changelog**
:cl:
- remove: Gas tanks will no longer explode violently when over-pressurized beyond all imaginable limits.
