### PR TITLE
NSF Rogue: Sprite update

### DIFF
--- a/Resources/Maps/_NF/Shuttles/Security/rogue.yml
+++ b/Resources/Maps/_NF/Shuttles/Security/rogue.yml
@@ -136,28 +136,28 @@ entities:
     - type: RadiationGridResistance
 - proto: AirlockExternalGlassLocked
   entities:
-  - uid: 19
+  - uid: 2
     components:
     - type: Transform
       pos: -0.5,-0.5
       parent: 1
 - proto: AirlockGlassShuttle
   entities:
-  - uid: 23
+  - uid: 3
     components:
     - type: Transform
       pos: 1.5,-3.5
       parent: 1
-- proto: AirlockSecurityGlassLocked
+- proto: AirlockNfsdGlassLocked
   entities:
-  - uid: 22
+  - uid: 4
     components:
     - type: Transform
       pos: 0.5,-1.5
       parent: 1
 - proto: APCBasic
   entities:
-  - uid: 61
+  - uid: 5
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -165,305 +165,169 @@ entities:
       parent: 1
 - proto: AtmosDeviceFanTiny
   entities:
-  - uid: 24
+  - uid: 6
     components:
     - type: Transform
       pos: -0.5,-0.5
       parent: 1
-  - uid: 25
+  - uid: 7
     components:
     - type: Transform
       pos: 1.5,-3.5
       parent: 1
 - proto: AtmosFixBlockerMarker
   entities:
-  - uid: 101
+  - uid: 8
     components:
     - type: Transform
       pos: -1.5,-3.5
       parent: 1
-  - uid: 102
+  - uid: 9
     components:
     - type: Transform
       pos: -1.5,-3.5
       parent: 1
-  - uid: 103
+  - uid: 10
     components:
     - type: Transform
       pos: -0.5,-3.5
       parent: 1
-  - uid: 104
+  - uid: 11
     components:
     - type: Transform
       pos: -0.5,0.5
       parent: 1
-  - uid: 105
+  - uid: 12
     components:
     - type: Transform
       pos: -0.5,1.5
       parent: 1
-  - uid: 106
+  - uid: 13
     components:
     - type: Transform
       pos: -0.5,2.5
       parent: 1
-  - uid: 107
+  - uid: 14
     components:
     - type: Transform
       pos: -0.5,3.5
       parent: 1
-  - uid: 108
+  - uid: 15
     components:
     - type: Transform
       pos: -0.5,4.5
       parent: 1
-  - uid: 109
+  - uid: 16
     components:
     - type: Transform
       pos: -1.5,0.5
       parent: 1
-  - uid: 110
+  - uid: 17
     components:
     - type: Transform
       pos: -1.5,1.5
       parent: 1
-  - uid: 111
+  - uid: 18
     components:
     - type: Transform
       pos: -1.5,2.5
       parent: 1
-  - uid: 112
+  - uid: 19
     components:
     - type: Transform
       pos: -1.5,3.5
       parent: 1
-  - uid: 113
+  - uid: 20
     components:
     - type: Transform
       pos: -1.5,4.5
       parent: 1
-  - uid: 114
+  - uid: 21
     components:
     - type: Transform
       pos: 0.5,4.5
       parent: 1
-  - uid: 115
+  - uid: 22
     components:
     - type: Transform
       pos: 0.5,3.5
       parent: 1
-  - uid: 116
+  - uid: 23
     components:
     - type: Transform
       pos: 1.5,4.5
       parent: 1
-  - uid: 117
+  - uid: 24
     components:
     - type: Transform
       pos: 1.5,3.5
       parent: 1
-  - uid: 118
+  - uid: 25
     components:
     - type: Transform
       pos: 2.5,4.5
       parent: 1
-  - uid: 119
+  - uid: 26
     components:
     - type: Transform
       pos: 2.5,3.5
       parent: 1
 - proto: CableApcExtension
   entities:
