### PR TITLE
Make super bite burger easier to craft (#24231)

### DIFF
--- a/Resources/Prototypes/Recipes/Cooking/meal_recipes.yml
+++ b/Resources/Prototypes/Recipes/Cooking/meal_recipes.yml
@@ -291,9 +291,9 @@
     TableSalt: 5
   solids:
     FoodBreadBun: 1
-    FoodMeat: 3
-    FoodCheeseSlice: 3
-    FoodTomato: 3
+    FoodMeat: 2
+    FoodCheeseSlice: 2
+    FoodTomato: 2
     FoodEgg: 2
 
 - type: microwaveMealRecipe


### PR DESCRIPTION

## About the PR
<!-- What did you change in this PR? -->
currently super big bite burger is not craftable, merging it from upstream directly since its a small fix

original pr 
https://github.com/new-frontiers-14/frontier-station-14/pull/1041

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

tweak: super big bite burger easier to craft