### PR TITLE
Tweak crushers to wizden stats

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
@@ -45,10 +45,11 @@
     capacity: 1
     count: 1
   - type: MeleeWeapon
+    attackRate: 1.5
     wideAnimationRotation: -135
     damage:
       types:
-        Blunt: 5
+        Blunt: 10
         Slash: 5
   - type: Wieldable
   - type: IncreaseDamageOnWield
@@ -75,17 +76,17 @@
   parent: BaseWeaponCrusher
   id: WeaponCrusherDagger
   name: crusher dagger
-  description: A scaled down version of a proto-kinetic crusher, usually used in a last ditch scenario.
+  description: A scaled down version of a proto-kinetic crusher. Uses kinetic energy to vibrate the blade at high speeds.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Melee/crusher_dagger.rsi
     state: icon
   - type: MeleeWeapon
     wideAnimationRotation: -135
-    attackRate: 1.5
+    attackRate: 2
     damage:
       types:
-        Slash: 7
+        Slash: 15
   - type: Tag
     tags:
     - Knife
@@ -106,9 +107,8 @@
   - type: LeechOnMarker
     leech:
       groups:
-        Brute: -15
+        Brute: -21
   - type: MeleeWeapon
-    attackRate: 1.25
   - type: Tag
     tags:
       - Pickaxe


### PR DESCRIPTION
## About the PR
Updated crusher dagger, axe and glaive stats up to current wizden ones. First PR i've ever made, hope it works proper.


## Why / Balance
They just feel too good to use after those buffs, can't wait for them to appear in same form on frontier as well.

## Technical details
Crusher axe and glaive damage is set to 10 blunt 5 slash (from 5 blunt 5 slash), attack rate of both are set to 1.5 (axe was sitting at 1 and glaive was at 1.25). Crusher glaive leech went up by 6, from 15 brute perk mark to 21 brute perk mark.
Crusher dagger damage is set to 15 slash and attack rate to 2.
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase



**Changelog**
Updated Crushers stats

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
