### PR TITLE
Bookworm (New): Library

### DIFF
--- a/Resources/Maps/_NF/Shuttles/bookworm.yml
+++ b/Resources/Maps/_NF/Shuttles/bookworm.yml
@@ -1,0 +1,3909 @@
+meta:
+  format: 6
+  postmapinit: false
+tilemap:
+  0: Space
+  30: FloorDark
+  31: FloorDarkDiagonal
+  34: FloorDarkMini
+  35: FloorDarkMono
+  46: FloorGlass
+  92: FloorSteel
+  97: FloorSteelDiagonal
+  107: FloorTechMaint
+  121: FloorWood
+  122: FloorWoodLarge
+  124: Lattice
+  125: Plating
+entities:
+- proto: ""
+  entities:
+  - uid: 2
+    components:
+    - type: MetaData
+      name: grid
+    - type: Transform
+      pos: -0.53125,-0.55733174
+      parent: invalid
+    - type: MapGrid
+      chunks:
+        0,0:
+          ind: 0,0
+          tiles: YQAAAAAAYQAAAAAAXAAAAAADXAAAAAADXAAAAAABXAAAAAACXAAAAAAAegAAAAAAegAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAAADXAAAAAACXAAAAAACXAAAAAAAXAAAAAABIwAAAAAAXAAAAAAAegAAAAABegAAAAACfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAXAAAAAADYQAAAAAAXAAAAAADXAAAAAAAfQAAAAAAXAAAAAABegAAAAADegAAAAABfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAXAAAAAADYQAAAAAAegAAAAADegAAAAABegAAAAACegAAAAADegAAAAAAegAAAAABfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAXAAAAAAAYQAAAAAAegAAAAABegAAAAABegAAAAAAegAAAAABegAAAAACegAAAAADfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALgAAAAADfQAAAAAAfQAAAAAAegAAAAADegAAAAAAegAAAAABegAAAAACegAAAAAAegAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAALgAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          version: 6
+        0,-1:
+          ind: 0,-1
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAfQAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAAACHgAAAAACfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAALgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAAABHgAAAAADHgAAAAAAfQAAAAAAeQAAAAABeQAAAAADeQAAAAADeQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAAAAHgAAAAACHgAAAAADfQAAAAAAeQAAAAAAeQAAAAAAeQAAAAADeQAAAAADfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAHgAAAAADfQAAAAAAeQAAAAAAeQAAAAADeQAAAAADeQAAAAACeQAAAAABfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAIgAAAAACfQAAAAAAeQAAAAACeQAAAAACeQAAAAABeQAAAAABeQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAIgAAAAAAfQAAAAAAfQAAAAAAHgAAAAACfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXAAAAAAAXAAAAAADXAAAAAAAXAAAAAACXAAAAAAAYQAAAAAAYQAAAAAAYQAAAAAAfQAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYQAAAAAAYQAAAAAAXAAAAAABXAAAAAABXAAAAAAAXAAAAAAAXAAAAAACXAAAAAADfQAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          version: 6
+        -1,-1:
+          ind: -1,-1
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAHwAAAAADHwAAAAACHwAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAawAAAAAAawAAAAAAawAAAAAAfQAAAAAAHwAAAAAALgAAAAAAHwAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAHwAAAAABHwAAAAACHwAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAfQAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAfQAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAfQAAAAAAIwAAAAADfQAAAAAAfQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALgAAAAAAfQAAAAAAeQAAAAACeQAAAAABeQAAAAABfQAAAAAAXAAAAAAC
+          version: 6
+        -1,0:
+          ind: -1,0
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAeQAAAAABeQAAAAABLgAAAAABeQAAAAACXAAAAAACXAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAeQAAAAAAeQAAAAAALgAAAAABeQAAAAADfQAAAAAAHgAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAeQAAAAADeQAAAAAAeQAAAAAAeQAAAAABfQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAHwAAAAAAfQAAAAAAfQAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAHwAAAAADHwAAAAADHwAAAAACfQAAAAAAfAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAHwAAAAACHwAAAAABHwAAAAACfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAHwAAAAAAHwAAAAAAHwAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALgAAAAADfQAAAAAAfQAAAAAAfQAAAAAALgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          version: 6
+    - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      angularDamping: 0.05
+      linearDamping: 0.05
+      fixedRotation: False
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures: {}
+    - type: OccluderTree
+    - type: SpreaderGrid
+    - type: Shuttle
+    - type: GridPathfinding
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+    - type: DecalGrid
+      chunkCollection:
+        version: 2
+        nodes:
+        - node:
+            color: '#FFFFFFFF'
+            id: Bot
+          decals:
+            137: -2,-4
+        - node:
+            color: '#FFFFFFFF'
+            id: Box
+          decals:
+            87: -4,-4
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileDarkCornerNe
+          decals:
+            34: -1,-6
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileDarkCornerNw
+          decals:
+            31: -3,-6
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileDarkCornerSe
+          decals:
+            32: -1,-8
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileDarkCornerSw
+          decals:
+            33: -3,-8
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileDarkInnerNe
+          decals:
+            43: -3,-8
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileDarkInnerNw
+          decals:
+            44: -1,-8
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileDarkInnerSe
+          decals:
+            45: -3,-6
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileDarkInnerSw
+          decals:
+            46: -1,-6
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileDarkLineE
+          decals:
+            41: -3,-7
+            42: -1,-7
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileDarkLineN
+          decals:
+            37: -2,-6
+            38: -2,-8
+            85: 1,-3
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileDarkLineS
+          decals:
+            35: -2,-8
+            36: -2,-6
+            86: 1,-4
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileDarkLineW
+          decals:
+            39: -1,-7
+            40: -3,-7
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileSteelCornerNe
+          decals:
+            78: 1,0
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileSteelCornerNw
+          decals:
+            79: 0,0
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileSteelCornerSe
+          decals:
+            81: 1,-1
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileSteelCornerSw
+          decals:
+            80: 0,-1
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileSteelEndE
+          decals:
+            62: 7,-2
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileSteelEndN
+          decals:
+            63: 2,4
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileSteelEndS
+          decals:
+            64: 2,2
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileSteelEndW
+          decals:
+            65: 5,-2
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileSteelLineE
+          decals:
+            67: 2,3
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileSteelLineN
+          decals:
+            68: 6,-2
+            92: 4,-3
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileSteelLineS
+          decals:
+            69: 6,-2
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileSteelLineW
+          decals:
+            66: 2,3
+        - node:
+            angle: 1.5707963267948966 rad
+            color: '#FFFFFFFF'
+            id: Caution
+          decals:
+            97: -6,-8
+            98: -6,-6
+        - node:
+            color: '#FFFFFFFF'
+            id: Delivery
+          decals:
+            88: -1,-3
+            89: -1,-4
+        - node:
+            color: '#FFA647FF'
+            id: DeliveryGreyscale
+          decals:
+            90: -4,-2
+        - node:
+            color: '#52B4E9FF'
+            id: DiagonalCheckerAOverlay
+          decals:
+            59: 5,-2
+            60: 6,-2
+            61: 7,-2
+        - node:
+            color: '#639137FF'
+            id: DiagonalCheckerAOverlay
+          decals:
+            23: -3,-6
+            24: -3,-7
+            25: -3,-8
+            26: -2,-8
+            27: -1,-8
+            28: -1,-7
+            29: -1,-6
+            30: -2,-6
+        - node:
+            color: '#9A54BFFF'
+            id: DiagonalCheckerAOverlay
+          decals:
+            56: 2,2
+            57: 2,3
+            58: 2,4
+        - node:
+            color: '#FF9821FF'
+            id: DiagonalCheckerAOverlay
+          decals:
+            74: 0,-1
+            75: 1,-1
+            76: 1,0
+            77: 0,0
+        - node:
+            color: '#334E6DC8'
+            id: DiagonalCheckerBOverlay
+          decals:
+            7: -5,4
+            8: -4,4
+            101: -5,5
+            102: -4,5
+            122: -6,4
+            123: -6,5
+            135: -4,3
+        - node:
+            color: '#37789BFF'
+            id: DiagonalCheckerBOverlay
+          decals:
+            50: 5,-2
+            51: 6,-2
+            52: 7,-2
+        - node:
+            color: '#446326FF'
+            id: DiagonalCheckerBOverlay
+          decals:
+            15: -3,-6
+            16: -3,-7
+            17: -3,-8
+            18: -2,-6
+            19: -1,-6
+            20: -1,-7
+            21: -1,-8
+            22: -2,-8
+        - node:
+            color: '#774194FF'
+            id: DiagonalCheckerBOverlay
+          decals:
+            53: 2,4
+            54: 2,3
+            55: 2,2
+        - node:
+            color: '#AE6716FF'
+            id: DiagonalCheckerBOverlay
+          decals:
+            70: 0,-1
+            71: 1,-1
+            72: 1,0
+            73: 0,0
+        - node:
+            color: '#334E6DC8'
+            id: DiagonalOverlay
+          decals:
+            103: -4,6
+            104: -5,6
+            124: -6,6
+        - node:
+            color: '#EFB3414C'
+            id: HalfTileOverlayGreyscale
+          decals:
+            136: -4,-3
+        - node:
+            color: '#639137CC'
+            id: MiniTileCheckerAOverlay
+          decals:
+            83: 1,-3
+            84: 1,-4
+        - node:
+            color: '#FFFFFFFF'
+            id: MiniTileDarkInnerNe
+          decals:
+            96: 4,0
+        - node:
+            color: '#FFFFFFFF'
+            id: MiniTileDarkInnerNw
+          decals:
+            127: 6,0
+        - node:
+            color: '#FFFFFFFF'
+            id: MiniTileDarkInnerSe
+          decals:
+            94: 4,2
+        - node:
+            color: '#FFFFFFFF'
+            id: MiniTileDarkInnerSw
+          decals:
+            126: 6,2
+        - node:
+            color: '#FFFFFFFF'
+            id: MiniTileDarkLineE
+          decals:
+            93: 4,1
+        - node:
+            color: '#FFFFFFFF'
+            id: MiniTileDarkLineN
+          decals:
+            95: 5,0
+        - node:
+            color: '#FFFFFFFF'
+            id: MiniTileDarkLineW
+          decals:
+            133: 6,1
+        - node:
+            color: '#FFFF00FF'
+            id: WarnLineGreyscaleW
+          decals:
+            99: -6,-8
+            100: -6,-6
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinCornerNe
+          decals:
+            10: 7,-4
+            117: -3,2
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinCornerNw
+          decals:
+            0: -5,2
+            9: 3,-4
+            118: -6,2
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinCornerSe
+          decals:
+            1: -3,-1
+            112: 7,-7
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinCornerSw
+          decals:
+            2: -5,-1
+            11: 3,-5
+            82: 3,3
+            107: 4,-7
+            116: -6,0
+            128: 7,0
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinEndN
+          decals:
+            113: -4,1
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinEndS
+          decals:
+            114: -4,0
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinInnerSw
+          decals:
+            105: 4,-5
+            121: -5,0
+            131: 7,3
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinLineE
+          decals:
+            4: -3,1
+            5: -3,0
+            110: 7,-5
+            111: 7,-6
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinLineN
+          decals:
+            3: -4,2
+            12: 4,-4
+            13: 5,-4
+            14: 6,-4
+            119: -5,2
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinLineS
+          decals:
+            6: -4,-1
+            48: 4,3
+            49: 5,3
+            91: 4,-3
+            108: 5,-7
+            109: 6,-7
+            115: -4,-1
+            132: 6,3
+            134: 8,0
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinLineW
+          decals:
+            47: 3,4
+            106: 4,-6
+            120: -6,1
+            125: 3,5
+            129: 7,1
+            130: 7,2
+    - type: GridAtmosphere
+      version: 2
+      data:
+        tiles:
+          0,0:
+            0: 65535
+          0,-1:
+            0: 65535
+          -1,-1:
+            0: 65535
+          0,1:
+            0: 3311
+            1: 528
+          1,0:
+            0: 65535
+          1,1:
+            0: 4095
+          2,0:
+            0: 13107
+          2,1:
+            0: 307
+            1: 512
+          0,-3:
+            0: 12288
+            1: 49152
+          0,-2:
+            0: 65535
+          1,-2:
+            0: 65535
+          1,-1:
+            0: 65535
+          2,-2:
+            0: 4368
+            1: 1
+          2,-1:
+            0: 4369
+            1: 8704
+          -2,-3:
+            0: 57344
+          -2,-2:
+            0: 61166
+          -2,-1:
+            1: 9284
+            0: 51336
+          -1,-3:
+            0: 61440
+          -1,-2:
+            0: 65535
+          -2,0:
+            0: 61166
+          -2,1:
+            0: 52974
+            1: 8192
+          -1,0:
+            0: 32767
+            1: 32768
+          -1,1:
+            0: 22387
+            1: 8204
+          1,-3:
+            1: 4096
+        uniqueMixes:
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 21.824879
+          - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        chunkSize: 4
+    - type: GasTileOverlay
+    - type: RadiationGridResistance
+    - type: NavMap
+- proto: AirAlarm
+  entities:
+  - uid: 480
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 2
+    - type: DeviceList
+      devices:
+      - 386
+      - 384
+      - 469
+      - 512
+      - 193
+      - 197
+    - type: AtmosDevice
+      joinedGrid: 2
+- proto: AirCanister
+  entities:
+  - uid: 299
+    components:
+    - type: Transform
+      pos: -3.5,-3.5
+      parent: 2
+    - type: AtmosDevice
+      joinedGrid: 2
+- proto: Airlock
+  entities:
+  - uid: 3
+    components:
+    - type: Transform
+      pos: 4.5,-2.5
+      parent: 2
+- proto: AirlockCommand
+  entities:
+  - uid: 22
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 2
+- proto: AirlockCommandGlass
+  entities:
+  - uid: 161
+    components:
+    - type: Transform
+      pos: -3.5,3.5
+      parent: 2
+- proto: AirlockEngineering
+  entities:
+  - uid: 23
+    components:
+    - type: Transform
+      pos: -3.5,-1.5
+      parent: 2
+- proto: AirlockExternalGlass
+  entities:
+  - uid: 159
+    components:
+    - type: Transform
+      pos: -3.5,-7.5
+      parent: 2
+  - uid: 160
+    components:
+    - type: Transform
+      pos: -3.5,-5.5
+      parent: 2
+- proto: AirlockGlass
+  entities:
+  - uid: 24
+    components:
+    - type: Transform
+      pos: 1.5,-4.5
+      parent: 2
+- proto: AirlockGlassShuttle
+  entities:
+  - uid: 410
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-5.5
+      parent: 2
+  - uid: 412
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-7.5
+      parent: 2
+- proto: AirSensor
+  entities:
+  - uid: 512
+    components:
+    - type: Transform
+      pos: 7.5,4.5
+      parent: 2
+    - type: DeviceNetwork
+      configurators:
+      - invalid
+      deviceLists:
+      - 480
+- proto: APCBasic
+  entities:
+  - uid: 288
+    components:
+    - type: Transform
+      rot: 4.71238898038469 rad
+      pos: 2.5,-2.5
+      parent: 2
+  - uid: 298
+    components:
+    - type: Transform
+      pos: -2.5,-1.5
+      parent: 2
+- proto: AtmosDeviceFanTiny
+  entities:
+  - uid: 25
+    components:
+    - type: Transform
+      pos: -6.5,-7.5
+      parent: 2
+  - uid: 26
+    components:
+    - type: Transform
+      pos: -6.5,-5.5
+      parent: 2
+- proto: AtmosFixBlockerMarker
+  entities:
+  - uid: 30
+    components:
+    - type: Transform
+      pos: -2.5,7.5
+      parent: 2
+  - uid: 254
+    components:
+    - type: Transform
+      pos: 9.5,-0.5
+      parent: 2
+  - uid: 287
+    components:
+    - type: Transform
+      pos: 4.5,-8.5
+      parent: 2
+  - uid: 290
+    components:
+    - type: Transform
+      pos: 1.5,6.5
+      parent: 2
+  - uid: 402
+    components:
+    - type: Transform
+      pos: -5.5,-1.5
+      parent: 2
+  - uid: 403
+    components:
+    - type: Transform
+      pos: -5.5,-2.5
+      parent: 2
+  - uid: 404
+    components:
+    - type: Transform
+      pos: -5.5,-3.5
+      parent: 2
+  - uid: 405
+    components:
+    - type: Transform
+      pos: 2.5,-8.5
+      parent: 2
+  - uid: 407
+    components:
+    - type: Transform
+      pos: -0.5,4.5
+      parent: 2
+  - uid: 408
+    components:
+    - type: Transform
+      pos: -0.5,3.5
+      parent: 2
+  - uid: 435
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 2
+  - uid: 444
+    components:
+    - type: Transform
+      pos: 8.5,-7.5
+      parent: 2
+  - uid: 454
+    components:
+    - type: Transform
+      pos: -6.5,7.5
+      parent: 2
+  - uid: 462
+    components:
+    - type: Transform
+      pos: 3.5,-8.5
+      parent: 2
+  - uid: 484
+    components:
+    - type: Transform
+      pos: 9.5,6.5
+      parent: 2
+  - uid: 485
+    components:
+    - type: Transform
+      pos: -1.5,4.5
+      parent: 2
+  - uid: 486
+    components:
+    - type: Transform
+      pos: -6.5,-0.5
+      parent: 2
+  - uid: 513
+    components:
+    - type: Transform
+      pos: 9.5,-1.5
+      parent: 2
+- proto: BookshelfFilled
+  entities:
+  - uid: 14
+    components:
+    - type: Transform
+      pos: 3.5,2.5
+      parent: 2
+  - uid: 244
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 2
+  - uid: 245
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 2
+  - uid: 246
+    components:
+    - type: Transform
+      pos: 7.5,-0.5
+      parent: 2
+  - uid: 247
+    components:
+    - type: Transform
+      pos: 6.5,-0.5
+      parent: 2
+  - uid: 248
+    components:
+    - type: Transform
+      pos: 3.5,1.5
+      parent: 2
+  - uid: 250
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 2
+  - uid: 251
+    components:
+    - type: Transform
+      pos: 5.5,-0.5
+      parent: 2
+  - uid: 255
+    components:
+    - type: Transform
+      pos: -0.5,-0.5
+      parent: 2
+  - uid: 256
+    components:
+    - type: Transform
+      pos: 1.5,2.5
+      parent: 2
+  - uid: 257
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 2
+  - uid: 259
+    components:
+    - type: Transform
+      pos: 3.5,-1.5
+      parent: 2
+  - uid: 300
+    components:
+    - type: Transform
+      pos: 2.5,-1.5
+      parent: 2
+- proto: CableApcExtension
+  entities:
+  - uid: 4
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 2
+  - uid: 27
+    components:
+    - type: Transform
+      pos: -5.5,-6.5
+      parent: 2
+  - uid: 28
+    components:
+    - type: Transform
+      pos: -5.5,-5.5
+      parent: 2
+  - uid: 81
+    components:
+    - type: Transform
+      pos: -3.5,3.5
+      parent: 2
+  - uid: 92
+    components:
+    - type: Transform
+      pos: 5.5,-5.5
+      parent: 2
+  - uid: 146
+    components:
+    - type: Transform
+      pos: 6.5,-1.5
+      parent: 2
+  - uid: 149
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 2
+  - uid: 151
+    components:
+    - type: Transform
+      pos: -5.5,-7.5
+      parent: 2
+  - uid: 191
+    components:
+    - type: Transform
+      pos: -4.5,5.5
+      parent: 2
+  - uid: 311
+    components:
+    - type: Transform
+      pos: -2.5,-1.5
+      parent: 2
+  - uid: 312
+    components:
+    - type: Transform
+      pos: -3.5,-1.5
+      parent: 2
+  - uid: 313
+    components:
+    - type: Transform
+      pos: -3.5,-2.5
+      parent: 2
+  - uid: 314
+    components:
+    - type: Transform
+      pos: -3.5,-3.5
+      parent: 2
+  - uid: 315
+    components:
+    - type: Transform
+      pos: -3.5,-0.5
+      parent: 2
+  - uid: 316
+    components:
+    - type: Transform
+      pos: -3.5,0.5
+      parent: 2
+  - uid: 317
+    components:
+    - type: Transform
+      pos: -3.5,1.5
+      parent: 2
+  - uid: 318
+    components:
+    - type: Transform
+      pos: -3.5,2.5
+      parent: 2
+  - uid: 322
+    components:
+    - type: Transform
+      pos: -3.5,4.5
+      parent: 2
+  - uid: 333
+    components:
+    - type: Transform
+      pos: 2.5,-2.5
+      parent: 2
+  - uid: 334
+    components:
+    - type: Transform
+      pos: 1.5,-2.5
+      parent: 2
+  - uid: 335
+    components:
+    - type: Transform
+      pos: 1.5,-3.5
+      parent: 2
+  - uid: 336
+    components:
+    - type: Transform
+      pos: 1.5,-4.5
+      parent: 2
+  - uid: 337
+    components:
+    - type: Transform
+      pos: 1.5,-5.5
+      parent: 2
+  - uid: 338
+    components:
+    - type: Transform
+      pos: 1.5,-6.5
+      parent: 2
+  - uid: 339
+    components:
+    - type: Transform
+      pos: 2.5,-6.5
+      parent: 2
+  - uid: 340
+    components:
+    - type: Transform
+      pos: 0.5,-6.5
+      parent: 2
+  - uid: 341
+    components:
+    - type: Transform
+      pos: -0.5,-6.5
+      parent: 2
+  - uid: 342
+    components:
+    - type: Transform
+      pos: -1.5,-6.5
+      parent: 2
+  - uid: 343
+    components:
+    - type: Transform
+      pos: -2.5,-6.5
+      parent: 2
+  - uid: 344
+    components:
+    - type: Transform
+      pos: -2.5,-5.5
+      parent: 2
+  - uid: 345
+    components:
+    - type: Transform
+      pos: -3.5,-5.5
+      parent: 2
+  - uid: 346
+    components:
+    - type: Transform
+      pos: -4.5,-5.5
+      parent: 2
+  - uid: 349
+    components:
+    - type: Transform
+      pos: 1.5,-1.5
+      parent: 2
+  - uid: 350
+    components:
+    - type: Transform
+      pos: 1.5,-0.5
+      parent: 2
+  - uid: 351
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 2
+  - uid: 352
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 2
+  - uid: 353
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 2
+  - uid: 354
+    components:
+    - type: Transform
+      pos: -0.5,1.5
+      parent: 2
+  - uid: 355
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 2
+  - uid: 356
+    components:
+    - type: Transform
+      pos: 2.5,2.5
+      parent: 2
+  - uid: 357
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 2
+  - uid: 359
+    components:
+    - type: Transform
+      pos: -4.5,4.5
+      parent: 2
+  - uid: 365
+    components:
+    - type: Transform
+      pos: 2.5,-0.5
+      parent: 2
+  - uid: 366
+    components:
+    - type: Transform
+      pos: 3.5,-0.5
+      parent: 2
+  - uid: 367
+    components:
+    - type: Transform
+      pos: 4.5,-0.5
+      parent: 2
+  - uid: 368
+    components:
+    - type: Transform
+      pos: 4.5,-1.5
+      parent: 2
+  - uid: 369
+    components:
+    - type: Transform
+      pos: 5.5,-1.5
+      parent: 2
+  - uid: 370
+    components:
+    - type: Transform
+      pos: 4.5,-2.5
+      parent: 2
+  - uid: 371
+    components:
+    - type: Transform
+      pos: 4.5,-3.5
+      parent: 2
+  - uid: 372
+    components:
+    - type: Transform
+      pos: 4.5,-4.5
+      parent: 2
+  - uid: 434
+    components:
+    - type: Transform
+      pos: 4.5,-5.5
+      parent: 2
+  - uid: 439
+    components:
+    - type: Transform
+      pos: 6.5,-5.5
+      parent: 2
+  - uid: 515
+    components:
+    - type: Transform
+      pos: 4.5,4.5
+      parent: 2
+  - uid: 517
+    components:
+    - type: Transform
+      pos: 5.5,4.5
+      parent: 2
+  - uid: 518
+    components:
+    - type: Transform
+      pos: 6.5,4.5
+      parent: 2
+  - uid: 519
+    components:
+    - type: Transform
+      pos: 7.5,4.5
+      parent: 2
+  - uid: 520
+    components:
+    - type: Transform
+      pos: 7.5,3.5
+      parent: 2
+  - uid: 521
+    components:
+    - type: Transform
+      pos: 7.5,2.5
+      parent: 2
+  - uid: 522
+    components:
+    - type: Transform
+      pos: 7.5,1.5
+      parent: 2
+- proto: CableHV
+  entities:
+  - uid: 304
+    components:
+    - type: Transform
+      pos: -0.5,-2.5
+      parent: 2
+  - uid: 305
+    components:
+    - type: Transform
+      pos: -0.5,-3.5
+      parent: 2
+- proto: CableMV
+  entities:
+  - uid: 306
+    components:
+    - type: Transform
+      pos: -0.5,-3.5
+      parent: 2
+  - uid: 307
+    components:
+    - type: Transform
+      pos: -1.5,-3.5
+      parent: 2
+  - uid: 308
+    components:
+    - type: Transform
+      pos: -2.5,-3.5
+      parent: 2
+  - uid: 309
+    components:
+    - type: Transform
+      pos: -2.5,-2.5
+      parent: 2
+  - uid: 310
+    components:
+    - type: Transform
+      pos: -2.5,-1.5
+      parent: 2
+  - uid: 323
+    components:
+    - type: Transform
+      pos: -2.5,-0.5
+      parent: 2
+  - uid: 324
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 2
+  - uid: 325
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 2
+  - uid: 326
+    components:
+    - type: Transform
+      pos: -0.5,0.5
+      parent: 2
+  - uid: 327
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 2
+  - uid: 328
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 2
+  - uid: 329
+    components:
+    - type: Transform
+      pos: 1.5,-0.5
+      parent: 2
+  - uid: 330
+    components:
+    - type: Transform
+      pos: 1.5,-1.5
+      parent: 2
+  - uid: 331
+    components:
+    - type: Transform
+      pos: 1.5,-2.5
+      parent: 2
+  - uid: 332
+    components:
+    - type: Transform
+      pos: 2.5,-2.5
+      parent: 2
+- proto: CarpetBlack
+  entities:
+  - uid: 47
+    components:
+    - type: Transform
+      pos: 7.5,-4.5
+      parent: 2
+  - uid: 56
+    components:
+    - type: Transform
+      pos: 6.5,-4.5
+      parent: 2
+  - uid: 57
+    components:
+    - type: Transform
+      pos: 7.5,-5.5
+      parent: 2
+  - uid: 400
+    components:
+    - type: Transform
+      pos: 6.5,-5.5
+      parent: 2
+  - uid: 401
+    components:
+    - type: Transform
+      pos: 6.5,-6.5
+      parent: 2
+  - uid: 437
+    components:
+    - type: Transform
+      pos: 5.5,-5.5
+      parent: 2
+  - uid: 442
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-4.5
+      parent: 2
+  - uid: 465
+    components:
+    - type: Transform
+      pos: 4.5,-5.5
+      parent: 2
+  - uid: 466
+    components:
+    - type: Transform
+      pos: 4.5,-4.5
+      parent: 2
+  - uid: 467
+    components:
+    - type: Transform
+      pos: 7.5,-6.5
+      parent: 2
+  - uid: 468
+    components:
+    - type: Transform
+      pos: 5.5,-6.5
+      parent: 2
+  - uid: 476
+    components:
+    - type: Transform
+      pos: 4.5,-6.5
+      parent: 2
+- proto: CarpetPurple
+  entities:
+  - uid: 527
+    components:
+    - type: Transform
+      pos: -5.5,0.5
+      parent: 2
+  - uid: 528
+    components:
+    - type: Transform
+      pos: -4.5,2.5
+      parent: 2
+  - uid: 529
+    components:
+    - type: Transform
+      pos: -5.5,1.5
+      parent: 2
+  - uid: 530
+    components:
+    - type: Transform
+      pos: -5.5,2.5
+      parent: 2
+  - uid: 531
+    components:
+    - type: Transform
+      pos: -4.5,1.5
+      parent: 2
+  - uid: 532
+    components:
+    - type: Transform
+      pos: -4.5,0.5
+      parent: 2
+- proto: ChairOfficeLight
+  entities:
+  - uid: 71
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,1.5
+      parent: 2
+- proto: ChairPilotSeat
+  entities:
+  - uid: 321
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,5.5
+      parent: 2
+- proto: ChairWood
+  entities:
+  - uid: 88
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-5.5
+      parent: 2
+  - uid: 154
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-4.5
+      parent: 2
+  - uid: 227
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-5.5
+      parent: 2
+  - uid: 438
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-6.5
+      parent: 2
+  - uid: 447
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-6.5
+      parent: 2
+- proto: ClothingEyesGlasses
+  entities:
+  - uid: 534
+    components:
+    - type: Transform
+      pos: -5.477126,1.2807136
+      parent: 2
+- proto: ClothingNeckHeadphones
+  entities:
+  - uid: 441
+    components:
+    - type: Transform
+      pos: 3.5629697,-3.3435507
+      parent: 2
+- proto: ComfyChair
+  entities:
+  - uid: 64
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,0.5
+      parent: 2
+  - uid: 66
+    components:
+    - type: Transform
+      pos: 7.5,2.5
+      parent: 2
+  - uid: 141
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,5.5
+      parent: 2
+  - uid: 142
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,4.5
+      parent: 2
+  - uid: 176
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,4.5
+      parent: 2
+  - uid: 218
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,5.5
+      parent: 2
+  - uid: 225
+    components:
+    - type: Transform
+      pos: 5.5,-4.5
+      parent: 2
+  - uid: 235
+    components:
+    - type: Transform
+      pos: 8.5,2.5
+      parent: 2
+  - uid: 271
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,4.5
+      parent: 2
+  - uid: 362
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,5.5
+      parent: 2
+- proto: ComputerTabletopShuttle
+  entities:
+  - uid: 186
+    components:
+    - type: Transform
+      pos: -4.5,6.5
+      parent: 2
+- proto: ComputerTabletopStationRecords
+  entities:
+  - uid: 67
+    components:
+    - type: Transform
+      pos: -3.5,6.5
+      parent: 2
+- proto: ComputerWallmountWithdrawBankATM
+  entities:
+  - uid: 523
+    components:
+    - type: Transform
+      pos: -2.5,-4.5
+      parent: 2
+    - type: Physics
+      canCollide: False
+    - type: ContainerContainer
+      containers:
+        board: !type:Container
+          ents: []
+        bank-ATM-cashSlot: !type:ContainerSlot {}
+    - type: ItemSlots
+- proto: CrateServiceGuidebooks
+  entities:
+  - uid: 73
+    components:
+    - type: Transform
+      pos: -2.5,2.5
+      parent: 2
+- proto: DefibrillatorCabinetFilled
+  entities:
+  - uid: 430
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,-2.5
+      parent: 2
+- proto: Dresser
+  entities:
+  - uid: 516
+    components:
+    - type: Transform
+      pos: -4.5,-0.5
+      parent: 2
+- proto: EmergencyLight
+  entities:
+  - uid: 35
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,4.5
+      parent: 2
+  - uid: 242
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-6.5
+      parent: 2
+  - uid: 263
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-2.5
+      parent: 2
+  - uid: 280
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,1.5
+      parent: 2
+  - uid: 284
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-0.5
+      parent: 2
+  - uid: 285
+    components:
+    - type: Transform
+      pos: -2.5,-2.5
+      parent: 2
+  - uid: 363
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,5.5
+      parent: 2
+  - uid: 385
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,0.5
+      parent: 2
+  - uid: 392
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-1.5
+      parent: 2
+  - uid: 397
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-6.5
+      parent: 2
+  - uid: 399
+    components:
+    - type: Transform
+      pos: 6.5,-3.5
+      parent: 2
+- proto: ExtinguisherCabinetFilled
+  entities:
+  - uid: 525
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 2
+- proto: FaxMachineShip
+  entities:
+  - uid: 292
+    components:
+    - type: Transform
+      pos: -5.5,2.5
+      parent: 2
+- proto: filingCabinetDrawerRandom
+  entities:
+  - uid: 296
+    components:
+    - type: Transform
+      pos: -3.5,5.5
+      parent: 2
+- proto: Firelock
+  entities:
+  - uid: 387
+    components:
+    - type: Transform
+      pos: -3.5,-1.5
+      parent: 2
+- proto: FirelockGlass
+  entities:
+  - uid: 34
+    components:
+    - type: Transform
+      pos: -3.5,3.5
+      parent: 2
+  - uid: 384
+    components:
+    - type: Transform
+      pos: 1.5,-4.5
+      parent: 2
+    - type: DeviceNetwork
+      configurators:
+      - invalid
+      deviceLists:
+      - 480
+  - uid: 386
+    components:
+    - type: Transform
+      pos: 4.5,-2.5
+      parent: 2
+    - type: DeviceNetwork
+      configurators:
+      - invalid
+      deviceLists:
+      - 480
+  - uid: 469
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 2
+    - type: DeviceNetwork
+      configurators:
+      - invalid
+      deviceLists:
+      - 480
+- proto: Fireplace
+  entities:
+  - uid: 258
+    components:
+    - type: Transform
+      pos: 5.5,1.5
+      parent: 2
+- proto: FolderSpawner
+  entities:
+  - uid: 32
+    components:
+    - type: Transform
+      pos: -0.17129111,1.5183665
+      parent: 2
+  - uid: 33
+    components:
+    - type: Transform
+      pos: 0.016208887,1.6643009
+      parent: 2
+  - uid: 302
+    components:
+    - type: Transform
+      pos: -4.3900414,2.6233003
+      parent: 2
+- proto: GasPassiveVent
+  entities:
+  - uid: 134
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-2.5
+      parent: 2
+    - type: AtmosDevice
+      joinedGrid: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPipeBend
+  entities:
+  - uid: 77
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 78
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 80
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 181
+    components:
+    - type: Transform
+      pos: -3.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 208
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 212
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 226
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 232
+    components:
+    - type: Transform
+      pos: 4.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 234
+    components:
+    - type: Transform
+      pos: 5.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 237
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 319
+    components:
+    - type: Transform
+      pos: -4.5,4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 415
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPipeFourway
+  entities:
+  - uid: 128
+    components:
+    - type: Transform
+      pos: -4.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPipeStraight
+  entities:
+  - uid: 54
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 55
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 70
+    components:
+    - type: Transform
+      pos: -4.5,3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 72
+    components:
+    - type: Transform
+      pos: -4.5,2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 76
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 122
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 135
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 165
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 171
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 172
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 177
+    components:
+    - type: Transform
+      pos: -3.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 178
+    components:
+    - type: Transform
+      pos: -3.5,2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 179
+    components:
+    - type: Transform
+      pos: -3.5,3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 182
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 189
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 190
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 192
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 194
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 195
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 198
+    components:
+    - type: Transform
+      pos: 1.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 199
+    components:
+    - type: Transform
+      pos: 1.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 200
+    components:
+    - type: Transform
+      pos: 1.5,-2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 201
+    components:
+    - type: Transform
+      pos: 1.5,-3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 202
+    components:
+    - type: Transform
+      pos: 1.5,-4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 204
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 205
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 206
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 207
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 210
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 216
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 219
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 220
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 221
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 222
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 223
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 228
+    components:
+    - type: Transform
+      pos: 5.5,-2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 229
+    components:
+    - type: Transform
+      pos: 5.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 231
+    components:
+    - type: Transform
+      pos: 5.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 360
+    components:
+    - type: Transform
+      pos: -4.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 416
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 417
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 418
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 419
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasPipeTJunction
+  entities:
+  - uid: 83
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 126
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 163
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 170
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 174
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 183
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 196
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 203
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 230
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 265
+    components:
+    - type: Transform
+      pos: 0.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPort
+  entities:
+  - uid: 168
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-3.5
+      parent: 2
+    - type: AtmosDevice
+      joinedGrid: 2
+- proto: GasPressurePump
+  entities:
+  - uid: 169
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-3.5
+      parent: 2
+    - type: AtmosDevice
+      joinedGrid: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasVentPump
+  entities:
+  - uid: 75
+    components:
+    - type: Transform
+      pos: -3.5,4.5
+      parent: 2
+    - type: AtmosDevice
+      joinedGrid: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 90
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-3.5
+      parent: 2
+    - type: AtmosDevice
+      joinedGrid: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 167
+    components:
+    - type: Transform
+      pos: -1.5,-2.5
+      parent: 2
+    - type: AtmosDevice
+      joinedGrid: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 193
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-0.5
+      parent: 2
+    - type: DeviceNetwork
+      configurators:
+      - invalid
+      deviceLists:
+      - 480
+    - type: AtmosDevice
+      joinedGrid: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 213
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-5.5
+      parent: 2
+    - type: AtmosDevice
+      joinedGrid: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 320
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,1.5
+      parent: 2
+    - type: AtmosDevice
+      joinedGrid: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 421
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-5.5
+      parent: 2
+    - type: AtmosDevice
+      joinedGrid: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasVentScrubber
+  entities:
+  - uid: 166
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-2.5
+      parent: 2
+    - type: AtmosDevice
+      joinedGrid: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 180
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,0.5
+      parent: 2
+    - type: AtmosDevice
+      joinedGrid: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 197
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-0.5
+      parent: 2
+    - type: DeviceNetwork
+      configurators:
+      - invalid
+      deviceLists:
+      - 480
+    - type: AtmosDevice
+      joinedGrid: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 209
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-3.5
+      parent: 2
+    - type: AtmosDevice
+      joinedGrid: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 217
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-7.5
+      parent: 2
+    - type: AtmosDevice
+      joinedGrid: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 393
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,4.5
+      parent: 2
+    - type: AtmosDevice
+      joinedGrid: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 420
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-7.5
+      parent: 2
+    - type: AtmosDevice
+      joinedGrid: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GrassBattlemap
+  entities:
+  - uid: 85
+    components:
+    - type: Transform
+      pos: 6.0013742,-5.916195
+      parent: 2
+- proto: GravityGeneratorMini
+  entities:
+  - uid: 394
+    components:
+    - type: Transform
+      pos: -1.5,-3.5
+      parent: 2
+- proto: Grille
+  entities:
+  - uid: 21
+    components:
+    - type: Transform
+      pos: -0.5,-8.5
+      parent: 2
+  - uid: 40
+    components:
+    - type: Transform
+      pos: -4.5,-2.5
+      parent: 2
+  - uid: 51
+    components:
+    - type: Transform
+      pos: 8.5,-1.5
+      parent: 2
+  - uid: 53
+    components:
+    - type: Transform
+      pos: -0.5,2.5
+      parent: 2
+  - uid: 58
+    components:
+    - type: Transform
+      pos: -3.5,7.5
+      parent: 2
+  - uid: 87
+    components:
+    - type: Transform
+      pos: 8.5,-4.5
+      parent: 2
+  - uid: 99
+    components:
+    - type: Transform
+      pos: 0.5,-8.5
+      parent: 2
+  - uid: 102
+    components:
+    - type: Transform
+      pos: -4.5,7.5
+      parent: 2
+  - uid: 264
+    components:
+    - type: Transform
+      pos: -6.5,6.5
+      parent: 2
+  - uid: 270
+    components:
+    - type: Transform
+      pos: -5.5,7.5
+      parent: 2
+  - uid: 358
+    components:
+    - type: Transform
+      pos: -2.5,6.5
+      parent: 2
+  - uid: 406
+    components:
+    - type: Transform
+      pos: 5.5,-7.5
+      parent: 2
+  - uid: 413
+    components:
+    - type: Transform
+      pos: -6.5,-6.5
+      parent: 2
+  - uid: 449
+    components:
+    - type: Transform
+      pos: 6.5,-7.5
+      parent: 2
+  - uid: 452
+    components:
+    - type: Transform
+      pos: 8.5,-5.5
+      parent: 2
+  - uid: 459
+    components:
+    - type: Transform
+      pos: -6.5,2.5
+      parent: 2
+  - uid: 460
+    components:
+    - type: Transform
+      pos: -6.5,1.5
+      parent: 2
+  - uid: 487
+    components:
+    - type: Transform
+      pos: 3.5,6.5
+      parent: 2
+  - uid: 488
+    components:
+    - type: Transform
+      pos: 4.5,6.5
+      parent: 2
+  - uid: 489
+    components:
+    - type: Transform
+      pos: 5.5,6.5
+      parent: 2
+  - uid: 490
+    components:
+    - type: Transform
+      pos: 6.5,6.5
+      parent: 2
+  - uid: 491
+    components:
+    - type: Transform
+      pos: 7.5,6.5
+      parent: 2
+  - uid: 492
+    components:
+    - type: Transform
+      pos: 8.5,6.5
+      parent: 2
+  - uid: 493
+    components:
+    - type: Transform
+      pos: 9.5,5.5
+      parent: 2
+  - uid: 494
+    components:
+    - type: Transform
+      pos: 9.5,4.5
+      parent: 2
+  - uid: 495
+    components:
+    - type: Transform
+      pos: 9.5,3.5
+      parent: 2
+  - uid: 496
+    components:
+    - type: Transform
+      pos: 9.5,2.5
+      parent: 2
+  - uid: 497
+    components:
+    - type: Transform
+      pos: 9.5,1.5
+      parent: 2
+- proto: GrilleDiagonal
+  entities:
+  - uid: 272
+    components:
+    - type: Transform
+      pos: -6.5,7.5
+      parent: 2
+  - uid: 273
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,7.5
+      parent: 2
+- proto: Gyroscope
+  entities:
+  - uid: 48
+    components:
+    - type: Transform
+      pos: -0.5,3.5
+      parent: 2
+- proto: LampGold
+  entities:
+  - uid: 84
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.7832494,-3.1715982
+      parent: 2
+  - uid: 233
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.622149,5.6428695
+      parent: 2
+  - uid: 249
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.68543017,1.7031286
+      parent: 2
+- proto: LuxuryPen
+  entities:
+  - uid: 79
+    components:
+    - type: Transform
+      pos: -5.2979145,1.5203409
+      parent: 2
+- proto: MagicDiceBag
+  entities:
+  - uid: 289
+    components:
+    - type: Transform
+      pos: 5.9076242,-5.3741517
+      parent: 2
+- proto: MysteryFigureBox
+  entities:
+  - uid: 86
+    components:
+    - type: Transform
+      pos: 6.3284388,-3.2490983
+      parent: 2
+  - uid: 238
+    components:
+    - type: Transform
+      pos: 6.2763557,-3.4680002
+      parent: 2
+- proto: PaintingCafeTerraceAtNight
+  entities:
+  - uid: 428
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-2.5
+      parent: 2
+- proto: Paper
+  entities:
+  - uid: 82
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.527081,1.7600908
+      parent: 2
+  - uid: 125
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.589581,1.6245801
+      parent: 2
+  - uid: 293
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.3604145,1.9268732
+      parent: 2
+  - uid: 295
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.4437475,1.8539064
+      parent: 2
+- proto: PaperBin20
+  entities:
+  - uid: 483
+    components:
+    - type: Transform
+      pos: -5.5,5.5
+      parent: 2
+- proto: PaperCNCSheet
+  entities:
+  - uid: 93
+    components:
+    - type: Transform
+      pos: 6.7097077,-6.218488
+      parent: 2
+  - uid: 153
+    components:
+    - type: Transform
+      pos: 5.3701053,-6.094825
+      parent: 2
+  - uid: 348
+    components:
+    - type: Transform
+      pos: 5.4013553,-5.4693894
+      parent: 2
+  - uid: 473
+    components:
+    - type: Transform
+      pos: 6.690682,-5.355764
+      parent: 2
+- proto: Pen
+  entities:
+  - uid: 291
+    components:
+    - type: Transform
+      pos: 6.3492723,-5.2817597
+      parent: 2
+  - uid: 470
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.6166532,1.7344003
+      parent: 2
+  - uid: 472
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.59581983,1.4946504
+      parent: 2
+- proto: PlushieLizard
+  entities:
+  - uid: 89
+    components:
+    - type: Transform
+      pos: 5.5065675,-4.5128217
+      parent: 2
+- proto: PlushieMoffRandom
+  entities:
+  - uid: 286
+    components:
+    - type: Transform
+      pos: 2.628676,-6.4389977
+      parent: 2
+- proto: PortableGeneratorPacmanShuttle
+  entities:
+  - uid: 131
+    components:
+    - type: Transform
+      pos: -0.5,-2.5
+      parent: 2
+    - type: FuelGenerator
+      on: False
+    - type: Physics
+      bodyType: Static
+- proto: PosterContrabandWehWatches
+  entities:
+  - uid: 524
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 2
+- proto: PosterLegitWalk
+  entities:
+  - uid: 423
+    components:
+    - type: Transform
+      pos: -1.5,-4.5
+      parent: 2
+- proto: PottedPlantRandom
+  entities:
+  - uid: 143
+    components:
+    - type: Transform
+      pos: 6.5,5.5
+      parent: 2
+  - uid: 239
+    components:
+    - type: Transform
+      pos: 8.5,3.5
+      parent: 2
+  - uid: 241
+    components:
+    - type: Transform
+      pos: 0.5,-7.5
+      parent: 2
+  - uid: 281
+    components:
+    - type: Transform
+      pos: -5.5,-6.5
+      parent: 2
+  - uid: 297
+    components:
+    - type: Transform
+      pos: 0.5,-5.5
+      parent: 2
+- proto: PowerCellRecharger
+  entities:
+  - uid: 482
+    components:
+    - type: Transform
+      pos: -5.5,6.5
+      parent: 2
+- proto: Poweredlight
+  entities:
+  - uid: 74
+    components:
+    - type: Transform
+      pos: -4.5,2.5
+      parent: 2
+  - uid: 211
+    components:
+    - type: Transform
+      pos: 5.5,-3.5
+      parent: 2
+    - type: Timer
+  - uid: 260
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 2
+  - uid: 477
+    components:
+    - type: Transform
+      pos: -0.5,-5.5
+      parent: 2
+- proto: PoweredSmallLight
+  entities:
+  - uid: 31
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,3.5
+      parent: 2
+  - uid: 243
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-6.5
+      parent: 2
+  - uid: 253
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 2
+  - uid: 262
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-3.5
+      parent: 2
+  - uid: 377
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,4.5
+      parent: 2
+  - uid: 391
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-1.5
+      parent: 2
+  - uid: 396
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-3.5
+      parent: 2
+  - uid: 478
+    components:
+    - type: Transform
+      pos: 3.5,-8.5
+      parent: 2
+  - uid: 514
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,4.5
+      parent: 2
+  - uid: 526
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-3.5
+      parent: 2
+- proto: RandomBook
+  entities:
+  - uid: 117
+    components:
+    - type: Transform
+      pos: -5.5,0.5
+      parent: 2
+  - uid: 147
+    components:
+    - type: Transform
+      pos: 7.5,1.5
+      parent: 2
+  - uid: 425
+    components:
+    - type: Transform
+      pos: 4.5,4.5
+      parent: 2
+  - uid: 431
+    components:
+    - type: Transform
+      pos: 3.5,-3.5
+      parent: 2
+- proto: RandomPainting
+  entities:
+  - uid: 61
+    components:
+    - type: Transform
+      pos: -5.5,3.5
+      parent: 2
+  - uid: 422
+    components:
+    - type: Transform
+      pos: -0.5,-4.5
+      parent: 2
+  - uid: 426
+    components:
+    - type: Transform
+      pos: -2.5,-8.5
+      parent: 2
+  - uid: 429
+    components:
+    - type: Transform
+      pos: 2.5,-3.5
+      parent: 2
+- proto: RandomPosterAny
+  entities:
+  - uid: 424
+    components:
+    - type: Transform
+      pos: 6.5,-2.5
+      parent: 2
+- proto: ReinforcedWindow
+  entities:
+  - uid: 42
+    components:
+    - type: Transform
+      pos: -4.5,-2.5
+      parent: 2
+  - uid: 59
+    components:
+    - type: Transform
+      pos: -0.5,2.5
+      parent: 2
+  - uid: 91
+    components:
+    - type: Transform
+      pos: 8.5,-4.5
+      parent: 2
+  - uid: 100
+    components:
+    - type: Transform
+      pos: -0.5,-8.5
+      parent: 2
+  - uid: 101
+    components:
+    - type: Transform
+      pos: 0.5,-8.5
+      parent: 2
+  - uid: 137
+    components:
+    - type: Transform
+      pos: -6.5,2.5
+      parent: 2
+  - uid: 138
+    components:
+    - type: Transform
+      pos: -6.5,1.5
+      parent: 2
+  - uid: 155
+    components:
+    - type: Transform
+      pos: -6.5,6.5
+      parent: 2
+  - uid: 175
+    components:
+    - type: Transform
+      pos: -5.5,7.5
+      parent: 2
+  - uid: 376
+    components:
+    - type: Transform
+      pos: -2.5,6.5
+      parent: 2
+  - uid: 388
+    components:
+    - type: Transform
+      pos: 8.5,-1.5
+      parent: 2
+  - uid: 414
+    components:
+    - type: Transform
+      pos: -6.5,-6.5
+      parent: 2
+  - uid: 448
+    components:
+    - type: Transform
+      pos: 8.5,-5.5
+      parent: 2
+  - uid: 450
+    components:
+    - type: Transform
+      pos: 5.5,-7.5
+      parent: 2
+  - uid: 456
+    components:
+    - type: Transform
+      pos: -3.5,7.5
+      parent: 2
+  - uid: 458
+    components:
+    - type: Transform
+      pos: -4.5,7.5
+      parent: 2
+  - uid: 464
+    components:
+    - type: Transform
+      pos: 6.5,-7.5
+      parent: 2
+  - uid: 499
+    components:
+    - type: Transform
+      pos: 9.5,1.5
+      parent: 2
+  - uid: 500
+    components:
+    - type: Transform
+      pos: 9.5,2.5
+      parent: 2
+  - uid: 501
+    components:
+    - type: Transform
+      pos: 9.5,3.5
+      parent: 2
+  - uid: 502
+    components:
+    - type: Transform
+      pos: 9.5,4.5
+      parent: 2
+  - uid: 503
+    components:
+    - type: Transform
+      pos: 9.5,5.5
+      parent: 2
+  - uid: 504
+    components:
+    - type: Transform
+      pos: 3.5,6.5
+      parent: 2
+  - uid: 505
+    components:
+    - type: Transform
+      pos: 4.5,6.5
+      parent: 2
+  - uid: 506
+    components:
+    - type: Transform
+      pos: 5.5,6.5
+      parent: 2
+  - uid: 507
+    components:
+    - type: Transform
+      pos: 6.5,6.5
+      parent: 2
+  - uid: 508
+    components:
+    - type: Transform
+      pos: 7.5,6.5
+      parent: 2
+  - uid: 509
+    components:
+    - type: Transform
+      pos: 8.5,6.5
+      parent: 2
+- proto: ReinforcedWindowDiagonal
+  entities:
+  - uid: 29
+    components:
+    - type: Transform
+      pos: -6.5,7.5
+      parent: 2
+  - uid: 164
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,7.5
+      parent: 2
+- proto: SheetPlasma
+  entities:
+  - uid: 274
+    components:
+    - type: Transform
+      pos: -1.5,-2.5
+      parent: 2
+- proto: ShuttersNormalOpen
+  entities:
+  - uid: 15
+    components:
+    - type: Transform
+      pos: 7.5,6.5
+      parent: 2
+    - type: DeviceLinkSink
+      links:
+      - 214
+  - uid: 68
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,1.5
+      parent: 2
+    - type: DeviceLinkSink
+      links:
+      - 63
+  - uid: 123
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,2.5
+      parent: 2
+    - type: DeviceLinkSink
+      links:
+      - 63
+  - uid: 144
+    components:
+    - type: Transform
+      pos: 3.5,6.5
+      parent: 2
+    - type: DeviceLinkSink
+      links:
+      - 214
+  - uid: 158
+    components:
+    - type: Transform
+      pos: 6.5,-7.5
+      parent: 2
+    - type: DeviceLinkSink
+      links:
+      - 475
+  - uid: 162
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-4.5
+      parent: 2
+    - type: DeviceLinkSink
+      links:
+      - 475
+  - uid: 240
+    components:
+    - type: Transform
+      pos: 5.5,6.5
+      parent: 2
+    - type: DeviceLinkSink
+      links:
+      - 214
+  - uid: 275
+    components:
+    - type: Transform
+      pos: 4.5,6.5
+      parent: 2
+    - type: DeviceLinkSink
+      links:
+      - 214
+  - uid: 276
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,2.5
+      parent: 2
+    - type: DeviceLinkSink
+      links:
+      - 283
+  - uid: 277
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,3.5
+      parent: 2
+    - type: DeviceLinkSink
+      links:
+      - 283
+  - uid: 278
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,4.5
+      parent: 2
+    - type: DeviceLinkSink
+      links:
+      - 283
+  - uid: 279
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,5.5
+      parent: 2
+    - type: DeviceLinkSink
+      links:
+      - 283
+  - uid: 282
+    components:
+    - type: Transform
+      pos: 8.5,6.5
+      parent: 2
+    - type: DeviceLinkSink
+      links:
+      - 214
+  - uid: 294
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,1.5
+      parent: 2
+    - type: DeviceLinkSink
+      links:
+      - 283
+  - uid: 301
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-5.5
+      parent: 2
+    - type: DeviceLinkSink
+      links:
+      - 475
+  - uid: 373
+    components:
+    - type: Transform
+      pos: 5.5,-7.5
+      parent: 2
+    - type: DeviceLinkSink
+      links:
+      - 475
+  - uid: 380
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-2.5
+      parent: 2
+    - type: DeviceLinkSink
+      links:
+      - 381
+  - uid: 432
+    components:
+    - type: Transform
+      pos: 6.5,6.5
+      parent: 2
+    - type: DeviceLinkSink
+      links:
+      - 214
+- proto: SignalButtonDirectional
+  entities:
+  - uid: 63
+    components:
+    - type: Transform
+      pos: -4.5,3.5
+      parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        123:
+        - Pressed: Toggle
+        68:
+        - Pressed: Toggle
+  - uid: 214
+    components:
+    - type: Transform
+      pos: 2.5,5.5
+      parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        144:
+        - Pressed: Toggle
+        275:
+        - Pressed: Toggle
+        240:
+        - Pressed: Toggle
+        432:
+        - Pressed: Toggle
+        15:
+        - Pressed: Toggle
+        282:
+        - Pressed: Toggle
+  - uid: 283
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,0.5
+      parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        294:
+        - Pressed: Toggle
+        276:
+        - Pressed: Toggle
+        277:
+        - Pressed: Toggle
+        278:
+        - Pressed: Toggle
+        279:
+        - Pressed: Toggle
+  - uid: 381
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-3.5
+      parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        380:
+        - Pressed: Toggle
+  - uid: 475
+    components:
+    - type: Transform
+      pos: 5.5,-2.5
+      parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        162:
+        - Pressed: Toggle
+        301:
+        - Pressed: Toggle
+        373:
+        - Pressed: Toggle
+        158:
+        - Pressed: Toggle
+- proto: SignBridge
+  entities:
+  - uid: 69
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 2
+- proto: SignDirectionalLibrary
+  entities:
+  - uid: 148
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-6.5
+      parent: 2
+- proto: SignElectricalMed
+  entities:
+  - uid: 133
+    components:
+    - type: Transform
+      pos: -1.5,-1.5
+      parent: 2
+- proto: SignLibrary
+  entities:
+  - uid: 382
+    components:
+    - type: Transform
+      pos: -6.5,-4.5
+      parent: 2
+  - uid: 409
+    components:
+    - type: Transform
+      pos: -6.5,-8.5
+      parent: 2
+- proto: SpawnPointLatejoin
+  entities:
+  - uid: 398
+    components:
+    - type: Transform
+      pos: -3.5,0.5
+      parent: 2
+- proto: SpawnPointLibrarian
+  entities:
+  - uid: 62
+    components:
+    - type: Transform
+      pos: -3.5,1.5
+      parent: 2
+- proto: SpawnPointPilot
+  entities:
+  - uid: 136
+    components:
+    - type: Transform
+      pos: -4.5,4.5
+      parent: 2
+- proto: SteelBench
+  entities:
+  - uid: 129
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-6.5
+      parent: 2
+- proto: SubstationBasic
+  entities:
+  - uid: 132
+    components:
+    - type: Transform
+      pos: -0.5,-3.5
+      parent: 2
+- proto: SuitStorageWallmountEVA
+  entities:
+  - uid: 433
+    components:
+    - type: Transform
+      pos: -2.5,3.5
+      parent: 2
+    - type: Physics
+      canCollide: False
+- proto: Table
+  entities:
+  - uid: 130
+    components:
+    - type: Transform
+      pos: -4.5,6.5
+      parent: 2
+  - uid: 236
+    components:
+    - type: Transform
+      pos: -3.5,6.5
+      parent: 2
+  - uid: 479
+    components:
+    - type: Transform
+      pos: -5.5,5.5
+      parent: 2
+  - uid: 481
+    components:
+    - type: Transform
+      pos: -5.5,6.5
+      parent: 2
+- proto: TableCarpet
+  entities:
+  - uid: 127
+    components:
+    - type: Transform
+      pos: 5.5,-6.5
+      parent: 2
+  - uid: 152
+    components:
+    - type: Transform
+      pos: 6.5,-6.5
+      parent: 2
+  - uid: 395
+    components:
+    - type: Transform
+      pos: 5.5,-5.5
+      parent: 2
+  - uid: 440
+    components:
+    - type: Transform
+      pos: 6.5,-5.5
+      parent: 2
+- proto: TableWood
+  entities:
+  - uid: 16
+    components:
+    - type: Transform
+      pos: -0.5,1.5
+      parent: 2
+  - uid: 65
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,1.5
+      parent: 2
+  - uid: 140
+    components:
+    - type: Transform
+      pos: 4.5,5.5
+      parent: 2
+  - uid: 185
+    components:
+    - type: Transform
+      pos: 7.5,1.5
+      parent: 2
+  - uid: 224
+    components:
+    - type: Transform
+      pos: 8.5,5.5
+      parent: 2
+  - uid: 266
+    components:
+    - type: Transform
+      pos: -5.5,1.5
+      parent: 2
+  - uid: 268
+    components:
+    - type: Transform
+      pos: 4.5,4.5
+      parent: 2
+  - uid: 269
+    components:
+    - type: Transform
+      pos: -5.5,0.5
+      parent: 2
+  - uid: 347
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 2
+  - uid: 361
+    components:
+    - type: Transform
+      pos: -4.5,2.5
+      parent: 2
+  - uid: 379
+    components:
+    - type: Transform
+      pos: -5.5,2.5
+      parent: 2
+  - uid: 436
+    components:
+    - type: Transform
+      pos: 3.5,-3.5
+      parent: 2
+  - uid: 446
+    components:
+    - type: Transform
+      pos: 6.5,-3.5
+      parent: 2
+- proto: Thruster
+  entities:
+  - uid: 5
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-1.5
+      parent: 2
+  - uid: 38
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-3.5
+      parent: 2
+  - uid: 49
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-8.5
+      parent: 2
+  - uid: 215
+    components:
+    - type: Transform
+      pos: -1.5,4.5
+      parent: 2
+  - uid: 261
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-8.5
+      parent: 2
+  - uid: 364
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-8.5
+      parent: 2
+  - uid: 375
+    components:
+    - type: Transform
+      pos: -0.5,4.5
+      parent: 2
+  - uid: 510
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,6.5
+      parent: 2
+- proto: ToyFigurineLibrarian
+  entities:
+  - uid: 1
+    components:
+    - type: Transform
+      pos: -4.8586664,2.6752667
+      parent: 2
+- proto: ToyFigurineRatServant
+  entities:
+  - uid: 474
+    components:
+    - type: Transform
+      pos: 5.9909577,-5.7285647
+      parent: 2
+- proto: ToyFigurineWizard
+  entities:
+  - uid: 188
+    components:
+    - type: Transform
+      pos: 5.5308723,-6.265061
+      parent: 2
+- proto: ToySkeleton
+  entities:
+  - uid: 156
+    components:
+    - type: Transform
+      pos: 6.2513747,-6.322727
+      parent: 2
+- proto: VendingMachineCuraDrobe
+  entities:
+  - uid: 150
+    components:
+    - type: Transform
+      pos: -2.5,-0.5
+      parent: 2
+- proto: VendingMachineGames
+  entities:
+  - uid: 445
+    components:
+    - type: Transform
+      pos: 7.5,-3.5
+      parent: 2
+- proto: WallReinforced
+  entities:
+  - uid: 6
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 2
+  - uid: 7
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 2
+  - uid: 8
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 2
+  - uid: 9
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 2
+  - uid: 11
+    components:
+    - type: Transform
+      pos: 1.5,5.5
+      parent: 2
+  - uid: 13
+    components:
+    - type: Transform
+      pos: 7.5,-7.5
+      parent: 2
+  - uid: 17
+    components:
+    - type: Transform
+      pos: 3.5,-7.5
+      parent: 2
+  - uid: 18
+    components:
+    - type: Transform
+      pos: 2.5,-7.5
+      parent: 2
+  - uid: 20
+    components:
+    - type: Transform
+      pos: 1.5,-8.5
+      parent: 2
+  - uid: 36
+    components:
+    - type: Transform
+      pos: -5.5,-0.5
+      parent: 2
+  - uid: 39
+    components:
+    - type: Transform
+      pos: -4.5,-1.5
+      parent: 2
+  - uid: 41
+    components:
+    - type: Transform
+      pos: -4.5,-3.5
+      parent: 2
+  - uid: 43
+    components:
+    - type: Transform
+      pos: -5.5,-4.5
+      parent: 2
+  - uid: 44
+    components:
+    - type: Transform
+      pos: -4.5,-4.5
+      parent: 2
+  - uid: 45
+    components:
+    - type: Transform
+      pos: -3.5,-4.5
+      parent: 2
+  - uid: 50
+    components:
+    - type: Transform
+      pos: 8.5,-2.5
+      parent: 2
+  - uid: 52
+    components:
+    - type: Transform
+      pos: 8.5,-0.5
+      parent: 2
+  - uid: 60
+    components:
+    - type: Transform
+      pos: 2.5,5.5
+      parent: 2
+  - uid: 94
+    components:
+    - type: Transform
+      pos: -5.5,-8.5
+      parent: 2
+  - uid: 95
+    components:
+    - type: Transform
+      pos: -4.5,-8.5
+      parent: 2
+  - uid: 96
+    components:
+    - type: Transform
+      pos: -3.5,-8.5
+      parent: 2
+  - uid: 97
+    components:
+    - type: Transform
+      pos: -2.5,-8.5
+      parent: 2
+  - uid: 98
+    components:
+    - type: Transform
+      pos: -1.5,-8.5
+      parent: 2
+  - uid: 112
+    components:
+    - type: Transform
+      pos: 8.5,-3.5
+      parent: 2
+  - uid: 139
+    components:
+    - type: Transform
+      pos: 2.5,6.5
+      parent: 2
+  - uid: 145
+    components:
+    - type: Transform
+      pos: -3.5,-6.5
+      parent: 2
+  - uid: 173
+    components:
+    - type: Transform
+      pos: -6.5,5.5
+      parent: 2
+  - uid: 187
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 2
+  - uid: 252
+    components:
+    - type: Transform
+      pos: 5.5,2.5
+      parent: 2
+  - uid: 267
+    components:
+    - type: Transform
+      pos: -2.5,3.5
+      parent: 2
+  - uid: 303
+    components:
+    - type: Transform
+      pos: -6.5,-8.5
+      parent: 2
+  - uid: 374
+    components:
+    - type: Transform
+      pos: -2.5,5.5
+      parent: 2
+  - uid: 383
+    components:
+    - type: Transform
+      pos: -6.5,-4.5
+      parent: 2
+  - uid: 427
+    components:
+    - type: Transform
+      pos: -2.5,4.5
+      parent: 2
+  - uid: 453
+    components:
+    - type: Transform
+      pos: 8.5,-6.5
+      parent: 2
+  - uid: 455
+    components:
+    - type: Transform
+      pos: -6.5,4.5
+      parent: 2
+  - uid: 457
+    components:
+    - type: Transform
+      pos: -6.5,3.5
+      parent: 2
+  - uid: 461
+    components:
+    - type: Transform
+      pos: -6.5,0.5
+      parent: 2
+  - uid: 463
+    components:
+    - type: Transform
+      pos: 4.5,-7.5
+      parent: 2
+  - uid: 498
+    components:
+    - type: Transform
+      pos: 9.5,0.5
+      parent: 2
+- proto: WallReinforcedDiagonal
+  entities:
+  - uid: 10
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 2
+  - uid: 12
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-7.5
+      parent: 2
+  - uid: 19
+    components:
+    - type: Transform
+      pos: 1.5,-7.5
+      parent: 2
+  - uid: 37
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-1.5
+      parent: 2
+  - uid: 184
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,6.5
+      parent: 2
+  - uid: 471
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-0.5
+      parent: 2
+  - uid: 511
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-0.5
+      parent: 2
+- proto: WallSolid
+  entities:
+  - uid: 46
+    components:
+    - type: Transform
+      pos: -2.5,-4.5
+      parent: 2
+  - uid: 103
+    components:
+    - type: Transform
+      pos: -2.5,-1.5
+      parent: 2
+  - uid: 104
+    components:
+    - type: Transform
+      pos: -1.5,-4.5
+      parent: 2
+  - uid: 105
+    components:
+    - type: Transform
+      pos: -0.5,-4.5
+      parent: 2
+  - uid: 106
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 2
+  - uid: 107
+    components:
+    - type: Transform
+      pos: 2.5,-4.5
+      parent: 2
+  - uid: 108
+    components:
+    - type: Transform
+      pos: 3.5,-5.5
+      parent: 2
+  - uid: 109
+    components:
+    - type: Transform
+      pos: 2.5,-3.5
+      parent: 2
+  - uid: 110
+    components:
+    - type: Transform
+      pos: 3.5,-2.5
+      parent: 2
+  - uid: 111
+    components:
+    - type: Transform
+      pos: 2.5,-2.5
+      parent: 2
+  - uid: 113
+    components:
+    - type: Transform
+      pos: 6.5,-2.5
+      parent: 2
+  - uid: 114
+    components:
+    - type: Transform
+      pos: 7.5,-2.5
+      parent: 2
+  - uid: 115
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 2
+  - uid: 116
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 2
+  - uid: 118
+    components:
+    - type: Transform
+      pos: -0.5,-1.5
+      parent: 2
+  - uid: 119
+    components:
+    - type: Transform
+      pos: -1.5,-1.5
+      parent: 2
+  - uid: 120
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 2
+  - uid: 121
+    components:
+    - type: Transform
+      pos: -1.5,-0.5
+      parent: 2
+  - uid: 124
+    components:
+    - type: Transform
+      pos: -4.5,3.5
+      parent: 2
+  - uid: 157
+    components:
+    - type: Transform
+      pos: 5.5,-2.5
+      parent: 2
+  - uid: 378
+    components:
+    - type: Transform
+      pos: -5.5,3.5
+      parent: 2
+  - uid: 451
+    components:
+    - type: Transform
+      pos: 3.5,-6.5
+      parent: 2
+- proto: WallSolidDiagonal
+  entities:
+  - uid: 389
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-1.5
+      parent: 2
+  - uid: 390
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-5.5
+      parent: 2
+- proto: WarpPointShip
+  entities:
+  - uid: 411
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-0.5
+      parent: 2
+- proto: WaterCooler
+  entities:
+  - uid: 443
+    components:
+    - type: Transform
+      pos: -2.5,-6.5
+      parent: 2
+- proto: Wrench
+  entities:
+  - uid: 533
+    components:
+    - type: Transform
+      pos: -3.5,-3.5
+      parent: 2
+...

