### PR TITLE
MOSIN WITH MELEE?? (Do not merge) 

### DIFF
--- a/Resources/Maps/_NF/Shuttles/mayflower.yml
+++ b/Resources/Maps/_NF/Shuttles/mayflower.yml
@@ -35,19 +35,19 @@ entities:
           version: 6
         -1,-1:
           ind: -1,-1
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAZAAAAAAAZAAAAAAAZAAAAAAAZAAAAAAAYQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAXgAAAAAAZAAAAAAAZAAAAAAAZAAAAAAAYQAAAAAAYQAAAAAAYQAAAAAAYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAYQAAAAAAYQAAAAAAYQAAAAAAZAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAcgAAAAAAZAAAAAAAIgAAAAAAIgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAcgAAAAAAIgAAAAAAIgAAAAAAIgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAIgAAAAAAcgAAAAAAcgAAAAAAbwAAAAAAawAAAAAAZAAAAAAAZAAAAAAAIgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAXgAAAAAAXgAAAAAAXgAAAAAAIgAAAAAAIgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIgAAAAAAZAAAAAAAZAAAAAAAIgAAAAAAXgAAAAAAXgAAAAAAXgAAAAAAXgAAAAAAIgAAAAAAZAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIgAAAAAAIgAAAAAAIgAAAAAAcgAAAAAAXgAAAAAAXgAAAAAAZAAAAAAAXgAAAAAAIgAAAAAAIgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIgAAAAAAIgAAAAAAZAAAAAAAIgAAAAAAIgAAAAAAIgAAAAAAXgAAAAAAXgAAAAAAIgAAAAAAIgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAZAAAAAAAIgAAAAAAIgAAAAAAIgAAAAAAZAAAAAAAIgAAAAAAcgAAAAAAIgAAAAAAIgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAZAAAAAAAIgAAAAAAIgAAAAAAIgAAAAAAZAAAAAAAIgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAIgAAAAAAIgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAAAAAAAAAcgAAAAAAPwAAAAAAPwAAAAAAPwAAAAAAcgAAAAAAIgAAAAAAIgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAIgAAAAAAZAAAAAAAIgAAAAAA
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAXgAAAAAAZAAAAAAAXgAAAAAAZAAAAAAAYQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAXgAAAAAAXgAAAAAAXgAAAAAAXgAAAAAAYQAAAAAAYQAAAAAAYQAAAAAAYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAYQAAAAAAYQAAAAAAYQAAAAAAZAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAcgAAAAAAZAAAAAAAIgAAAAAAIgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAcgAAAAAAIgAAAAAAIgAAAAAAIgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAIgAAAAAAcgAAAAAAcgAAAAAAbwAAAAAAawAAAAAAZAAAAAAAZAAAAAAAIgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAXgAAAAAAXgAAAAAAXgAAAAAAIgAAAAAAIgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIgAAAAAAZAAAAAAAZAAAAAAAIgAAAAAAXgAAAAAAXgAAAAAAXgAAAAAAXgAAAAAAIgAAAAAAZAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIgAAAAAAIgAAAAAAIgAAAAAAcgAAAAAAXgAAAAAAXgAAAAAAZAAAAAAAXgAAAAAAIgAAAAAAIgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIgAAAAAAIgAAAAAAZAAAAAAAIgAAAAAAIgAAAAAAIgAAAAAAXgAAAAAAXgAAAAAAIgAAAAAAIgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAZAAAAAAAIgAAAAAAIgAAAAAAIgAAAAAAZAAAAAAAIgAAAAAAcgAAAAAAIgAAAAAAIgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAZAAAAAAAIgAAAAAAIgAAAAAAIgAAAAAAZAAAAAAAIgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAIgAAAAAAIgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAAAAAAAAAcgAAAAAAPwAAAAAAPwAAAAAAPwAAAAAAcgAAAAAAIgAAAAAAIgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAIgAAAAAAZAAAAAAAIgAAAAAA
           version: 6
         0,-1:
           ind: 0,-1
