### PR TITLE
Pilot Job Gear Fixes

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Masks/masks.yml
@@ -35,7 +35,7 @@
     replacement: mumble
 
 - type: entity
-  parent: ClothingMaskBase
+  parent: ClothingMaskPullableBase
   id: ClothingMaskPilot
   name: pilot breathing mask
   description: A close-fitting breathing mask designed for, it would seems, minimal comfort of wearer.

--- a/Resources/Prototypes/_NF/Roles/Jobs/Wildcards/pilot.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Wildcards/pilot.yml
@@ -32,7 +32,7 @@
     ears: ClothingHeadsetAltPilot
     belt: ClothingBeltPilotFilled
 #    pocket1: ClothingShoesBootsMag
-    pocket2: ExtendedEmergencyOxygenTank
+    pocket2: ExtendedEmergencyOxygenTankFilled
   innerClothingSkirt: ClothingUniformJumpsuitPilot #ClothingUniformJumpskirtPilot Doesn't exist yet
   satchel: ClothingBackpackSatchelPilotFilled
   duffelbag: ClothingBackpackDuffelPilotFilled


### PR DESCRIPTION
## About the PR
- Now it's possible to pull down pilot breathing mask.
- Players who join round as Pilots now start with filled extended capacity gas tank in their pocket instead of empty one.

## Why / Balance
Bug fixes.

## Media
- [X] This PR does not require an ingame showcase

**Changelog**
:cl: erhardsteinhauer
- tweak: Now you can pull down pilot mask.
- tweak: Players who join round as Pilots now start with filled extended capacity gas tank in their pocket.