### PR TITLE
Fix visual bug on disabled magnets

### DIFF
--- a/Content.Shared/Storage/Components/MagnetPickupComponent.cs
+++ b/Content.Shared/Storage/Components/MagnetPickupComponent.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Inventory;
+using Robust.Shared.GameStates;
 
 // namespace Content.Server.Storage.Components;
 namespace Content.Shared.Storage.Components;    // Frontier
@@ -7,6 +8,7 @@ namespace Content.Shared.Storage.Components;    // Frontier
 /// Applies an ongoing pickup area around the attached entity.
 /// </summary>
 [RegisterComponent]
+[NetworkedComponent, AutoGenerateComponentState] // Frontier
 public sealed partial class MagnetPickupComponent : Component
 {
     [ViewVariables(VVAccess.ReadWrite), DataField("nextScan")]
@@ -26,6 +28,6 @@ public sealed partial class MagnetPickupComponent : Component
     /// <summary>
     /// Is the magnet currently enabled?
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite), DataField("magnetEnabled")]
+    [AutoNetworkedField, ViewVariables(VVAccess.ReadWrite), DataField("magnetEnabled")]
     public bool MagnetEnabled = true;
 }

--- a/Content.Shared/Storage/EntitySystems/MagnetPickupSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/MagnetPickupSystem.cs
@@ -83,9 +83,8 @@ public sealed class MagnetPickupSystem : EntitySystem
     // Frontier, used to toggle the magnet on the ore bag/box
     public bool ToggleMagnet(EntityUid uid, MagnetPickupComponent comp)
     {
-        var query = EntityQueryEnumerator<MagnetPickupComponent>();
         comp.MagnetEnabled = !comp.MagnetEnabled;
-
+        Dirty(uid, comp);
         return comp.MagnetEnabled;
     }
 


### PR DESCRIPTION
## About the PR
Fixes the bugged pickup animation & sound that would play on all clients for disabled magnets.

## Why / Balance
*screams incomprehensibly*

## Technical details
Added the NetworkedComponent and AutoGenerateComponentState to MagnetPickupComponent, and AutoNetworkedField to the MagnetEnabled field; Called Dirty(...) in the magnet toggle method.

## Media
See the #development channel on discord

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
- [X] Github won't let me upload it

## Breaking changes
None

**Changelog**
:cl:
- fix: Fixed the buggy client-side magnet belt pickup animation