### PR TITLE
Allow Selling Alive Contraband Prisoners To NFSD

### DIFF
--- a/Content.Server/_NF/Contraband/Systems/ContrabandSystem.cs
+++ b/Content.Server/_NF/Contraband/Systems/ContrabandSystem.cs
@@ -165,7 +165,7 @@ public sealed partial class ContrabandSystem : SharedContrabandSystem
     {
         if (_mobQuery.HasComponent(uid))
         {
-            if (_mobQuery.GetComponent(uid).CurrentState == MobState.Alive)
+            if (_mobQuery.GetComponent(uid).CurrentState == MobState.Dead) // Allow selling alive prisoners
             {
                 return false;
             }


### PR DESCRIPTION
## About the PR
Change the code to allow selling alive prisoners that have contraband comp on them.
Block selling of dead ones.

## Why / Balance
Merc gameplay to hunt down alive syndicate agents on planets and sell them to security.

## How to test
Spawn syndicate on sell platform, sell it.
If its dead selling is blocked. 

## Media
N/A

## Breaking changes
N.A

**Changelog**
:cl: dvir01
- tweak: You can now sell alive antagonist AI like the Syndicate agents to NFSD, as long as they are alive, for NFSD coins.