--- a/Resources/Maps/_NF/Shuttles/bookworm.yml
+++ b/Resources/Maps/_NF/Shuttles/bookworm.yml
@@ -37,7 +37,7 @@ entities:
           version: 6
         -1,-1:
           ind: -1,-1
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAHwAAAAADHwAAAAACHwAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAawAAAAAAawAAAAAAawAAAAAAfQAAAAAAHwAAAAAALgAAAAAAHwAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAHwAAAAABHwAAAAACHwAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAfQAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAfQAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAfQAAAAAAIwAAAAADfQAAAAAAfQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALgAAAAAAfQAAAAAAeQAAAAACeQAAAAABeQAAAAABfQAAAAAAXAAAAAAC
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAHwAAAAADHwAAAAACHwAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAawAAAAAAawAAAAAAawAAAAAAfQAAAAAAHwAAAAAALgAAAAAAHwAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAHwAAAAABHwAAAAACHwAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAfQAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAfQAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAfQAAAAAAfQAAAAAAIwAAAAAAfQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALgAAAAAAfQAAAAAAeQAAAAACeQAAAAABeQAAAAABfQAAAAAAXAAAAAAC
           version: 6
         -1,0:
           ind: -1,0
@@ -180,10 +180,25 @@ entities:
           decals:
             65: 5,-2
         - node:
