### PR TITLE
Fix Pen Sign

### DIFF
--- a/Content.Server/Paper/PaperSystem.cs
+++ b/Content.Server/Paper/PaperSystem.cs
@@ -116,18 +116,8 @@ namespace Content.Server.Paper
             var editable = paperComp.StampedBy.Count == 0 || _tagSystem.HasTag(args.Used, "WriteIgnoreStamps");
             if (_tagSystem.HasTag(args.Used, "Write") && editable)
             {
-                bool write = true;
-
-                if (TryComp<PenComponent>(args.Used, out var penComp))
-                {
-                    // If a pen in sign mod, dont try to write.
-                    if (penComp.Pen == PenMode.PenSign)
-                    {
-                        write = false;
-                    }
-                }
-
-                if (write)
+                if (TryComp<PenComponent>(args.Used, out var penComp) && penComp.Pen == PenMode.PenSign);
+                else // Frontier - Else the rest
                 {
                     var writeEvent = new PaperWriteEvent(uid, args.User);
                     RaiseLocalEvent(args.Used, ref writeEvent);
@@ -145,37 +135,16 @@ namespace Content.Server.Paper
             // If a stamp, attempt to stamp paper
             if (TryComp<StampComponent>(args.Used, out var stampComp) && TryStamp(uid, GetStampInfo(stampComp), stampComp.StampState, paperComp))
             {
-                var actionOther = "stamps";
-                var actionSelf = "stamp";
-
-                if (stampComp.StampedPersonal)
-                {
-                    stampComp.StampedIdUser = args.User;
-
-                    var userName = Loc.GetString("stamp-component-unknown-name");
-                    var userJob = Loc.GetString("stamp-component-unknown-job");
-                    if (_idCardSystem.TryFindIdCard(stampComp.StampedIdUser!.Value, out var card))
-                    {
-                        if (card.Comp.FullName != null)
-                            userName = card.Comp.FullName;
-                        if (card.Comp.JobTitle != null)
-                            userJob = card.Comp.JobTitle;
-                    }
-                    //string stampedName = userJob + " - " + userName;
-                    string stampedName = userName;
-                    stampComp.StampedName = stampedName;
-
-                    actionOther = "signs";
-                    actionSelf = "sign";
-                }
+                if (stampComp.StampedPersonal) // Frontier
+                    stampComp.StampedName = Loc.GetString("stamp-component-signee-name", ("user", args.User)); // Frontier
 
                 // successfully stamped, play popup
                 var stampPaperOtherMessage = Loc.GetString("paper-component-action-stamp-paper-other",
-                        ("action", actionOther), ("user", args.User), ("target", args.Target), ("stamp", args.Used));
+                    ("user", args.User), ("target", args.Target), ("stamp", args.Used));
 
                 _popupSystem.PopupEntity(stampPaperOtherMessage, args.User, Filter.PvsExcept(args.User, entityManager: EntityManager), true);
                 var stampPaperSelfMessage = Loc.GetString("paper-component-action-stamp-paper-self",
-                        ("action", actionSelf), ("target", args.Target), ("stamp", args.Used));
+                        ("target", args.Target), ("stamp", args.Used));
                 _popupSystem.PopupEntity(stampPaperSelfMessage, args.User, args.User);
 
                 _audio.PlayPvs(stampComp.Sound, uid);
@@ -275,20 +244,8 @@ namespace Content.Server.Paper
         {
             if (stampComp.StampedPersonal)
             {
-                stampComp.StampedIdUser = args.User;
-
-                var userName = Loc.GetString("stamp-component-unknown-name");
-                var userJob = Loc.GetString("stamp-component-unknown-job");
-                if (_idCardSystem.TryFindIdCard(stampComp.StampedIdUser!.Value, out var card))
-                {
-                    if (card.Comp.FullName != null)
-                        userName = card.Comp.FullName;
-                    if (card.Comp.JobTitle != null)
-                        userJob = card.Comp.JobTitle;
-                }
-                //string stampedName = userJob + " - " + userName;
-                string stampedName = userName;
-                stampComp.StampedName = stampedName;
+                if (stampComp.StampedPersonal) // Frontier
+                    stampComp.StampedName = Loc.GetString("stamp-component-signee-name", ("user", args.User)); // Frontier
             }
         }
 

--- a/Content.Server/Paper/PaperSystem.cs
+++ b/Content.Server/Paper/PaperSystem.cs
@@ -140,7 +140,7 @@ namespace Content.Server.Paper
 
                 // successfully stamped, play popup
                 var stampPaperOtherMessage = Loc.GetString("paper-component-action-stamp-paper-other",
-                    ("user", args.User), ("target", args.Target), ("stamp", args.Used));
+                        ("user", args.User), ("target", args.Target), ("stamp", args.Used));
 
                 _popupSystem.PopupEntity(stampPaperOtherMessage, args.User, Filter.PvsExcept(args.User, entityManager: EntityManager), true);
                 var stampPaperSelfMessage = Loc.GetString("paper-component-action-stamp-paper-self",

--- a/Content.Shared/Paper/PenComponent.cs
+++ b/Content.Shared/Paper/PenComponent.cs
@@ -17,12 +17,12 @@ namespace Content.Shared.Paper
     public enum PenMode : byte
     {
         /// <summary>
-        /// Sensor doesn't send any information about owner
+        /// Frontier - The normal mode of a pen.
         /// </summary>
         PenWrite = 0,
 
         /// <summary>
-        /// Sensor sends only binary status (alive/dead)
+        /// Frontier - The sign mode of a pen.
         /// </summary>
         PenSign = 1,
     }

--- a/Content.Shared/Paper/StampComponent.cs
+++ b/Content.Shared/Paper/StampComponent.cs
@@ -55,7 +55,7 @@ public sealed partial class StampComponent : Component
     public SoundSpecifier? Sound = null;
 
     /// <summary>
-    /// The stamp using the person name on it
+    /// Frontier - The stamp using the person name on it
     /// </summary>
     [DataField("stampedPersonal")]
     public bool StampedPersonal = false;

--- a/Resources/Locale/en-US/_NF/paper/stamp-component.ftl
+++ b/Resources/Locale/en-US/_NF/paper/stamp-component.ftl
@@ -1,7 +1,6 @@
 ## Components
 
-stamp-component-unknown-name = Unknown
-stamp-component-unknown-job = No job
+stamp-component-signee-name = {$user}
 
 stamp-component-stamped-name-psychologist = Psychologist
 stamp-component-stamped-name-lawyer = Lawyer

--- a/Resources/Locale/en-US/paper/paper-component.ftl
+++ b/Resources/Locale/en-US/paper/paper-component.ftl
@@ -8,5 +8,7 @@ paper-component-examine-detail-has-words = {CAPITALIZE(THE($paper))} has somethi
 # Shown when paper with stamps examined
 paper-component-examine-detail-stamped-by = {CAPITALIZE(THE($paper))} {CONJUGATE-HAVE($paper)} been stamped by: {$stamps}.
 
-paper-component-action-stamp-paper-other = {CAPITALIZE(THE($user))} {$action} {THE($target)} with {THE($stamp)}.
-paper-component-action-stamp-paper-self = You {$action} {THE($target)} with {THE($stamp)}.
+paper-component-action-stamp-paper-other = {CAPITALIZE(THE($user))} stamps {THE($target)} with {THE($stamp)}.
+paper-component-action-stamp-paper-self = You stamp {THE($target)} with {THE($stamp)}.
+
+paper-ui-save-button = Save ({$keybind})

--- a/Resources/Prototypes/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/paper.yml
@@ -279,6 +279,18 @@
   - type: PhysicalComposition
     materialComposition:
       Steel: 25
+  - type: Pen # Frontier
+    mode: PenWrite # Frontier
+  - type: Stamp
+    stampedColor: "#000001"
+    stampState: "paper_stamp-generic"
+    stampedPersonal: true
+    stampedBorderless: true
+    sound:
+      path: /Audio/_NF/Items/Pen/pen_sign.ogg
+      params:
+        volume: -2
+        maxDistance: 5
 
 - type: entity
   parent: Pen
@@ -294,18 +306,6 @@
     damage:
       types:
         Piercing: 3
-  - type: Pen
-    mode: PenWrite
-  - type: Stamp
-    stampedColor: "#000001"
-    stampState: "paper_stamp-generic"
-    stampedPersonal: true
-    stampedBorderless: true
-    sound:
-      path: /Audio/_NF/Items/Pen/pen_sign.ogg
-      params:
-        volume: -2
-        maxDistance: 5
   - type: StaticPrice
     price: 1
 
@@ -386,18 +386,6 @@
   - type: Sprite
     sprite: Objects/Misc/bureaucracy.rsi
     state: pen_hop
-  - type: Pen
-    mode: PenWrite
-  - type: Stamp
-    stampedColor: "#000001"
-    stampState: "paper_stamp-generic"
-    stampedPersonal: true
-    stampedBorderless: true
-    sound:
-      path: /Audio/_NF/Items/Pen/pen_sign.ogg
-      params:
-        volume: -2
-        maxDistance: 5
   - type: StaticPrice
     price: 10
 


### PR DESCRIPTION
## About the PR
Pen sign is back
And now also using the player name and not your ID name.

## Why / Balance
The code was broken after upstream yml update with pen parent change,
And the player name from ID name is for QOL.

## Technical details
Cleaned my old shit code.

## Media
N/A

## Breaking changes
N/A

**Changelog**
:cl: dvir01
- tweak: Pen sign is back, signing is now based on your name and not your ID name.
