### PR TITLE
Tabletop computers hotfix

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers_tabletop.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers_tabletop.yml
@@ -40,6 +40,7 @@
   id: ComputerTabletopAlert
   components:
   - type: Sprite
+    drawdepth: SmallObjects
     layers:
     - map: ["computerLayerBody"]
       sprite: _NF/Structures/Machines/computer_tabletop.rsi
@@ -61,6 +62,7 @@
   components:
   - type: Sprite
     sprite: _NF/Structures/Machines/computer_tabletop.rsi
+    drawdepth: SmallObjects
     layers:
     - map: ["computerLayerBody"]
       sprite: _NF/Structures/Machines/computer_tabletop.rsi
@@ -79,6 +81,7 @@
   id: ComputerTabletopShuttle
   components:
   - type: Sprite
+    drawdepth: SmallObjects
     layers:
     - map: ["computerLayerBody"]
       sprite: _NF/Structures/Machines/computer_tabletop.rsi
@@ -98,6 +101,7 @@
   id: ComputerTabletopShuttleSyndie
   components:
   - type: Sprite
+    drawdepth: SmallObjects
     layers:
     - map: ["computerLayerBody"]
       sprite: _NF/Structures/Machines/computer_tabletop.rsi
@@ -118,6 +122,7 @@
   noSpawn: true
   components:
   - type: Sprite
+    drawdepth: SmallObjects
     layers:
     - map: ["computerLayerBody"]
       sprite: _NF/Structures/Machines/computer_tabletop.rsi
@@ -138,6 +143,7 @@
   noSpawn: true
   components:
   - type: Sprite
+    drawdepth: SmallObjects
     layers:
     - map: ["computerLayerBody"]
       sprite: _NF/Structures/Machines/computer_tabletop.rsi
@@ -157,6 +163,7 @@
   id: ComputerTabletopIFF
   components:
   - type: Sprite
+    drawdepth: SmallObjects
     layers:
     - map: ["computerLayerBody"]
       sprite: _NF/Structures/Machines/computer_tabletop.rsi
@@ -177,6 +184,7 @@
   suffix: Syndicate, Tabletop
   components:
   - type: Sprite
+    drawdepth: SmallObjects
     layers:
     - map: ["computerLayerBody"]
       sprite: _NF/Structures/Machines/computer_tabletop.rsi
@@ -196,6 +204,7 @@
   id: ComputerTabletopPowerMonitoring
   components:
   - type: Sprite
+    drawdepth: SmallObjects
     layers:
     - map: ["computerLayerBody"]
       sprite: _NF/Structures/Machines/computer_tabletop.rsi
@@ -215,6 +224,7 @@
   id: ComputerTabletopMedicalRecords
   components:
   - type: Sprite
+    drawdepth: SmallObjects
     layers:
     - map: ["computerLayerBody"]
       sprite: _NF/Structures/Machines/computer_tabletop.rsi
@@ -234,6 +244,7 @@
   id: ComputerTabletopCriminalRecords
   components:
   - type: Sprite
+    drawdepth: SmallObjects
     layers:
     - map: ["computerLayerBody"]
       sprite: _NF/Structures/Machines/computer_tabletop.rsi
@@ -253,6 +264,7 @@
   id: ComputerTabletopStationRecords
   components:
   - type: Sprite
+    drawdepth: SmallObjects
     layers:
     - map: ["computerLayerBody"]
       sprite: _NF/Structures/Machines/computer_tabletop.rsi
@@ -272,6 +284,7 @@
   id: ComputerTabletopCrewMonitoring
   components:
   - type: Sprite
+    drawdepth: SmallObjects
     layers:
     - map: ["computerLayerBody"]
       sprite: _NF/Structures/Machines/computer_tabletop.rsi
@@ -291,6 +304,7 @@
   id: ComputerTabletopResearchAndDevelopment
   components:
   - type: Sprite
+    drawdepth: SmallObjects
     layers:
     - map: ["computerLayerBody"]
       sprite: _NF/Structures/Machines/computer_tabletop.rsi
@@ -310,6 +324,7 @@
   id: ComputerTabletopAnalysisConsole
   components:
   - type: Sprite
