### PR TITLE
Remove RCD and Ammo from Eagle

### DIFF
--- a/Resources/Maps/_NF/Shuttles/eagle.yml
+++ b/Resources/Maps/_NF/Shuttles/eagle.yml
@@ -4071,20 +4071,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: -2.5,6.5
       parent: 1
-- proto: RCD
-  entities:
-  - uid: 632
-    components:
-    - type: Transform
-      pos: -5.5,-0.5
-      parent: 1
-- proto: RCDAmmo
-  entities:
-  - uid: 633
-    components:
-    - type: Transform
-      pos: -5.5,-0.5
-      parent: 1
 - proto: SheetPlasma
   entities:
   - uid: 73


### PR DESCRIPTION
## About the PR
Removes RCD and Ammo from the Eagle.

## Why / Balance
Unbalanced 

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- remove: RCD and Ammo have been removed from the Eagle.
