### PR TITLE
Remove gravity guns

### DIFF
--- a/Resources/Prototypes/Research/experimental.yml
+++ b/Resources/Prototypes/Research/experimental.yml
@@ -170,18 +170,18 @@
   - SuperMatterBinStockPart
   - PicoManipulatorStockPart
 
-- type: technology
-  id: GravityManipulation
-  name: research-technology-gravity-manipulation
-  icon:
-    sprite: Objects/Weapons/Guns/Launchers/tether_gun.rsi
-    state: base
-  discipline: Experimental
-  tier: 3
-  cost: 10000
-  recipeUnlocks:
-    - WeaponForceGun
-    - WeaponTetherGun
+#- type: technology # Frontier - too many physics issues, bugs and exploits, the less we look like gmod the better.
+#  id: GravityManipulation
+#  name: research-technology-gravity-manipulation
+#  icon:
+#    sprite: Objects/Weapons/Guns/Launchers/tether_gun.rsi
+#    state: base
+#  discipline: Experimental
+#  tier: 3
+#  cost: 10000
+#  recipeUnlocks:
+#    - WeaponForceGun
+#    - WeaponTetherGun
 
 #- type: technology # Frontier - disabled because why the fuck are we adding a god damned FOURTH exploit to the game intentionally holy shit
 #  id: QuantumLeaping


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
No more gravity guns, i have come with complains about them for long time but always forget to make the PR for it, until now.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Bad for RP, exploited for bugs and physics issues, don't bring anything of value besides being annoying.



**Changelog**

:cl: Leander
- remove: Gravity guns have disappeared from the public research database forever.
