### PR TITLE
Increased respawn/rotting times again

### DIFF
--- a/Content.Shared/Atmos/Rotting/PerishableComponent.cs
+++ b/Content.Shared/Atmos/Rotting/PerishableComponent.cs
@@ -15,7 +15,7 @@ public sealed partial class PerishableComponent : Component
     /// How long it takes after death to start rotting.
     /// </summary>
     [DataField("rotAfter"), ViewVariables(VVAccess.ReadWrite)]
-    public TimeSpan RotAfter = TimeSpan.FromMinutes(15);
+    public TimeSpan RotAfter = TimeSpan.FromMinutes(20);
 
     /// <summary>
     /// How much rotting has occured

--- a/Content.Shared/_NF/CCVars/CCVars.cs
+++ b/Content.Shared/_NF/CCVars/CCVars.cs
@@ -15,7 +15,7 @@ public sealed class NF14CVars
     /// Respawn time, how long the player has to wait in seconds after death.
     /// </summary>
     public static readonly CVarDef<float> RespawnTime =
-        CVarDef.Create("nf14.respawn.time", 900.0f, CVar.SERVER | CVar.REPLICATED);
+        CVarDef.Create("nf14.respawn.time", 1200.0f, CVar.SERVER | CVar.REPLICATED);
 
     /// <summary>
     /// Whether or not returning from cryosleep is enabled.


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Adds 5 more minutes to the times it takes to rot away and respawn.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Making dying a little more meaningful and giving more chance for people to rescue recently dead people.


:cl: Leander

- tweak: Respawn times take longer but your body takes longer until it starts rotting away.
