### PR TITLE
Revert "Tabletop computer deconstruct fix"

### DIFF
--- a/Content.Server/Construction/NodeEntities/BoardNodeEntity.cs
+++ b/Content.Server/Construction/NodeEntities/BoardNodeEntity.cs
@@ -31,7 +31,7 @@ public sealed partial class BoardNodeEntity : IGraphNodeEntity
 
         // Frontier - adds tabletop variants
         if (args.EntityManager.TryGetComponent(container.Owner, out ConstructionComponent? constructionComponent)
-            && constructionComponent.Graph == "ComputerTabletop"
+            && constructionComponent.Graph == "GraphComputerTabletop"
             && args.EntityManager.TryGetComponent(board, out ComputerTabletopBoardComponent? tabletopComputer))
         {
             return tabletopComputer.Prototype;

--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers_tabletop.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers_tabletop.yml
@@ -1,3 +1,39 @@
+# Base structures
+- type: entity
+  id: BaseStructureComputerTabletop
+  suffix: Tabletop
+  abstract: true
+  components:
+  - type: Sprite
+    sprite: _NF/Structures/Machines/computer_tabletop.rsi
+    drawdepth: SmallObjects
+    layers:
+    - map: ["computerLayerBody"]
+      sprite: _NF/Structures/Machines/computer_tabletop.rsi
+      state: computer_tabletop
+    - map: ["computerLayerKeyboard"]
+      sprite: _NF/Structures/Machines/computer_tabletop.rsi
+      state: generic_keyboard_tabletop
+    - map: ["computerLayerScreen"]
+      sprite: Structures/Machines/computers.rsi
+      state: generic
+    - map: ["computerLayerKeys"]
+      sprite: Structures/Machines/computers.rsi
+      state: generic_keys
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.45,-0.45,0.45,0.45"
+        density: 60
+        mask:
+        - Impassable
+        - LowImpassable
+#        - TabletopMachineMask
+#        layer:
+#        - TabletopMachineLayer
+
 # Computers: Base Game
 - type: entity
   parent: [BaseStructureComputerTabletop, ComputerAlert]

--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/frame_tabletop.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/frame_tabletop.yml
@@ -1,69 +1,10 @@
 - type: entity
-  id: BaseStructureComputerTabletop
-  parent: BaseStructure
-  suffix: Tabletop
-  abstract: true
-  components:
-    - type: Physics
-    - type: Fixtures
-      fixtures:
-        fix1:
-          shape:
-            !type:PhysShapeAabb
-            bounds: "-0.25,-0.35,0.25,0.35"
-          density: 190
-          mask:
-            - TabletopMachineMask
-          layer:
-            - TabletopMachineLayer
-    - type: InteractionOutline
-    - type: Rotatable
-    - type: Anchorable
-    - type: Construction
-      graph: ComputerTabletop
-      node: frameUnsecured
-    - type: Sprite
-      sprite: _NF/Structures/Machines/computer_tabletop.rsi
-      drawdepth: Objects
-      layers:
-        - map: [ "computerLayerBody" ]
-          sprite: _NF/Structures/Machines/computer_tabletop.rsi
-          state: computer_tabletop
-        - map: [ "computerLayerKeyboard" ]
-          sprite: _NF/Structures/Machines/computer_tabletop.rsi
-          state: generic_keyboard_tabletop
-        - map: [ "computerLayerScreen" ]
-          sprite: Structures/Machines/computers.rsi
-          state: generic
-        - map: [ "computerLayerKeys" ]
-          sprite: Structures/Machines/computers.rsi
-          state: generic_keys
-    - type: Damageable
-      damageContainer: Inorganic
-      damageModifierSet: Electronic
-    - type: Destructible
-      thresholds:
-        - trigger:
-            !type:DamageTrigger
-            damage: 100
-          behaviors:
-            - !type:PlaySoundBehavior
-              sound:
-                collection: GlassBreak
-            - !type:ChangeConstructionNodeBehavior
-              node: monitorBroken
-            - !type:DoActsBehavior
-              acts: ["Destruction"]
-    - type: StaticPrice
-      price: 100
-
-- type: entity
-  parent: BaseStructureComputerTabletop
+  parent: ComputerFrame
   name: computer
   id: ComputerTabletopFrame
   components:
   - type: Construction
-    graph: ComputerTabletop
+    graph: GraphComputerTabletop
     node: frameUnsecured
     containers:
       - board

--- a/Resources/Prototypes/_NF/Recipes/Construction/Graphs/machines/computer_tabletop.yml
+++ b/Resources/Prototypes/_NF/Recipes/Construction/Graphs/machines/computer_tabletop.yml
@@ -1,5 +1,5 @@
 ﻿- type: constructionGraph
-  id: ComputerTabletop
+  id: GraphComputerTabletop
   start: start
   graph:
     - node: start

--- a/Resources/Prototypes/_NF/Recipes/Construction/machines.yml
+++ b/Resources/Prototypes/_NF/Recipes/Construction/machines.yml
@@ -1,7 +1,7 @@
 - type: construction
   name: computer (tabletop)
   id: ConstructionComputerTabletop
-  graph: ComputerTabletop
+  graph: GraphComputerTabletop
   startNode: start
   targetNode: tabletop computer
   category: construction-category-machines


### PR DESCRIPTION
Computers are now under tables. Need to figure out why, so for now reverting it

Reverts new-frontiers-14/frontier-station-14#1090