+            color: '#EFB341FF'
+            id: BrickTileSteelInnerNe
+          decals:
+            141: -4,-3
+        - node:
+            color: '#EFB341FF'
+            id: BrickTileSteelInnerNw
+          decals:
+            140: -2,-3
+        - node:
             color: '#FFFFFFFF'
             id: BrickTileSteelLineE
           decals:
             67: 2,3
+        - node:
+            color: '#EFB341FF'
+            id: BrickTileSteelLineN
+          decals:
+            139: -3,-3
         - node:
             color: '#FFFFFFFF'
             id: BrickTileSteelLineN
@@ -214,10 +229,10 @@ entities:
             88: -1,-3
             89: -1,-4
         - node:
-            color: '#FFA647FF'
+            color: '#EFB34196'
             id: DeliveryGreyscale
           decals:
-            90: -4,-2
+            138: -3,-2
         - node:
             color: '#52B4E9FF'
             id: DiagonalCheckerAOverlay
@@ -304,11 +319,6 @@ entities:
             103: -4,6
             104: -5,6
             124: -6,6
-        - node:
-            color: '#EFB3414C'
-            id: HalfTileOverlayGreyscale
-          decals:
-            136: -4,-3
         - node:
             color: '#639137CC'
             id: MiniTileCheckerAOverlay
