### PR TITLE
Syndie Jumpsuit Sensors Fix

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Uniforms/jumpsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/jumpsuits.yml
@@ -1277,7 +1277,6 @@
     sprite: Clothing/Uniforms/Jumpsuit/syndieformal.rsi
   - type: Clothing
     sprite: Clothing/Uniforms/Jumpsuit/syndieformal.rsi
-  - type: Contraband #frontier
 
 - type: entity
   parent: ClothingUniformBase

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/ship_vs_ship.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/ship_vs_ship.yml
@@ -24,7 +24,6 @@
     sprite: Clothing/Uniforms/Jumpsuit/recruit_syndie.rsi
   - type: Clothing
     sprite: Clothing/Uniforms/Jumpsuit/recruit_syndie.rsi
-  - type: Contraband #frontier
 
 #Repairman
 - type: entity
@@ -48,7 +47,6 @@
     sprite: Clothing/Uniforms/Jumpsuit/repairman_syndie.rsi
   - type: Clothing
     sprite: Clothing/Uniforms/Jumpsuit/repairman_syndie.rsi
-  - type: Contraband #frontier
 
 #Paramedic
 - type: entity
@@ -72,7 +70,6 @@
     sprite: Clothing/Uniforms/Jumpsuit/paramedic_syndie.rsi
   - type: Clothing
     sprite: Clothing/Uniforms/Jumpsuit/paramedic_syndie.rsi
-  - type: Contraband #frontier
 
 #HEADS OF STAFF
 #Chief Engineer
@@ -97,4 +94,3 @@
     sprite: Clothing/Uniforms/Jumpsuit/ce_syndie.rsi
   - type: Clothing
     sprite: Clothing/Uniforms/Jumpsuit/ce_syndie.rsi
-  - type: Contraband #frontier

--- a/Resources/Prototypes/_NF/Entities/Clothing/Uniforms/jumpsuits.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Uniforms/jumpsuits.yml
@@ -141,3 +141,49 @@
     sprite: _NF/Clothing/Uniforms/Jumpsuit/nfsd_tac_cream.rsi
   - type: Clothing
     sprite: _NF/Clothing/Uniforms/Jumpsuit/nfsd_tac_cream.rsi
+
+# Syndicate Jupsuits with sensors off
+- type: entity
+  parent: ClothingUniformJumpsuitRecruitSyndie
+  id: ClothingUniformJumpsuitRecruitSyndieNF
+  components:
+  - type: SuitSensor
+    randomMode: false
+    mode: SensorOff
+  - type: Contraband
+
+- type: entity
+  parent: ClothingUniformJumpsuitRepairmanSyndie
+  id: ClothingUniformJumpsuitRepairmanSyndieNF
+  components:
+  - type: SuitSensor
+    randomMode: false
+    mode: SensorOff
+  - type: Contraband
+
+- type: entity
+  parent: ClothingUniformJumpsuitParamedicSyndie
+  id: ClothingUniformJumpsuitParamedicSyndieNF
+  components:
+  - type: SuitSensor
+    randomMode: false
+    mode: SensorOff
+  - type: Contraband
+
+- type: entity
+  parent: ClothingUniformJumpsuitChiefEngineerSyndie
+  id: ClothingUniformJumpsuitChiefEngineerSyndieNF
+  components:
+  - type: SuitSensor
+    randomMode: false
+    mode: SensorOff
+  - type: Contraband
+
+- type: entity
+  parent: ClothingUniformJumpsuitSyndieFormal
+  id: ClothingUniformJumpsuitSyndieFormalNF
+  components:
+  - type: SuitSensor
+    randomMode: false
+    mode: SensorOff
+  - type: Contraband

--- a/Resources/Prototypes/_NF/Roles/Jobs/Hostile/syndicate_naval_forces.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Hostile/syndicate_naval_forces.yml
@@ -3,7 +3,7 @@
   id: SyndicateNavalCaptainGearA
   equipment:
     head: ClothingHeadHatSyndieMAA