-          tiles: cgAAAAAAYQAAAAAAZAAAAAAAXgAAAAAAZAAAAAAAXgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYQAAAAAAZAAAAAAAXgAAAAAAXgAAAAAAXgAAAAAAXgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYQAAAAAAYQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIgAAAAAAcgAAAAAASAAAAAAASAAAAAAASAAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIgAAAAAAcgAAAAAASAAAAAAASAAAAAAASAAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIgAAAAAAawAAAAAASAAAAAAAcgAAAAAAcgAAAAAASAAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZwAAAAAAZwAAAAAAZwAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZwAAAAAAZwAAAAAAZwAAAAAAZwAAAAAAIgAAAAAAZAAAAAAAZAAAAAAAIgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZwAAAAAAZwAAAAAAZwAAAAAAZwAAAAAAcgAAAAAAZAAAAAAAIgAAAAAAIgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZwAAAAAAcgAAAAAAIgAAAAAAZAAAAAAAIgAAAAAAIgAAAAAAIgAAAAAAIgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAIgAAAAAAZAAAAAAAIgAAAAAAIgAAAAAAIgAAAAAAZAAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIgAAAAAAZAAAAAAAIgAAAAAAZAAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAPwAAAAAAPwAAAAAAPwAAAAAAcgAAAAAAAAAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          tiles: cgAAAAAAYQAAAAAAXgAAAAAAZAAAAAAAZAAAAAAAZAAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYQAAAAAAYQAAAAAAZAAAAAAAZAAAAAAAXgAAAAAAZAAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYQAAAAAAYQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIgAAAAAAcgAAAAAASAAAAAAASAAAAAAASAAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIgAAAAAAcgAAAAAASAAAAAAASAAAAAAASAAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIgAAAAAAawAAAAAASAAAAAAAcgAAAAAAcgAAAAAASAAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZwAAAAAAZwAAAAAAZwAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZwAAAAAAZwAAAAAAZwAAAAAAZwAAAAAAIgAAAAAAZAAAAAAAZAAAAAAAIgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZwAAAAAAZwAAAAAAZwAAAAAAZwAAAAAAcgAAAAAAZAAAAAAAIgAAAAAAIgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZwAAAAAAcgAAAAAAIgAAAAAAZAAAAAAAIgAAAAAAIgAAAAAAIgAAAAAAIgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAIgAAAAAAZAAAAAAAIgAAAAAAIgAAAAAAIgAAAAAAZAAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIgAAAAAAZAAAAAAAIgAAAAAAZAAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAPwAAAAAAPwAAAAAAPwAAAAAAcgAAAAAAAAAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
           version: 6
         0,-2:
           ind: 0,-2
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZAAAAAAAcgAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAYQAAAAAAcgAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZAAAAAAAZAAAAAAAXgAAAAAAcgAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYQAAAAAAYQAAAAAAZAAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAZAAAAAAAXgAAAAAAXgAAAAAAXgAAAAAAZAAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYQAAAAAAYQAAAAAAXgAAAAAAZAAAAAAAXgAAAAAAXgAAAAAAZAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZAAAAAAAcgAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAYQAAAAAAcgAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZAAAAAAAZAAAAAAAXgAAAAAAcgAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYQAAAAAAYQAAAAAAZAAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAZAAAAAAAXgAAAAAAXgAAAAAAXgAAAAAAZAAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYQAAAAAAYQAAAAAAZAAAAAAAZAAAAAAAZAAAAAAAXgAAAAAAZAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
           version: 6
         -1,-2:
           ind: -1,-2
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcgAAAAAAZAAAAAAAXgAAAAAAXgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcgAAAAAAYQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcgAAAAAAXgAAAAAAXgAAAAAAXgAAAAAAXgAAAAAAXgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAXgAAAAAAZAAAAAAAYQAAAAAAYQAAAAAAYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAXgAAAAAAZAAAAAAAZAAAAAAAZAAAAAAAYQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAZAAAAAAAZAAAAAAAZAAAAAAAZAAAAAAAYQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAA
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcgAAAAAAZAAAAAAAXgAAAAAAXgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcgAAAAAAYQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcgAAAAAAXgAAAAAAXgAAAAAAXgAAAAAAXgAAAAAAXgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAZAAAAAAAZAAAAAAAYQAAAAAAYQAAAAAAYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAXgAAAAAAXgAAAAAAXgAAAAAAXgAAAAAAYQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAXgAAAAAAXgAAAAAAXgAAAAAAZAAAAAAAYQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAA
           version: 6
       type: MapGrid
     - type: Broadphase
@@ -108,199 +108,215 @@ entities:
             30: 3,-8
             31: 3,-7
             32: 2,-7