@@ -587,10 +597,10 @@ entities:
       parent: 2
 - proto: AirlockEngineering
   entities:
-  - uid: 23
+  - uid: 541
     components:
     - type: Transform
-      pos: -3.5,-1.5
+      pos: -2.5,-1.5
       parent: 2
 - proto: AirlockExternalGlass
   entities:
@@ -645,10 +655,10 @@ entities:
       rot: 4.71238898038469 rad
       pos: 2.5,-2.5
       parent: 2
-  - uid: 298
+  - uid: 311
     components:
     - type: Transform
-      pos: -2.5,-1.5
+      pos: -3.5,-1.5
       parent: 2
 - proto: AtmosDeviceFanTiny
   entities:
@@ -867,11 +877,6 @@ entities:
     components:
     - type: Transform
       pos: -4.5,5.5
-      parent: 2
-  - uid: 311
-    components:
-    - type: Transform
-      pos: -2.5,-1.5
       parent: 2
   - uid: 312
     components:
@@ -1120,6 +1125,11 @@ entities:
       parent: 2
 - proto: CableHV
   entities:
+  - uid: 150
+    components:
+    - type: Transform
+      pos: -1.5,-2.5
+      parent: 2
   - uid: 304
     components:
     - type: Transform
@@ -1130,8 +1140,23 @@ entities:
     - type: Transform
       pos: -0.5,-3.5
       parent: 2