-    jumpsuit: ClothingUniformJumpsuitSyndieFormal
+    jumpsuit: ClothingUniformJumpsuitSyndieFormalNF
     shoes: ClothingShoesBootsCombat
     gloves: ClothingHandsGlovesColorBlackPython
     neck: ClothingNeckScarfStripedSyndieRed
@@ -17,7 +17,7 @@
   id: SyndicateNavalCaptainGearB
   equipment:
     head: ClothingHeadHatSyndieMAA
-    jumpsuit: ClothingUniformJumpsuitSyndieFormal
+    jumpsuit: ClothingUniformJumpsuitSyndieFormalNF
     shoes: ClothingShoesBootsCombat
     gloves: ClothingHandsGlovesColorBlackPython
     neck: ClothingNeckScarfStripedSyndieRed
@@ -31,7 +31,7 @@
   id: SyndicateNavalCaptainGearC
   equipment:
     head: ClothingHeadHatSyndieMAA
-    jumpsuit: ClothingUniformJumpsuitSyndieFormal
+    jumpsuit: ClothingUniformJumpsuitSyndieFormalNF
     shoes: ClothingShoesBootsCombat
     gloves: ClothingHandsGlovesColorBlackPython
     neck: ClothingNeckScarfStripedSyndieRed
@@ -43,7 +43,7 @@
   id: SyndicateNavalCaptainGearD
   equipment:
     head: ClothingHeadHatSyndieMAA
-    jumpsuit: ClothingUniformJumpsuitSyndieFormal
+    jumpsuit: ClothingUniformJumpsuitSyndieFormalNF
     shoes: ClothingShoesBootsCombat
     gloves: ClothingHandsGlovesColorBlackPython
     neck: ClothingNeckScarfStripedSyndieRed
@@ -56,7 +56,7 @@
   id: SyndicateNavalEngineerGearA
   equipment:
     head: ClothingHeadHatHardhatRed
-    jumpsuit: ClothingUniformJumpsuitChiefEngineerSyndie
+    jumpsuit: ClothingUniformJumpsuitChiefEngineerSyndieNF
     shoes: ClothingShoesBootsCombat
     gloves: ClothingHandsGlovesColorBlackShotgun
     belt: ClothingBeltUtility
@@ -70,7 +70,7 @@
   id: SyndicateNavalEngineerGearB
   equipment:
     head: ClothingHeadHatHardhatRed
-    jumpsuit: ClothingUniformJumpsuitChiefEngineerSyndie
+    jumpsuit: ClothingUniformJumpsuitChiefEngineerSyndieNF
     shoes: ClothingShoesBootsCombat
     gloves: ClothingHandsGlovesColorBlackShotgun
     belt: ClothingBeltUtility
@@ -84,7 +84,7 @@
   id: SyndicateNavalEngineerGearC
   equipment:
     head: ClothingHeadHatHardhatRed
-    jumpsuit: ClothingUniformJumpsuitChiefEngineerSyndie
+    jumpsuit: ClothingUniformJumpsuitChiefEngineerSyndieNF
     shoes: ClothingShoesBootsCombat
     gloves: ClothingHandsGlovesColorBlackShotgun
     belt: ClothingBeltUtility
@@ -98,7 +98,7 @@
   id: SyndicateNavalEngineerGearD
   equipment:
     head: ClothingHeadHatHardhatRed
-    jumpsuit: ClothingUniformJumpsuitChiefEngineerSyndie
+    jumpsuit: ClothingUniformJumpsuitChiefEngineerSyndieNF
     shoes: ClothingShoesBootsCombat
     gloves: ClothingHandsGlovesColorBlackShotgun
     belt: ClothingBeltUtility
@@ -113,7 +113,7 @@
   id: SyndicateNavalMedicGearA
   equipment:
     head: ClothingHeadHatSyndie
