### PR TITLE
Fix space platform dungeon generation

### DIFF
--- a/Content.Server/Procedural/DungeonJob.Generator.cs
+++ b/Content.Server/Procedural/DungeonJob.Generator.cs
@@ -351,7 +351,8 @@ public sealed partial class DungeonJob
                             grid.SetTile(tilePos, fallbackTile);
                         }
 
-                        var result = _decals.TryAddDecal(
+                        // var result =
+                        _decals.TryAddDecal(
                             decal.Id,
                             new EntityCoordinates(gridUid, position),
                             out _,
@@ -360,7 +361,10 @@ public sealed partial class DungeonJob
                             decal.ZIndex,
                             decal.Cleanable);
 
-                        DebugTools.Assert(result);
+                        // Frontier change
+                        // We disable the assertion here because generation of spaceplatform stops prematurely since it has holes.
+                        // Dont care if decals dont get placed because of holes, generation works fine if we ignore the assertion.
+                        // DebugTools.Assert(result);
                     }
                 }
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Space platform dungeon generation is broken, this pr fixes it
When you start the server you get some errors as well about some `DebugTools.Assert(result);` line in DungeonJob.Generator.cs.

Before:
![image](https://github.com/new-frontiers-14/frontier-station-14/assets/1354802/b79d912f-48f5-4b90-bad8-1f14cdb4cd87)

After: 

https://github.com/new-frontiers-14/frontier-station-14/assets/1354802/ad318457-45bc-4ee5-ba59-ae7170b6e923

## Why
In the current situation, generation stops whenever decal placement system finds a hole in the `spaceplatform.yml`, in theory this should spawn one or two rooms but it's really weird its just a huge platform with a single room or two, thats it.
The space platform has holes all over the place, so generation stops only because decal system before generating anything that makes remotely sense.

## Technical details
Simply commenting out the debug assertion fixes the dungeon generation and wont hurt anything.
Dungeon generation was probably not meant to be generating on a platform like spaceplatform.yml with a bunch of holes in it.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
-

**Changelog**
fix: errors in decal placement