+    drawdepth: SmallObjects
     layers:
     - map: ["computerLayerBody"]
       sprite: _NF/Structures/Machines/computer_tabletop.rsi
@@ -329,6 +344,7 @@
   id: ComputerTabletopId
   components:
   - type: Sprite
+    drawdepth: SmallObjects
     layers:
     - map: ["computerLayerBody"]
       sprite: _NF/Structures/Machines/computer_tabletop.rsi
@@ -349,6 +365,7 @@
   components:
   - type: Sprite
     sprite: _NF/Structures/Machines/computer_tabletop.rsi
+    drawdepth: SmallObjects
     layers:
     - map: ["computerLayerBody"]
       state: computer_tabletop
@@ -366,6 +383,7 @@
   id: ComputerTabletopComms
   components:
   - type: Sprite
+    drawdepth: SmallObjects
     layers:
     - map: ["computerLayerBody"]
       sprite: _NF/Structures/Machines/computer_tabletop.rsi
@@ -385,6 +403,7 @@
   id: SyndicateComputerTabletopComms
   components:
   - type: Sprite
+    drawdepth: SmallObjects
     layers:
     - map: ["computerLayerBody"]
       sprite: _NF/Structures/Machines/computer_tabletop.rsi
@@ -404,6 +423,7 @@
   id: ComputerTabletopSolarControl
   components:
   - type: Sprite
+    drawdepth: SmallObjects
     layers:
     - map: ["computerLayerBody"]
       sprite: _NF/Structures/Machines/computer_tabletop.rsi
@@ -423,6 +443,7 @@
   id: ComputerTabletopRadar
   components:
   - type: Sprite
+    drawdepth: SmallObjects
     layers:
     - map: ["computerLayerBody"]
       sprite: _NF/Structures/Machines/computer_tabletop.rsi
@@ -443,6 +464,7 @@
   noSpawn: true
   components:
   - type: Sprite
+    drawdepth: SmallObjects
     layers:
     - map: ["computerLayerBody"]
       sprite: _NF/Structures/Machines/computer_tabletop.rsi
@@ -462,6 +484,7 @@
   id: ComputerTabletopCargoOrders
   components:
   - type: Sprite
+    drawdepth: SmallObjects
     layers:
     - map: ["computerLayerBody"]
       sprite: _NF/Structures/Machines/computer_tabletop.rsi
@@ -481,6 +504,7 @@
   id: ComputerTabletopCargoBounty
   components:
   - type: Sprite
+    drawdepth: SmallObjects
     layers:
     - map: ["computerLayerBody"]
       sprite: _NF/Structures/Machines/computer_tabletop.rsi
@@ -500,6 +524,7 @@
   id: ComputerTabletopCloningConsole
   components:
   - type: Sprite
+    drawdepth: SmallObjects
     layers:
     - map: ["computerLayerBody"]
       sprite: _NF/Structures/Machines/computer_tabletop.rsi
@@ -519,6 +544,7 @@
   id: ComputerTabletopSalvageExpedition
   components:
   - type: Sprite
+    drawdepth: SmallObjects
     layers:
     - map: ["computerLayerBody"]
       sprite: _NF/Structures/Machines/computer_tabletop.rsi
@@ -538,6 +564,7 @@
   id: ComputerTabletopSurveillanceCameraMonitor
   components:
   - type: Sprite
+    drawdepth: SmallObjects
     layers:
     - map: ["computerLayerBody"]
       sprite: _NF/Structures/Machines/computer_tabletop.rsi
@@ -557,6 +584,7 @@
   id: ComputerTabletopSurveillanceWirelessCameraMonitor
   components:
   - type: Sprite
+    drawdepth: SmallObjects
     layers:
     - map: ["computerLayerBody"]
       sprite: _NF/Structures/Machines/computer_tabletop.rsi
@@ -576,6 +604,7 @@
   id: ComputerTabletopMassMedia
   components:
   - type: Sprite
+    drawdepth: SmallObjects
     layers:
     - map: ["computerLayerBody"]
       sprite: _NF/Structures/Machines/computer_tabletop.rsi
@@ -597,6 +626,7 @@
   noSpawn: true
   components:
   - type: Sprite