-    jumpsuit: ClothingUniformJumpsuitParamedicSyndie
+    jumpsuit: ClothingUniformJumpsuitParamedicSyndieNF
     shoes: ClothingShoesBootsCombat
     gloves: ClothingHandsGlovesCombat
     belt: ClothingBeltMedical
@@ -128,7 +128,7 @@
   id: SyndicateNavalMedicGearB
   equipment:
     head: ClothingHeadHatSyndie
-    jumpsuit: ClothingUniformJumpsuitParamedicSyndie
+    jumpsuit: ClothingUniformJumpsuitParamedicSyndieNF
     shoes: ClothingShoesBootsCombat
     gloves: ClothingHandsGlovesCombat
     belt: ClothingBeltMedical
@@ -143,7 +143,7 @@
   id: SyndicateNavalMedicGearC
   equipment:
     head: ClothingHeadHatSyndie
-    jumpsuit: ClothingUniformJumpsuitParamedicSyndie
+    jumpsuit: ClothingUniformJumpsuitParamedicSyndieNF
     shoes: ClothingShoesBootsCombat
     gloves: ClothingHandsGlovesCombat
     belt: ClothingBeltMedical
@@ -158,7 +158,7 @@
   id: SyndicateNavalMedicGearD
   equipment:
     head: ClothingHeadHatSyndie
-    jumpsuit: ClothingUniformJumpsuitParamedicSyndie
+    jumpsuit: ClothingUniformJumpsuitParamedicSyndieNF
     shoes: ClothingShoesBootsCombat
     gloves: ClothingHandsGlovesCombat
     belt: ClothingBeltMedical
@@ -174,7 +174,7 @@
   id: SyndicateNavalSecondOfficerGearA
   equipment:
     head: ClothingHeadHatSyndie
-    jumpsuit: ClothingUniformJumpsuitRecruitSyndie
+    jumpsuit: ClothingUniformJumpsuitRecruitSyndieNF
     shoes: ClothingShoesBootsCombat
     gloves: ClothingHandsGlovesColorBlackLaserPistol
     eyes: ClothingEyesGlassesSunglasses
@@ -189,7 +189,7 @@
   id: SyndicateNavalSecondOfficerGearB
   equipment:
     head: ClothingHeadHatSyndie
-    jumpsuit: ClothingUniformJumpsuitRecruitSyndie
+    jumpsuit: ClothingUniformJumpsuitRecruitSyndieNF
     shoes: ClothingShoesBootsCombat
     gloves: ClothingHandsGlovesColorBlackLaserPistol
     eyes: ClothingEyesGlassesSunglasses
@@ -204,7 +204,7 @@
   id: SyndicateNavalSecondOfficerGearC
   equipment:
     head: ClothingHeadHatSyndie
-    jumpsuit: ClothingUniformJumpsuitRecruitSyndie
+    jumpsuit: ClothingUniformJumpsuitRecruitSyndieNF
     shoes: ClothingShoesBootsCombat
     gloves: ClothingHandsGlovesColorBlackLaserPistol
     eyes: ClothingEyesGlassesSunglasses
@@ -219,7 +219,7 @@
   id: SyndicateNavalSecondOfficerGearD
   equipment:
     head: ClothingHeadHatSyndie
-    jumpsuit: ClothingUniformJumpsuitRecruitSyndie
+    jumpsuit: ClothingUniformJumpsuitRecruitSyndieNF
     shoes: ClothingShoesBootsCombat
     gloves: ClothingHandsGlovesColorBlackLaserPistol
     eyes: ClothingEyesGlassesSunglasses
@@ -407,7 +407,7 @@
   equipment:
     mask: ClothingMaskGasSyndicate
     neck: BedsheetSyndie
-    jumpsuit: ClothingUniformJumpsuitSyndieFormal
+    jumpsuit: ClothingUniformJumpsuitSyndieFormalNF
     outerClothing: ClothingOuterHardsuitSyndieEliteUnremoveable
     head: ClothingHeadHelmetHardsuitSyndieEliteUnremoveable
     gloves: ClothingHandsGlovesColorBlackAK
