### PR TITLE
[Fix] Printable Advanced Magboots

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -288,6 +288,7 @@
       - SynthesizerInstrument
       - RPED
       - ClothingShoesBootsMagSci
+      - ClothingShoesBootsMagAdv
       - ClothingShoesBootsSpeed
       - NodeScanner
       - HolofanProjector

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -288,7 +288,7 @@
       - SynthesizerInstrument
       - RPED
       - ClothingShoesBootsMagSci
-      - ClothingShoesBootsMagAdv
+      - ClothingShoesBootsMagAdv # Frontier
       - ClothingShoesBootsSpeed
       - NodeScanner
       - HolofanProjector


### PR DESCRIPTION
## About the PR
Allows to print Advanced Magboots after they were researched.

## Why / Balance
The "Localized Magnetism" research in Experimental tree says that it'll unlock Advanced Magboots, but it doesn't, so here is the fix.

## Media
- [X] This PR does not require an ingame showcase.

**Changelog**
:cl: erhardsteinhauer
- fix: Advanced Magboots can be printed after they were researched.