### PR TITLE
Comments out Artifact Portals from list of Artifact effects

### DIFF
--- a/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
+++ b/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
@@ -667,14 +667,14 @@
     maxIntensity: 50
     canCreateVacuum: false
 
-#- type: artifactEffect
+#- type: artifactEffect # Frontier
 #  id: EffectPortal
 #  targetDepth: 3
 #  effectHint: artifact-effect-hint-displacement
 #  components:
 #  - type: PortalArtifact
 
-# - type: artifactEffect
+# - type: artifactEffect # Frontier
   # id: EffectSingulo
   # targetDepth: 10
   # effectHint: artifact-effect-hint-destruction

--- a/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
+++ b/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
@@ -667,12 +667,12 @@
     maxIntensity: 50
     canCreateVacuum: false
 
-- type: artifactEffect
-  id: EffectPortal
-  targetDepth: 3
-  effectHint: artifact-effect-hint-displacement
-  components:
-  - type: PortalArtifact
+#- type: artifactEffect
+#  id: EffectPortal
+#  targetDepth: 3
+#  effectHint: artifact-effect-hint-displacement
+#  components:
+#  - type: PortalArtifact
 
 # - type: artifactEffect
   # id: EffectSingulo


### PR DESCRIPTION
## About the PR
Bye bye artifact portals.

## Why / Balance
There are many unintended and uncontrollable player deaths, such as when a portal opens up on someone teleporting them to someone else's 50-reacting artifact pit and instantly dies.

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

no cl