-            33: 1,-7
-            34: 1,-7
-            35: 0,-7
-            36: 0,-8
-            37: 1,-8
-            38: -1,-6
-            39: -2,-6
-            40: -2,-7
-            41: -1,-7
-            42: -1,-8
-            43: -2,-8
-            44: -2,-5
-            45: -1,-5
-            46: -1,-4
-            47: -2,-4
-            48: -4,-4
+            33: 0,-7
+            34: 0,-8
+            35: 1,-8
+            36: -1,-6
+            37: -2,-6
+            38: -2,-7
+            39: -1,-7
+            40: -1,-8
+            41: -2,-8
+            42: -2,-5
+            43: -1,-5
+            44: -1,-4
+            45: -2,-4
+            46: -4,-4
+            47: -4,-4
+            48: -5,-4
             49: -4,-4
-            50: -5,-4
+            50: -4,-4
             51: -4,-4
             52: -4,-4
             53: -4,-4
-            54: -4,-4
-            55: -4,-4
-            56: -2,-2
-            57: -2,-3
+            54: -2,-2
+            55: -2,-3
+            56: -1,-2
+            57: -1,-3
             58: -1,-2
-            59: -1,-3
-            60: -1,-2
-            61: -1,-1
-            62: -2,-1
-            63: -2,0
-            64: -1,0
-            65: 0,0
-            66: -1,1
-            67: -2,1
-            68: -3,1
-            69: -3,0
-            70: 0,1
-            71: 1,-4
-            72: 2,-4
-            73: 2,-5
-            74: 3,-4
-            75: 3,-5
-            76: 4,-5
-            77: 5,-5
-            78: 5,-6
-            79: 6,-6
-            80: 6,-7
-            81: 5,-7
-            82: 5,-8
-            83: 6,-8
-            84: 7,-8
-            85: 7,-7
-            86: 7,-6
-            87: -5,-3
-            88: -1,-11
-            89: -2,-11
-            90: -2,-10
-            91: -1,-10
-            92: -3,-12
-            93: -3,-13
-            94: -2,-13
-            95: 0,-13
-            96: -1,-13
-            97: 0,-14
-            98: -3,-14
-            99: -4,-15
-            100: -3,-15
-            101: -2,-15
-            102: 0,-15
-            103: 0,-15
-            104: 1,-15
-            105: 1,-14
-            106: 1,-15
-            107: 1,-16
-            108: 1,-17
-            109: 1,-18
-            110: 2,-18
-            111: 3,-18
-            112: 4,-18
-            113: 5,-18
-            114: 5,-17
-            115: 4,-17
-            116: 3,-17
-            117: 2,-17
-            118: 2,-16
-            119: 3,-16
-            120: 3,-15
-            121: 2,-15
-            122: 4,-16
-            123: 5,-16
-            124: 5,-15
-            125: 4,-15
-            126: -5,-15
-            127: -6,-15
-            128: -7,-15
-            129: -8,-15
-            130: -8,-16
-            131: -7,-16
-            132: -5,-16
-            133: -6,-16
-            134: -5,-17
-            135: -6,-17
-            136: -7,-17
-            137: -8,-17
-            138: -8,-18
-            139: -7,-18
-            140: -6,-18
-            141: -5,-18
-            142: -5,-19
-            143: -4,-18
-            144: -4,-17
-            145: -4,-19
-            146: -4,-20
+            59: -1,-1
+            60: -2,-1
+            61: -2,0
+            62: -1,0
+            63: 0,0
+            64: -1,1
+            65: -2,1
+            66: -3,1
+            67: -3,0
+            68: 0,1
+            69: 1,-4
+            70: 2,-4
+            71: 2,-5
+            72: 3,-4
+            73: 3,-5
+            74: 4,-5
+            75: 5,-5
+            76: 5,-6
+            77: 6,-6
+            78: 6,-7
+            79: 5,-7
+            80: 5,-8
+            81: 6,-8
+            82: 7,-8
+            83: 7,-7
+            84: 7,-6
+            85: -5,-3
+            86: -1,-11
+            87: -2,-10
+            88: -1,-10
+            89: -3,-12
+            90: -3,-13
+            91: -2,-13
+            92: 0,-13
+            93: -1,-13
+            94: 0,-14
+            95: -3,-14
+            96: -4,-15
+            97: -3,-15
+            98: -2,-15
+            99: 0,-15
+            100: 0,-15
+            101: 1,-15
+            102: 1,-14
+            103: 1,-15
+            104: 1,-16
+            105: 1,-17
+            106: 1,-18
+            107: 2,-18
+            108: 3,-18
+            109: 4,-18
+            110: 5,-18
+            111: 5,-17
+            112: 4,-17
+            113: 3,-17
+            114: 2,-17
+            115: 2,-16
+            116: 3,-16
+            117: 3,-15
+            118: 2,-15
+            119: 4,-16
+            120: 5,-16
+            121: 5,-15
+            122: 4,-15
+            123: -5,-15
+            124: -6,-15
+            125: -7,-15
+            126: -8,-15
+            127: -8,-16
+            128: -7,-16
+            129: -5,-16
+            130: -6,-16
+            131: -5,-17
+            132: -6,-17
+            133: -7,-17
+            134: -8,-17
+            135: -8,-18
+            136: -7,-18
+            137: -6,-18
+            138: -5,-18
+            139: -5,-19
+            140: -4,-18
+            141: -4,-17
+            142: -4,-19
+            143: -4,-20
+            144: -4,-20
+            145: -3,-20
+            146: -5,-20
             147: -4,-20