+  - uid: 538
+    components:
+    - type: Transform
+      pos: -2.5,-2.5
+      parent: 2
+  - uid: 539
+    components:
+    - type: Transform
+      pos: -3.5,-2.5
+      parent: 2
 - proto: CableMV
   entities:
+  - uid: 133
+    components:
+    - type: Transform
+      pos: -3.5,-0.5
+      parent: 2
   - uid: 306
     components:
     - type: Transform
@@ -1155,12 +1180,7 @@ entities:
   - uid: 310
     components:
     - type: Transform
-      pos: -2.5,-1.5
-      parent: 2
-  - uid: 323
-    components:
-    - type: Transform
-      pos: -2.5,-0.5
+      pos: -3.5,0.5
       parent: 2
   - uid: 324
     components:
@@ -1206,6 +1226,16 @@ entities:
     components:
     - type: Transform
       pos: 2.5,-2.5
+      parent: 2
+  - uid: 536
+    components:
+    - type: Transform
+      pos: -3.5,-1.5
+      parent: 2
+  - uid: 537
+    components:
+    - type: Transform
+      pos: -3.5,-2.5
       parent: 2
 - proto: CarpetBlack
   entities:
@@ -1272,32 +1302,32 @@ entities:
       parent: 2
 - proto: CarpetPurple
   entities:
-  - uid: 527
+  - uid: 528
     components:
     - type: Transform
       pos: -5.5,0.5
       parent: 2
-  - uid: 528
+  - uid: 529
     components:
     - type: Transform
       pos: -4.5,2.5
       parent: 2
-  - uid: 529
+  - uid: 530
     components:
     - type: Transform
       pos: -5.5,1.5
       parent: 2
-  - uid: 530
+  - uid: 531
     components:
     - type: Transform
       pos: -5.5,2.5
       parent: 2
-  - uid: 531
+  - uid: 532
     components:
     - type: Transform
       pos: -4.5,1.5
       parent: 2
-  - uid: 532
+  - uid: 533
     components:
     - type: Transform
       pos: -4.5,0.5
@@ -1352,7 +1382,7 @@ entities:
       parent: 2
 - proto: ClothingEyesGlasses
   entities:
-  - uid: 534
+  - uid: 535
     components:
     - type: Transform
       pos: -5.477126,1.2807136
@@ -1422,6 +1452,14 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,5.5
+      parent: 2
+- proto: ComputerPowerMonitoring
+  entities:
+  - uid: 540
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-2.5
       parent: 2
 - proto: ComputerTabletopShuttle
   entities:
@@ -1506,10 +1544,10 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -2.5,-0.5
       parent: 2
