### PR TITLE
Fix Harpy speed

### DIFF
--- a/Resources/Prototypes/DeltaV/Entities/Mobs/Species/harpy.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Mobs/Species/harpy.yml
@@ -119,9 +119,6 @@
         singingLayer:
           False:  {visible: false}
           True:  {visible: true}
-  - type: MovementSpeedModifier
-    baseWalkSpeed: 2.5
-    baseSprintSpeed: 5.0
   - type: Inventory 
     speciesId: harpy
     templateId: digitigrade


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Harpies were too fast and too furious. They now walk the same speed as everyone else.
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Speed is too much of a bonus for species, this speed boost was also removed from Vulpkanin when they were ported over to Frontier.

**Changelog**

:cl: MagnusCrowe
- tweak: Harpies are no longer fast and furious.

