### PR TITLE
Adjusts the price of the NC Hauler to cost what it should

### DIFF
--- a/Resources/Prototypes/_NF/Shipyard/hauler.yml
+++ b/Resources/Prototypes/_NF/Shipyard/hauler.yml
@@ -2,7 +2,7 @@
   id: hauler
   name: NC Hauler
   description: A medium sized vessel specializing in long-haul salvage, mining, and cargo operations.
-  price: 49500
+  price: 60000
   category: Medium
   group: Civilian
   shuttlePath: /Maps/_NF/Shuttles/hauler.yml


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Adjusts the price of the NC Hauler to cost what it should

## Why / Balance
The initial addition of the ship did not push with the correct value of the ship and it sells for a few thousand more than it buys for. This adjusts the buy price up to 60,000

## Technical details
Just a YML change

## Media

- [X] This PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->


:cl:
- fix: Adjusts the price of the NC Hauler from 49,500 to 60,000 to cost what it should.

