### PR TITLE
Fix diona reform banking

### DIFF
--- a/Content.Server/Species/Systems/NymphSystem.cs
+++ b/Content.Server/Species/Systems/NymphSystem.cs
@@ -1,4 +1,6 @@
+using Content.Server.Cargo.Components;
 using Content.Server.Mind;
+using Content.Shared.Bank.Components;
 using Content.Shared.Species.Components;
 using Content.Shared.Body.Events;
 using Robust.Shared.Prototypes;
@@ -34,7 +36,23 @@ public sealed partial class NymphSystem : EntitySystem
         var nymph = EntityManager.SpawnAtPosition(entityProto.ID, coords);
 
         if (comp.TransferMind == true && _mindSystem.TryGetMind(args.OldBody, out var mindId, out var mind))
+        {
             _mindSystem.TransferTo(mindId, nymph, mind: mind);
+
+
+            // Frontier
+            EnsureComp<CargoSellBlacklistComponent>(nymph);
+
+            // Frontier
+            // bank account transfer
+            if (TryComp<BankAccountComponent>(args.OldBody, out var bank))
+            {
+                // Do this carefully since changing the value of a bank account component on a entity will save the balance immediately through subscribers.
+                var oldBankBalance = bank.Balance;
+                var newBank = EnsureComp<BankAccountComponent>(nymph);
+                newBank.Balance = oldBankBalance;
+            }
+        }
 
         QueueDel(uid);
     }

--- a/Content.Server/_NF/Species/Systems/ReformSystem.cs
+++ b/Content.Server/_NF/Species/Systems/ReformSystem.cs
@@ -1,0 +1,21 @@
+﻿using Content.Server.Cargo.Components;
+using Content.Shared.Mind;
+using Content.Shared.Species.Components;
+using static Content.Shared.Species.ReformSystem;
+
+namespace Content.Server._NF.Species.Systems;
+
+// Frontier - This adds cargo sell blacklist component to the newly reformed diona.
+public sealed partial class ReformSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<SetDionaCargoBlacklistEvent>(OnDionaReformed);
+    }
+
+    private void OnDionaReformed(SetDionaCargoBlacklistEvent ev)
+    {
+        EnsureComp<CargoSellBlacklistComponent>(ev.ReformedDiona);
+    }
+}


### PR DESCRIPTION
## About the PR
this fixes the issues adressed in https://discord.com/channels/1123826877245694004/1220441283894448278

> if you die as diona and decided to gib yourself then reform as a nymph , you will lose access to your account as if you were borged. this is because the new diona is a different reference from the original player , 

Steps to reproduce
> 1.die as a diona
> 2.gib yourself so you split into nymphs
> 3.reform as a new diona
> 4.try to acess your acount , you are locked out

Also, newly formed dionas can be sold at cargo so basically you can sell yourself

## Why / Balance
-

## Technical details
This PR transfers bank from dead corpse to nymph and then further to the newly formed diona.

## Media
![image](https://github.com/new-frontiers-14/frontier-station-14/assets/1354802/9f2c7973-88b2-4f02-b99b-547e743c7d5e)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
-

**Changelog**
fix: Diona reform missing bank component
