### PR TITLE
Chem rebalance towards meds

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -219,7 +219,7 @@
 #      - id: ClothingMaskSterile # Frontier - bloat
 #      - id: ClothingHeadHatBeretCmo # Frontier - bloat
       - id: ClothingOuterHardsuitMedical
-      - id: Hypospray
+#      - id: Hypospray # Frontier - brigmeds only
       - id: HandheldCrewMonitor
 #      - id: DoorRemoteMedical # Frontier
       - id: RubberStampCMO
@@ -252,7 +252,7 @@
 #      - id: ClothingHeadHatBeretCmo # Frontier - bloat
 #      - id: DiagnoserMachineCircuitboard # Frontier - bloat
 #      - id: VaccinatorMachineCircuitboard # Frontier - bloat
-      - id: Hypospray
+#      - id: Hypospray # Frontier - brigmeds only
       - id: HandheldCrewMonitor
 #      - id: DoorRemoteMedical # Frontier
       - id: RubberStampCMO

--- a/Resources/Prototypes/Recipes/Reactions/chemicals.yml
+++ b/Resources/Prototypes/Recipes/Reactions/chemicals.yml
@@ -347,6 +347,8 @@
       amount: 1
     Water:
       amount: 1
+    Fresium:
+      amount: 5
   products:
     ChloralHydrate: 1
 
@@ -356,12 +358,12 @@
   reactants:
     MindbreakerToxin:
       amount: 1
-    Synaptizine:
+    Diphenylmethylamine:
       amount: 1
-    Water:
+    Omnizine:
       amount: 1
   products:
-    Pax: 3
+    Pax: 2
 
 - type: reaction
   id: Charcoal

--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -156,6 +156,8 @@
       amount: 1
     Ammonia:
       amount: 1
+    CarbonDioxide:
+      amount: 4
   products:
     Ipecac: 2
 


### PR DESCRIPTION
## About the PR
This PR makes some troublesome combat chemicals harder to obtain, by complicating their recipes and increasing cost - as well as removing hyposprays from CMO lockers.

## Why / Balance
I'm gonna be honest, nobody should make these chems unless they feel really spicy - some of these are used more than guns. Also fixes the recurrent balance of hyposprays by (effectively) restricting them to security/syndies (i forget, do they have gorlax hypos? lol)
*Ideally*, we would have something like Mining Station with hidden chems and slightly more convoluted recipes for even basic chems, but I can't port code for shit.

## Technical details
Not code.

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
Not code.

**Changelog**
:cl: router
- remove: Hyposprays no longer appear in CMO lockers; in favor of syringes and brigmedic hypos
- tweak: Some commonly used combat chems are now harder to make.
