### PR TITLE
Ceres (update): defib location hotfix

### DIFF
--- a/Resources/Maps/_NF/Shuttles/ceres.yml
+++ b/Resources/Maps/_NF/Shuttles/ceres.yml
@@ -2046,7 +2046,7 @@ entities:
   - uid: 147
     components:
     - type: Transform
-      pos: -0.5,-12.5
+      pos: 3.5,-9.5
       parent: 2
   - uid: 445
     components:


### PR DESCRIPTION
## About the PR
Move the dining area defib to a reachable location.

## Why / Balance
After adding the dispensers, I forgot about the defib, and now it's _very_ hard to reach. :)

## Technical details
Single line of .yml

## Media
![image](https://github.com/new-frontiers-14/frontier-station-14/assets/30327355/02749ee3-9975-46e7-8e53-87b8d2987140)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
Feels unnecessary for such a tiny change