### PR TITLE
Nerf mass scaner and add radar console

### DIFF
--- a/Resources/Maps/_NF/Shuttles/anchor.yml
+++ b/Resources/Maps/_NF/Shuttles/anchor.yml
@@ -4480,8 +4480,6 @@ entities:
     - type: Transform
       pos: -2.5,7.5
       parent: 1
-    - type: RadarConsole
-      maxRange: 768
 - proto: ComputerSalvageExpedition
   entities:
   - uid: 669

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/computer.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/computer.yml
@@ -332,6 +332,18 @@
 
 - type: entity
   parent: BaseComputerCircuitboard
+  id: AdvancedRadarConsoleCircuitboard # Frontier
+  name: advanced radar console computer board
+  components:
+  - type: Sprite
+    state: cpu_security
+  - type: ComputerBoard
+    prototype: ComputerAdvancedRadar
+  - type: ComputerTabletopBoard # Frontier
+    prototype: ComputerTabletopAdvancedRadar # Frontier
+
+- type: entity
+  parent: BaseComputerCircuitboard
   id: SolarControlComputerCircuitboard
   name: solar control computer board
   description: A computer printed circuit board for a solar control console.

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -658,7 +658,7 @@
     - map: ["computerLayerKeys"]
       state: generic_keys
   - type: RadarConsole
-    maxRange: 512
+    maxRange: 256 # Frontier
   - type: ActivatableUI
     key: enum.RadarConsoleUiKey.Key
   - type: UserInterface
@@ -671,6 +671,27 @@
     radius: 1.5
     energy: 1.6
     color: "#e6e227"
+
+- type: entity
+  parent: ComputerRadar
+  id: ComputerAdvancedRadar # Frontier
+  name: radar computer
+  description: Better CPU and components gives this radar the technological and tactical advantage on detection of far away objects.
+  components:
+  - type: Computer
+    board: AdvancedRadarConsoleCircuitboard
+  - type: RadarConsole
+    maxRange: 768
+  - type: Sprite
+    layers:
+    - map: ["computerLayerBody"]
+      state: computer
+    - map: ["computerLayerKeyboard"]
+      state: generic_keyboard
+    - map: ["computerLayerScreen"]
+      state: eris_control
+    - map: ["computerLayerKeys"]
+      state: generic_keys
 
 - type: entity
   id: ComputerCargoShuttle

--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers_tabletop.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers_tabletop.yml
@@ -423,6 +423,26 @@
       state: generic_keys
 
 - type: entity
+  parent: [BaseStructureComputerTabletop, ComputerAdvancedRadar]
+  id: ComputerTabletopAdvancedRadar
+  components:
+  - type: Sprite
+    drawdepth: SmallObjects
+    layers:
+    - map: ["computerLayerBody"]
+      sprite: _NF/Structures/Machines/computer_tabletop.rsi
+      state: computer_tabletop
+    - map: ["computerLayerKeyboard"]
+      sprite: _NF/Structures/Machines/computer_tabletop.rsi
+      state: generic_keyboard_tabletop
+    - map: ["computerLayerScreen"]
+      sprite: Structures/Machines/computers.rsi
+      state: eris_control
+    - map: ["computerLayerKeys"]
+      sprite: Structures/Machines/computers.rsi
+      state: generic_keys
+
+- type: entity
   parent: [BaseStructureComputerTabletop, ComputerCargoShuttle]
   id: ComputerTabletopCargoShuttle
   noSpawn: true
@@ -790,7 +810,7 @@
     - map: ["computerLayerKeys"]
       sprite: Structures/Machines/computers.rsi
       state: tech_key
- 
+
 - type: entity
   parent: [BaseStructureComputerTabletop, ComputerPalletConsoleNFVeryLowMarket]
   id: ComputerTabletopPalletConsoleNFVeryLowMarket
@@ -811,7 +831,7 @@
     - map: ["computerLayerKeys"]
       sprite: Structures/Machines/computers.rsi
       state: tech_key
- 
+
 - type: entity
   parent: [BaseStructureComputerTabletop, StationAdminBankATM]
   id: ComputerTabletopStationAdminBankATM


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
All mass scanners have been nerfed to be the same range as the shuttle console radar range and also added a new radar computer with 768 range that will be only available for mapping. 

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
People where taking the mass scanner from POIs to have much better range trying to find places like the listening post or the pirate cove, this also evens out the play field for everyone when it comes to ship combat and chases.

This console will be only available for very select ships and on the frontier outpost for the STC.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Added the console with included board also removed unintended expanded range from the anchor, (such an old ship and until now that i found about this issue lol) 

![20240318-185935](https://github.com/new-frontiers-14/frontier-station-14/assets/80334192/0c30dfff-ffb0-4b10-a357-82cd44331493)


## Media

Comparison side by side
![20240318-185908](https://github.com/new-frontiers-14/frontier-station-14/assets/80334192/8f0e9fc9-82cb-4ff3-9630-fd43a46217a1)


## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl: Leander
- add: Nanotrasen just its newest radar microchip NSR-882 now available on latest radar consoles. 
- tweak: The paid trial of all mass scanners has ended and has been locked to the demo version as by Nanotrasen terms of service.


