### PR TITLE
Removes OP IFF from the Menace

### DIFF
--- a/Resources/Maps/_NF/Shuttles/menace.yml
+++ b/Resources/Maps/_NF/Shuttles/menace.yml
@@ -540,7 +540,7 @@ entities:
       pos: 0.5,2.5
       parent: 103
       type: Transform
-- proto: ComputerTabletopIFFSyndicate
+- proto: ComputerTabletopIFF
   entities:
   - uid: 63
     components:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Removes the perfect IFF console.
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
It should never have had it in the first place.

**Changelog**
:cl: MagnusCrowe
- remove: Removed the perfect IFF from the Menace.