-  - uid: 77
-    components:
-    - type: Transform
-      pos: 1.5,-0.5
-      parent: 1
-  - uid: 78
-    components:
-    - type: Transform
-      pos: 0.5,-0.5
-      parent: 1
-  - uid: 79
-    components:
-    - type: Transform
-      pos: 1.5,0.5
-      parent: 1
-  - uid: 80
-    components:
-    - type: Transform
-      pos: 1.5,1.5
-      parent: 1
-  - uid: 81
-    components:
-    - type: Transform
-      pos: -0.5,0.5
-      parent: 1
-  - uid: 82
-    components:
-    - type: Transform
-      pos: 1.5,3.5
-      parent: 1
-  - uid: 83
-    components:
-    - type: Transform
-      pos: 1.5,4.5
-      parent: 1
-  - uid: 84
-    components:
-    - type: Transform
-      pos: 2.5,4.5
-      parent: 1
-  - uid: 85
-    components:
-    - type: Transform
-      pos: -0.5,-0.5
-      parent: 1
-  - uid: 86
-    components:
-    - type: Transform
-      pos: -0.5,-1.5
-      parent: 1
-  - uid: 87
-    components:
-    - type: Transform
-      pos: -0.5,-2.5
-      parent: 1
-  - uid: 88
-    components:
-    - type: Transform
-      pos: -0.5,-3.5
-      parent: 1
-  - uid: 89
-    components:
-    - type: Transform
-      pos: -1.5,-3.5
-      parent: 1
-  - uid: 95
-    components:
-    - type: Transform
-      pos: 1.5,-1.5
-      parent: 1
-  - uid: 96
-    components:
-    - type: Transform
-      pos: 1.5,-2.5
-      parent: 1
-  - uid: 97
-    components:
-    - type: Transform
-      pos: -0.5,1.5
-      parent: 1
-  - uid: 98
-    components:
-    - type: Transform
-      pos: -0.5,2.5
-      parent: 1
-  - uid: 99
-    components:
-    - type: Transform
-      pos: -0.5,3.5
-      parent: 1
-  - uid: 100
-    components:
-    - type: Transform
-      pos: 0.5,3.5
-      parent: 1
-- proto: CableHV
-  entities:
-  - uid: 71
-    components:
-    - type: Transform
-      pos: 2.5,-2.5
-      parent: 1
-  - uid: 72
-    components:
-    - type: Transform
-      pos: 2.5,-1.5
-      parent: 1
-  - uid: 73
-    components:
-    - type: Transform
-      pos: 2.5,-0.5
-      parent: 1
-- proto: CableMV
-  entities:
-  - uid: 74
-    components:
-    - type: Transform
-      pos: 2.5,-0.5
-      parent: 1
-  - uid: 75
-    components:
-    - type: Transform
-      pos: 1.5,-0.5
-      parent: 1
-  - uid: 76
-    components:
-    - type: Transform
-      pos: 0.5,-0.5
-      parent: 1
-- proto: Catwalk
-  entities:
-  - uid: 26
-    components:
-    - type: Transform
-      pos: -1.5,4.5
-      parent: 1
   - uid: 27
     components:
     - type: Transform
-      pos: -1.5,4.5
+      pos: 1.5,-0.5
       parent: 1
   - uid: 28
     components:
     - type: Transform
-      pos: -1.5,3.5
+      pos: 0.5,-0.5
       parent: 1
   - uid: 29
     components:
     - type: Transform
-      pos: -1.5,2.5
+      pos: 1.5,0.5
       parent: 1
   - uid: 30
     components:
     - type: Transform
-      pos: -1.5,1.5
+      pos: 1.5,1.5
       parent: 1
   - uid: 31
     components:
     - type: Transform
-      pos: -1.5,0.5
+      pos: -0.5,0.5
       parent: 1
   - uid: 32
     components:
     - type: Transform
-      pos: -0.5,4.5
+      pos: 1.5,3.5
       parent: 1
   - uid: 33
     components:
     - type: Transform
