### PR TITLE
Bluespace Bag Rebalance

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
@@ -270,7 +270,7 @@
   - type: Storage
     maxItemSize: Huge
     grid:
-    - 0,0,19,9
+    - 0,0,10,3
 
 - type: entity
   parent: ClothingBackpackClown

--- a/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
@@ -270,7 +270,7 @@
   - type: Storage
     maxItemSize: Huge
     grid:
-    - 0,0,10,3
+    - 0,0,11,4
 
 - type: entity
   parent: ClothingBackpackClown

--- a/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
@@ -238,8 +238,7 @@
     grid:
     - 0,0,11,4
   - type: ClothingSpeedModifier
-    walkModifier: 1
-    sprintModifier: 0.9
+    sprintModifier: 1 # makes its stats identical to other variants of bag of holding
   - type: HeldSpeedModifier
 
 - type: entity

--- a/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
@@ -236,9 +236,10 @@
   - type: Storage
     maxItemSize: Huge
     grid:
-    - 0,0,19,9
+    - 0,0,11,4
   - type: ClothingSpeedModifier
-    sprintModifier: 1 # makes its stats identical to other variants of bag of holding
+    walkModifier: 1
+    sprintModifier: 0.9
   - type: HeldSpeedModifier
 
 - type: entity

--- a/Resources/Prototypes/Entities/Clothing/Back/satchel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/satchel.yml
@@ -177,4 +177,4 @@
   - type: Storage
     maxItemSize: Huge
     grid:
-    - 0,0,19,9
+    - 0,0,10,3

--- a/Resources/Prototypes/Entities/Clothing/Back/satchel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/satchel.yml
@@ -177,4 +177,4 @@
   - type: Storage
     maxItemSize: Huge
     grid:
-    - 0,0,10,3
+    - 0,0,11,4


### PR DESCRIPTION
## About the PR
This PR reduces the size of the the bags of holding, duffel, and satchel to be 4 more columns then a duffel bag, adding the ability to carry more items then normal while not quite the same as before this PR.

## Why / Balance
The size of items before was a grid of 19x9 which was far too many slots for people to be carrying, it took up a majority of the screen and broke gameplay.

## Media
![image](https://github.com/new-frontiers-14/frontier-station-14/assets/96151729/40904e43-463c-40a8-910c-81ffb6e1825f)
![image](https://github.com/new-frontiers-14/frontier-station-14/assets/96151729/aa458b1a-5846-4b6b-abd9-a5afb1cbb07b)

**Changelog**
:cl:
- tweak: Nerfed bluespace bags to only 4 additional bag columns.