+    drawdepth: SmallObjects
     layers:
     - map: ["computerLayerBody"]
       sprite: _NF/Structures/Machines/computer_tabletop.rsi
@@ -618,6 +648,7 @@
   id: ComputerTabletopShipyard
   components:
   - type: Sprite
+    drawdepth: SmallObjects
     layers:
     - map: ["computerLayerBody"]
       sprite: _NF/Structures/Machines/computer_tabletop.rsi
@@ -638,6 +669,7 @@
   abstract: true
   components:
   - type: Sprite
+    drawdepth: SmallObjects
     layers:
     - map: ["computerLayerBody"]
       sprite: _NF/Structures/Machines/computer_tabletop.rsi
@@ -657,6 +689,7 @@
   id: ComputerTabletopShipyardSecurity
   components:
   - type: Sprite
+    drawdepth: SmallObjects
     layers:
     - map: ["computerLayerBody"]
       sprite: _NF/Structures/Machines/computer_tabletop.rsi
@@ -676,6 +709,7 @@
   id: ComputerTabletopShipyardBlackMarket
   components:
   - type: Sprite
+    drawdepth: SmallObjects
     layers:
     - map: ["computerLayerBody"]
       sprite: _NF/Structures/Machines/computer_tabletop.rsi
@@ -695,6 +729,7 @@
   id: ComputerTabletopShipyardExpedition
   components:
   - type: Sprite
+    drawdepth: SmallObjects
     layers:
     - map: ["computerLayerBody"]
       sprite: _NF/Structures/Machines/computer_tabletop.rsi
@@ -714,6 +749,7 @@
   id: ComputerTabletopShipyardScrap
   components:
   - type: Sprite
+    drawdepth: SmallObjects
     layers:
     - map: ["computerLayerBody"]
       sprite: _NF/Structures/Machines/computer_tabletop.rsi
@@ -734,6 +770,7 @@
   suffix: High, Tabletop
   components:
   - type: Sprite
+    drawdepth: SmallObjects
     layers:
     - map: ["computerLayerBody"]
       sprite: _NF/Structures/Machines/computer_tabletop.rsi
@@ -754,6 +791,7 @@
   suffix: Normal, Tabletop
   components:
   - type: Sprite
+    drawdepth: SmallObjects
     layers:
     - map: ["computerLayerBody"]
       sprite: _NF/Structures/Machines/computer_tabletop.rsi
@@ -774,6 +812,7 @@
   suffix: Low, Tabletop
   components:
   - type: Sprite
+    drawdepth: SmallObjects
     layers:
     - map: ["computerLayerBody"]
       sprite: _NF/Structures/Machines/computer_tabletop.rsi
@@ -794,6 +833,7 @@
   suffix: VeryLow, Tabletop
   components:
   - type: Sprite
+    drawdepth: SmallObjects
     layers:
     - map: ["computerLayerBody"]
       sprite: _NF/Structures/Machines/computer_tabletop.rsi
@@ -813,6 +853,7 @@
   id: ComputerTabletopStationAdminBankATM
   components:
   - type: Sprite
+    drawdepth: SmallObjects
     layers:
     - map: ["computerLayerBody"]
       sprite: _NF/Structures/Machines/computer_tabletop.rsi
@@ -832,6 +873,7 @@
   id: ComputerTabletopContrabandPalletConsole
   components:
   - type: Sprite
+    drawdepth: SmallObjects
     layers:
     - map: ["computerLayerBody"]
       sprite: _NF/Structures/Machines/computer_tabletop.rsi


### PR DESCRIPTION
## About the PR
Because tabletop computers override the SpriteComponent of their parents, they do not inherit their parent's drawdepth, and instead use the game's default drawdepth. To fix it, every tabletop computer needs to individually have drawdepth set for its SpriteComponent. Yes this is extremely annoying, and unfortunately there isn't really any other way around this. 

## Media

![image](https://github.com/new-frontiers-14/frontier-station-14/assets/16548818/3b5bae0d-f84c-44f3-a204-c62d0461a854)


- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl: VMSolidus
- fix: Tabletop computers now correctly sit on top of tables