-      pos: -0.5,3.5
+      pos: 1.5,4.5
       parent: 1
   - uid: 34
     components:
     - type: Transform
-      pos: -0.5,2.5
+      pos: 2.5,4.5
       parent: 1
   - uid: 35
     components:
     - type: Transform
-      pos: -0.5,1.5
+      pos: -0.5,-0.5
       parent: 1
   - uid: 36
     components:
     - type: Transform
-      pos: -0.5,0.5
+      pos: -0.5,-1.5
       parent: 1
   - uid: 37
     components:
     - type: Transform
-      pos: -1.5,-3.5
+      pos: -0.5,-2.5
       parent: 1
   - uid: 38
     components:
@@ -473,31 +337,167 @@ entities:
   - uid: 39
     components:
     - type: Transform
-      pos: 1.5,3.5
+      pos: -1.5,-3.5
       parent: 1
   - uid: 40
     components:
     - type: Transform
-      pos: 1.5,3.5
+      pos: 1.5,-1.5
       parent: 1
   - uid: 41
     components:
     - type: Transform
-      pos: 1.5,4.5
+      pos: 1.5,-2.5
       parent: 1
   - uid: 42
     components:
     - type: Transform
-      pos: 2.5,3.5
+      pos: -0.5,1.5
       parent: 1
   - uid: 43
+    components:
+    - type: Transform
+      pos: -0.5,2.5
+      parent: 1
+  - uid: 44
+    components:
+    - type: Transform
+      pos: -0.5,3.5
+      parent: 1
+  - uid: 45
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 1
+- proto: CableHV
+  entities:
+  - uid: 46
+    components:
+    - type: Transform
+      pos: 2.5,-2.5
+      parent: 1
+  - uid: 47
+    components:
+    - type: Transform
+      pos: 2.5,-1.5
+      parent: 1
+  - uid: 48
+    components:
+    - type: Transform
+      pos: 2.5,-0.5
+      parent: 1
+- proto: CableMV
+  entities:
+  - uid: 49
+    components:
+    - type: Transform
+      pos: 2.5,-0.5
+      parent: 1
+  - uid: 50
+    components:
+    - type: Transform
+      pos: 1.5,-0.5
+      parent: 1
+  - uid: 51
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 1
+- proto: Catwalk
+  entities:
+  - uid: 52
+    components:
+    - type: Transform
+      pos: -1.5,4.5
+      parent: 1
+  - uid: 53
+    components:
+    - type: Transform
+      pos: -1.5,4.5
+      parent: 1
+  - uid: 54
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 1
+  - uid: 55
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 1
+  - uid: 56
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 1
+  - uid: 57
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 1
+  - uid: 58
+    components:
+    - type: Transform
+      pos: -0.5,4.5
+      parent: 1
+  - uid: 59
+    components:
+    - type: Transform
+      pos: -0.5,3.5
+      parent: 1
+  - uid: 60
+    components:
+    - type: Transform
+      pos: -0.5,2.5
+      parent: 1
+  - uid: 61
+    components:
+    - type: Transform
+      pos: -0.5,1.5
+      parent: 1
+  - uid: 62
+    components:
+    - type: Transform
+      pos: -0.5,0.5
+      parent: 1
+  - uid: 63
+    components:
+    - type: Transform
+      pos: -1.5,-3.5
+      parent: 1
+  - uid: 64
+    components:
+    - type: Transform
+      pos: -0.5,-3.5
+      parent: 1
+  - uid: 65
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 1
+  - uid: 66
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 1
+  - uid: 67
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 1
+  - uid: 68
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 69
     components:
     - type: Transform
       pos: 2.5,4.5
       parent: 1
 - proto: ChairPilotSeat
   entities:
-  - uid: 45
+  - uid: 70
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -505,81 +505,81 @@ entities:
       parent: 1
 - proto: ComputerShuttle
   entities:
-  - uid: 44
+  - uid: 71
     components:
     - type: Transform
       pos: 1.5,1.5
       parent: 1
 - proto: GeneratorWallmountAPU
   entities:
-  - uid: 62
+  - uid: 72
     components:
     - type: Transform
       pos: 2.5,-2.5
       parent: 1
-  - uid: 63
+  - uid: 73
     components:
     - type: Transform
       pos: 2.5,-1.5
       parent: 1
 - proto: GravityGeneratorMini
   entities:
-  - uid: 51
+  - uid: 74
     components:
     - type: Transform
       pos: 1.5,3.5
       parent: 1
 - proto: Grille
   entities:
-  - uid: 52
+  - uid: 75
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,2.5
       parent: 1
-  - uid: 53
+  - uid: 76
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,1.5
       parent: 1
-  - uid: 54
+  - uid: 77
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,1.5
       parent: 1
-  - uid: 55
+  - uid: 78
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,0.5
       parent: 1
-  - uid: 56
+  - uid: 79
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,1.5
       parent: 1
-  - uid: 57
+  - uid: 80
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,1.5
       parent: 1
-  - uid: 58
+  - uid: 81
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,0.5
       parent: 1
-  - uid: 59
+  - uid: 82
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,-2.5
       parent: 1
-  - uid: 60
+  - uid: 83
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -587,61 +587,61 @@ entities:
       parent: 1
 - proto: PlastitaniumWindow
   entities:
-  - uid: 14
+  - uid: 84
     components:
     - type: Transform
       pos: 1.5,2.5
       parent: 1
-  - uid: 15
+  - uid: 85
     components:
     - type: Transform
       pos: 0.5,1.5
       parent: 1
-  - uid: 16
+  - uid: 86
     components:
     - type: Transform
       pos: 0.5,0.5
       parent: 1
-  - uid: 17
+  - uid: 87
     components:
     - type: Transform
       pos: 2.5,1.5
       parent: 1
-  - uid: 18
+  - uid: 88
     components:
     - type: Transform
       pos: 2.5,0.5
       parent: 1
-  - uid: 20
+  - uid: 89
     components:
     - type: Transform
       pos: -0.5,-2.5
       parent: 1
-  - uid: 21
+  - uid: 90
     components:
     - type: Transform
       pos: -1.5,-1.5
       parent: 1
 - proto: PowerCellHigh
   entities:
-  - uid: 124
+  - uid: 91
     components:
     - type: Transform
       pos: -1.676467,1.1426032
       parent: 1
-  - uid: 125
+  - uid: 92
     components:
     - type: Transform
       pos: -1.2806337,1.1426032
       parent: 1
-  - uid: 126
+  - uid: 93
     components:
     - type: Transform
       pos: -1.488967,0.89260316
       parent: 1
 - proto: PowerCellRecharger
   entities:
-  - uid: 69
+  - uid: 94
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -649,7 +649,7 @@ entities:
       parent: 1
 - proto: Poweredlight
   entities:
-  - uid: 123
+  - uid: 95
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -657,7 +657,7 @@ entities:
       parent: 1
 - proto: PoweredlightColoredFrostyBlue
   entities:
-  - uid: 94
+  - uid: 96
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -665,25 +665,25 @@ entities:
       parent: 1
 - proto: Railing
   entities:
-  - uid: 90
+  - uid: 97
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,4.5
       parent: 1
-  - uid: 91
+  - uid: 98
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,3.5
       parent: 1
-  - uid: 92
+  - uid: 99
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,4.5
       parent: 1
-  - uid: 93
+  - uid: 100
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -691,7 +691,7 @@ entities:
       parent: 1
 - proto: ShuttleGunSvalinnMachineGun
   entities:
-  - uid: 68
+  - uid: 101
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -699,10 +699,10 @@ entities:
       parent: 1
     - type: DeviceLinkSink
       links:
-      - 121
+      - 102
 - proto: SignalButtonDirectional
   entities:
-  - uid: 121
+  - uid: 102
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -710,27 +710,26 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        68:
+        101:
         - Pressed: Toggle
         - Pressed: Trigger
 - proto: SignSecureSmallRed
   entities:
-  - uid: 120
+  - uid: 103
     components:
     - type: Transform
       pos: 0.5,1.5
       parent: 1
-- proto: SmallGyroscopeSecurity
+- proto: SmallGyroscopeNfsd
   entities:
-  - uid: 50
+  - uid: 112
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 1.5,4.5
       parent: 1
 - proto: SubstationWallBasic
   entities:
-  - uid: 64
+  - uid: 105
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -738,109 +737,109 @@ entities:
       parent: 1
 - proto: TableReinforced
   entities:
-  - uid: 65
+  - uid: 106
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,0.5
       parent: 1
-  - uid: 66
+  - uid: 107
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,0.5
       parent: 1
-  - uid: 67
+  - uid: 108
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,1.5
       parent: 1
-- proto: ThrusterSecurity
+- proto: ThrusterNfsd
   entities:
-  - uid: 46
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -0.5,-3.5
-      parent: 1
-  - uid: 47
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -1.5,-3.5
-      parent: 1
-  - uid: 48
-    components:
-    - type: Transform
-      pos: 2.5,4.5
-      parent: 1
-  - uid: 49
+  - uid: 104
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,3.5
       parent: 1
+  - uid: 109
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-3.5
+      parent: 1
+  - uid: 110
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 1
+  - uid: 111
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-3.5
+      parent: 1
 - proto: WallPlastitanium
   entities:
-  - uid: 3
+  - uid: 113
     components:
     - type: Transform
       pos: 0.5,-3.5
       parent: 1
-  - uid: 4
+  - uid: 114
     components:
     - type: Transform
       pos: 0.5,-2.5
       parent: 1
-  - uid: 5
+  - uid: 115
     components:
     - type: Transform
       pos: 2.5,-3.5
       parent: 1
-  - uid: 6
+  - uid: 116
     components:
     - type: Transform
       pos: 2.5,-2.5
       parent: 1
-  - uid: 7
+  - uid: 117
     components:
     - type: Transform
       pos: 2.5,-1.5
       parent: 1
-  - uid: 8
+  - uid: 118
     components:
     - type: Transform
       pos: 2.5,-0.5
       parent: 1
-  - uid: 9
+  - uid: 119
     components:
     - type: Transform
       pos: -1.5,-2.5
       parent: 1
-  - uid: 10
+  - uid: 120
     components:
     - type: Transform
       pos: 0.5,2.5
       parent: 1
-  - uid: 11
+  - uid: 121
     components:
     - type: Transform
       pos: 0.5,-0.5
       parent: 1
-  - uid: 12
+  - uid: 122
     components:
     - type: Transform
       pos: -1.5,-0.5
       parent: 1
-  - uid: 13
+  - uid: 123
     components:
     - type: Transform
       pos: 2.5,2.5
       parent: 1
 - proto: WarpPointShip
   entities:
-  - uid: 122
+  - uid: 124
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -848,7 +847,7 @@ entities:
       parent: 1
 - proto: WeaponCapacitorRecharger
   entities:
-  - uid: 70
+  - uid: 125
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -856,7 +855,7 @@ entities:
       parent: 1
 - proto: WindoorSecureSecurityLocked
   entities:
-  - uid: 2
+  - uid: 126
     components:
     - type: Transform
       rot: 3.141592653589793 rad


### PR DESCRIPTION
## About the PR
Updated the NSF Rogue to bring it in line with the new NFSD look as per #1230. 

## Why / Balance
Thrusters, gyro and airlock were replaced with their new NFSD-specific sprites.

## How to test
Checkout branch, loadgrid.

## Media
![2024-04-20 11_58_10-Window](https://github.com/new-frontiers-14/frontier-station-14/assets/151581207/3d432b8c-36b1-4749-a647-fdecc2440d8b)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None!

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- tweak: Updated the NSF Rogue with the new NFSD sprites.

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