-            148: -3,-20
-            149: -5,-20
-            150: -4,-20
-            151: -4,-20
-            152: -4,-20
+            148: -4,-20
+            149: -4,-20
+            150: -2,-20
+            151: -2,-20
+            152: -2,-20
             153: -2,-20
             154: -2,-20
-            155: -2,-20
-            156: -2,-20
-            157: -2,-20
-            158: -1,-20
-            159: -1,-20
-            160: 0,-20
+            155: -1,-20
+            156: -1,-20
+            157: 0,-20
+            158: 1,-20
+            159: 1,-19
+            160: 0,-19
             161: 1,-20
-            162: 1,-19
-            163: 0,-19
-            164: 1,-20
-            165: 2,-20
-            166: 2,-19
-            167: 2,-18
-            168: 1,-18
-            169: -1,-22
-            170: -2,-22
-            171: -1,-21
-            172: -2,-21
-            173: -1,-9
-            174: -1,-9
-            175: -2,-7
-            176: -2,-7
-            177: -2,-7
+            162: 2,-20
+            163: 2,-19
+            164: 2,-18
+            165: 1,-18
+            166: -1,-22
+            167: -2,-22
+            168: -1,-21
+            169: -2,-21
+            170: -1,-9
+            171: -1,-9
+            172: -2,-7
+            173: -2,-7
+            174: -2,-7
+            175: -2,1
+            176: -2,1
+            177: -2,1
             178: -2,1
             179: -2,1
-            180: -2,1
-            181: -2,1
-            182: -2,1
+            180: -2,-4
+            181: -2,-4
+            182: -2,-4
             183: -2,-4
             184: -2,-4
             185: -2,-4
-            186: -2,-4
-            187: -2,-4
-            188: -2,-4
+            186: 5,-5
+            187: 5,-5
+            188: 5,-5
             189: 5,-5
-            190: 5,-5
-            191: 5,-5
-            192: 5,-5
-            193: -5,-11
-            194: -4,-11
-            195: -5,-12
-            196: -6,-12
-            197: -6,-13
-            198: -7,-13
-            199: -6,-13
-            200: -5,-13
-            201: 2,-13
-            202: 2,-12
-            203: 2,-11
-            204: 3,-12
-            205: 4,-13
-            206: 4,-13
-            207: 4,-13
-            208: 3,-12
-            209: 2,-12
-            210: 2,-13
-            211: 1,-12
-            212: 2,-2
-            213: 1,-2
-            214: -5,-2
-            215: -6,-2
-            216: -4,-2
+            190: -5,-11
+            191: -4,-11
+            192: -5,-12
+            193: -6,-12
+            194: -6,-13
+            195: -7,-13
+            196: -6,-13
+            197: -5,-13
+            198: 2,-13
+            199: 2,-12
+            200: 2,-11
+            201: 3,-12
+            202: 4,-13
+            203: 4,-13
+            204: 4,-13
+            205: 3,-12
+            206: 2,-12
+            207: 2,-13
+            208: 1,-12
+            209: 2,-2
+            210: 1,-2
+            211: -5,-2
+            212: -6,-2
+            213: -4,-2
+            214: 4,-12
+            215: 4,-12
+            216: 4,-12
             217: 4,-12
