### PR TITLE
Dungeons Mobs Fixup

### DIFF
--- a/Content.Server/Explosion/Components/OnTrigger/GibOnTriggerComponent.cs
+++ b/Content.Server/Explosion/Components/OnTrigger/GibOnTriggerComponent.cs
@@ -13,4 +13,11 @@ public sealed partial class GibOnTriggerComponent : Component
     [ViewVariables(VVAccess.ReadWrite)]
     [DataField("deleteItems")]
     public bool DeleteItems = false;
+
+    /// <summary>
+    /// Frontier - Should gibbing also delete the owners organs?
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite)]
+    [DataField("deleteOrgans")]
+    public bool DeleteOrgans = false;
 }

--- a/Content.Server/Explosion/EntitySystems/TriggerSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/TriggerSystem.cs
@@ -33,6 +33,7 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Player;
 using Content.Shared.Coordinates;
+using Content.Shared.Body.Components; // Frontier - Gib organs
 
 namespace Content.Server.Explosion.EntitySystems
 {
@@ -175,6 +176,19 @@ namespace Content.Server.Explosion.EntitySystems
                     Del(item);
                 }
             }
+
+            if (component.DeleteOrgans) // Frontier - Gib organs
+            {
+                if (TryComp<BodyComponent>(xform.ParentUid, out var body))
+                {
+                    var organs = _body.GetBodyOrganComponents<TransformComponent>(xform.ParentUid, body);
+                    foreach (var (_, organ) in organs)
+                    {
+                        Del(organ.Owner);
+                    }
+                }
+            } // Frontier
+
             _body.GibBody(xform.ParentUid, true);
             args.Handled = true;
         }

--- a/Content.Shared/Bed/Sleep/AutoWakeUpComponent.cs
+++ b/Content.Shared/Bed/Sleep/AutoWakeUpComponent.cs
@@ -1,0 +1,13 @@
+using Content.Shared.FixedPoint;
+using Robust.Shared.GameStates;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+
+namespace Content.Shared.Bed.Sleep;
+
+/// <summary>
+/// Frontier - Added to AI to allow auto waking up after 5 secs.
+/// </summary>
+[NetworkedComponent, RegisterComponent]
+public sealed partial class AutoWakeUpComponent : Component
+{
+}

--- a/Content.Shared/Bed/Sleep/SharedSleepingSystem.cs
+++ b/Content.Shared/Bed/Sleep/SharedSleepingSystem.cs
@@ -7,6 +7,7 @@ using Content.Shared.Speech;
 using Robust.Shared.Network;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
+using System.Threading.Tasks; // Frontier
 
 namespace Content.Server.Bed.Sleep
 {
@@ -38,6 +39,16 @@ namespace Content.Server.Bed.Sleep
 
             // TODO remove hardcoded time.
             _actionsSystem.SetCooldown(component.WakeAction, _gameTiming.CurTime, _gameTiming.CurTime + TimeSpan.FromSeconds(15));
+
+            if (TryComp<AutoWakeUpComponent>(uid, out var autoWakeUp))  // Frontier
+            {
+                Task.Run(async () =>
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(5));
+                    ev = new SleepStateChangedEvent(false);
+                    RaiseLocalEvent(uid, ev);
+                });
+            }  // Frontier
         }
 
         private void OnShutdown(EntityUid uid, SleepingComponent component, ComponentShutdown args)

--- a/Content.Shared/Buckle/Components/BuckleComponent.cs
+++ b/Content.Shared/Buckle/Components/BuckleComponent.cs
@@ -75,6 +75,13 @@ public sealed partial class BuckleComponent : Component
     /// Used for client rendering
     /// </summary>
     [ViewVariables] public int? OriginalDrawDepth;
+
+    /// <summary>
+    /// Frontier - True if the entity is blocked from buckling.
+    /// </summary>
+    [DataField]
+    [ViewVariables(VVAccess.ReadWrite)]
+    public bool Disable;
 }
 
 [ByRefEvent]

