### PR TITLE
Fix super big bite burgers being too big for a microwave.

### DIFF
--- a/Content.Server/Kitchen/Components/MicrowaveComponent.cs
+++ b/Content.Server/Kitchen/Components/MicrowaveComponent.cs
@@ -71,8 +71,11 @@ namespace Content.Server.Kitchen.Components
 
         public Container Storage = default!;
 
+        /// <summary>
+        ///     The maximum number of items this microwave can store.
+        /// </summary>
         [DataField, ViewVariables(VVAccess.ReadWrite)]
-        public int Capacity = 10;
+        public int Capacity = 16;
     }
 
     public sealed class BeingMicrowavedEvent : HandledEntityEventArgs

--- a/Resources/Prototypes/Entities/Structures/Machines/microwave.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/microwave.yml
@@ -5,7 +5,7 @@
   description: It's magic.
   components:
   - type: Microwave
-    capacity: 10
+    capacity: 16
   - type: Appearance
   - type: GenericVisualizer
     visuals:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
I increased the capacity of the kitchen microwave.  At the moment, super big bite burger ingredients can't actually fit in a microwave (13 items needed, 10 capacity currently).  With these changes, they're back on the menu.

## Why / Balance
As the game currently stands, the super big bite burger cannot be made by a chef.

Solutions immediate to me were as follows:
1. Restrict the super bite burger recipe to 10 items (restoring to mainline).
2. Increase the capacity of the base microwave.
3. Increase the capacity of the microwave as an upgrade, i.e. only upgraded microwaves can make certain recipes, or giant portions of food.

1 seems odd given the prior, deliberate change to the super big bite recipe.  3 seems fun and incentivizes kitchens to work with scientists, but I settled on 2 for the simplest solution.

This change should only affect how many things a chef can batch cook in a microwave at once.  I've listed all impacted recipes below, with maximum possible recipe batch amounts before and after, and the capacities needed to get to an increase in batch size.

```
RECIPE_ID, OLD_MAX_BATCH to NEW_MAX_BATCH (@CAPACITY)
=======================================================
RecipeCaesarSalad, 1 to 3 (@11, 16)
RecipeMothCottonSoup, 1 to 3 (@11, 16)
RecipeBaconBurger, 2 to 3 (@12)
RecipeRiceGumbo, 1 to 2 (@12)
All fruity cake recipes (e.g. RecipeAppleCake), 2 to 3 (@12)
RecipeFruitSalad, 1 to 2 (@12)
RecipeMeatKebab, 2 to 4 (@12, 16)
RecipeHawaiianKebab, 2 to 4 (@12, 16)
RecipeFoodMealSoftTaco, 1 to 2 (@12)
RecipeTacoFish, 1 to 2 (@12)
RecipeSuperBiteBurger, 0 to 1 (@13)
RecipeBisque, 2 to 3 (@13)
RecipeMeatballSoup, 2 to 3 (@13)
RecipeEyeballSoup, 2 to 3 (@13)
RecipeBungoSoup, 2 to 3 (@13)
RecipeCheeseCake, 2 to 3 (@13)
RecipeKimchiSalad, 2 to 3 (@13)
RecipeColeslaw, 3 to 5 (@13, @16)
RecipeBigBiteBurger, 1 to 2 (@14)
RecipeValidSalad, 1 to 2 (@14)
RecipeTacoBeefSupreme, 1 to 2 (@14)
RecipeTacoChickenSupreme, 1 to 2 (@14)
RecipeChowMein, 2 to 3 (@15)
RecipeOnionSoup, 1 to 2 (@15)
RecipeHerbSalad, 2 to 3 (@15)
RecipeWatermelonFruitBowlSalad, 2 to 3 (@15)
RecipeFiestaKebab, 2 to 3 (@15)
RecipeVegetableSoup, 1 to 3 (@16)
```

16 seemed like a reasonable number to me, supports 4 groups of 4 ingredients (4x4) and 3 groups of 5 ingredients plus a beaker with liquid reagents.  This should also allow for more elaborate meals, possibly suitable for group dining in the new Ceres class ship.

## Technical details
Changes the constant for microwave capacity, both in YAML and C#.

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None.

**Changelog**
- fix: Increased microwave capacity, super bite burgers are craftable again.