-  - uid: 285
+  - uid: 298
     components:
     - type: Transform
-      pos: -2.5,-2.5
+      pos: -1.5,-2.5
       parent: 2
   - uid: 363
     components:
@@ -1563,10 +1601,10 @@ entities:
       parent: 2
 - proto: Firelock
   entities:
-  - uid: 387
+  - uid: 1
     components:
     - type: Transform
-      pos: -3.5,-1.5
+      pos: -2.5,-1.5
       parent: 2
 - proto: FirelockGlass
   entities:
@@ -2203,8 +2241,6 @@ entities:
     - type: Transform
       pos: -1.5,-2.5
       parent: 2
-    - type: AtmosDevice
-      joinedGrid: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 193
@@ -2585,6 +2621,94 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -5.4437475,1.8539064
       parent: 2
+  - uid: 323
+    components:
+    - type: MetaData
+      name: pre-flight checklist
+    - type: Transform
+      pos: -2.2431207,-2.5094283
+      parent: 2
+    - type: Paper
+      stampState: paper_stamp-ce
+      stampedBy:
+      - stampedBorderless: False
+        stampedColor: '#C69B17FF'
+        stampedName: stamp-component-stamped-name-ce
+      content: >2
+
+        [color=#1B8CD6][head=1]=BB=[/head]
+
+        [head=2]BlueBird Starship Design & Construction[/head][/color]
+
+
+        [head=2][bold][color=#9413ED]Bookworm[/color][/bold][/head]
+
+        Dear Captain,
+
+        Thank you for your purchase of the BB Bookworm!
+
+        We hope this ship will serve you well as a place of respite for travellers from near and far.
+
+
+        [head=3][color=#1B8CD6]Pre-Flight Checklist[/head][/color]
+
+        1. Check all machines, generators and canisters are [bold]anchored[/bold].
+
+        2. Top off generator fuel.
+
+        3. Set [bold]generator output to 17 kW[/bold].
+
+        4. Start generator.
+
+        5. Check distro mixer and pump settings, then turn on.
+
+        6. Check gyro is turned on. 
+
+        7. Check all APCs are functioning and charged.
+  - uid: 387
+    components:
+    - type: MetaData
+      name: pre-flight checklist
+    - type: Transform
+      pos: -5.435256,6.066874
+      parent: 2
+    - type: Paper
+      stampState: paper_stamp-ce
+      stampedBy:
+      - stampedBorderless: False
+        stampedColor: '#C69B17FF'
+        stampedName: stamp-component-stamped-name-ce
+      content: >2
+
+        [color=#1B8CD6][head=1]=BB=[/head]
+
+        [head=2]BlueBird Starship Design & Construction[/head][/color]
+
+
+        [head=2][bold][color=#9413ED]Bookworm[/color][/bold][/head]
+
+        Dear Captain,
+
+        Thank you for your purchase of the BB Bookworm!
+
+        We hope this ship will serve you well as a place of respite for travellers from near and far.
+
+
+        [head=3][color=#1B8CD6]Pre-Flight Checklist[/head][/color]
+
+        1. Check all machines, generators and canisters are [bold]anchored[/bold].
+
+        2. Top off generator fuel.
+
+        3. Set [bold]generator output to 17 kW[/bold].
+
+        4. Start generator.
+
+        5. Check distro mixer and pump settings, then turn on.
+
+        6. Check gyro is turned on. 
+
+        7. Check all APCs are functioning and charged.
 - proto: PaperBin20
   entities:
   - uid: 483
@@ -2642,7 +2766,7 @@ entities:
       parent: 2
 - proto: PlushieMoffRandom
   entities:
-  - uid: 286
+  - uid: 478
     components:
     - type: Transform
       pos: 2.628676,-6.4389977
@@ -2731,7 +2855,7 @@ entities:
       parent: 2
 - proto: PoweredSmallLight
   entities:
-  - uid: 31
+  - uid: 188
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2772,18 +2896,18 @@ entities:
       rot: 3.141592653589793 rad
       pos: -2.5,-3.5
       parent: 2
-  - uid: 478
+  - uid: 514
     components:
     - type: Transform
       pos: 3.5,-8.5
       parent: 2
-  - uid: 514
+  - uid: 526
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,4.5
       parent: 2
-  - uid: 526
+  - uid: 527
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3211,8 +3335,7 @@ entities:
   - uid: 381
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,-3.5
+      pos: -1.75,-1.5
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
@@ -3250,10 +3373,10 @@ entities:
       parent: 2
 - proto: SignElectricalMed
   entities:
-  - uid: 133
+  - uid: 285
     components:
     - type: Transform
-      pos: -1.5,-1.5
+      pos: -0.5,-1.5
       parent: 2
 - proto: SignLibrary
   entities:
@@ -3474,7 +3597,7 @@ entities:
       parent: 2
 - proto: ToyFigurineLibrarian
   entities:
-  - uid: 1
+  - uid: 31
     components:
     - type: Transform
       pos: -4.8586664,2.6752667
@@ -3488,7 +3611,7 @@ entities:
       parent: 2
 - proto: ToyFigurineWizard
   entities:
-  - uid: 188
+  - uid: 286
     components:
     - type: Transform
       pos: 5.5308723,-6.265061
@@ -3502,10 +3625,10 @@ entities:
       parent: 2
 - proto: VendingMachineCuraDrobe
   entities:
-  - uid: 150
+  - uid: 23
     components:
     - type: Transform
-      pos: -2.5,-0.5
+      pos: -3.5,-0.5
       parent: 2
 - proto: VendingMachineGames
   entities:
@@ -3768,7 +3891,7 @@ entities:
   - uid: 103
     components:
     - type: Transform
-      pos: -2.5,-1.5
+      pos: -3.5,-1.5
       parent: 2
   - uid: 104
     components:
@@ -3901,7 +4024,7 @@ entities:
       parent: 2
 - proto: Wrench
   entities:
-  - uid: 533
+  - uid: 534
     components:
     - type: Transform
       pos: -3.5,-3.5

--- a/Resources/Prototypes/_NF/Shipyard/bookworm.yml
+++ b/Resources/Prototypes/_NF/Shipyard/bookworm.yml
@@ -1,0 +1,28 @@
+- type: vessel
+  id: Bookworm
+  name: SBB Bookworm
+  description: A cozy medium-size library for travellers who wish to relax with a book or perhaps a board game.
+  price: 28000
+  category: Medium
+  group: Civilian
+  shuttlePath: /Maps/_NF/Shuttles/bookworm.yml
+
+- type: gameMap
+  id: Bookworm
+  mapName: 'SBB Bookworm'
+  mapPath: /Maps/_NF/Shuttles/bookworm.yml
+  minPlayers: 0
+  stations:
+    Bookworm:
+      stationProto: StandardFrontierVessel
+      components:
+        - type: StationNameSetup
+          mapNameTemplate: 'Bookworm {1}'
+          nameGenerator:
+            !type:NanotrasenNameGenerator
+            prefixCreator: '14'
+        - type: StationJobs
+          overflowJobs: []
+          availableJobs:
+            Librarian: [ 0, 0 ]
+            Pilot: [ 0, 0 ]


### PR DESCRIPTION
## About the PR
Adds a new shuttle, the SBB Bookworm, a library ship with a large open reading room, a games room, and a private study for the librarian. This is the second vessel to come out of Shipyard BlueBird (the first being Lyrae, #1110).

## Why / Balance
You've mined every rock in sight, stripped every wreck, gone to planets and killed four dozen dragons and xenos, and your account balance is overflowing with more spesos than you could spend in a lifetime. It's time to _relax_. Why not visit the local library to read a book or play a board game? Maybe the librarian will write epic tales of your heroic conquests, or _you_ can write about your exciting smuggling adventures.

More RP-focused ships have been requested for a long time now, and I've been enjoying playing librarian on upstream. :)

Design considerations:

* The main library section, with all the bookshelves, is free of walls so librarians can redecorate as they see fit. The bookshelves were deliberately placed to break up the line of sight, helping this fairly small library feel dense with bookshelves.
* With such a big main compartment, I could imagine people retrofitting the ship for use as a cheap cargo hauler or inconspicuous smuggling vessel. The narrow corridor between the entrance area and the library is designed to counteract that kind of lame powergaming, or at least make it more work.
* With a total of 8 thrusters, the generator must run at an inefficient 17 kW. This did not feel like enough power draw to warrant using two generators or a SUPERPACMAN.
* Though libraries have limited money-making potential, there is still a withdraw-only ATM for librarians who wish to charge for their services.
* The large glass wall in the reading corner was heavily inspired by [Malmö City Library's](https://en.wikipedia.org/wiki/Malm%C3%B6_City_Library) [*Calendar of Light*](https://malmo.se/images/18.35f28b8a1706703719d4223/1582904720929/stadsbiblioteket-interior-753x500.jpg).
* The cell recharger on the bridge is for the many desk lamps strewn about the library.

**Statistics & info:**

* **Tile count:** 258 (medium)
* **Appraisal price:** ~25,330
* **Shipyard price:** 28,000, ~10% markup – I don't imagine owners of this ship will make much money, so I definitely don't want a huge markup
* **Recommended crew:** 1–3
* **Available roles:** Librarian, Pilot

### Known issues
* Wood is an incredibly expensive commodity on the Frontier, with a single stack of wood costing 7,000 spesos. With this ship's modest markup, a powergamer hungry for wood could save 12 grand by buying a Bookworm and breaking apart the bookshelves. Hopefully no one is silly enough to actually do this.
* The current random bookshelf fills are _too_ random. You may end up with 12 copies of _how to keep station clean_, or you get a bunch of unique titles. The number of books per shelf also varies. To introduce an element of non-randomness, there is a guidebooks crate in the librarian's office. Luckily, books have a value of 0 spesos, so the appraisal price of the shuttle won't vary at least.
* Several of the guidebooks open URLs that no longer work, making them effectively useless. If you get unlucky, you may get a mostly unreadable library.
* The only books that can be ordered from cargo are guidebooks (fixed selection) and blanks.

I may create a few more bookshelf prototypes for Frontier with different, more predictable, perhaps even themed random fills. I may also add more orderable book crates. These will both be separate PRs.

## Technical details
.yml

## Media
Preinit, with and without subfloor:
![image_2024-03-31_16-52-10](https://github.com/new-frontiers-14/frontier-station-14/assets/30327355/84b42fdb-0ff6-4f96-bc2a-d87d4a4520bb)
![image_2024-03-31_16-50-52](https://github.com/new-frontiers-14/frontier-station-14/assets/30327355/1bc20fce-4ca6-455b-831c-2f00873b9303)

Postinit:
![image_2024-03-31_16-49-59](https://github.com/new-frontiers-14/frontier-station-14/assets/30327355/dfc64870-0e47-4cec-ae63-79be5cb6bb16)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- add: Added the SBB Bookworm, a medium-sized library ship.