-            218: 4,-12
-            219: 4,-12
-            220: 4,-12
-            221: -1,-12
-            222: -2,-12
-            223: 3,-13
-            224: -2,-14
-            225: -1,-15
+            218: -1,-12
+            219: -2,-12
+            220: 3,-13
+            221: -2,-14
+            222: -1,-15
+        - node:
+            cleanable: True
+            color: '#4D0000FF'
+            id: a
+          decals:
+            224: -7.104003,-13.216866
+            225: -3.1560862,-11.048694
+        - node:
+            cleanable: True
+            color: '#4D0000FF'
+            id: m
+          decals:
+            226: 3.9688463,-13.17517
+        - node:
+            cleanable: True
+            color: '#4D0000FF'
+            id: s
+          decals:
+            223: 1.9992087,-9.260017
       type: DecalGrid
     - version: 2
       data:
@@ -1796,6 +1812,27 @@ entities:
     - pos: -1.5,1.5
       parent: 1
       type: Transform
+- proto: CrateChemistryD
+  entities:
+  - uid: 378
+    components:
+    - pos: -5.5,-17.5
+      parent: 1
+      type: Transform
+- proto: CrateChemistryP
+  entities:
+  - uid: 379
+    components:
+    - pos: -5.5,-14.5
+      parent: 1
+      type: Transform
+- proto: CrateChemistryS
+  entities:
+  - uid: 380
+    components:
+    - pos: -7.5,-14.5
+      parent: 1
+      type: Transform
 - proto: CrowbarRed
   entities:
   - uid: 425
@@ -1903,6 +1940,53 @@ entities:
   - uid: 456
     components:
     - pos: -2.6394038,1.270113
+      parent: 1
+      type: Transform
+- proto: Eggshells
+  entities:
+  - uid: 341
+    components:
+    - pos: 1.239249,-15.080102
+      parent: 1
+      type: Transform
+  - uid: 351
+    components:
+    - pos: 2.30122,-15.863964
+      parent: 1
+      type: Transform
+  - uid: 354
+    components:
+    - pos: 2.715496,-18.09944
+      parent: 1
+      type: Transform
+  - uid: 355
+    components:
+    - pos: 0.040803254,-18.866049
+      parent: 1
+      type: Transform
+  - uid: 363
+    components:
+    - pos: 1.0616367,-19.105799
+      parent: 1
+      type: Transform
+  - uid: 370
+    components:
+    - pos: 1.2866013,-18.318907
+      parent: 1
+      type: Transform
+  - uid: 451
+    components:
+    - pos: 3.7988815,-15.246962
+      parent: 1
+      type: Transform
+  - uid: 496
+    components:
+    - pos: 2.621189,-16.868666
+      parent: 1
+      type: Transform
+  - uid: 513
+    components:
+    - pos: -0.4859361,-14.443678
       parent: 1
       type: Transform
 - proto: EmergencyLight
@@ -2162,6 +2246,43 @@ entities:
     - ShutdownSubscribers:
       - 466
       type: DeviceNetwork
+- proto: FoodEgg
+  entities:
+  - uid: 47
+    components:
+    - name: Spider egg
+      type: MetaData
+    - pos: 3.9900136,-16.748203
+      parent: 1
+      type: Transform
+  - uid: 360
+    components:
+    - name: Spider egg
+      type: MetaData
+    - pos: 4.104988,-16.852442
+      parent: 1
+      type: Transform
+  - uid: 375
+    components:
+    - name: Spider egg
+      type: MetaData
+    - pos: 4.2191806,-16.748203
+      parent: 1
+      type: Transform
+  - uid: 444
+    components:
+    - name: Spider egg
+      type: MetaData
+    - pos: 3.9691806,-16.92541
+      parent: 1
+      type: Transform
+  - uid: 514
+    components:
+    - name: Spider egg
+      type: MetaData
+    - pos: 4.1926556,-17.002691
+      parent: 1
+      type: Transform
 - proto: FoodPlateSmallTrash
   entities:
   - uid: 486
@@ -2992,14 +3113,6 @@ entities:
       type: Transform
     - canCollide: False
       type: Physics
-  - uid: 609
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 84
-      type: Transform
-    - canCollide: False
-      type: Physics
   - uid: 617
     components:
     - flags: InContainer
@@ -3328,15 +3441,17 @@ entities:
       pos: -0.5,-0.5
       parent: 1
       type: Transform