--- a/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
+++ b/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
@@ -323,6 +323,9 @@ public abstract partial class SharedBuckleSystem
         if (attemptEvent.Cancelled)
             return false;
 
+        if (buckleComp.Disable) // Frontier
+            return false; // Frontier
+
         return true;
     }
 

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/syndicatemob.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/syndicatemob.yml
@@ -22,6 +22,9 @@
     minimumWait: 120 # 1 * 2
     maximumWait: 240 # 2 * 60
     NextAdvertisementTime: 0
+  - type: Buckle
+    disable: true
+  - type: AutoWakeUp
 
 # Humans
 - type: entity
@@ -164,7 +167,7 @@
         - SyndicateNavalGrenadierGear
     - type: AutoImplant
       implants:
-      - DeathAcidifierImplant
+      - DeathAcidifierImplantNF
     - type: RechargeBasicEntityAmmo
       rechargeCooldown: 5
       rechargeSound:
@@ -236,16 +239,12 @@
     - type: Loadout
       prototypes:
         - SyndicateNavalCommanderGear
-    - type: MobThresholds
-      thresholds:
-        0: Alive
-        140: Dead # No crit state to ensure that mob explodes ASAP
     - type: Stamina
       critThreshold: 500 # Extra hard to incapacitate and loot
     - type: AutoImplant
       implants:
       - DeathRattleImplant
-      - DeathAcidifierImplant
+      - DeathAcidifierImplantNF
     - type: RechargeBasicEntityAmmo
       rechargeCooldown: 0.5
       rechargeSound:

--- a/Resources/Prototypes/_NF/Entities/Objects/Misc/implanters.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Misc/implanters.yml
@@ -15,4 +15,4 @@
   parent: BaseImplantOnlyImplanterSyndi
   components:
   - type: Implanter
-    implant: DeathAcidifierImplantSF
+    implant: DeathAcidifierImplantNF

--- a/Resources/Prototypes/_NF/Entities/Objects/Misc/implanters.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Misc/implanters.yml
@@ -7,3 +7,12 @@
   components:
     - type: Implanter
       implant: MedicalTrackingImplant
+
+- type: entity
+  id: DeathAcidifierImplanterNF
+  name: death acidifier implanter
+  suffix: All
+  parent: BaseImplantOnlyImplanterSyndi
+  components:
+  - type: Implanter
+    implant: DeathAcidifierImplantSF

--- a/Resources/Prototypes/_NF/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Misc/subdermal_implants.yml
@@ -25,3 +25,29 @@
       - Dead
     - type: Rattle
       radioChannel: "Medical"
+
+- type: entity
+  parent: BaseSubdermalImplant
+  id: DeathAcidifierImplantNF
+  name: death-acidifier implant
+  description: This implant melts the user and their equipment upon death.
+  noSpawn: true
+  components:
+  - type: SubdermalImplant
+    permanent: true
+#    implantAction: ActionActivateDeathAcidifier
+  - type: TriggerOnMobstateChange
+    mobState:
+    - Dead
+    - Critical
+#  - type: TriggerImplantAction
+  - type: GibOnTrigger
+    deleteItems: true
+    deleteOrgans: true
+  - type: SpawnOnTrigger
+    proto: Acidifier
+  - type: Tag
+    tags:
+    - SubdermalImplant
+    - HideContextMenu
+    - DeathAcidifier


### PR DESCRIPTION
## About the PR
Added a new comp called ``AutoWakeUp`` to allow mobs who went into sleep to wake up alone after 5 secs.
Added a new Disable option to buckling to make it possible to remove buckling from a nested mob (Ignore parent control)
Added a new death acidifier that also remove organs, and working from crit state, this is done to remove entity spam of organs on floors and nothing else to be honest.

## Why / Balance
Added the comps to the syndicate faction to fix abuse of them.

## Technical details
C#

## Media
N/A

## Breaking changes
N/A

**Changelog**
:cl: dvir01
- tweak: Syndicate agents are now more agitated, refusing to sit, and having issues with sleeping for long duration.