@@ -420,7 +420,7 @@
   id: SyndicateNavalCommanderGearB
   equipment:
     mask: ClothingMaskGasSyndicate
-    jumpsuit: ClothingUniformJumpsuitSyndieFormal
+    jumpsuit: ClothingUniformJumpsuitSyndieFormalNF
     outerClothing: ClothingOuterHardsuitSyndieEliteUnremoveable
     head: ClothingHeadHelmetHardsuitSyndieEliteUnremoveable
     gloves: ClothingHandsGlovesColorBlackAK
@@ -434,7 +434,7 @@
   equipment:
     mask: ClothingMaskGasSyndicate
     neck: BedsheetSyndie
-    jumpsuit: ClothingUniformJumpsuitSyndieFormal
+    jumpsuit: ClothingUniformJumpsuitSyndieFormalNF
     outerClothing: ClothingOuterHardsuitSyndieBloodRedUnremoveable
     head: ClothingHeadHelmetHardsuitSyndieUnremoveable
     gloves: ClothingHandsGlovesColorBlackAK
@@ -447,7 +447,7 @@
   id: SyndicateNavalCommanderGearD
   equipment:
     mask: ClothingMaskGasSyndicate
-    jumpsuit: ClothingUniformJumpsuitSyndieFormal
+    jumpsuit: ClothingUniformJumpsuitSyndieFormalNF
     outerClothing: ClothingOuterHardsuitSyndieBloodRedUnremoveable
     head: ClothingHeadHelmetHardsuitSyndieUnremoveable
     gloves: ClothingHandsGlovesColorBlackAK
@@ -461,7 +461,7 @@
   id: SyndicateNavalDeckhandGearA
   equipment:
     head: ClothingHeadHatSyndie
-    jumpsuit: ClothingUniformJumpsuitRecruitSyndie
+    jumpsuit: ClothingUniformJumpsuitRecruitSyndieNF
     shoes: ClothingShoesBootsWork
     outerClothing: ClothingOuterArmorBasic
     gloves: ClothingHandsGlovesColorBlackPistol
@@ -473,7 +473,7 @@
   id: SyndicateNavalDeckhandGearB
   equipment:
     head: ClothingHeadHatSyndie
-    jumpsuit: ClothingUniformJumpsuitRecruitSyndie
+    jumpsuit: ClothingUniformJumpsuitRecruitSyndieNF
     shoes: ClothingShoesBootsWork
     outerClothing: ClothingOuterArmorBasic
     gloves: ClothingHandsGlovesColorBlackPistol
@@ -485,7 +485,7 @@
   id: SyndicateNavalDeckhandGearC
   equipment:
     head: ClothingHeadHatSyndie
-    jumpsuit: ClothingUniformJumpsuitRecruitSyndie
+    jumpsuit: ClothingUniformJumpsuitRecruitSyndieNF
     shoes: ClothingShoesBootsWork
     outerClothing: ClothingOuterArmorBasic
     gloves: ClothingHandsGlovesColorBlackPistol
@@ -497,7 +497,7 @@
   id: SyndicateNavalDeckhandGearD
   equipment:
     head: ClothingHeadHatSyndie
-    jumpsuit: ClothingUniformJumpsuitRecruitSyndie
+    jumpsuit: ClothingUniformJumpsuitRecruitSyndieNF
     shoes: ClothingShoesBootsWork
     outerClothing: ClothingOuterArmorBasic
     gloves: ClothingHandsGlovesColorBlackPistol


### PR DESCRIPTION
## About the PR
Turns jumpsuit sensors off on syndicate agents jumpsuits to keep secrecy. Also reverts some of the changes made to base game files, so a little bit les maint work. Yay!

## Why / Balance
Turns out some of the syndicate jumpsuits had their sensors on, which spoils the location of Listening Post Bravo. This PR fixes it.

## Media
- [X] This PR does not require an ingame showcase.