-    - enabled: False
+    - softness: 0.5
+      energy: 4
+      color: '#FFAF38FF'
       type: PointLight
     - containers:
         light_bulb: !type:ContainerSlot
           showEnts: False
           occludes: True
-          ent: 609
+          ent: 280
       type: ContainerContainer
-    - powerLoad: 0
+    - powerLoad: 100
       type: ApcPowerReceiver
   - uid: 613
     components:
@@ -3877,7 +3992,7 @@ entities:
         68:
         - Pressed: Toggle
       type: DeviceLinkSource
-
+    - type: ItemCooldown
 - proto: SignArmory
   entities:
   - uid: 686
@@ -3924,6 +4039,16 @@ entities:
     - pos: 0.5,-15.5
       parent: 1
       type: Transform
+- proto: SodiumLightTube
+  entities:
+  - uid: 280
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 84
+      type: Transform
+    - canCollide: False
+      type: Physics
 - proto: SpawnPointLatejoin
   entities:
   - uid: 627
@@ -3950,8 +4075,7 @@ entities:
   entities:
   - uid: 14
     components:
-    - rot: 3.141592653589793 rad
-      pos: 0.5,-15.5
+    - pos: -2.5,-18.5
       parent: 1
       type: Transform
   - uid: 33
@@ -3959,15 +4083,9 @@ entities:
     - pos: -8.5,-7.5
       parent: 1
       type: Transform
-  - uid: 47
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -4.5,-19.5
-      parent: 1
-      type: Transform
   - uid: 59
     components:
-    - pos: -0.5,-19.5
+    - pos: -2.5,-15.5
       parent: 1
       type: Transform
   - uid: 131
@@ -3978,8 +4096,7 @@ entities:
       type: Transform
   - uid: 133
     components:
-    - rot: 3.141592653589793 rad
-      pos: -5.5,-4.5
+    - pos: 0.5,-13.5
       parent: 1
       type: Transform
   - uid: 144
@@ -3989,8 +4106,7 @@ entities:
       type: Transform
   - uid: 212
     components:
-    - rot: 3.141592653589793 rad
-      pos: -0.5,-8.5
+    - pos: 4.5,-17.5
       parent: 1
       type: Transform
   - uid: 279
@@ -4001,14 +4117,12 @@ entities:
       type: Transform
   - uid: 299
     components:
-    - rot: -1.5707963267948966 rad
-      pos: -7.5,-17.5
+    - pos: -1.5,-7.5
       parent: 1
       type: Transform
   - uid: 337
     components:
-    - rot: 1.5707963267948966 rad
-      pos: 6.5,-16.5
+    - pos: -6.5,-16.5
       parent: 1
       type: Transform
   - uid: 342
@@ -4017,9 +4131,149 @@ entities:
       pos: -8.5,-16.5
       parent: 1
       type: Transform
+  - uid: 381
+    components:
+    - pos: 0.5,-17.5
+      parent: 1
+      type: Transform
+  - uid: 382
+    components:
+    - pos: -5.5,-17.5
+      parent: 1
+      type: Transform
+  - uid: 384
+    components:
+    - pos: -7.5,-17.5
+      parent: 1
+      type: Transform
+  - uid: 401
+    components:
+    - pos: -2.5,-17.5
+      parent: 1
+      type: Transform
   - uid: 447
     components:
