### PR TITLE
Add 'Admeme' to mapchecker as an illegal match

### DIFF
--- a/.github/mapchecker/config.py
+++ b/.github/mapchecker/config.py
@@ -2,6 +2,7 @@
 ILLEGAL_MATCHES = [
     "DO NOT MAP",
     "DEBUG",
+    "Admeme",
 	"CaptainSabre",
 	"ClothingBeltSheath",
 	"MagazinePistolHighCapacity",

--- a/.github/mapchecker/config.py
+++ b/.github/mapchecker/config.py
@@ -3,29 +3,29 @@ ILLEGAL_MATCHES = [
     "DO NOT MAP",
     "DEBUG",
     "Admeme",
-	"CaptainSabre",
-	"ClothingBeltSheath",
-	"MagazinePistolHighCapacity",
-	"MagazinePistolHighCapacityRubber",
-	"EncryptionKeyCommand",
-	"SurveillanceCameraWireless",
-	"CrewMonitoringServer",
-	"APCHighCapacity",
-	"APCSuperCapacity",
-	"APCHyperCapacity",
-	"PDA",
-	"SpawnPointPassenger",
-	"Python",
-	"SalvageShuttleMarker",
-	"FTLPoint",
+    "CaptainSabre",
+    "ClothingBeltSheath",
+    "MagazinePistolHighCapacity",
+    "MagazinePistolHighCapacityRubber",
+    "EncryptionKeyCommand",
+    "SurveillanceCameraWireless",
+    "CrewMonitoringServer",
+    "APCHighCapacity",
+    "APCSuperCapacity",
+    "APCHyperCapacity",
+    "PDA",
+    "SpawnPointPassenger",
+    "Python",
+    "SalvageShuttleMarker",
+    "FTLPoint",
 ]
 # List of matchers that are illegal to use, unless the map is a ship and the ship belongs to the keyed shipyard.
 CONDITIONALLY_ILLEGAL_MATCHES = {
     "Security": [  # These matchers are illegal unless the ship is part of the security shipyard.
         "Security",  # Anything with the word security in it should also only be appearing on security ships.
         "Plastitanium",  # Plastitanium walls should only be appearing on security ships.
-		"Kammerer", # Opportunity
-		"HighSecDoor",
+        "Kammerer", # Opportunity
+        "HighSecDoor",
     ],
     "BlackMarket": [
         "Plastitanium",  # And also on blackmarket ships cause syndicate.


### PR DESCRIPTION
## About the PR
Adds "Admeme" to the mapchecker's list of illegal matches.

## Why / Balance
The suffixes `Admeme` and `DO NOT MAP` are currently mutually exclusive, but admeme entities should under no circumstances be mapped. Since it's easy to detect them, let's do so!

## Technical details
One line of Python!

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
Not unless someone's committed a severe mapping sin. :)