### PR TITLE
Fix access on Bison Doors

### DIFF
--- a/Resources/Maps/_NF/Shuttles/bison.yml
+++ b/Resources/Maps/_NF/Shuttles/bison.yml
@@ -1610,7 +1610,7 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -3.5,-21.5
       parent: 1
-- proto: AirlockAtmosphericsLocked
+- proto: AirlockAtmospherics
   entities:
   - uid: 2091
     components:
@@ -1713,7 +1713,7 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -10.5,-24.5
       parent: 1
-- proto: AirlockEngineeringLocked
+- proto: AirlockEngineering
   entities:
   - uid: 67
     components:
@@ -20427,7 +20427,7 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -6.5,-34.5
       parent: 1
-- proto: WindoorSecureAtmosphericsLocked
+- proto: WindoorSecure
   entities:
   - uid: 2035
     components:


### PR DESCRIPTION
## About the PR
Three doors on the Bison are now no longer locked.

## Why / Balance
Three doors on the Bison have access that only the Captain has, making it a bit more difficult for the crew to operate the ship.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
