### PR TITLE
Adds BoxShotgunSlug to ammo.yml

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/ammo.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/ammo.yml
@@ -8,6 +8,7 @@
     MagazineBoxLightRiflePractice: 15
     MagazineBoxLightRifleRubber: 15
     WeaponShotgunDoubleBarreled: 15
+    BoxShotgunSlug: 15
     BoxLethalshot: 15
     BoxBeanbag: 15
     BoxShellTranquilizer: 15


### PR DESCRIPTION
## About the PR
Adds boxes of slug rounds to Liberation Station.

## Why / Balance
Slugs got changed from the upstream merge, they do 28 piercing damage now which makes them useful.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- add: Liberation Station now offers slug rounds.