### PR TITLE
Divine cookie, an admin reward

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Objects/Consumable/Food/Baked/misc.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Consumable/Food/Baked/misc.yml
@@ -1,0 +1,30 @@
+- type: entity
+  name: divine cookie
+  parent: FoodBakedBase
+  id: FoodBakedCookieDivine
+  description: This cookie looks incredibly delicious. Whoever made it must really appreciate you.
+  suffix: DO NOT MAP
+  components:
+  - type: Sprite
+    state: cookie-sugar
+  - type: FlavorProfile
+    flavors:
+    - sublime
+    - magical
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 15
+        reagents:
+        - ReagentId: Sugar
+          Quantity: 5
+        - ReagentId: Nutriment
+          Quantity: 2
+        - ReagentId: Omnizine
+          Quantity: 5
+        - ReagentId: Flavorol
+          Quantity: 3
+  - type: PointLight
+    color: "#FFFFCC"
+    radius: 1.25
+    energy: 0.75


### PR DESCRIPTION
## About the PR
Adds a new admin item, the _divine cookie_.

## Why / Balance
Suggested by Jester: https://discord.com/channels/1123826877245694004/1224110014877139087/1224110014877139087

It can serve as a small reward for players who do something good, like submit an ahelp about a rule violation, or whatever else admins feel like. :) It glows with a soft, magical aura. It also tastes _so_ good it even heals your injuries!

This entity is marked "DO NOT MAP" for obvious reasons.

## Technical details
.yml

## Media
![image](https://github.com/new-frontiers-14/frontier-station-14/assets/30327355/0df87ebc-e65e-4213-b65f-073fa759a55d)
![image](https://github.com/new-frontiers-14/frontier-station-14/assets/30327355/94f1ede5-6a42-4606-bca5-61f00380e0e8)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
Not for an admin-only thing.