### PR TITLE
Added Air tank to fill

### DIFF
--- a/Resources/Prototypes/_NF/Catalog/Fills/Lockers/medical.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/Lockers/medical.yml
@@ -17,8 +17,9 @@
       - id: ClothingMaskSterile
       - id: ClothingBeltMedicalEMTFilled # Frontier
       - id: MedkitFilled # Frontier
-      - id: NitrogenTankFilled # Frontier
-      - id: OxygenTankFilled # Frontier
+#      - id: NitrogenTankFilled # Frontier
+#      - id: OxygenTankFilled # Frontier
+      - id: AirTankFilled #Frontier
       - id: ClothingMaskBreathMedical # Frontier
       - id: JetpackMiniFilled # Frontier
       - id: HandheldGPSBasic # Frontier


### PR DESCRIPTION
## About the PR
Added Air tank
Removed nitrogen and oxygen tanks

## Why / Balance
The only locker with hardsuit has nitrogen and oxygen tanks instead of air.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Paramedic lockers with hardsuits now come with the standard air tank.