### PR TITLE
Ceres (update): QoL tweaks

### DIFF
--- a/Resources/Maps/_NF/Shuttles/lyrae.yml
+++ b/Resources/Maps/_NF/Shuttles/lyrae.yml
@@ -1,0 +1,5342 @@
+meta:
+  format: 6
+  postmapinit: false
+tilemap:
+  0: Space
+  30: FloorDark
+  31: FloorDarkDiagonal
+  35: FloorDarkMono
+  46: FloorGlass
+  107: FloorTechMaint
+  111: FloorWhite
+  114: FloorWhiteHerringbone
+  116: FloorWhiteMono
+  120: FloorWhitePlastic
+  121: FloorWood
+  124: Lattice
+  125: Plating
+entities:
+- proto: ""
+  entities:
+  - uid: 2
+    components:
+    - type: MetaData
+      name: grid
+    - type: Transform
+      pos: 6.660883,-12.527287
+      parent: invalid
+    - type: MapGrid
+      chunks:
+        0,0:
+          ind: 0,0
+          tiles: fQAAAAAAHgAAAAADfQAAAAAAdAAAAAAAfQAAAAAAHgAAAAABHgAAAAAAIwAAAAABHgAAAAADHgAAAAACHgAAAAACHgAAAAACfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAbwAAAAADbwAAAAACbwAAAAAAbwAAAAAAbwAAAAADfQAAAAAAfQAAAAAAfQAAAAAAawAAAAAAawAAAAAAfQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAbwAAAAABLgAAAAAALgAAAAACLgAAAAACbwAAAAABfQAAAAAAfAAAAAAAfQAAAAAAawAAAAAAawAAAAAAawAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAbwAAAAADLgAAAAABLgAAAAACLgAAAAACbwAAAAABfQAAAAAAfAAAAAAAfQAAAAAAawAAAAAAawAAAAAAawAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAbwAAAAAAbwAAAAABbwAAAAACbwAAAAAAbwAAAAACfQAAAAAAfAAAAAAAfQAAAAAAawAAAAAAawAAAAAAawAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAAAAAAAAALgAAAAAAfAAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALgAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALgAAAAADAAAAAAAAAAAAAAAAfAAAAAAAfQAAAAAAfAAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAfQAAAAAAfAAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAfQAAAAAAfAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAfQAAAAAAfAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAfQAAAAAAfAAAAAAALgAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAfAAAAAAAfAAAAAAALgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAfAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          version: 6
+        0,-1:
+          ind: 0,-1
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALgAAAAADfQAAAAAAfQAAAAAAfQAAAAAALgAAAAADAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAALgAAAAABAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAfQAAAAAALgAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAfQAAAAAAfAAAAAAAfAAAAAAAfQAAAAAAeAAAAAADfQAAAAAAfQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAcgAAAAADcgAAAAAAcgAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAawAAAAAAfQAAAAAAHgAAAAABIwAAAAADIwAAAAABfQAAAAAAcgAAAAAAcgAAAAACcgAAAAADfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAAAAHgAAAAAAHgAAAAABHgAAAAAAHgAAAAADHgAAAAADHgAAAAADHgAAAAACHgAAAAACHgAAAAABfQAAAAAAbwAAAAACfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAIwAAAAAAIwAAAAADHgAAAAACHgAAAAACHgAAAAADHgAAAAABHgAAAAADHgAAAAABHgAAAAACHgAAAAAAHgAAAAADfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          version: 6
+        -1,0:
+          ind: -1,0
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAHgAAAAADHgAAAAACHgAAAAACHgAAAAACHwAAAAADHwAAAAABHwAAAAABHwAAAAACHwAAAAAAHwAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAHgAAAAAAawAAAAAAawAAAAAAHgAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAHgAAAAACfQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAawAAAAAAawAAAAAAawAAAAAAHgAAAAABfAAAAAAAfQAAAAAAeQAAAAABeQAAAAABfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAAADawAAAAAAawAAAAAAawAAAAAAfQAAAAAAfAAAAAAAfQAAAAAAeQAAAAABeQAAAAABfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAawAAAAAAawAAAAAAawAAAAAAHgAAAAAAfAAAAAAAfQAAAAAAfQAAAAAAHgAAAAABfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAfQAAAAAAHgAAAAADfQAAAAAALgAAAAAAAAAAAAAAfQAAAAAAHgAAAAAAHgAAAAADfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAfAAAAAAAfQAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAHgAAAAADHgAAAAADfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAfAAAAAAAfQAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAHgAAAAABHgAAAAACfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAfAAAAAAAfQAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAHgAAAAAAHgAAAAABfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAfAAAAAAAfQAAAAAAfAAAAAAAAAAAAAAAAAAAAAAALgAAAAAAfQAAAAAAfQAAAAAALgAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALgAAAAAAfAAAAAAAfAAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAfAAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          version: 6
+        -1,-1:
+          ind: -1,-1
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALgAAAAACfQAAAAAAfQAAAAAAfQAAAAAALgAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALgAAAAAAfQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAALgAAAAADfQAAAAAAawAAAAAAawAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAeAAAAAABfQAAAAAAfAAAAAAAfAAAAAAAfQAAAAAAawAAAAAAawAAAAAAawAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAcgAAAAABcgAAAAACcgAAAAADfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAawAAAAAAawAAAAAAawAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAcgAAAAAAcgAAAAACcgAAAAACfQAAAAAAIwAAAAADIwAAAAACHgAAAAAAfQAAAAAAawAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAbwAAAAACfQAAAAAAHgAAAAADHgAAAAABHwAAAAABHwAAAAABHwAAAAABHwAAAAADHwAAAAACHwAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAHgAAAAABHgAAAAAAHgAAAAACHgAAAAADHwAAAAABLgAAAAAALgAAAAACLgAAAAABLgAAAAADHwAAAAAC
+          version: 6
+    - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      angularDamping: 0.05
+      linearDamping: 0.05
+      fixedRotation: False
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures: {}
+    - type: OccluderTree
+    - type: SpreaderGrid
+    - type: BecomesStation
+      id: Lyrae
+    - type: Shuttle
+    - type: GridPathfinding
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+    - type: DecalGrid
+      chunkCollection:
+        version: 2
+        nodes:
+        - node:
+            angle: -1.5707963267948966 rad
+            color: '#FFFFFFFF'
+            id: Arrows
+          decals:
+            9: -10,2
+            76: -10,4
+        - node:
+            angle: 1.5707963267948966 rad
+            color: '#FFFFFFFF'
+            id: Arrows
+          decals:
+            10: 11,2
+            52: 11,4
+        - node:
+            color: '#FFFFFFFF'
+            id: Box
+          decals:
+            45: -8,-3
+            46: 9,-3
+            51: 7,0
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileDarkCornerNe
+          decals:
+            66: -1,0
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileDarkCornerNw
+          decals:
+            63: -6,0
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileDarkCornerSe
+          decals:
+            64: -1,-2
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileDarkCornerSw
+          decals:
+            65: -6,-2
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileDarkLineE
+          decals:
+            62: -1,-1
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileDarkLineN
+          decals:
+            59: -5,0
+            60: -4,0
+            61: -2,0
+            69: -3,0
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileDarkLineS
+          decals:
+            55: -5,-2
+            56: -4,-2
+            57: -3,-2
+            70: -2,-2
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileDarkLineW
+          decals:
+            58: -6,-1
+        - node:
+            color: '#D381C996'
+            id: BrickTileWhiteCornerNe
+          decals:
+            143: 4,3
+        - node:
+            color: '#D381C9FF'
+            id: BrickTileWhiteCornerNe
+          decals:
+            16: 11,-3
+            21: -8,-3
+            125: 5,4
+        - node:
+            color: '#EFB34196'
+            id: BrickTileWhiteCornerNe
+          decals:
+            222: 4,-4
+        - node:
+            color: '#D381C996'
+            id: BrickTileWhiteCornerNw
+          decals:
+            142: 2,3
+        - node:
+            color: '#D381C9FF'
+            id: BrickTileWhiteCornerNw
+          decals:
+            13: 9,-3
+            20: -10,-3
+            124: 1,4
+        - node:
+            color: '#D381C996'
+            id: BrickTileWhiteCornerSe
+          decals:
+            151: 4,2
+        - node:
+            color: '#D381C9FF'
+            id: BrickTileWhiteCornerSe
+          decals:
+            12: 5,1
+            14: 11,-4
+            24: -8,-4
+        - node:
+            color: '#EFB34196'
+            id: BrickTileWhiteCornerSe
+          decals:
+            220: 3,-6
+            221: 4,-5
+        - node:
+            color: '#D381C996'
+            id: BrickTileWhiteCornerSw
+          decals:
+            150: 2,2
+        - node:
+            color: '#D381C9FF'
+            id: BrickTileWhiteCornerSw
+          decals:
+            15: 9,-4
+            22: -10,-4
+            141: 1,1
+        - node:
+            color: '#EFB34196'
+            id: BrickTileWhiteCornerSw
+          decals:
+            227: -2,-6
+        - node:
+            color: '#EFB34196'
+            id: BrickTileWhiteEndW
+          decals:
+            215: -3,-4
+        - node:
+            color: '#EFB34196'
+            id: BrickTileWhiteInnerSe
+          decals:
+            226: 3,-5
+        - node:
+            color: '#EFB34196'
+            id: BrickTileWhiteInnerSw
+          decals:
+            214: -2,-4
+        - node:
+            color: '#D381C9FF'
+            id: BrickTileWhiteLineE
+          decals:
+            11: 5,2
+            129: 5,3
+        - node:
+            color: '#D381C996'
+            id: BrickTileWhiteLineN
+          decals:
+            144: 3,3
+        - node:
+            color: '#D381C9FF'
+            id: BrickTileWhiteLineN
+          decals:
+            17: 10,-3
+            23: -9,-3
+            126: 4,4
+            127: 3,4
+            128: 2,4
+        - node:
+            color: '#EFB34196'
+            id: BrickTileWhiteLineN
+          decals:
+            36: 2,-4
+            223: 1,-4
+            224: 0,-4
+            225: -1,-4
+        - node:
+            color: '#D381C996'
+            id: BrickTileWhiteLineS
+          decals:
+            152: 3,2
+        - node:
+            color: '#D381C9FF'
+            id: BrickTileWhiteLineS
+          decals:
+            18: 10,-4
+            19: -9,-4
+            145: 2,1
+            146: 4,1
+        - node:
+            color: '#EFB34196'
+            id: BrickTileWhiteLineS
+          decals:
+            218: 1,-6
+            219: 2,-6
+            228: -1,-6
+            229: 0,-6
+        - node:
+            color: '#D381C9FF'
+            id: BrickTileWhiteLineW
+          decals:
+            147: 1,2
+            148: 1,3
+        - node:
+            color: '#EFB34196'
+            id: BrickTileWhiteLineW
+          decals:
+            230: -2,-5
+        - node:
+            angle: -1.5707963267948966 rad
+            color: '#FFFFFFFF'
+            id: Delivery
+          decals:
+            67: -8,4
+            68: -9,4
+        - node:
+            color: '#FFFFFFFF'
+            id: Delivery
+          decals:
+            0: 1,-1
+            1: 2,-1
+            2: 6,-3
+            3: 7,-3
+            4: 0,0
+            53: 9,4
+            54: 10,4
+            139: -6,-3
+            140: -5,-3
+        - node:
+            cleanable: True
+            angle: -1.5707963267948966 rad
+            color: '#FFFFFFFF'
+            id: DirtHeavy
+          decals:
+            77: -10,4
+        - node:
+            color: '#FFFFFFFF'
+            id: DirtHeavy
+          decals:
+            234: 3,-5
+        - node:
+            cleanable: True
+            color: '#FFFFFFFF'
+            id: DirtHeavy
+          decals:
+            89: 11,4
+            93: 9,2
+            97: 11,-6
+            99: -10,-6
+            106: 12,4
+            107: 12,2
+            113: -2,-3
+            114: 11,-2
+            115: -10,-2
+            118: -11,2
+            122: -8,-5
+        - node:
+            color: '#FFFFFFFF'
+            id: DirtHeavyMonotile
+          decals:
+            236: 1,-4
+        - node:
+            cleanable: True
+            color: '#FFFFFFFF'
+            id: DirtHeavyMonotile
+          decals:
+            111: 3,0
+        - node:
+            cleanable: True
+            angle: -1.5707963267948966 rad
+            color: '#FFFFFFFF'
+            id: DirtLight
+          decals:
+            73: -10,-1
+            74: -9,2
+        - node:
+            color: '#FFFFFFFF'
+            id: DirtLight
+          decals:
+            235: -2,-5
+        - node:
+            cleanable: True
+            color: '#FFFFFFFF'
+            id: DirtLight
+          decals:
+            78: -8,3
+            79: -8,2
+            80: -8,3
+            83: -8,0
+            84: 1,-2
+            85: 3,-2
+            87: 9,0
+            88: 11,3
+            94: 6,-2
+            95: 11,-1
+            96: 4,-2
+            98: 9,-6
+            108: 10,1
+            112: 3,-3
+            117: -9,1
+            119: -11,4
+            120: -3,1
+            123: 0,-2
+        - node:
+            cleanable: True
+            angle: -1.5707963267948966 rad
+            color: '#FFFFFFFF'
+            id: DirtMedium
+          decals:
+            75: -10,2
+        - node:
+            color: '#FFFFFFFF'
+            id: DirtMedium
+          decals:
+            233: 1,-5
+        - node:
+            cleanable: True
+            color: '#FFFFFFFF'
+            id: DirtMedium
+          decals:
+            81: -9,0
+            82: -7,-1
+            86: 3,-1
+            90: 11,2
+            91: 10,0
+            92: 10,2
+            100: -8,-6
+            109: 9,1
+            110: 7,-2
+            116: -8,1
+            121: 9,-5
+        - node:
+            color: '#334E6DC8'
+            id: MiniTileWhiteCornerNe
+          decals:
+            136: -3,8
+        - node:
+            color: '#334E6DC8'
+            id: MiniTileWhiteCornerNw
+          decals:
+            135: -4,8
+        - node:
+            color: '#334E6DC8'
+            id: MiniTileWhiteCornerSe
+          decals:
+            137: -3,5
+        - node:
+            color: '#334E6DC8'
+            id: MiniTileWhiteCornerSw
+          decals:
+            130: -4,5
+        - node:
+            color: '#334E6DC8'
+            id: MiniTileWhiteLineE
+          decals:
+            133: -3,7
+            134: -3,6
+        - node:
+            color: '#334E6DC8'
+            id: MiniTileWhiteLineW
+          decals:
+            131: -4,6
+            132: -4,7
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnLineE
+          decals:
+            153: -8,3
+        - node:
+            color: '#334E6DFF'
+            id: WarnLineGreyscaleN
+          decals:
+            71: -3,0
+        - node:
+            color: '#D381C9FF'
+            id: WarnLineGreyscaleN
+          decals:
+            27: 3,-1
+        - node:
+            color: '#EFB34196'
+            id: WarnLineGreyscaleN
+          decals:
+            231: -2,-4
+            232: 3,-4
+        - node:
+            color: '#D381C9FF'
+            id: WarnLineGreyscaleS
+          decals:
+            25: -10,-1
+            26: 11,-1
+            149: 3,1
+        - node:
+            color: '#EFB34196'
+            id: WarnLineGreyscaleS
+          decals:
+            30: 3,-2
+            72: -2,-2
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnLineS
+          decals:
+            138: 9,3
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnLineW
+          decals:
+            5: -9,0
+            6: -8,0
+            7: 9,0
+            8: 10,0
+    - type: GridAtmosphere
+      version: 2
+      data:
+        tiles:
+          0,0:
+            0: 65535
+          0,-1:
+            0: 65535
+          -1,0:
+            0: 30719
+          0,1:
+            0: 255
+            1: 256
+          1,0:
+            0: 30719
+            1: 34816
+          1,1:
+            0: 127
+            1: 1024
+          2,0:
+            0: 65535
+          2,1:
+            0: 17647
+            1: 43536
+          2,2:
+            1: 43690
+            0: 17476
+          2,3:
+            0: 546
+            1: 204
+          3,0:
+            0: 4369
+          3,1:
+            0: 4369
+          3,2:
+            1: 273
+            0: 4096
+          0,-2:
+            0: 65280
+          1,-2:
+            0: 12544
+            1: 49152
+          1,-1:
+            0: 65535
+          2,-3:
+            0: 61440
+          2,-2:
+            1: 1
+            0: 65534
+          2,-1:
+            0: 65535
+          3,-2:
+            1: 1
+            0: 4368
+          3,-1:
+            0: 4369
+          -3,0:
+            0: 61166
+          -3,1:
+            0: 43758
+            1: 17408
+          -3,2:
+            1: 18022
+            0: 43144
+          -2,0:
+            0: 48127
+            1: 17408
+          -2,1:
+            0: 34971
+            1: 4388
+          -2,2:
+            1: 4497
+            0: 8
+          -2,3:
+            0: 273
+          -1,1:
+            0: 30583
+          -1,2:
+            0: 55
+            1: 64
+          -3,-2:
+            1: 2
+            0: 61164
+          -3,-1:
+            0: 61166
+          -3,-3:
+            0: 49152
+          -2,-3:
+            0: 12288
+          -2,-2:
+            0: 13105
+            1: 49154
+          -2,-1:
+            0: 65535
+          -1,-2:
+            0: 65024
+          -1,-1:
+            0: 65535
+          -3,3:
+            1: 206
+          3,3:
+            1: 1
+        uniqueMixes:
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 21.824879
+          - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        chunkSize: 4
+    - type: GasTileOverlay
+    - type: RadiationGridResistance
+    - type: NavMap
+- proto: AirAlarm
+  entities:
+  - uid: 627
+    components:
+    - type: MetaData
+      name: Starboard Air Alarm
+    - type: Transform
+      pos: 7.5,1.5
+      parent: 2
+    - type: DeviceList
+      devices:
+      - 306
+      - 625
+      - 629
+      - 626
+      - 624
+      - 623
+      - 628
+      - 619
+      - 325
+      - 116
+      - 286
+      - 285
+      - 697
+    - type: AtmosDevice
+      joinedGrid: 2
+  - uid: 631
+    components:
+    - type: MetaData
+      name: Port Air Alarm
+    - type: Transform
+      pos: -3.5,1.5
+      parent: 2
+    - type: DeviceList
+      devices:
+      - 348
+      - 350
+      - 630
+      - 297
+      - 326
+      - 321
+      - 320
+      - 629
+      - 625
+      - 626
+      - 624
+      - 306
+      - 696
+    - type: AtmosDevice
+      joinedGrid: 2
+  - uid: 635
+    components:
+    - type: MetaData
+      name: Engine Room Air Alarm
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 2
+    - type: DeviceList
+      devices:
+      - 626
+      - 628
+      - 634
+      - 638
+      - 696
+      - 697
+    - type: AtmosDevice
+      joinedGrid: 2
+- proto: AirCanister
+  entities:
+  - uid: 299
+    components:
+    - type: Transform
+      pos: 9.5,4.5
+      parent: 2
+    - type: AtmosDevice
+      joinedGrid: 2
+- proto: AirlockCommand
+  entities:
+  - uid: 1
+    components:
+    - type: Transform
+      pos: -2.5,1.5
+      parent: 2
+- proto: AirlockCommandGlass
+  entities:
+  - uid: 209
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,4.5
+      parent: 2
+- proto: AirlockEngineering
+  entities:
+  - uid: 211
+    components:
+    - type: Transform
+      pos: 3.5,-2.5
+      parent: 2
+  - uid: 522
+    components:
+    - type: Transform
+      pos: -1.5,-2.5
+      parent: 2
+    - type: Door
+      secondsUntilStateChange: -8444.698
+    - type: DeviceLinkSource
+      lastSignals:
+        DoorStatus: True
+- proto: AirlockExternal
+  entities:
+  - uid: 569
+    components:
+    - type: Transform
+      pos: -6.5,3.5
+      parent: 2
+  - uid: 640
+    components:
+    - type: Transform
+      pos: 8.5,3.5
+      parent: 2
+  - uid: 678
+    components:
+    - type: Transform
+      pos: -9.5,5.5
+      parent: 2
+  - uid: 693
+    components:
+    - type: Transform
+      pos: 11.5,5.5
+      parent: 2
+- proto: AirlockExternalGlass
+  entities:
+  - uid: 70
+    components:
+    - type: Transform
+      pos: -8.5,1.5
+      parent: 2
+  - uid: 202
+    components:
+    - type: Transform
+      pos: -7.5,1.5
+      parent: 2
+  - uid: 205
+    components:
+    - type: Transform
+      pos: 9.5,1.5
+      parent: 2
+  - uid: 670
+    components:
+    - type: Transform
+      pos: 10.5,1.5
+      parent: 2
+- proto: AirlockGlassShuttle
+  entities:
+  - uid: 215
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,2.5
+      parent: 2
+  - uid: 217
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -10.5,4.5
+      parent: 2
+  - uid: 219
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,4.5
+      parent: 2
+  - uid: 221
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -10.5,2.5
+      parent: 2
+- proto: AirlockScienceGlass
+  entities:
+  - uid: 3
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 2
+  - uid: 161
+    components:
+    - type: Transform
+      pos: 11.5,-1.5
+      parent: 2
+  - uid: 208
+    components:
+    - type: Transform
+      pos: -7.5,-4.5
+      parent: 2
+  - uid: 264
+    components:
+    - type: Transform
+      pos: -9.5,-1.5
+      parent: 2
+  - uid: 521
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 2
+  - uid: 597
+    components:
+    - type: Transform
+      pos: 9.5,-4.5
+      parent: 2
+- proto: AirSensor
+  entities:
+  - uid: 634
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 635
+  - uid: 696
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-0.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 631
+      - 635
+  - uid: 697
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-1.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 627
+      - 635
+- proto: AnomalyVesselCircuitboard
+  entities:
+  - uid: 237
+    components:
+    - type: Transform
+      pos: -8.508693,-5.497307
+      parent: 2
+- proto: APCBasic
+  entities:
+  - uid: 198
+    components:
+    - type: MetaData
+      name: Port Side APC
+    - type: Transform
+      pos: -5.5,1.5
+      parent: 2
+  - uid: 395
+    components:
+    - type: MetaData
+      name: Starboard Side APC
+    - type: Transform
+      pos: 4.5,0.5
+      parent: 2
+  - uid: 407
+    components:
+    - type: MetaData
+      name: Engine Room APC
+    - type: Transform
+      pos: 1.5,-2.5
+      parent: 2
+- proto: AtmosDeviceFanTiny
+  entities:
+  - uid: 71
+    components:
+    - type: Transform
+      pos: 12.5,2.5
+      parent: 2
+  - uid: 72
+    components:
+    - type: Transform
+      pos: -10.5,2.5
+      parent: 2
+  - uid: 139
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-4.5
+      parent: 2
+  - uid: 144
+    components:
+    - type: Transform
+      pos: -7.5,-4.5
+      parent: 2
+  - uid: 257
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -10.5,4.5
+      parent: 2
+  - uid: 526
+    components:
+    - type: Transform
+      pos: -6.5,3.5
+      parent: 2
+  - uid: 601
+    components:
+    - type: Transform
+      pos: 11.5,5.5
+      parent: 2
+  - uid: 603
+    components:
+    - type: Transform
+      pos: 12.5,4.5
+      parent: 2
+  - uid: 676
+    components:
+    - type: Transform
+      pos: -9.5,5.5
+      parent: 2
+  - uid: 725
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,3.5
+      parent: 2
+- proto: AtmosFixBlockerMarker
+  entities:
+  - uid: 34
+    components:
+    - type: Transform
+      pos: -9.5,13.5
+      parent: 2
+  - uid: 35
+    components:
+    - type: Transform
+      pos: 9.5,11.5
+      parent: 2
+  - uid: 48
+    components:
+    - type: Transform
+      pos: 12.5,10.5
+      parent: 2
+  - uid: 57
+    components:
+    - type: Transform
+      pos: -7.5,11.5
+      parent: 2
+  - uid: 58
+    components:
+    - type: Transform
+      pos: -10.5,12.5
+      parent: 2
+  - uid: 68
+    components:
+    - type: Transform
+      pos: -5.5,-4.5
+      parent: 2
+  - uid: 172
+    components:
+    - type: Transform
+      pos: 11.5,7.5
+      parent: 2
+  - uid: 176
+    components:
+    - type: Transform
+      pos: -10.5,10.5
+      parent: 2
+  - uid: 180
+    components:
+    - type: Transform
+      pos: 11.5,8.5
+      parent: 2
+  - uid: 183
+    components:
+    - type: Transform
+      pos: 9.5,7.5
+      parent: 2
+  - uid: 184
+    components:
+    - type: Transform
+      pos: 9.5,9.5
+      parent: 2
+  - uid: 216
+    components:
+    - type: Transform
+      pos: 11.5,6.5
+      parent: 2
+  - uid: 222
+    components:
+    - type: Transform
+      pos: 9.5,8.5
+      parent: 2
+  - uid: 223
+    components:
+    - type: Transform
+      pos: 9.5,6.5
+      parent: 2
+  - uid: 226
+    components:
+    - type: Transform
+      pos: 12.5,9.5
+      parent: 2
+  - uid: 227
+    components:
+    - type: Transform
+      pos: 12.5,8.5
+      parent: 2
+  - uid: 259
+    components:
+    - type: Transform
+      pos: 9.5,10.5
+      parent: 2
+  - uid: 381
+    components:
+    - type: Transform
+      pos: -7.5,6.5
+      parent: 2
+  - uid: 488
+    components:
+    - type: Transform
+      pos: 4.5,-6.5
+      parent: 2
+  - uid: 559
+    components:
+    - type: Transform
+      pos: -5.5,2.5
+      parent: 2
+  - uid: 560
+    components:
+    - type: Transform
+      pos: -5.5,3.5
+      parent: 2
+  - uid: 561
+    components:
+    - type: Transform
+      pos: -5.5,4.5
+      parent: 2
+  - uid: 563
+    components:
+    - type: Transform
+      pos: -7.5,10.5
+      parent: 2
+  - uid: 566
+    components:
+    - type: Transform
+      pos: -7.5,7.5
+      parent: 2
+  - uid: 568
+    components:
+    - type: Transform
+      pos: -7.5,8.5
+      parent: 2
+  - uid: 572
+    components:
+    - type: Transform
+      pos: -9.5,11.5
+      parent: 2
+  - uid: 573
+    components:
+    - type: Transform
+      pos: -10.5,8.5
+      parent: 2
+  - uid: 577
+    components:
+    - type: Transform
+      pos: -9.5,6.5
+      parent: 2
+  - uid: 578
+    components:
+    - type: Transform
+      pos: -9.5,7.5
+      parent: 2
+  - uid: 579
+    components:
+    - type: Transform
+      pos: -9.5,8.5
+      parent: 2
+  - uid: 580
+    components:
+    - type: Transform
+      pos: -9.5,9.5
+      parent: 2
+  - uid: 581
+    components:
+    - type: Transform
+      pos: -9.5,10.5
+      parent: 2
+  - uid: 584
+    components:
+    - type: Transform
+      pos: -10.5,-7.5
+      parent: 2
+  - uid: 587
+    components:
+    - type: Transform
+      pos: 8.5,-7.5
+      parent: 2
+  - uid: 593
+    components:
+    - type: Transform
+      pos: 12.5,-7.5
+      parent: 2
+  - uid: 594
+    components:
+    - type: Transform
+      pos: 8.5,5.5
+      parent: 2
+  - uid: 604
+    components:
+    - type: Transform
+      pos: -9.5,12.5
+      parent: 2
+  - uid: 610
+    components:
+    - type: Transform
+      pos: -7.5,9.5
+      parent: 2
+  - uid: 613
+    components:
+    - type: Transform
+      anchored: False
+      pos: 7.5,4.5
+      parent: 2
+  - uid: 614
+    components:
+    - type: Transform
+      pos: 7.5,3.5
+      parent: 2
+  - uid: 615
+    components:
+    - type: Transform
+      pos: 7.5,2.5
+      parent: 2
+  - uid: 616
+    components:
+    - type: Transform
+      pos: 7.5,2.5
+      parent: 2
+  - uid: 618
+    components:
+    - type: Transform
+      pos: -4.5,-4.5
+      parent: 2
+  - uid: 649
+    components:
+    - type: Transform
+      pos: -6.5,-7.5
+      parent: 2
+  - uid: 650
+    components:
+    - type: Transform
+      pos: 7.5,-4.5
+      parent: 2
+  - uid: 651
+    components:
+    - type: Transform
+      pos: 11.5,9.5
+      parent: 2
+  - uid: 655
+    components:
+    - type: Transform
+      pos: 6.5,-4.5
+      parent: 2
+  - uid: 660
+    components:
+    - type: Transform
+      pos: 12.5,12.5
+      parent: 2
+  - uid: 668
+    components:
+    - type: Transform
+      pos: -8.5,12.5
+      parent: 2
+  - uid: 669
+    components:
+    - type: Transform
+      pos: -10.5,9.5
+      parent: 2
+  - uid: 672
+    components:
+    - type: Transform
+      pos: -6.5,5.5
+      parent: 2
+  - uid: 685
+    components:
+    - type: Transform
+      pos: -8.5,13.5
+      parent: 2
+  - uid: 709
+    components:
+    - type: Transform
+      pos: 11.5,10.5
+      parent: 2
+  - uid: 710
+    components:
+    - type: Transform
+      pos: 11.5,11.5
+      parent: 2
+  - uid: 711
+    components:
+    - type: Transform
+      pos: 11.5,12.5
+      parent: 2
+  - uid: 712
+    components:
+    - type: Transform
+      pos: 10.5,12.5
+      parent: 2
+  - uid: 714
+    components:
+    - type: Transform
+      pos: 10.5,13.5
+      parent: 2
+  - uid: 715
+    components:
+    - type: Transform
+      pos: 11.5,13.5
+      parent: 2
+  - uid: 716
+    components:
+    - type: Transform
+      pos: 6.5,6.5
+      parent: 2
+  - uid: 717
+    components:
+    - type: Transform
+      pos: 0.5,6.5
+      parent: 2
+  - uid: 718
+    components:
+    - type: Transform
+      pos: -1.5,9.5
+      parent: 2
+  - uid: 719
+    components:
+    - type: Transform
+      pos: -4.5,9.5
+      parent: 2
+  - uid: 737
+    components:
+    - type: Transform
+      pos: -3.5,-5.5
+      parent: 2
+  - uid: 738
+    components:
+    - type: Transform
+      pos: -2.5,-6.5
+      parent: 2
+  - uid: 739
+    components:
+    - type: Transform
+      pos: 5.5,-5.5
+      parent: 2
+- proto: Autolathe
+  entities:
+  - uid: 394
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 2
+- proto: Bed
+  entities:
+  - uid: 528
+    components:
+    - type: Transform
+      pos: -3.5,2.5
+      parent: 2
+- proto: BedsheetRD
+  entities:
+  - uid: 529
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,2.5
+      parent: 2
+- proto: BlastDoor
+  entities:
+  - uid: 86
+    components:
+    - type: Transform
+      pos: 12.5,-5.5
+      parent: 2
+    - type: DeviceLinkSink
+      links:
+      - 558
+      - 620
+  - uid: 138
+    components:
+    - type: Transform
+      pos: -10.5,-5.5
+      parent: 2
+    - type: DeviceLinkSink
+      links:
+      - 567
+      - 549
+- proto: CableApcExtension
+  entities:
+  - uid: 19
+    components:
+    - type: Transform
+      pos: -4.5,-2.5
+      parent: 2
+  - uid: 33
+    components:
+    - type: Transform
+      pos: 10.5,-3.5
+      parent: 2
+  - uid: 37
+    components:
+    - type: Transform
+      pos: -8.5,-3.5
+      parent: 2
+  - uid: 63
+    components:
+    - type: Transform
+      pos: 6.5,-2.5
+      parent: 2
+  - uid: 111
+    components:
+    - type: Transform
+      pos: -7.5,-3.5
+      parent: 2
+  - uid: 117
+    components:
+    - type: Transform
+      pos: 6.5,-1.5
+      parent: 2
+  - uid: 145
+    components:
+    - type: Transform
+      pos: -5.5,1.5
+      parent: 2
+  - uid: 175
+    components:
+    - type: Transform
+      pos: 11.5,12.5
+      parent: 2
+  - uid: 181
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 2
+  - uid: 185
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 2
+  - uid: 192
+    components:
+    - type: Transform
+      pos: 3.5,3.5
+      parent: 2
+  - uid: 199
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 2
+  - uid: 245
+    components:
+    - type: Transform
+      pos: -2.5,8.5
+      parent: 2
+  - uid: 403
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 2
+  - uid: 421
+    components:
+    - type: Transform
+      pos: 5.5,4.5
+      parent: 2
+  - uid: 429
+    components:
+    - type: Transform
+      pos: 1.5,-2.5
+      parent: 2
+  - uid: 430
+    components:
+    - type: Transform
+      pos: 1.5,-3.5
+      parent: 2
+  - uid: 431
+    components:
+    - type: Transform
+      pos: 2.5,-3.5
+      parent: 2
+  - uid: 432
+    components:
+    - type: Transform
+      pos: 3.5,-3.5
+      parent: 2
+  - uid: 433
+    components:
+    - type: Transform
+      pos: 4.5,-3.5
+      parent: 2
+  - uid: 434
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 2
+  - uid: 435
+    components:
+    - type: Transform
+      pos: -0.5,-3.5
+      parent: 2
+  - uid: 436
+    components:
+    - type: Transform
+      pos: -1.5,-3.5
+      parent: 2
+  - uid: 437
+    components:
+    - type: Transform
+      pos: -2.5,-3.5
+      parent: 2
+  - uid: 438
+    components:
+    - type: Transform
+      pos: 4.5,0.5
+      parent: 2
+  - uid: 439
+    components:
+    - type: Transform
+      pos: 4.5,-0.5
+      parent: 2
+  - uid: 440
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 2
+  - uid: 441
+    components:
+    - type: Transform
+      pos: 3.5,1.5
+      parent: 2
+  - uid: 442
+    components:
+    - type: Transform
+      pos: 3.5,2.5
+      parent: 2
+  - uid: 444
+    components:
+    - type: Transform
+      pos: -4.5,0.5
+      parent: 2
+  - uid: 445
+    components:
+    - type: Transform
+      pos: -3.5,0.5
+      parent: 2
+  - uid: 446
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 2
+  - uid: 447
+    components:
+    - type: Transform
+      pos: 5.5,-0.5
+      parent: 2
+  - uid: 448
+    components:
+    - type: Transform
+      pos: 6.5,-0.5
+      parent: 2
+  - uid: 449
+    components:
+    - type: Transform
+      pos: -2.5,1.5
+      parent: 2
+  - uid: 450
+    components:
+    - type: Transform
+      pos: -2.5,2.5
+      parent: 2
+  - uid: 451
+    components:
+    - type: Transform
+      pos: -2.5,3.5
+      parent: 2
+  - uid: 452
+    components:
+    - type: Transform
+      pos: -2.5,4.5
+      parent: 2
+  - uid: 453
+    components:
+    - type: Transform
+      pos: -2.5,5.5
+      parent: 2
+  - uid: 454
+    components:
+    - type: Transform
+      pos: -2.5,6.5
+      parent: 2
+  - uid: 455
+    components:
+    - type: Transform
+      pos: 7.5,-0.5
+      parent: 2
+  - uid: 456
+    components:
+    - type: Transform
+      pos: 8.5,-0.5
+      parent: 2
+  - uid: 457
+    components:
+    - type: Transform
+      pos: 9.5,-0.5
+      parent: 2
+  - uid: 458
+    components:
+    - type: Transform
+      pos: 10.5,-0.5
+      parent: 2
+  - uid: 459
+    components:
+    - type: Transform
+      pos: -5.5,0.5
+      parent: 2
+  - uid: 460
+    components:
+    - type: Transform
+      pos: -6.5,0.5
+      parent: 2
+  - uid: 461
+    components:
+    - type: Transform
+      pos: -7.5,0.5
+      parent: 2
+  - uid: 462
+    components:
+    - type: Transform
+      pos: -8.5,0.5
+      parent: 2
+  - uid: 463
+    components:
+    - type: Transform
+      pos: 11.5,-0.5
+      parent: 2
+  - uid: 464
+    components:
+    - type: Transform
+      pos: 11.5,-1.5
+      parent: 2
+  - uid: 465
+    components:
+    - type: Transform
+      pos: -8.5,1.5
+      parent: 2
+  - uid: 466
+    components:
+    - type: Transform
+      pos: -8.5,2.5
+      parent: 2
+  - uid: 467
+    components:
+    - type: Transform
+      pos: -8.5,3.5
+      parent: 2
+  - uid: 468
+    components:
+    - type: Transform
+      pos: 11.5,-2.5
+      parent: 2
+  - uid: 469
+    components:
+    - type: Transform
+      pos: -9.5,0.5
+      parent: 2
+  - uid: 470
+    components:
+    - type: Transform
+      pos: 11.5,-3.5
+      parent: 2
+  - uid: 471
+    components:
+    - type: Transform
+      pos: 10.5,0.5
+      parent: 2
+  - uid: 472
+    components:
+    - type: Transform
+      pos: 10.5,1.5
+      parent: 2
+  - uid: 473
+    components:
+    - type: Transform
+      pos: 9.5,-3.5
+      parent: 2
+  - uid: 474
+    components:
+    - type: Transform
+      pos: 10.5,2.5
+      parent: 2
+  - uid: 475
+    components:
+    - type: Transform
+      pos: -9.5,-0.5
+      parent: 2
+  - uid: 476
+    components:
+    - type: Transform
+      pos: -9.5,-1.5
+      parent: 2
+  - uid: 477
+    components:
+    - type: Transform
+      pos: -9.5,-2.5
+      parent: 2
+  - uid: 478
+    components:
+    - type: Transform
+      pos: -9.5,-3.5
+      parent: 2
+  - uid: 483
+    components:
+    - type: Transform
+      pos: 10.5,3.5
+      parent: 2
+  - uid: 484
+    components:
+    - type: Transform
+      pos: -4.5,-0.5
+      parent: 2
+  - uid: 485
+    components:
+    - type: Transform
+      pos: -4.5,-1.5
+      parent: 2
+  - uid: 490
+    components:
+    - type: Transform
+      pos: -9.5,3.5
+      parent: 2
+  - uid: 491
+    components:
+    - type: Transform
+      pos: -9.5,4.5
+      parent: 2
+  - uid: 492
+    components:
+    - type: Transform
+      pos: -9.5,5.5
+      parent: 2
+  - uid: 493
+    components:
+    - type: Transform
+      pos: -9.5,6.5
+      parent: 2
+  - uid: 494
+    components:
+    - type: Transform
+      pos: -9.5,7.5
+      parent: 2
+  - uid: 495
+    components:
+    - type: Transform
+      pos: -9.5,8.5
+      parent: 2
+  - uid: 496
+    components:
+    - type: Transform
+      pos: -9.5,9.5
+      parent: 2
+  - uid: 497
+    components:
+    - type: Transform
+      pos: -9.5,10.5
+      parent: 2
+  - uid: 499
+    components:
+    - type: Transform
+      pos: 11.5,3.5
+      parent: 2
+  - uid: 500
+    components:
+    - type: Transform
+      pos: 11.5,4.5
+      parent: 2
+  - uid: 501
+    components:
+    - type: Transform
+      pos: 11.5,5.5
+      parent: 2
+  - uid: 502
+    components:
+    - type: Transform
+      pos: 11.5,6.5
+      parent: 2
+  - uid: 503
+    components:
+    - type: Transform
+      pos: 11.5,7.5
+      parent: 2
+  - uid: 504
+    components:
+    - type: Transform
+      pos: 11.5,8.5
+      parent: 2
+  - uid: 505
+    components:
+    - type: Transform
+      pos: 11.5,9.5
+      parent: 2
+  - uid: 506
+    components:
+    - type: Transform
+      pos: 11.5,10.5
+      parent: 2
+  - uid: 534
+    components:
+    - type: Transform
+      pos: 4.5,4.5
+      parent: 2
+  - uid: 547
+    components:
+    - type: Transform
+      pos: -8.5,12.5
+      parent: 2
+  - uid: 553
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 2
+  - uid: 582
+    components:
+    - type: Transform
+      pos: -9.5,11.5
+      parent: 2
+  - uid: 612
+    components:
+    - type: Transform
+      pos: 11.5,11.5
+      parent: 2
+  - uid: 661
+    components:
+    - type: Transform
+      pos: 10.5,12.5
+      parent: 2
+  - uid: 703
+    components:
+    - type: Transform
+      pos: -2.5,7.5
+      parent: 2
+  - uid: 705
+    components:
+    - type: Transform
+      pos: -9.5,12.5
+      parent: 2
+  - uid: 722
+    components:
+    - type: Transform
+      pos: -3.5,8.5
+      parent: 2
+- proto: CableHV
+  entities:
+  - uid: 49
+    components:
+    - type: Transform
+      pos: 2.5,-5.5
+      parent: 2
+  - uid: 52
+    components:
+    - type: Transform
+      pos: 1.5,-5.5
+      parent: 2
+  - uid: 263
+    components:
+    - type: Transform
+      pos: -0.5,-5.5
+      parent: 2
+  - uid: 382
+    components:
+    - type: Transform
+      pos: 0.5,-5.5
+      parent: 2
+  - uid: 408
+    components:
+    - type: Transform
+      pos: -1.5,-5.5
+      parent: 2
+- proto: CableMV
+  entities:
+  - uid: 173
+    components:
+    - type: Transform
+      pos: -5.5,-0.5
+      parent: 2
+  - uid: 174
+    components:
+    - type: Transform
+      pos: -5.5,0.5
+      parent: 2
+  - uid: 396
+    components:
+    - type: Transform
+      pos: 2.5,-5.5
+      parent: 2
+  - uid: 397
+    components:
+    - type: Transform
+      pos: 2.5,-4.5
+      parent: 2
+  - uid: 409
+    components:
+    - type: Transform
+      pos: 1.5,-3.5
+      parent: 2
+  - uid: 410
+    components:
+    - type: Transform
+      pos: 1.5,-2.5
+      parent: 2
+  - uid: 411
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 2
+  - uid: 412
+    components:
+    - type: Transform
+      pos: -0.5,-3.5
+      parent: 2
+  - uid: 413
+    components:
+    - type: Transform
+      pos: -1.5,-3.5
+      parent: 2
+  - uid: 414
+    components:
+    - type: Transform
+      pos: -1.5,-2.5
+      parent: 2
+  - uid: 415
+    components:
+    - type: Transform
+      pos: -1.5,-1.5
+      parent: 2
+  - uid: 416
+    components:
+    - type: Transform
+      pos: -1.5,-0.5
+      parent: 2
+  - uid: 417
+    components:
+    - type: Transform
+      pos: -2.5,-0.5
+      parent: 2
+  - uid: 418
+    components:
+    - type: Transform
+      pos: -3.5,-0.5
+      parent: 2
+  - uid: 419
+    components:
+    - type: Transform
+      pos: 2.5,-3.5
+      parent: 2
+  - uid: 420
+    components:
+    - type: Transform
+      pos: -4.5,-0.5
+      parent: 2
+  - uid: 422
+    components:
+    - type: Transform
+      pos: 3.5,-3.5
+      parent: 2
+  - uid: 424
+    components:
+    - type: Transform
+      pos: 3.5,-1.5
+      parent: 2
+  - uid: 425
+    components:
+    - type: Transform
+      pos: 3.5,-2.5
+      parent: 2
+  - uid: 426
+    components:
+    - type: Transform
+      pos: 4.5,-1.5
+      parent: 2
+  - uid: 427
+    components:
+    - type: Transform
+      pos: 4.5,-0.5
+      parent: 2
+  - uid: 428
+    components:
+    - type: Transform
+      pos: 4.5,0.5
+      parent: 2
+  - uid: 606
+    components:
+    - type: Transform
+      pos: -5.5,1.5
+      parent: 2
+- proto: CableTerminal
+  entities:
+  - uid: 383
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,-5.5
+      parent: 2
+- proto: CapacitorStockPart
+  entities:
+  - uid: 261
+    components:
+    - type: Transform
+      pos: 5.341468,2.4274282
+      parent: 2
+- proto: CarpetBlue
+  entities:
+  - uid: 713
+    components:
+    - type: Transform
+      pos: -2.5,7.5
+      parent: 2
+  - uid: 721
+    components:
+    - type: Transform
+      pos: -3.5,7.5
+      parent: 2
+- proto: CarpetPurple
+  entities:
+  - uid: 531
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,2.5
+      parent: 2
+  - uid: 532
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,3.5
+      parent: 2
+- proto: Catwalk
+  entities:
+  - uid: 13
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,12.5
+      parent: 2
+  - uid: 123
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,9.5
+      parent: 2
+  - uid: 124
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,8.5
+      parent: 2
+  - uid: 125
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,7.5
+      parent: 2
+  - uid: 126
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,6.5
+      parent: 2
+  - uid: 130
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,6.5
+      parent: 2
+  - uid: 132
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,7.5
+      parent: 2
+  - uid: 133
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,8.5
+      parent: 2
+  - uid: 135
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,9.5
+      parent: 2
+  - uid: 137
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,12.5
+      parent: 2
+  - uid: 169
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,10.5
+      parent: 2
+  - uid: 182
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,10.5
+      parent: 2
+  - uid: 213
+    components:
+    - type: Transform
+      pos: 11.5,5.5
+      parent: 2
+  - uid: 550
+    components:
+    - type: Transform
+      pos: -9.5,12.5
+      parent: 2
+  - uid: 599
+    components:
+    - type: Transform
+      pos: -9.5,11.5
+      parent: 2
+  - uid: 694
+    components:
+    - type: Transform
+      pos: -9.5,5.5
+      parent: 2
+  - uid: 704
+    components:
+    - type: Transform
+      pos: -8.5,12.5
+      parent: 2
+  - uid: 708
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,11.5
+      parent: 2
+- proto: ChairOfficeDark
+  entities:
+  - uid: 231
+    components:
+    - type: Transform
+      pos: 1.5,2.5
+      parent: 2
+  - uid: 554
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,1.5
+      parent: 2
+  - uid: 555
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,1.5
+      parent: 2
+  - uid: 621
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,-3.5
+      parent: 2
+- proto: ChairOfficeLight
+  entities:
+  - uid: 89
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -8.5,-3.5
+      parent: 2
+- proto: ChairPilotSeat
+  entities:
+  - uid: 85
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,7.5
+      parent: 2
+  - uid: 688
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,7.5
+      parent: 2
+- proto: CircuitImprinter
+  entities:
+  - uid: 600
+    components:
+    - type: Transform
+      pos: 5.5,4.5
+      parent: 2
+- proto: ClothingBeltUtilityFilled
+  entities:
+  - uid: 543
+    components:
+    - type: Transform
+      pos: 5.518552,2.8440952
+      parent: 2
+- proto: ClothingUnderSocksCoder
+  entities:
+  - uid: 740
+    components:
+    - type: Transform
+      pos: -3.473312,2.2555542
+      parent: 2
+- proto: ComputerAnalysisConsole
+  entities:
+  - uid: 59
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,-3.5
+      parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        84:
+        - ArtifactAnalyzerSender: ArtifactAnalyzerReceiver
+- proto: ComputerFrame
+  entities:
+  - uid: 622
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,-3.5
+      parent: 2
+- proto: ComputerResearchAndDevelopment
+  entities:
+  - uid: 605
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,1.5
+      parent: 2
+- proto: ComputerTabletopShuttle
+  entities:
+  - uid: 243
+    components:
+    - type: Transform
+      pos: -2.5,8.5
+      parent: 2
+- proto: ComputerTabletopStationRecords
+  entities:
+  - uid: 548
+    components:
+    - type: Transform
+      pos: -3.5,8.5
+      parent: 2
+- proto: ComputerWallmountWithdrawBankATM
+  entities:
+  - uid: 218
+    components:
+    - type: Transform
+      pos: -6.5,1.5
+      parent: 2
+    - type: Physics
+      canCollide: False
+    - type: ContainerContainer
+      containers:
+        board: !type:Container
+          ents: []
+        bank-ATM-cashSlot: !type:ContainerSlot {}
+    - type: ItemSlots
+- proto: CrateArtifactContainer
+  entities:
+  - uid: 511
+    components:
+    - type: Transform
+      pos: 7.5,-2.5
+      parent: 2
+- proto: CrateMaterials
+  entities:
+  - uid: 512
+    components:
+    - type: Transform
+      pos: -7.5,4.5
+      parent: 2
+- proto: CrateScienceSecure
+  entities:
+  - uid: 530
+    components:
+    - type: Transform
+      pos: 1.5,-0.5
+      parent: 2
+- proto: DefibrillatorCabinetFilled
+  entities:
+  - uid: 404
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,5.5
+      parent: 2
+  - uid: 677
+    components:
+    - type: Transform
+      pos: 8.5,1.5
+      parent: 2
+- proto: EmergencyLight
+  entities:
+  - uid: 206
+    components:
+    - type: Transform
+      pos: 1.5,-3.5
+      parent: 2
+  - uid: 589
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,-3.5
+      parent: 2
+  - uid: 590
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,-3.5
+      parent: 2
+  - uid: 639
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,2.5
+      parent: 2
+  - uid: 641
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-1.5
+      parent: 2
+  - uid: 643
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,2.5
+      parent: 2
+  - uid: 644
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,1.5
+      parent: 2
+  - uid: 645
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,3.5
+      parent: 2
+  - uid: 646
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,5.5
+      parent: 2
+  - uid: 727
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-1.5
+      parent: 2
+- proto: ExtinguisherCabinetFilled
+  entities:
+  - uid: 652
+    components:
+    - type: Transform
+      pos: -8.5,-1.5
+      parent: 2
+  - uid: 653
+    components:
+    - type: Transform
+      pos: 10.5,-1.5
+      parent: 2
+- proto: FaceHuggerPlushie
+  entities:
+  - uid: 691
+    components:
+    - type: Transform
+      pos: -3.5371642,2.4899292
+      parent: 2
+- proto: FaxMachineShip
+  entities:
+  - uid: 556
+    components:
+    - type: Transform
+      pos: -3.5,5.5
+      parent: 2
+- proto: filingCabinetRandom
+  entities:
+  - uid: 557
+    components:
+    - type: Transform
+      pos: -5.5,0.5
+      parent: 2
+- proto: Firelock
+  entities:
+  - uid: 626
+    components:
+    - type: Transform
+      pos: -1.5,-2.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 631
+      - 627
+      - 635
+  - uid: 628
+    components:
+    - type: Transform
+      pos: 3.5,-2.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 627
+      - 635
+- proto: FirelockGlass
+  entities:
+  - uid: 619
+    components:
+    - type: Transform
+      pos: 11.5,-1.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 627
+  - uid: 623
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 627
+  - uid: 624
+    components:
+    - type: Transform
+      pos: -2.5,1.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 631
+      - 627
+  - uid: 625
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 631
+      - 627
+  - uid: 629
+    components:
+    - type: Transform
+      pos: -9.5,-1.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 631
+      - 627
+  - uid: 630
+    components:
+    - type: Transform
+      pos: -2.5,4.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 631
+- proto: GasMixerFlipped
+  entities:
+  - uid: 149
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-3.5
+      parent: 2
+    - type: GasMixer
+      inletTwoConcentration: 0.22000003
+      inletOneConcentration: 0.78
+    - type: AtmosDevice
+      joinedGrid: 2
+- proto: GasPassiveVent
+  entities:
+  - uid: 268
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-6.5
+      parent: 2
+    - type: AtmosDevice
+      joinedGrid: 2
+  - uid: 317
+    components:
+    - type: Transform
+      pos: -5.5,2.5
+      parent: 2
+    - type: AtmosDevice
+      joinedGrid: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 340
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,-6.5
+      parent: 2
+    - type: AtmosDevice
+      joinedGrid: 2
+- proto: GasPipeBend
+  entities:
+  - uid: 134
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-4.5
+      parent: 2
+  - uid: 193
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 256
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 300
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 303
+    components:
+    - type: Transform
+      pos: 10.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 307
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 308
+    components:
+    - type: Transform
+      pos: -5.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 322
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 329
+    components:
+    - type: Transform
+      pos: -2.5,6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 330
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 360
+    components:
+    - type: Transform
+      pos: 11.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 373
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 374
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 402
+    components:
+    - type: Transform
+      pos: -0.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPipeStraight
+  entities:
+  - uid: 115
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 194
+    components:
+    - type: Transform
+      pos: -7.5,-5.5
+      parent: 2
+  - uid: 195
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -8.5,2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 201
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 270
+    components:
+    - type: Transform
+      pos: 9.5,-4.5
+      parent: 2
+  - uid: 271
+    components:
+    - type: Transform
+      pos: 9.5,-5.5
+      parent: 2
+  - uid: 279
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 280
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 281
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 284
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 288
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 289
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 290
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 292
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 293
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 296
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 298
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 305
+    components:
+    - type: Transform
+      pos: 10.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 309
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 312
+    components:
+    - type: Transform
+      pos: 9.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 313
+    components:
+    - type: Transform
+      pos: 9.5,2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 314
+    components:
+    - type: Transform
+      pos: 9.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 315
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 316
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 319
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 323
+    components:
+    - type: Transform
+      pos: -8.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 333
+    components:
+    - type: Transform
+      pos: -3.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 334
+    components:
+    - type: Transform
+      pos: -2.5,2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 335
+    components:
+    - type: Transform
+      pos: -2.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 336
+    components:
+    - type: Transform
+      pos: -2.5,4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 337
+    components:
+    - type: Transform
+      pos: -2.5,5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 338
+    components:
+    - type: Transform
+      pos: -3.5,4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 341
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 345
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 346
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 349
+    components:
+    - type: Transform
+      pos: -9.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 351
+    components:
+    - type: Transform
+      pos: -9.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 352
+    components:
+    - type: Transform
+      pos: 10.5,2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 353
+    components:
+    - type: Transform
+      pos: -7.5,-4.5
+      parent: 2
+  - uid: 354
+    components:
+    - type: Transform
+      pos: 10.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 355
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 356
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 357
+    components:
+    - type: Transform
+      pos: -5.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 359
+    components:
+    - type: Transform
+      pos: -8.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 361
+    components:
+    - type: Transform
+      pos: 11.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 362
+    components:
+    - type: Transform
+      pos: 11.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 364
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 365
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 366
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 369
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 371
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 372
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 375
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 376
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 378
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 379
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 380
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 393
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 636
+    components:
+    - type: Transform
+      pos: -0.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 637
+    components:
+    - type: Transform
+      pos: -0.5,-2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPipeTJunction
+  entities:
+  - uid: 11
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 114
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 191
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -8.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 283
+    components:
+    - type: Transform
+      pos: -1.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 287
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 291
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 294
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 302
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 304
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 324
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 331
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 332
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 344
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 358
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 363
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 370
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 377
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 633
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPort
+  entities:
+  - uid: 179
+    components:
+    - type: Transform
+      pos: -7.5,-2.5
+      parent: 2
+    - type: AtmosDevice
+      joinedGrid: 2
+  - uid: 347
+    components:
+    - type: Transform
+      pos: 9.5,-2.5
+      parent: 2
+    - type: AtmosDevice
+      joinedGrid: 2
+  - uid: 732
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-4.5
+      parent: 2
+    - type: AtmosDevice
+      joinedGrid: 2
+  - uid: 733
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-3.5
+      parent: 2
+    - type: AtmosDevice
+      joinedGrid: 2
+- proto: GasPressurePump
+  entities:
+  - uid: 39
+    components:
+    - type: Transform
+      pos: -7.5,-3.5
+      parent: 2
+    - type: AtmosDevice
+      joinedGrid: 2
+  - uid: 276
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-3.5
+      parent: 2
+    - type: AtmosDevice
+      joinedGrid: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 339
+    components:
+    - type: Transform
+      pos: 9.5,-3.5
+      parent: 2
+    - type: AtmosDevice
+      joinedGrid: 2
+- proto: GasVentPump
+  entities:
+  - uid: 286
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-2.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 627
+    - type: AtmosDevice
+      joinedGrid: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 297
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,5.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 631
+    - type: AtmosDevice
+      joinedGrid: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 306
+    components:
+    - type: Transform
+      pos: -4.5,-0.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 631
+      - 627
+    - type: AtmosDevice
+      joinedGrid: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 310
+    components:
+    - type: Transform
+      pos: 9.5,3.5
+      parent: 2
+    - type: AtmosDevice
+      joinedGrid: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 321
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -8.5,-2.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 631
+    - type: AtmosDevice
+      joinedGrid: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 325
+    components:
+    - type: Transform
+      pos: 5.5,-0.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 627
+    - type: AtmosDevice
+      joinedGrid: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 326
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,2.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 631
+    - type: AtmosDevice
+      joinedGrid: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 348
+    components:
+    - type: Transform
+      pos: -7.5,3.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 631
+    - type: AtmosDevice
+      joinedGrid: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 367
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 2
+    - type: AtmosDevice
+      joinedGrid: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 632
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-3.5
+      parent: 2
+    - type: AtmosDevice
+      joinedGrid: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasVentScrubber
+  entities:
+  - uid: 116
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-1.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 627
+    - type: AtmosDevice
+      joinedGrid: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 232
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,1.5
+      parent: 2
+    - type: AtmosDevice
+      joinedGrid: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 282
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-0.5
+      parent: 2
+    - type: AtmosDevice
+      joinedGrid: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 285
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,-2.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 627
+    - type: AtmosDevice
+      joinedGrid: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 311
+    components:
+    - type: Transform
+      pos: 10.5,3.5
+      parent: 2
+    - type: AtmosDevice
+      joinedGrid: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 320
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,-2.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 631
+    - type: AtmosDevice
+      joinedGrid: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 327
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,6.5
+      parent: 2
+    - type: AtmosDevice
+      joinedGrid: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 328
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,3.5
+      parent: 2
+    - type: AtmosDevice
+      joinedGrid: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 350
+    components:
+    - type: Transform
+      pos: -8.5,3.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 631
+    - type: AtmosDevice
+      joinedGrid: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 638
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-3.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 635
+    - type: AtmosDevice
+      joinedGrid: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GravityGeneratorMini
+  entities:
+  - uid: 734
+    components:
+    - type: Transform
+      pos: 3.5,-5.5
+      parent: 2
+- proto: Grille
+  entities:
+  - uid: 55
+    components:
+    - type: Transform
+      pos: 4.5,5.5
+      parent: 2
+  - uid: 56
+    components:
+    - type: Transform
+      pos: 3.5,5.5
+      parent: 2
+  - uid: 95
+    components:
+    - type: Transform
+      pos: -10.5,3.5
+      parent: 2
+  - uid: 99
+    components:
+    - type: Transform
+      pos: 12.5,3.5
+      parent: 2
+  - uid: 140
+    components:
+    - type: Transform
+      pos: -9.5,-4.5
+      parent: 2
+  - uid: 141
+    components:
+    - type: Transform
+      pos: -8.5,-4.5
+      parent: 2
+  - uid: 142
+    components:
+    - type: Transform
+      pos: 10.5,-4.5
+      parent: 2
+  - uid: 143
+    components:
+    - type: Transform
+      pos: 11.5,-4.5
+      parent: 2
+  - uid: 164
+    components:
+    - type: Transform
+      pos: -7.5,5.5
+      parent: 2
+  - uid: 187
+    components:
+    - type: Transform
+      pos: -3.5,9.5
+      parent: 2
+  - uid: 224
+    components:
+    - type: Transform
+      pos: -1.5,8.5
+      parent: 2
+  - uid: 240
+    components:
+    - type: Transform
+      pos: 12.5,-2.5
+      parent: 2
+  - uid: 250
+    components:
+    - type: Transform
+      pos: 5.5,0.5
+      parent: 2
+  - uid: 251
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 2
+  - uid: 253
+    components:
+    - type: Transform
+      pos: 12.5,-0.5
+      parent: 2
+  - uid: 258
+    components:
+    - type: Transform
+      pos: 12.5,0.5
+      parent: 2
+  - uid: 275
+    components:
+    - type: Transform
+      pos: -2.5,9.5
+      parent: 2
+  - uid: 278
+    components:
+    - type: Transform
+      pos: -10.5,-2.5
+      parent: 2
+  - uid: 342
+    components:
+    - type: Transform
+      pos: -1.5,7.5
+      parent: 2
+  - uid: 343
+    components:
+    - type: Transform
+      pos: -0.5,-6.5
+      parent: 2
+  - uid: 399
+    components:
+    - type: Transform
+      pos: -10.5,0.5
+      parent: 2
+  - uid: 400
+    components:
+    - type: Transform
+      pos: -10.5,-0.5
+      parent: 2
+  - uid: 406
+    components:
+    - type: Transform
+      pos: -7.5,-1.5
+      parent: 2
+  - uid: 486
+    components:
+    - type: Transform
+      pos: 9.5,-1.5
+      parent: 2
+  - uid: 489
+    components:
+    - type: Transform
+      pos: 2.5,-6.5
+      parent: 2
+  - uid: 545
+    components:
+    - type: Transform
+      pos: 2.5,5.5
+      parent: 2
+  - uid: 575
+    components:
+    - type: Transform
+      pos: 9.5,5.5
+      parent: 2
+  - uid: 662
+    components:
+    - type: Transform
+      pos: 5.5,5.5
+      parent: 2
+  - uid: 663
+    components:
+    - type: Transform
+      pos: 1.5,5.5
+      parent: 2
+- proto: Gyroscope
+  entities:
+  - uid: 731
+    components:
+    - type: Transform
+      pos: -2.5,-3.5
+      parent: 2
+- proto: HospitalCurtainsOpen
+  entities:
+  - uid: 533
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,2.5
+      parent: 2
+- proto: LockerResearchDirectorFilled
+  entities:
+  - uid: 539
+    components:
+    - type: Transform
+      pos: -3.5,3.5
+      parent: 2
+- proto: LockerScienceFilled
+  entities:
+  - uid: 266
+    components:
+    - type: Transform
+      pos: -0.5,0.5
+      parent: 2
+  - uid: 674
+    components:
+    - type: Transform
+      pos: -0.5,-0.5
+      parent: 2
+- proto: MachineArtifactAnalyzer
+  entities:
+  - uid: 84
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-6.5
+      parent: 2
+    - type: DeviceLinkSink
+      links:
+      - 59
+- proto: MachineFrame
+  entities:
+  - uid: 236
+    components:
+    - type: Transform
+      pos: -8.5,-6.5
+      parent: 2
+- proto: MatterBinStockPart
+  entities:
+  - uid: 542
+    components:
+    - type: Transform
+      pos: 5.334321,1.48242
+      parent: 2
+- proto: MicroManipulatorStockPart
+  entities:
+  - uid: 241
+    components:
+    - type: Transform
+      pos: 5.724946,1.685545
+      parent: 2
+  - uid: 260
+    components:
+    - type: Transform
+      pos: 5.362302,2.1461782
+      parent: 2
+- proto: NitrogenCanister
+  entities:
+  - uid: 207
+    components:
+    - type: Transform
+      pos: 4.5,-3.5
+      parent: 2
+    - type: AtmosDevice
+      joinedGrid: 2
+- proto: OxygenCanister
+  entities:
+  - uid: 203
+    components:
+    - type: Transform
+      pos: 4.5,-4.5
+      parent: 2
+    - type: AtmosDevice
+      joinedGrid: 2
+- proto: Paper
+  entities:
+  - uid: 695
+    components:
+    - type: Transform
+      pos: -1.4682765,-3.4819927
+      parent: 2
+    - type: Paper
+      stampState: paper_stamp-ce
+      stampedBy:
+      - stampedBorderless: False
+        stampedColor: '#C69B17FF'
+        stampedName: stamp-component-stamped-name-ce
+      content: >2-
+
+        [head=1][color=#1B8CD6]=BB=[/head]
+
+        [head=2]BlueBird Starship Design & Construction[/head][/color]
+
+
+        [head=2][bold][color=#9413ED]Lyrae[/head][/color][/bold]
+
+        [bold]Dear Captain,
+
+        Thank you for your purchase of the BB Lyrae!
+
+        We hope this ship will serve you well, and be a worthy platform for conducting your valuable research.[/bold]
+
+
+        [head=3][color=#1B8CD6]Pre-Flight Checklist[/head][/color]
+
+        [bold]1. Check all machines, generators and canisters are anchored.
+
+        2. Top off generator fuel.
+
+        3. Set generators to 25kW each. (If using a second analyser, increase power generation accordingly.)
+
+        4. Start generators.
+
+        5. Check distro mixer and pump settings, then turn on.
+
+        6. Check gyro is turned on. 
+
+        7. Check all APCs are functioning and charged.[/bold]
+- proto: PaperBin5
+  entities:
+  - uid: 188
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,6.5
+      parent: 2
+- proto: Pen
+  entities:
+  - uid: 92
+    components:
+    - type: Transform
+      pos: -3.280119,6.3682494
+      parent: 2
+- proto: PortableGeneratorSuperPacmanShuttle
+  entities:
+  - uid: 272
+    components:
+    - type: Transform
+      pos: -1.5,-5.5
+      parent: 2
+    - type: FuelGenerator
+      on: False
+    - type: Physics
+      bodyType: Static
+  - uid: 481
+    components:
+    - type: Transform
+      pos: -0.5,-5.5
+      parent: 2
+    - type: FuelGenerator
+      on: False
+    - type: Physics
+      bodyType: Static
+- proto: PosterContrabandHackingGuide
+  entities:
+  - uid: 398
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,4.5
+      parent: 2
+- proto: PosterContrabandLamarr
+  entities:
+  - uid: 679
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 2
+- proto: PosterLegitPeriodicTable
+  entities:
+  - uid: 595
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 2
+- proto: PosterLegitSMAnomalies
+  entities:
+  - uid: 680
+    components:
+    - type: Transform
+      pos: -6.5,-2.5
+      parent: 2
+- proto: PottedPlantBioluminscent
+  entities:
+  - uid: 551
+    components:
+    - type: Transform
+      pos: -9.5,0.5
+      parent: 2
+  - uid: 552
+    components:
+    - type: Transform
+      pos: 11.5,0.5
+      parent: 2
+- proto: Poweredlight
+  entities:
+  - uid: 74
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,6.5
+      parent: 2
+  - uid: 120
+    components:
+    - type: Transform
+      pos: 10.5,4.5
+      parent: 2
+  - uid: 163
+    components:
+    - type: Transform
+      pos: -8.5,-2.5
+      parent: 2
+  - uid: 295
+    components:
+    - type: Transform
+      pos: 2.5,-0.5
+      parent: 2
+  - uid: 385
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,3.5
+      parent: 2
+  - uid: 387
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 2
+  - uid: 388
+    components:
+    - type: Transform
+      pos: 8.5,0.5
+      parent: 2
+  - uid: 389
+    components:
+    - type: Transform
+      pos: 10.5,-2.5
+      parent: 2
+  - uid: 390
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,-6.5
+      parent: 2
+  - uid: 391
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,-6.5
+      parent: 2
+  - uid: 401
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,3.5
+      parent: 2
+  - uid: 480
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,0.5
+      parent: 2
+  - uid: 507
+    components:
+    - type: Transform
+      pos: -3.5,3.5
+      parent: 2
+  - uid: 508
+    components:
+    - type: Transform
+      pos: -6.5,0.5
+      parent: 2
+  - uid: 524
+    components:
+    - type: Transform
+      pos: -8.5,4.5
+      parent: 2
+- proto: PoweredlightExterior
+  entities:
+  - uid: 723
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-4.5
+      parent: 2
+  - uid: 724
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-4.5
+      parent: 2
+- proto: PoweredlightGreen
+  entities:
+  - uid: 12
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 11.5,11.5
+      parent: 2
+- proto: PoweredlightRed
+  entities:
+  - uid: 82
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,11.5
+      parent: 2
+- proto: Protolathe
+  entities:
+  - uid: 196
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 2
+- proto: RandomPosterAny
+  entities:
+  - uid: 684
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 2
+  - uid: 692
+    components:
+    - type: Transform
+      pos: 8.5,-2.5
+      parent: 2
+- proto: ReinforcedPlasmaWindow
+  entities:
+  - uid: 81
+    components:
+    - type: Transform
+      pos: 11.5,-4.5
+      parent: 2
+  - uid: 147
+    components:
+    - type: Transform
+      pos: -9.5,-4.5
+      parent: 2
+  - uid: 148
+    components:
+    - type: Transform
+      pos: -8.5,-4.5
+      parent: 2
+  - uid: 150
+    components:
+    - type: Transform
+      pos: 10.5,-4.5
+      parent: 2
+- proto: ReinforcedWindow
+  entities:
+  - uid: 517
+    components:
+    - type: Transform
+      pos: -7.5,-1.5
+      parent: 2
+  - uid: 518
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 2
+  - uid: 519
+    components:
+    - type: Transform
+      pos: 5.5,0.5
+      parent: 2
+  - uid: 520
+    components:
+    - type: Transform
+      pos: 9.5,-1.5
+      parent: 2
+- proto: ResearchAndDevelopmentServer
+  entities:
+  - uid: 100
+    components:
+    - type: Transform
+      pos: -5.5,-2.5
+      parent: 2
+- proto: SheetUranium
+  entities:
+  - uid: 200
+    components:
+    - type: Transform
+      pos: -0.4215579,-5.5064983
+      parent: 2
+    - type: Stack
+      count: 15
+- proto: SheetUranium1
+  entities:
+  - uid: 482
+    components:
+    - type: Transform
+      pos: -1.4980612,-5.5533733
+      parent: 2
+    - type: Stack
+      count: 15
+- proto: ShuttersNormalOpen
+  entities:
+  - uid: 94
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,8.5
+      parent: 2
+    - type: DeviceLinkSink
+      links:
+      - 659
+  - uid: 228
+    components:
+    - type: Transform
+      pos: 3.5,5.5
+      parent: 2
+    - type: DeviceLinkSink
+      links:
+      - 666
+  - uid: 229
+    components:
+    - type: Transform
+      pos: 4.5,5.5
+      parent: 2
+    - type: DeviceLinkSink
+      links:
+      - 666
+  - uid: 234
+    components:
+    - type: Transform
+      pos: 5.5,5.5
+      parent: 2
+    - type: DeviceLinkSink
+      links:
+      - 666
+  - uid: 277
+    components:
+    - type: Transform
+      pos: 1.5,5.5
+      parent: 2
+    - type: DeviceLinkSink
+      links:
+      - 666
+  - uid: 386
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,7.5
+      parent: 2
+    - type: DeviceLinkSink
+      links:
+      - 659
+  - uid: 592
+    components:
+    - type: Transform
+      pos: -3.5,9.5
+      parent: 2
+    - type: DeviceLinkSink
+      links:
+      - 659
+  - uid: 598
+    components:
+    - type: Transform
+      pos: -2.5,9.5
+      parent: 2
+    - type: DeviceLinkSink
+      links:
+      - 659
+  - uid: 702
+    components:
+    - type: Transform
+      pos: 2.5,5.5
+      parent: 2
+    - type: DeviceLinkSink
+      links:
+      - 666
+- proto: ShuttersRadiationOpen
+  entities:
+  - uid: 51
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 2
+    - type: DeviceLinkSink
+      links:
+      - 165
+  - uid: 239
+    components:
+    - type: Transform
+      pos: -0.5,-6.5
+      parent: 2
+    - type: DeviceLinkSink
+      links:
+      - 165
+  - uid: 683
+    components:
+    - type: Transform
+      pos: -1.5,-4.5
+      parent: 2
+    - type: DeviceLinkSink
+      links:
+      - 165
+  - uid: 728
+    components:
+    - type: Transform
+      pos: -0.5,-4.5
+      parent: 2
+    - type: DeviceLinkSink
+      links:
+      - 165
+  - uid: 729
+    components:
+    - type: Transform
+      pos: 0.5,-5.5
+      parent: 2
+    - type: DeviceLinkSink
+      links:
+      - 165
+- proto: ShuttleWindow
+  entities:
+  - uid: 40
+    components:
+    - type: Transform
+      pos: -0.5,-6.5
+      parent: 2
+  - uid: 62
+    components:
+    - type: Transform
+      pos: -1.5,7.5
+      parent: 2
+  - uid: 73
+    components:
+    - type: Transform
+      pos: 12.5,3.5
+      parent: 2
+  - uid: 96
+    components:
+    - type: Transform
+      pos: 2.5,-6.5
+      parent: 2
+  - uid: 101
+    components:
+    - type: Transform
+      pos: -10.5,3.5
+      parent: 2
+  - uid: 190
+    components:
+    - type: Transform
+      pos: 12.5,-2.5
+      parent: 2
+  - uid: 230
+    components:
+    - type: Transform
+      pos: -1.5,8.5
+      parent: 2
+  - uid: 235
+    components:
+    - type: Transform
+      pos: 4.5,5.5
+      parent: 2
+  - uid: 244
+    components:
+    - type: Transform
+      pos: -3.5,9.5
+      parent: 2
+  - uid: 252
+    components:
+    - type: Transform
+      pos: -10.5,-2.5
+      parent: 2
+  - uid: 301
+    components:
+    - type: Transform
+      pos: 3.5,5.5
+      parent: 2
+  - uid: 368
+    components:
+    - type: Transform
+      pos: 2.5,5.5
+      parent: 2
+  - uid: 509
+    components:
+    - type: Transform
+      pos: 1.5,5.5
+      parent: 2
+  - uid: 513
+    components:
+    - type: Transform
+      pos: -10.5,-0.5
+      parent: 2
+  - uid: 514
+    components:
+    - type: Transform
+      pos: -10.5,0.5
+      parent: 2
+  - uid: 515
+    components:
+    - type: Transform
+      pos: 12.5,-0.5
+      parent: 2
+  - uid: 516
+    components:
+    - type: Transform
+      pos: 12.5,0.5
+      parent: 2
+  - uid: 546
+    components:
+    - type: Transform
+      pos: -2.5,9.5
+      parent: 2
+  - uid: 602
+    components:
+    - type: Transform
+      pos: -7.5,5.5
+      parent: 2
+  - uid: 607
+    components:
+    - type: Transform
+      pos: 9.5,5.5
+      parent: 2
+  - uid: 664
+    components:
+    - type: Transform
+      pos: 5.5,5.5
+      parent: 2
+- proto: SignalButtonDirectional
+  entities:
+  - uid: 165
+    components:
+    - type: MetaData
+      name: Radiation Shutters
+    - type: Transform
+      pos: -0.5,-2.5
+      parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        683:
+        - Pressed: Toggle
+        728:
+        - Pressed: Toggle
+        51:
+        - Pressed: Toggle
+        729:
+        - Pressed: Toggle
+        239:
+        - Pressed: Toggle
+  - uid: 549
+    components:
+    - type: MetaData
+      name: Blast Door Control
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-5.5
+      parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        138:
+        - Pressed: Toggle
+  - uid: 558
+    components:
+    - type: MetaData
+      name: Blast Door Control
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,-3.5
+      parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        86:
+        - Pressed: Toggle
+  - uid: 567
+    components:
+    - type: MetaData
+      name: Blast Door Control
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-3.5
+      parent: 2
+    - type: SignalSwitch
+      state: True
+    - type: DeviceLinkSource
+      linkedPorts:
+        138:
+        - Pressed: Toggle
+  - uid: 620
+    components:
+    - type: MetaData
+      name: Blast Door Control
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,-5.5
+      parent: 2
+    - type: SignalSwitch
+      state: True
+    - type: DeviceLinkSource
+      linkedPorts:
+        86:
+        - Pressed: Toggle
+  - uid: 659
+    components:
+    - type: MetaData
+      name: Bridge Shutters
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,6.5
+      parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        386:
+        - Pressed: Toggle
+        94:
+        - Pressed: Toggle
+        598:
+        - Pressed: Toggle
+        592:
+        - Pressed: Toggle
+  - uid: 666
+    components:
+    - type: MetaData
+      name: Workshop Shutters
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,0.5
+      parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        234:
+        - Pressed: Toggle
+        229:
+        - Pressed: Toggle
+        228:
+        - Pressed: Toggle
+        702:
+        - Pressed: Toggle
+        277:
+        - Pressed: Toggle
+- proto: SignBridge
+  entities:
+  - uid: 681
+    components:
+    - type: Transform
+      pos: -3.5,4.5
+      parent: 2
+- proto: SignEngine
+  entities:
+  - uid: 570
+    components:
+    - type: Transform
+      pos: 10.5,7.5
+      parent: 2
+  - uid: 687
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -8.5,7.5
+      parent: 2
+- proto: SignLaserMed
+  entities:
+  - uid: 689
+    components:
+    - type: Transform
+      pos: 6.5,2.5
+      parent: 2
+- proto: SignRadiationMed
+  entities:
+  - uid: 735
+    components:
+    - type: Transform
+      pos: -2.5,-2.5
+      parent: 2
+  - uid: 736
+    components:
+    - type: Transform
+      pos: 4.5,-2.5
+      parent: 2
+- proto: SignScience
+  entities:
+  - uid: 700
+    components:
+    - type: Transform
+      pos: 8.5,2.5
+      parent: 2
+  - uid: 726
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,2.5
+      parent: 2
+- proto: SignSpace
+  entities:
+  - uid: 405
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,4.5
+      parent: 2
+  - uid: 583
+    components:
+    - type: Transform
+      pos: -6.5,4.5
+      parent: 2
+  - uid: 667
+    components:
+    - type: Transform
+      pos: 10.5,5.5
+      parent: 2
+  - uid: 671
+    components:
+    - type: Transform
+      pos: -8.5,5.5
+      parent: 2
+- proto: SMESBasic
+  entities:
+  - uid: 220
+    components:
+    - type: Transform
+      pos: 1.5,-5.5
+      parent: 2
+- proto: SpawnPointLatejoin
+  entities:
+  - uid: 686
+    components:
+    - type: Transform
+      pos: -1.5,-0.5
+      parent: 2
+- proto: SpawnPointPilot
+  entities:
+  - uid: 64
+    components:
+    - type: Transform
+      pos: -2.5,6.5
+      parent: 2
+- proto: SpawnPointResearchDirector
+  entities:
+  - uid: 648
+    components:
+    - type: Transform
+      pos: -2.5,3.5
+      parent: 2
+- proto: SpawnPointScientist
+  entities:
+  - uid: 690
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 2
+- proto: SubstationBasic
+  entities:
+  - uid: 238
+    components:
+    - type: Transform
+      pos: 2.5,-5.5
+      parent: 2
+- proto: SuitStorageEVA
+  entities:
+  - uid: 654
+    components:
+    - type: Transform
+      pos: 7.5,0.5
+      parent: 2
+- proto: SuitStorageWallmountRD
+  entities:
+  - uid: 538
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,2.5
+      parent: 2
+    - type: Physics
+      canCollide: False
+- proto: Table
+  entities:
+  - uid: 78
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,2.5
+      parent: 2
+  - uid: 166
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,6.5
+      parent: 2
+  - uid: 527
+    components:
+    - type: Transform
+      pos: -3.5,5.5
+      parent: 2
+  - uid: 535
+    components:
+    - type: Transform
+      pos: 5.5,1.5
+      parent: 2
+- proto: TableReinforced
+  entities:
+  - uid: 151
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,8.5
+      parent: 2
+  - uid: 167
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,8.5
+      parent: 2
+- proto: Thruster
+  entities:
+  - uid: 53
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,10.5
+      parent: 2
+  - uid: 54
+    components:
+    - type: Transform
+      pos: 10.5,13.5
+      parent: 2
+  - uid: 91
+    components:
+    - type: Transform
+      pos: -9.5,13.5
+      parent: 2
+  - uid: 178
+    components:
+    - type: Transform
+      pos: -8.5,13.5
+      parent: 2
+  - uid: 225
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,8.5
+      parent: 2
+  - uid: 233
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,8.5
+      parent: 2
+  - uid: 574
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-4.5
+      parent: 2
+  - uid: 586
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-4.5
+      parent: 2
+  - uid: 591
+    components:
+    - type: Transform
+      pos: 11.5,13.5
+      parent: 2
+  - uid: 608
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,9.5
+      parent: 2
+  - uid: 611
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,9.5
+      parent: 2
+  - uid: 656
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-4.5
+      parent: 2
+  - uid: 699
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,10.5
+      parent: 2
+  - uid: 720
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-4.5
+      parent: 2
+- proto: UnfinishedMachineFrame
+  entities:
+  - uid: 106
+    components:
+    - type: Transform
+      pos: 4.5,4.5
+      parent: 2
+- proto: VendingMachineSciDrobe
+  entities:
+  - uid: 9
+    components:
+    - type: Transform
+      pos: -4.5,0.5
+      parent: 2
+- proto: WallShuttle
+  entities:
+  - uid: 4
+    components:
+    - type: Transform
+      pos: -3.5,-3.5
+      parent: 2
+  - uid: 6
+    components:
+    - type: Transform
+      pos: -4.5,7.5
+      parent: 2
+  - uid: 8
+    components:
+    - type: Transform
+      pos: 0.5,-6.5
+      parent: 2
+  - uid: 10
+    components:
+    - type: Transform
+      pos: 4.5,-5.5
+      parent: 2
+  - uid: 14
+    components:
+    - type: Transform
+      pos: -4.5,3.5
+      parent: 2
+  - uid: 15
+    components:
+    - type: Transform
+      pos: -4.5,4.5
+      parent: 2
+  - uid: 16
+    components:
+    - type: Transform
+      pos: -4.5,5.5
+      parent: 2
+  - uid: 17
+    components:
+    - type: Transform
+      pos: 10.5,11.5
+      parent: 2
+  - uid: 18
+    components:
+    - type: Transform
+      pos: -1.5,4.5
+      parent: 2
+  - uid: 20
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 2
+  - uid: 21
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 2
+  - uid: 22
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 2
+  - uid: 23
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 2
+  - uid: 24
+    components:
+    - type: Transform
+      pos: -0.5,1.5
+      parent: 2
+  - uid: 25
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 2
+  - uid: 26
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 2
+  - uid: 27
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 2
+  - uid: 28
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 2
+  - uid: 29
+    components:
+    - type: Transform
+      pos: 6.5,4.5
+      parent: 2
+  - uid: 30
+    components:
+    - type: Transform
+      pos: 6.5,2.5
+      parent: 2
+  - uid: 31
+    components:
+    - type: Transform
+      pos: 6.5,3.5
+      parent: 2
+  - uid: 32
+    components:
+    - type: Transform
+      pos: 6.5,1.5
+      parent: 2
+  - uid: 36
+    components:
+    - type: Transform
+      pos: -3.5,4.5
+      parent: 2
+  - uid: 38
+    components:
+    - type: Transform
+      pos: 7.5,1.5
+      parent: 2
+  - uid: 41
+    components:
+    - type: Transform
+      pos: -4.5,-3.5
+      parent: 2
+  - uid: 42
+    components:
+    - type: Transform
+      pos: -5.5,-3.5
+      parent: 2
+  - uid: 43
+    components:
+    - type: Transform
+      pos: 8.5,-3.5
+      parent: 2
+  - uid: 44
+    components:
+    - type: Transform
+      pos: -6.5,-2.5
+      parent: 2
+  - uid: 45
+    components:
+    - type: Transform
+      pos: 5.5,-3.5
+      parent: 2
+  - uid: 46
+    components:
+    - type: Transform
+      pos: 6.5,-3.5
+      parent: 2
+  - uid: 47
+    components:
+    - type: Transform
+      pos: 7.5,-3.5
+      parent: 2
+  - uid: 50
+    components:
+    - type: Transform
+      pos: 3.5,-6.5
+      parent: 2
+  - uid: 60
+    components:
+    - type: Transform
+      pos: 8.5,1.5
+      parent: 2
+  - uid: 61
+    components:
+    - type: Transform
+      pos: 8.5,2.5
+      parent: 2
+  - uid: 65
+    components:
+    - type: Transform
+      pos: 8.5,-4.5
+      parent: 2
+  - uid: 66
+    components:
+    - type: Transform
+      pos: 8.5,-5.5
+      parent: 2
+  - uid: 67
+    components:
+    - type: Transform
+      pos: 8.5,-6.5
+      parent: 2
+  - uid: 69
+    components:
+    - type: Transform
+      pos: 8.5,-2.5
+      parent: 2
+  - uid: 75
+    components:
+    - type: Transform
+      pos: 11.5,-7.5
+      parent: 2
+  - uid: 76
+    components:
+    - type: Transform
+      pos: 10.5,-7.5
+      parent: 2
+  - uid: 77
+    components:
+    - type: Transform
+      pos: 9.5,-7.5
+      parent: 2
+  - uid: 79
+    components:
+    - type: Transform
+      pos: 12.5,-6.5
+      parent: 2
+  - uid: 80
+    components:
+    - type: Transform
+      pos: 12.5,-4.5
+      parent: 2
+  - uid: 83
+    components:
+    - type: Transform
+      pos: -3.5,1.5
+      parent: 2
+  - uid: 87
+    components:
+    - type: Transform
+      pos: 12.5,-3.5
+      parent: 2
+  - uid: 88
+    components:
+    - type: Transform
+      pos: 12.5,-1.5
+      parent: 2
+  - uid: 93
+    components:
+    - type: Transform
+      pos: 12.5,1.5
+      parent: 2
+  - uid: 97
+    components:
+    - type: Transform
+      pos: -6.5,2.5
+      parent: 2
+  - uid: 98
+    components:
+    - type: Transform
+      pos: -6.5,1.5
+      parent: 2
+  - uid: 102
+    components:
+    - type: Transform
+      pos: -6.5,-3.5
+      parent: 2
+  - uid: 103
+    components:
+    - type: Transform
+      pos: -6.5,-4.5
+      parent: 2
+  - uid: 104
+    components:
+    - type: Transform
+      pos: -6.5,-5.5
+      parent: 2
+  - uid: 105
+    components:
+    - type: Transform
+      pos: -6.5,-6.5
+      parent: 2
+  - uid: 107
+    components:
+    - type: Transform
+      pos: -7.5,-7.5
+      parent: 2
+  - uid: 108
+    components:
+    - type: Transform
+      pos: -8.5,-7.5
+      parent: 2
+  - uid: 109
+    components:
+    - type: Transform
+      pos: -9.5,-7.5
+      parent: 2
+  - uid: 110
+    components:
+    - type: Transform
+      pos: -10.5,-6.5
+      parent: 2
+  - uid: 112
+    components:
+    - type: Transform
+      pos: -10.5,-4.5
+      parent: 2
+  - uid: 113
+    components:
+    - type: Transform
+      pos: -10.5,-3.5
+      parent: 2
+  - uid: 118
+    components:
+    - type: Transform
+      pos: -10.5,1.5
+      parent: 2
+  - uid: 119
+    components:
+    - type: Transform
+      pos: 10.5,6.5
+      parent: 2
+  - uid: 121
+    components:
+    - type: Transform
+      pos: -8.5,11.5
+      parent: 2
+  - uid: 122
+    components:
+    - type: Transform
+      pos: -6.5,4.5
+      parent: 2
+  - uid: 128
+    components:
+    - type: Transform
+      pos: 10.5,5.5
+      parent: 2
+  - uid: 129
+    components:
+    - type: Transform
+      pos: 12.5,5.5
+      parent: 2
+  - uid: 136
+    components:
+    - type: Transform
+      pos: 10.5,-1.5
+      parent: 2
+  - uid: 152
+    components:
+    - type: Transform
+      pos: -8.5,-1.5
+      parent: 2
+  - uid: 153
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 2
+  - uid: 154
+    components:
+    - type: Transform
+      pos: 1.5,-2.5
+      parent: 2
+  - uid: 157
+    components:
+    - type: Transform
+      pos: -2.5,-2.5
+      parent: 2
+  - uid: 158
+    components:
+    - type: Transform
+      pos: -0.5,-2.5
+      parent: 2
+  - uid: 159
+    components:
+    - type: Transform
+      pos: 2.5,-2.5
+      parent: 2
+  - uid: 160
+    components:
+    - type: Transform
+      pos: 10.5,9.5
+      parent: 2
+  - uid: 162
+    components:
+    - type: Transform
+      pos: 4.5,-2.5
+      parent: 2
+  - uid: 168
+    components:
+    - type: Transform
+      pos: 9.5,12.5
+      parent: 2
+  - uid: 170
+    components:
+    - type: Transform
+      pos: -8.5,6.5
+      parent: 2
+  - uid: 171
+    components:
+    - type: Transform
+      pos: -8.5,7.5
+      parent: 2
+  - uid: 177
+    components:
+    - type: Transform
+      pos: -7.5,12.5
+      parent: 2
+  - uid: 189
+    components:
+    - type: Transform
+      pos: -4.5,6.5
+      parent: 2
+  - uid: 212
+    components:
+    - type: Transform
+      pos: 11.5,1.5
+      parent: 2
+  - uid: 214
+    components:
+    - type: Transform
+      pos: -9.5,1.5
+      parent: 2
+  - uid: 242
+    components:
+    - type: Transform
+      pos: -4.5,1.5
+      parent: 2
+  - uid: 246
+    components:
+    - type: Transform
+      pos: 10.5,10.5
+      parent: 2
+  - uid: 247
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 2
+  - uid: 249
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 2
+  - uid: 254
+    components:
+    - type: Transform
+      pos: 4.5,0.5
+      parent: 2
+  - uid: 255
+    components:
+    - type: Transform
+      pos: -8.5,10.5
+      parent: 2
+  - uid: 265
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 2
+  - uid: 267
+    components:
+    - type: Transform
+      pos: -8.5,5.5
+      parent: 2
+  - uid: 269
+    components:
+    - type: Transform
+      pos: -8.5,8.5
+      parent: 2
+  - uid: 274
+    components:
+    - type: Transform
+      pos: 10.5,7.5
+      parent: 2
+  - uid: 318
+    components:
+    - type: Transform
+      pos: -5.5,1.5
+      parent: 2
+  - uid: 384
+    components:
+    - type: Transform
+      pos: -7.5,13.5
+      parent: 2
+  - uid: 392
+    components:
+    - type: Transform
+      pos: 9.5,13.5
+      parent: 2
+  - uid: 443
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 2
+  - uid: 487
+    components:
+    - type: Transform
+      pos: 6.5,5.5
+      parent: 2
+  - uid: 498
+    components:
+    - type: Transform
+      pos: 8.5,4.5
+      parent: 2
+  - uid: 523
+    components:
+    - type: Transform
+      pos: -10.5,-1.5
+      parent: 2
+  - uid: 525
+    components:
+    - type: Transform
+      pos: -10.5,5.5
+      parent: 2
+  - uid: 536
+    components:
+    - type: Transform
+      pos: -3.5,-4.5
+      parent: 2
+  - uid: 537
+    components:
+    - type: Transform
+      pos: -1.5,-6.5
+      parent: 2
+  - uid: 540
+    components:
+    - type: Transform
+      pos: -2.5,-5.5
+      parent: 2
+  - uid: 541
+    components:
+    - type: Transform
+      pos: 5.5,-4.5
+      parent: 2
+  - uid: 544
+    components:
+    - type: Transform
+      pos: -7.5,14.5
+      parent: 2
+  - uid: 562
+    components:
+    - type: Transform
+      pos: -1.5,6.5
+      parent: 2
+  - uid: 564
+    components:
+    - type: Transform
+      pos: -4.5,8.5
+      parent: 2
+  - uid: 571
+    components:
+    - type: Transform
+      pos: -10.5,7.5
+      parent: 2
+  - uid: 576
+    components:
+    - type: Transform
+      pos: 12.5,6.5
+      parent: 2
+  - uid: 585
+    components:
+    - type: Transform
+      pos: 1.5,-6.5
+      parent: 2
+  - uid: 588
+    components:
+    - type: Transform
+      pos: 12.5,7.5
+      parent: 2
+  - uid: 596
+    components:
+    - type: Transform
+      pos: -10.5,6.5
+      parent: 2
+  - uid: 609
+    components:
+    - type: Transform
+      pos: 10.5,8.5
+      parent: 2
+  - uid: 617
+    components:
+    - type: Transform
+      pos: -4.5,2.5
+      parent: 2
+  - uid: 647
+    components:
+    - type: Transform
+      pos: -8.5,9.5
+      parent: 2
+  - uid: 675
+    components:
+    - type: Transform
+      pos: 12.5,11.5
+      parent: 2
+  - uid: 682
+    components:
+    - type: Transform
+      pos: -10.5,11.5
+      parent: 2
+  - uid: 706
+    components:
+    - type: Transform
+      pos: 9.5,14.5
+      parent: 2
+  - uid: 730
+    components:
+    - type: Transform
+      pos: -2.5,-4.5
+      parent: 2
+- proto: WallShuttleDiagonal
+  entities:
+  - uid: 5
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-6.5
+      parent: 2
+  - uid: 7
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-5.5
+      parent: 2
+  - uid: 90
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,-7.5
+      parent: 2
+  - uid: 127
+    components:
+    - type: Transform
+      pos: 8.5,5.5
+      parent: 2
+  - uid: 131
+    components:
+    - type: Transform
+      pos: 8.5,-1.5
+      parent: 2
+  - uid: 146
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,5.5
+      parent: 2
+  - uid: 155
+    components:
+    - type: Transform
+      pos: -3.5,-2.5
+      parent: 2
+  - uid: 156
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-2.5
+      parent: 2
+  - uid: 186
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,-7.5
+      parent: 2
+  - uid: 197
+    components:
+    - type: Transform
+      pos: -4.5,9.5
+      parent: 2
+  - uid: 204
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-5.5
+      parent: 2
+  - uid: 248
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,0.5
+      parent: 2
+  - uid: 262
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-1.5
+      parent: 2
+  - uid: 273
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,-7.5
+      parent: 2
+  - uid: 423
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,9.5
+      parent: 2
+  - uid: 510
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-6.5
+      parent: 2
+  - uid: 565
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,12.5
+      parent: 2
+  - uid: 657
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,-7.5
+      parent: 2
+  - uid: 658
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,11.5
+      parent: 2
+  - uid: 665
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,11.5
+      parent: 2
+  - uid: 698
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,6.5
+      parent: 2
+  - uid: 701
+    components:
+    - type: Transform
+      pos: 0.5,6.5
+      parent: 2
+  - uid: 707
+    components:
+    - type: Transform
+      pos: -10.5,12.5
+      parent: 2
+- proto: WarningAir
+  entities:
+  - uid: 673
+    components:
+    - type: Transform
+      pos: 2.5,-2.5
+      parent: 2
+- proto: WarpPointShip
+  entities:
+  - uid: 479
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-1.5
+      parent: 2
+- proto: WaterCooler
+  entities:
+  - uid: 210
+    components:
+    - type: Transform
+      pos: -3.492401,0.53535557
+      parent: 2
+- proto: Wrench
+  entities:
+  - uid: 642
+    components:
+    - type: Transform
+      pos: 2.621132,-4.3118896
+      parent: 2
+...

--- a/Resources/Prototypes/_NF/Shipyard/lyrae.yml
+++ b/Resources/Prototypes/_NF/Shipyard/lyrae.yml
@@ -1,0 +1,29 @@
+- type: vessel
+  id: Lyrae
+  name: BB Lyrae
+  description: science, innit
+  price: 1
+  category: Medium
+  group: Civilian
+  shuttlePath: /Maps/_NF/Shuttles/lyrae.yml
+
+- type: gameMap
+  id: Lyrae
+  mapName: 'BB Lyrae'
+  mapPath: /Maps/_NF/Shuttles/lyrae.yml
+  minPlayers: 0
+  stations:
+    Lyrae:
+      stationProto: StandardFrontierVessel
+      components:
+        - type: StationNameSetup
+          mapNameTemplate: 'Lyrae {1}'
+          nameGenerator:
+            !type:NanotrasenNameGenerator
+            prefixCreator: '14'
+        - type: StationJobs
+          overflowJobs: []
+          availableJobs:
+            Scientist: [ 0, 0 ]
+            ResearchDirector: [ 0, 0 ]
+            Pilot: [ 0, 0 ]


### PR DESCRIPTION
## About the PR
Various quality of life tweaks to NC Ceres.

## Why / Balance
Based on my own experiences and having watched how people use the Ceres, I've made certain changes that I think will improve the ship.

* The possibly most contentious change: I added booze and soda dispensers to the bar/reception are, which I also expanded. Though it seemed fine at first to not have them, it felt weird and awkward in practice to have no easy way of dispensing drinks. Now that dispenser chems are limited and intended to stay that way, I feel less guilty about adding dispensers, given the purpose of the ship.
* Shifted the kitchen entrance and kitchen window down one tile, and moved a few things around to make it all fit. Now there's one extra table!
* Removed one of the EVA wallsuit lockers. They were intended for emergencies, but in practice restaurant ships do not get spaced, and it's strange for a restaurant to have more EVA equipment than some dedicated mining vessels.
* Reworked the engineering room to be just for power. The wallmount substation is now a regular substation, the generators are nearer the door (and easier to reach), and the room has an air vent alongside a scrubber.
* Moved the air canister onto the bridge and shifted the gyro to make room for it. It now also has a pump, which stops the canister from being mostly emptied almost instantly.
* Reworked wiring and piping due to these changes.

_Edit:_ As a result of the added dispensers, I also had to raise the price somewhat.

## Technical details
.yml

## Media
The changed section:

![Ceres, tweaked, preinit closeup](https://github.com/new-frontiers-14/frontier-station-14/assets/30327355/6ae03366-62b3-4185-be51-d6937234fca6)

The whole ship, pre and postinit:

![Ceres, tweaked, pre-init](https://github.com/new-frontiers-14/frontier-station-14/assets/30327355/8db38bd7-7e72-422e-994f-b3ad07c739a0)
![Ceres, tweaked, postinit](https://github.com/new-frontiers-14/frontier-station-14/assets/30327355/b57b53ca-acba-4942-8e53-c199068d57d0)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
I doubt I need to mention the minor layout changes - they don't really affect gameplay. :)

:cl:
- add: NC Ceres now comes with soda and booze dispensers.