### PR TITLE
Some Late Join Fixing

### DIFF
--- a/Content.Server/GameTicking/GameTicker.Spawning.cs
+++ b/Content.Server/GameTicking/GameTicker.Spawning.cs
@@ -209,7 +209,15 @@ namespace Content.Server.GameTicking
 
             _playTimeTrackings.PlayerRolesChanged(player);
 
-            var mobMaybe = _stationSpawning.SpawnPlayerCharacterOnStation(station, job, character);
+            // Delta-V: Add AlwaysUseSpawner.
+            var spawnPointType = SpawnPointType.Unset;
+            if (jobPrototype.AlwaysUseSpawner)
+            {
+                lateJoin = false;
+                spawnPointType = SpawnPointType.Job;
+            }
+
+            var mobMaybe = _stationSpawning.SpawnPlayerCharacterOnStation(station, job, character, spawnPointType: spawnPointType);
             DebugTools.AssertNotNull(mobMaybe);
             var mob = mobMaybe!.Value;
 

--- a/Content.Server/Spawners/EntitySystems/ContainerSpawnPointSystem.cs
+++ b/Content.Server/Spawners/EntitySystems/ContainerSpawnPointSystem.cs
@@ -1,4 +1,4 @@
-﻿using Content.Server.GameTicking;
+using Content.Server.GameTicking;
 using Content.Server.Spawners.Components;
 using Content.Server.Station.Systems;
 using Robust.Server.Containers;