-    - pos: 3.5,-6.5
+    - pos: -1.5,-10.5
+      parent: 1
+      type: Transform
+  - uid: 449
+    components:
+    - pos: -3.5,-19.5
+      parent: 1
+      type: Transform
+  - uid: 457
+    components:
+    - pos: -4.5,-19.5
+      parent: 1
+      type: Transform
+  - uid: 472
+    components:
+    - pos: 0.5,-16.5
+      parent: 1
+      type: Transform
+  - uid: 473
+    components:
+    - pos: -2.5,-6.5
+      parent: 1
+      type: Transform
+  - uid: 474
+    components:
+    - pos: -7.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 475
+    components:
+    - pos: -0.5,-5.5
+      parent: 1
+      type: Transform
+  - uid: 476
+    components:
+    - pos: -2.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 490
+    components:
+    - pos: 3.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 491
+    components:
+    - pos: 3.5,-16.5
+      parent: 1
+      type: Transform
+  - uid: 492
+    components:
+    - pos: 3.5,-17.5
+      parent: 1
+      type: Transform
+  - uid: 493
+    components:
+    - pos: 2.5,-17.5
+      parent: 1
+      type: Transform
+  - uid: 494
+    components:
+    - pos: -5.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 495
+    components:
+    - pos: 4.5,-16.5
+      parent: 1
+      type: Transform
+  - uid: 497
+    components:
+    - pos: -4.5,-18.5
+      parent: 1
+      type: Transform
+  - uid: 498
+    components:
+    - pos: -2.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 499
+    components:
+    - pos: -0.5,-15.5
+      parent: 1
+      type: Transform
+  - uid: 507
+    components:
+    - pos: -5.5,-15.5
+      parent: 1
+      type: Transform
+  - uid: 510
+    components:
+    - pos: -5.5,-16.5
+      parent: 1
+      type: Transform
+  - uid: 515
+    components:
+    - pos: 0.5,-19.5
+      parent: 1
+      type: Transform
+  - uid: 516
+    components:
+    - pos: -7.5,-5.5
+      parent: 1
+      type: Transform
+  - uid: 517
+    components:
+    - pos: 1.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 518
+    components:
+    - pos: 4.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 519
+    components:
+    - pos: 4.5,-15.5
+      parent: 1
+      type: Transform
+  - uid: 520
+    components:
+    - pos: 5.5,-16.5
       parent: 1
       type: Transform
   - uid: 610
@@ -4033,49 +4287,10 @@ entities:
     - pos: -1.5,-20.5
       parent: 1
       type: Transform
-  - uid: 621
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -2.5,-15.5
-      parent: 1
-      type: Transform
-  - uid: 624
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -0.5,-15.5
-      parent: 1
-      type: Transform
-  - uid: 639
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -2.5,-17.5
-      parent: 1
-      type: Transform
   - uid: 681
     components:
     - rot: -1.5707963267948966 rad
       pos: -0.5,-2.5
-      parent: 1
-      type: Transform
-  - uid: 683
-    components:
-    - pos: -5.5,-15.5
-      parent: 1
-      type: Transform
-  - uid: 695
-    components:
-    - pos: -6.5,-16.5
-      parent: 1
-      type: Transform
-  - uid: 696
-    components:
-    - pos: -4.5,-16.5
-      parent: 1
-      type: Transform
-  - uid: 699
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 1.5,-19.5
       parent: 1
       type: Transform
   - uid: 700
@@ -4084,146 +4299,9 @@ entities:
       pos: -1.5,-9.5
       parent: 1
       type: Transform
-  - uid: 701
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -1.5,-5.5
-      parent: 1
-      type: Transform
-  - uid: 702
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -2.5,-7.5
-      parent: 1
-      type: Transform
-  - uid: 703
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 3.5,-10.5
-      parent: 1
-      type: Transform
-  - uid: 705
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -2.5,0.5
-      parent: 1
-      type: Transform
-  - uid: 706
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -2.5,-4.5
-      parent: 1
-      type: Transform
-  - uid: 708
-    components:
-    - pos: -5.5,-3.5
-      parent: 1
-      type: Transform
-  - uid: 709
-    components:
-    - pos: -6.5,-10.5
-      parent: 1
-      type: Transform
-  - uid: 711
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 0.5,-8.5
-      parent: 1
-      type: Transform
-  - uid: 713
-    components:
-    - pos: 1.5,-6.5
-      parent: 1
-      type: Transform
-  - uid: 715
-    components:
-    - pos: 5.5,-15.5
-      parent: 1
-      type: Transform
-  - uid: 775
-    components:
-    - pos: -0.5,-21.5
-      parent: 1
-      type: Transform
-  - uid: 790
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -9.5,-5.5
-      parent: 1
-      type: Transform
-  - uid: 832
-    components:
-    - pos: -6.5,-16.5
-      parent: 1
-      type: Transform
-  - uid: 856
-    components:
-    - pos: -6.5,-15.5
-      parent: 1
-      type: Transform
-  - uid: 857
-    components:
-    - pos: -5.5,-16.5
-      parent: 1
-      type: Transform
-  - uid: 860
-    components:
-    - pos: -4.5,-17.5
-      parent: 1
-      type: Transform
-  - uid: 869
-    components:
-    - pos: -7.5,-15.5
-      parent: 1
-      type: Transform
-  - uid: 870
-    components:
-    - pos: -6.5,-14.5
-      parent: 1
-      type: Transform
-  - uid: 871
-    components:
-    - pos: 5.5,-17.5
-      parent: 1
-      type: Transform
-  - uid: 874
-    components:
-    - pos: 1.5,-14.5
-      parent: 1
-      type: Transform
-  - uid: 875
-    components:
-    - pos: -2.5,-13.5
-      parent: 1
-      type: Transform
   - uid: 877
     components:
     - pos: 2.5,-2.5
