### PR TITLE
Harpy speech localization 2: Electric Boogaloo

### DIFF
--- a/Resources/Locale/en-US/_NF/chat/managers/chat_manager.ftl
+++ b/Resources/Locale/en-US/_NF/chat/managers/chat_manager.ftl
@@ -8,3 +8,8 @@ chat-speech-verb-felinid-1 = mraows
 chat-speech-verb-felinid-2 = mews
 chat-speech-verb-felinid-3 = meows
 chat-speech-verb-felinid-4 = purrs out
+
+chat-speech-verb-harpy-1 = chirps
+chat-speech-verb-harpy-2 = tweets
+chat-speech-verb-harpy-3 = caws
+chat-speech-verb-harpy-4 = trills

--- a/Resources/Locale/en-US/deltav/chat/managers/chat_manager.ftl
+++ b/Resources/Locale/en-US/deltav/chat/managers/chat_manager.ftl
@@ -1,4 +1,0 @@
-chat-speech-verb-harpy-1 = chirps
-chat-speech-verb-harpy-2 = tweets
-chat-speech-verb-harpy-3 = caws
-chat-speech-verb-harpy-4 = trills


### PR DESCRIPTION
## About the PR

Apparently on the last go-around, I missed that Frontier's version of Wizden code doesn't have folder-agnostic .ftl files, and thus it straight up didn't actually read the localizations I put there. This was an easy fix, I just take all the harpy verb localizations and put them in the frontier localizations. 

## Media

![image](https://github.com/new-frontiers-14/frontier-station-14/assets/16548818/25a0aa4b-a986-4fa1-91bc-ad64161c16b7)

## Breaking changes

:cl: VMSolidus
- fix: Harpies now correctly trill, tweet, chirp, and caw instead of miraculously screeching about missing localizations.