### PR TITLE
Increase tall lizard density 

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
@@ -61,7 +61,9 @@
   - type: Wagging
   - type: SizeAttributeWhitelist # Frontier
     tall: true
+    tallDensity: 250
     tallscale: 1.2
+    tallCosmeticOnly: false
 
 - type: entity
   parent: BaseSpeciesDummy


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Makes lizards with the tall trait have more "mass" again.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
The mass was originally removed due to mass-contest issues and how it affected mostly combat with shoves insta stunning people with 1 or 2 shoves, but since it was removed it will not longer affect players with less mass.

On terms of what will affect on balance.

Pros:
More easy to pull crates and objects.

Cons:
- Harder to fit on tight spaces (already with the bigger size).
- Harder to move on low gravity areas or space since inertia will affect them more due to larger mass.
- When on critical or dead condition will be much harder to pull around and drag.
- Easier target to shoot at.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
2 lines of YML


**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->


:cl: Leander

- tweak: Tall lizards got into a new diet and all of them have gained more weight.