-      parent: 1
-      type: Transform
-  - uid: 881
-    components:
-    - pos: 5.5,-5.5
-      parent: 1
-      type: Transform
-  - uid: 882
-    components:
-    - pos: 6.5,-4.5
-      parent: 1
-      type: Transform
-  - uid: 883
-    components:
-    - pos: 5.5,-4.5
-      parent: 1
-      type: Transform
-  - uid: 885
-    components:
-    - pos: -7.5,-5.5
-      parent: 1
-      type: Transform
-  - uid: 886
-    components:
-    - pos: -7.5,-4.5
       parent: 1
       type: Transform
 - proto: Stairs
@@ -5253,33 +5331,26 @@ entities:
       type: Transform
     - id: Mayflower
       type: BecomesStation
-- proto: WeaponRackWallmountedMercenary
-  entities:
-  - uid: 280
-    components:
-    - pos: -3.5,-0.5
-      parent: 1
-      type: Transform
 - proto: WebNest
   entities:
-  - uid: 697
+  - uid: 343
     components:
-    - pos: -6.5,-15.5
+    - pos: 4.5,-16.5
       parent: 1
       type: Transform
-  - uid: 714
+  - uid: 350
     components:
-    - pos: -5.5,-16.5
+    - pos: 4.5,-17.5
       parent: 1
       type: Transform
-  - uid: 732
+  - uid: 361
     components:
-    - pos: -6.5,-16.5
+    - pos: 3.5,-16.5
       parent: 1
       type: Transform
-  - uid: 759
+  - uid: 362
     components:
-    - pos: -5.5,-15.5
+    - pos: 3.5,-17.5
       parent: 1
       type: Transform
 - proto: WindoorSecure

--- a/Resources/Textures/_NF/Objects/Weapons/Guns/Mosin.yml
+++ b/Resources/Textures/_NF/Objects/Weapons/Guns/Mosin.yml
@@ -1,0 +1,43 @@
+- type: entity
+  name: melee mosin
+  parent: BaseWeaponSniper
+  id: Weaponmeleemosin
+  description: A weapon for hunting, or endless trench warfare. Uses .30 rifle ammo.
+  components:
+  - type: Sprite
+    sprite: Objects/Weapons/Guns/Snipers/bolt_gun_wood.rsi
+    state: base
+  - type: AmmoCounter
+  - type: Gun
+    useKey: false
+    fireRate: 1.25
+    selectedMode: SemiAuto
+    availableModes:
+    - SemiAuto
+    soundGunshot:
+      path: /Audio/Weapons/Guns/Gunshots/sniper.ogg
+  - type: BallisticAmmoProvider
+    capacity: 5
+    proto: CartridgeLightRifle
+    whitelist:
+      tags:
+      - CartridgeLightRifle
+  - type: MeleeWeapon
+    attackRate: .85
+    damage:
+      types:
+       Piercing: 16
+       Slash: 5
+    angle: 0
+    wideAnimationRotation: -135
+  - type: DisarmMalus
+    animation: WeaponArcThrust
+    soundHit:
+      path: /Audio/Weapons/bladeslice.ogg
+  - type: Sharp
+  - type: Clothing
+    quickEquip: false
+    slots:
+    - back
+    - suitStorage
+    sprite: Objects/Weapons/Guns/Snipers/bolt_gun_wood.rsi


### PR DESCRIPTION


## About the PR
This is just a placeholder for the Mosin rework, So Testing by the Maintainers can be done. 
## Why / Balance
As we know the Mosin is Underused due to its lack of luster abilities in combat.  Now everyone has ALWAYS ask why does it have a Bayonet when we can't even use it.  Well, I attempt to give it to the best of my Ability. 

## Media

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
This functionally changes how to use the Mosin within it self. Due to how Upstream has Melee and Gun weapons,  with this. the the shooting button is Right-clicked.  which the left click performs a punching melee attack,  Now if you run out of ammo. The right lick ( Shooting) Turns into a Thrust melee attack (like the spear) 
-->

**Changelog**
<!--
Bayonets now work
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
