### PR TITLE
Removes BoxShellTranquilizer from Liberation Station

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/ammo.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/ammo.yml
@@ -11,7 +11,6 @@
     BoxShotgunSlug: 15
     BoxLethalshot: 15
     BoxBeanbag: 15
-    BoxShellTranquilizer: 15
     BoxShotgunPractice: 15
     WeaponRevolverArgenti: 15
     MagazineBoxRifle: 15


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Tranquilizers are removed from Liberation Station. Can only be obtained by crafting with an exotic recipe at Ammofab (expedition reward) or SecurityFab.

## Why / Balance
Two-shot, 20-second stuns sucks fun out of PvP and makes PvE horrifically easy.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- remove: Removed Tranquilizer rounds from LibertyVend.