@@ -18,6 +18,10 @@ public sealed class ContainerSpawnPointSystem : EntitySystem
     public void HandlePlayerSpawning(PlayerSpawningEvent args)
     {
         if (args.SpawnResult != null)
+            return;
+
+        // DeltaV - Ignore these two desired spawn types
+        if (args.DesiredSpawnPointType is SpawnPointType.Observer or SpawnPointType.LateJoin)
             return;
 
         var query = EntityQueryEnumerator<ContainerSpawnPointComponent, ContainerManagerComponent, TransformComponent>();

--- a/Content.Server/Spawners/EntitySystems/SpawnPointSystem.cs
+++ b/Content.Server/Spawners/EntitySystems/SpawnPointSystem.cs
@@ -1,4 +1,4 @@
-﻿using Content.Server.GameTicking;
+using Content.Server.GameTicking;
 using Content.Server.Spawners.Components;
 using Content.Server.Station.Systems;
 using Robust.Shared.Map;
@@ -31,6 +31,24 @@ public sealed class SpawnPointSystem : EntitySystem
         {
             if (args.Station != null && _stationSystem.GetOwningStation(uid, xform) != args.Station)
                 continue;
+
+            // Delta-V: Allow setting a desired SpawnPointType
+            if (args.DesiredSpawnPointType != SpawnPointType.Unset)
+            {
+                var isMatchingJob = spawnPoint.SpawnType == SpawnPointType.Job &&
+                    (args.Job == null || spawnPoint.Job?.ID == args.Job.Prototype);
+
+                switch (args.DesiredSpawnPointType)
+                {
+                    case SpawnPointType.Job when isMatchingJob:
+                    case SpawnPointType.LateJoin when spawnPoint.SpawnType == SpawnPointType.LateJoin:
+                    case SpawnPointType.Observer when spawnPoint.SpawnType == SpawnPointType.Observer:
+                        possiblePositions.Add(xform.Coordinates);
+                        break;
+                    default:
+                        continue;
+                }
+            }
 
             if (_gameTicker.RunLevel == GameRunLevel.InRound && spawnPoint.SpawnType == SpawnPointType.LateJoin)
             {

--- a/Content.Server/Station/Systems/StationSpawningSystem.cs
+++ b/Content.Server/Station/Systems/StationSpawningSystem.cs
@@ -26,6 +26,7 @@ using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Utility;
+using Content.Server.Spawners.Components; // DeltaV
 
 namespace Content.Server.Station.Systems;
 
@@ -72,17 +73,19 @@ public sealed class StationSpawningSystem : SharedStationSpawningSystem
     /// <param name="job">The job to assign, if any.</param>
     /// <param name="profile">The character profile to use, if any.</param>
     /// <param name="stationSpawning">Resolve pattern, the station spawning component for the station.</param>
+    /// <param name="spawnPointType">Delta-V: Set desired spawn point type.</param>
     /// <returns>The resulting player character, if any.</returns>
     /// <exception cref="ArgumentException">Thrown when the given station is not a station.</exception>
     /// <remarks>
     /// This only spawns the character, and does none of the mind-related setup you'd need for it to be playable.
     /// </remarks>
-    public EntityUid? SpawnPlayerCharacterOnStation(EntityUid? station, JobComponent? job, HumanoidCharacterProfile? profile, StationSpawningComponent? stationSpawning = null)
+    public EntityUid? SpawnPlayerCharacterOnStation(EntityUid? station, JobComponent? job, HumanoidCharacterProfile? profile, StationSpawningComponent? stationSpawning = null, SpawnPointType spawnPointType = SpawnPointType.Unset)
     {
         if (station != null && !Resolve(station.Value, ref stationSpawning))
             throw new ArgumentException("Tried to use a non-station entity as a station!", nameof(station));
 
-        var ev = new PlayerSpawningEvent(job, profile, station);
+        // Delta-V: Set desired spawn point type.
+        var ev = new PlayerSpawningEvent(job, profile, station, spawnPointType);
 
         if (station != null && profile != null)
         {
@@ -276,11 +279,16 @@ public sealed class PlayerSpawningEvent : EntityEventArgs
     /// The target station, if any.
     /// </summary>
     public readonly EntityUid? Station;
+    /// <summary>
+    /// Delta-V: Desired SpawnPointType, if any.
+    /// </summary>
+    public readonly SpawnPointType DesiredSpawnPointType;
 
-    public PlayerSpawningEvent(JobComponent? job, HumanoidCharacterProfile? humanoidCharacterProfile, EntityUid? station)
+    public PlayerSpawningEvent(JobComponent? job, HumanoidCharacterProfile? humanoidCharacterProfile, EntityUid? station, SpawnPointType spawnPointType = SpawnPointType.Unset)
     {
         Job = job;
         HumanoidCharacterProfile = humanoidCharacterProfile;
         Station = station;
+        DesiredSpawnPointType = spawnPointType;
     }
 }

--- a/Content.Shared/Roles/JobPrototype.cs
+++ b/Content.Shared/Roles/JobPrototype.cs
@@ -68,6 +68,12 @@ namespace Content.Shared.Roles
         public bool CanBeAntag { get; private set; } = true;
 
         /// <summary>
+        /// Nyano/DV: For e.g. prisoners, they'll never use their latejoin spawner.
+        /// </summary>
+        [DataField("alwaysUseSpawner")]
+        public bool AlwaysUseSpawner { get; } = false;
+
+        /// <summary>
         ///     Whether this job is a head.
         ///     The job system will try to pick heads before other jobs on the same priority level.
         /// </summary>

--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Cargo/mail_carrier.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Cargo/mail_carrier.yml
@@ -3,6 +3,7 @@
   name: job-name-mail-carrier
   description: job-name-mail-carrier
   startingGear: MailCarrierGear
+  alwaysUseSpawner: true
   playTimeTracker: JobMailCarrier
   requirements:
     - !type:OverallPlaytimeRequirement

--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Civilian/valet.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Civilian/valet.yml
@@ -7,6 +7,7 @@
     - !type:OverallPlaytimeRequirement
       time: 10800
   startingGear: ValetGear
+  alwaysUseSpawner: true
   icon: "JobIconServiceWorker"
   supervisors: job-supervisors-everyone
   access:

--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/prisoner.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/prisoner.yml
@@ -6,7 +6,7 @@
   requirements:
     - !type:WhitelistRequirement
   startingGear: PrisonerGear
-  alwaysUseSpawner: true
+#  alwaysUseSpawner: true
   canBeAntag: false
   whitelistRequired: true
   icon: "JobIconPrisoner"

--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/prisoner.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/prisoner.yml
@@ -6,6 +6,7 @@
   requirements:
     - !type:WhitelistRequirement
   startingGear: PrisonerGear
+  alwaysUseSpawner: true
   canBeAntag: false
   whitelistRequired: true
   icon: "JobIconPrisoner"

--- a/Resources/Prototypes/Roles/Jobs/Civilian/janitor.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/janitor.yml
@@ -7,6 +7,7 @@
     - !type:OverallPlaytimeRequirement
       time: 10800
   startingGear: JanitorGear
+  alwaysUseSpawner: true
   icon: "JobIconJanitor"
   supervisors: job-supervisors-hop
   access:

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -9,6 +9,7 @@
     - !type:WhitelistRequirement
   weight: 20
   startingGear: HoPGear
+  alwaysUseSpawner: true
   icon: "JobIconHeadOfPersonnel"
   requireAdminNotify: true
   supervisors: job-supervisors-centcom # Frontier

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -21,6 +21,7 @@
       # time: 108000 # 30 hrs
   weight: 10
   startingGear: HoSGear
+  alwaysUseSpawner: true
   icon: "JobIconHeadOfSecurity"
   requireAdminNotify: true
   supervisors: job-supervisors-hop # Frontier

--- a/Resources/Prototypes/_NF/Roles/Jobs/Command/stc.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Command/stc.yml
@@ -4,6 +4,7 @@
   description: job-description-stc
   playTimeTracker: JobStc
   startingGear: StcGear
+  alwaysUseSpawner: true
   requirements:
     - !type:OverallPlaytimeRequirement
       time: 72000 # 20 hrs

--- a/Resources/Prototypes/_NF/Roles/Jobs/Security/security_guard.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Security/security_guard.yml
@@ -7,6 +7,7 @@
     - !type:OverallPlaytimeRequirement
       time: 36000 # Frontier - 10 hrs
   startingGear: SecurityGuardGear
+  alwaysUseSpawner: true
   icon: "JobIconSecurityGuard"
   supervisors: job-supervisors-hop # not hos
   canBeAntag: false


### PR DESCRIPTION
## About the PR
Based on multi PR's from DeltaV
https://github.com/DeltaV-Station/Delta-v/pull/511
https://github.com/DeltaV-Station/Delta-v/pull/743

Making frontier jobs forced to spawn on the job spawns for them and not next to cryo.

## Why / Balance
Its a bit weird the spawn points for critical jobs don't get used and you just spawn next to cryo pods unless you ready on round start.

## Technical details
Frontier workers get sent to spawn points, that is all.

## Media
N/A

## Breaking changes
N/A

**Changelog**
N/A
