### PR TITLE
Change NFSD playtime requirements

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Security/prisonguard.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Security/prisonguard.yml
@@ -4,10 +4,13 @@
   description: job-description-guard
   playTimeTracker: JobPrisonGuard
   requirements:
+    - !type:DepartmentTimeRequirement
+      department: Security
+      time: 10800 # 3 hrs
     - !type:OverallPlaytimeRequirement
       time: 36000 # Frontier - 10 hrs
   startingGear: PrisonGuardGear
-  icon: "JobIconWarden" 
+  icon: "JobIconWarden"
   supervisors: job-supervisors-hos # Frontier
   canBeAntag: false
   access:

--- a/Resources/Prototypes/_NF/Roles/Jobs/NFSD/brigmedic.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/NFSD/brigmedic.yml
@@ -4,9 +4,9 @@
   description: job-description-brigmedic
   playTimeTracker: JobBrigmedic
   requirements:
-#    - !type:DepartmentTimeRequirement
-#      department: Medical
-#      time: 10800 # 3 hrs
+    - !type:DepartmentTimeRequirement
+      department: Security
+      time: 10800 # 3 hrs
     - !type:OverallPlaytimeRequirement
       time: 36000 # Frontier - 10 hrs
   startingGear: BrigmedicGear

--- a/Resources/Prototypes/_NF/Roles/Jobs/NFSD/detective.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/NFSD/detective.yml
@@ -4,6 +4,9 @@
   description: job-description-detective
   playTimeTracker: JobDetective
   requirements:
+    - !type:DepartmentTimeRequirement
+      department: Security
+      time: 10800 # 3 hrs
     - !type:OverallPlaytimeRequirement
       time: 36000 # Frontier - 10 hrs
   startingGear: DetectiveGear

--- a/Resources/Prototypes/_NF/Roles/Jobs/NFSD/head_of_security.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/NFSD/head_of_security.yml
@@ -4,21 +4,15 @@
   description: job-description-hos
   playTimeTracker: JobHeadOfSecurity
   requirements:
-    - !type:OverallPlaytimeRequirement
-      time: 50400
     - !type:WhitelistRequirement
-    # - !type:RoleTimeRequirement
-      # role: JobWarden
-      # time: 21600 #6 hrs
-    # - !type:RoleTimeRequirement
-      # role: JobDetective
-      # time: 7200 #2 hrs
-    # - !type:RoleTimeRequirement
-      # role: JobSecurityOfficer
-      # time: 36000 #10 hrs
-    # - !type:DepartmentTimeRequirement
-      # department: Security
-      # time: 108000 # 30 hrs
+    - !type:OverallPlaytimeRequirement
+      time: 108000 # Frontier - 30 hours
+    - !type:RoleTimeRequirement
+      role: JobSecurityOfficer
+      time: 10800 #3 hrs
+    - !type:DepartmentTimeRequirement
+      department: Security
+      time: 43200 # 12 hrs
   weight: 10
   startingGear: HoSGear
   alwaysUseSpawner: true
@@ -81,7 +75,7 @@
     head: ClothingHeadHatNfsdCampaign # Frontier
     id: NfsdSheriff # Frontier
     gloves: ClothingHandsGlovesCombatNfsdCream # Frontier
-    ears: ClothingHeadsetAltNFSDCreamandBrown # Frontier 
+    ears: ClothingHeadsetAltNFSDCreamandBrown # Frontier
     belt: ClothingBeltNfsdWebbingFilled # Frontier
     pocket1: WeaponPistolMk58Nonlethal
     pocket2: HoloprojectorSecurity # Frontier

--- a/Resources/Prototypes/_NF/Roles/Jobs/NFSD/security_officer.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/NFSD/security_officer.yml
@@ -5,7 +5,7 @@
   playTimeTracker: JobSecurityOfficer
   requirements:
     - !type:OverallPlaytimeRequirement
-      time: 36000 # Frontier - 10 hrs
+      time: 21600 # Frontier - 6 hrs
   startingGear: SecurityOfficerGear
   icon: "JobIconSecurityOfficer"
   supervisors: job-supervisors-hos

--- a/Resources/Prototypes/_NF/Roles/Jobs/NFSD/senior_officer.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/NFSD/senior_officer.yml
@@ -4,18 +4,14 @@
   description: job-description-senior-officer
   playTimeTracker: JobSeniorOfficer
   requirements:
-    - !type:RoleTimeRequirement
-      role: JobWarden
-      time: 21600 #6 hrs
-#    - !type:RoleTimeRequirement
-#      role: JobDetective
-#      time: 7200 #2 hrs
+    - !type:OverallPlaytimeRequirement
+      time: 108000 # Frontier - 30 hours
     - !type:RoleTimeRequirement
       role: JobSecurityOfficer
-      time: 21600 #6 hrs
+      time: 10800 #3 hrs
     - !type:DepartmentTimeRequirement
       department: Security
-      time: 72000 # 20 hrs
+      time: 32400 # 9 hrs
   startingGear: SeniorOfficerGear
   icon: "JobIconSeniorOfficer"
   supervisors: job-supervisors-hos

--- a/Resources/Prototypes/_NF/Roles/Jobs/NFSD/warden.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/NFSD/warden.yml
@@ -5,10 +5,13 @@
   playTimeTracker: JobWarden
   requirements:
     - !type:OverallPlaytimeRequirement
-      time: 21600 # Frontier - 6 hours
+      time: 54000 # Frontier - 15 hours
     - !type:RoleTimeRequirement
       role: JobSecurityOfficer
-      time: 36000 # Frontier - 10 hrs
+      time: 10800 # Frontier - 3 hrs
+    - !type:DepartmentTimeRequirement
+      department: Security
+      time: 21600 # 6 hrs
   startingGear: WardenGear
   icon: "JobIconWarden"
   supervisors: job-supervisors-hos


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Updates and changes NFSD hours so it ends up as:

- Sheriff 12 hours in sec department + 30 in general
- Sergeant 9 hours in sec department + 3 hours as Deputy + 30 in general
- Warden 6 hours in sec department + 3 hours as Deputy + 15 in general
- Brigmedic, Prison guard, Detective 3 hours in sec department + 10 in general
- Deputy 6 hours in general
- Cadet 3 hours in general 

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
This hours take into account that sometimes people get directly hired to the NFSD so they don't do their times regularly.

**Changelog**

:cl: Leander
- tweak: NFSD hour requirements have been updated.

