### PR TITLE
NSF Fighter: Sprite update

### DIFF
--- a/Resources/Maps/_NF/Shuttles/Security/fighter.yml
+++ b/Resources/Maps/_NF/Shuttles/Security/fighter.yml
@@ -159,17 +159,9 @@ entities:
         chunkSize: 4
     - type: GasTileOverlay
     - type: RadiationGridResistance
-- proto: AirlockBrigGlassLocked
-  entities:
-  - uid: 27
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 0.5,-1.5
-      parent: 1
 - proto: AirlockGlassShuttle
   entities:
-  - uid: 28
+  - uid: 3
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -177,14 +169,14 @@ entities:
       parent: 1
 - proto: APCBasic
   entities:
-  - uid: 47
+  - uid: 4
     components:
     - type: Transform
       pos: 0.5,3.5
       parent: 1
 - proto: AtmosDeviceFanTiny
   entities:
-  - uid: 29
+  - uid: 5
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -192,222 +184,222 @@ entities:
       parent: 1
 - proto: AtmosFixBlockerMarker
   entities:
-  - uid: 86
+  - uid: 6
     components:
     - type: Transform
       pos: -1.5,-3.5
       parent: 1
-  - uid: 87
+  - uid: 7
     components:
     - type: Transform
       pos: -1.5,-2.5
       parent: 1
-  - uid: 88
+  - uid: 8
     components:
     - type: Transform
       pos: -1.5,-1.5
       parent: 1
-  - uid: 89
+  - uid: 9
     components:
     - type: Transform
       pos: -1.5,-0.5
       parent: 1
-  - uid: 90
+  - uid: 10
     components:
     - type: Transform
       pos: 1.5,4.5
       parent: 1
-  - uid: 91
+  - uid: 11
     components:
     - type: Transform
       pos: 2.5,4.5
       parent: 1
 - proto: CableApcExtension
   entities:
-  - uid: 67
+  - uid: 12
     components:
     - type: Transform
       pos: 0.5,3.5
       parent: 1
-  - uid: 68
+  - uid: 13
     components:
     - type: Transform
       pos: 1.5,3.5
       parent: 1
-  - uid: 69
+  - uid: 14
     components:
     - type: Transform
       pos: 1.5,4.5
       parent: 1
-  - uid: 70
+  - uid: 15
     components:
     - type: Transform
       pos: 2.5,4.5
       parent: 1
-  - uid: 71
+  - uid: 16
     components:
     - type: Transform
       pos: 0.5,2.5
       parent: 1
-  - uid: 72
+  - uid: 17
     components:
     - type: Transform
       pos: 0.5,1.5
       parent: 1
-  - uid: 73
+  - uid: 18
     components:
     - type: Transform
       pos: 0.5,0.5
       parent: 1
-  - uid: 74
+  - uid: 19
     components:
     - type: Transform
       pos: 0.5,-0.5
       parent: 1
-  - uid: 75
+  - uid: 20
     components:
     - type: Transform
       pos: -1.5,-0.5
       parent: 1
-  - uid: 76
+  - uid: 21
     components:
     - type: Transform
       pos: -1.5,-1.5
       parent: 1
-  - uid: 77
+  - uid: 22
     components:
     - type: Transform
       pos: -1.5,-2.5
       parent: 1
-  - uid: 79
+  - uid: 23
     components:
     - type: Transform
       pos: 0.5,-1.5
       parent: 1
-  - uid: 80
+  - uid: 24
     components:
     - type: Transform
       pos: 0.5,-2.5
       parent: 1
-  - uid: 81
+  - uid: 25
     components:
     - type: Transform
       pos: 1.5,-2.5
       parent: 1
-  - uid: 82
+  - uid: 26
     components:
     - type: Transform
       pos: 1.5,-3.5
       parent: 1
-  - uid: 83
+  - uid: 27
     components:
     - type: Transform
       pos: 2.5,-2.5
       parent: 1
-  - uid: 84
+  - uid: 28
     components:
     - type: Transform
       pos: -0.5,-2.5
       parent: 1
-  - uid: 100
+  - uid: 29
     components:
     - type: Transform
       pos: -0.5,3.5
       parent: 1
 - proto: CableHV
   entities:
-  - uid: 57
+  - uid: 30
     components:
     - type: Transform
       pos: 2.5,-0.5
       parent: 1
-  - uid: 58
+  - uid: 31
     components:
     - type: Transform
       pos: 2.5,-1.5
       parent: 1
-  - uid: 59
+  - uid: 32
     components:
     - type: Transform
       pos: 1.5,-1.5
       parent: 1
 - proto: CableMV
   entities:
-  - uid: 60
+  - uid: 33
     components:
     - type: Transform
       pos: 1.5,-1.5
       parent: 1
-  - uid: 61
+  - uid: 34
     components:
     - type: Transform
       pos: 1.5,-0.5
       parent: 1
-  - uid: 62
+  - uid: 35
     components:
     - type: Transform
       pos: 1.5,0.5
       parent: 1
-  - uid: 63
+  - uid: 36
     components:
     - type: Transform
       pos: 0.5,0.5
       parent: 1
-  - uid: 64
+  - uid: 37
     components:
     - type: Transform
       pos: 0.5,1.5
       parent: 1
-  - uid: 65
+  - uid: 38
     components:
     - type: Transform
       pos: 0.5,2.5
       parent: 1
-  - uid: 66
+  - uid: 39
     components:
     - type: Transform
       pos: 0.5,3.5
       parent: 1
 - proto: Catwalk
   entities:
-  - uid: 93
+  - uid: 40
     components:
     - type: Transform
       pos: 1.5,4.5
       parent: 1
-  - uid: 94
+  - uid: 41
     components:
     - type: Transform
       pos: 1.5,4.5
       parent: 1
-  - uid: 95
+  - uid: 42
     components:
     - type: Transform
       pos: 2.5,4.5
       parent: 1
-  - uid: 96
+  - uid: 43
     components:
     - type: Transform
       pos: -1.5,-3.5
       parent: 1
-  - uid: 97
+  - uid: 44
     components:
     - type: Transform
       pos: -1.5,-2.5
       parent: 1
-  - uid: 98
+  - uid: 45
     components:
     - type: Transform
       pos: -1.5,-1.5
       parent: 1
-  - uid: 99
+  - uid: 46
     components:
     - type: Transform
       pos: -1.5,-0.5
       parent: 1
 - proto: ChairFolding
   entities:
-  - uid: 55
+  - uid: 47
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -415,7 +407,7 @@ entities:
       parent: 1
 - proto: ChairPilotSeat
   entities:
-  - uid: 54
+  - uid: 48
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -423,157 +415,157 @@ entities:
       parent: 1
 - proto: ComputerIFF
   entities:
-  - uid: 52
+  - uid: 49
     components:
     - type: Transform
       pos: 0.5,2.5
       parent: 1
 - proto: ComputerShuttle
   entities:
-  - uid: 53
+  - uid: 50
     components:
     - type: Transform
       pos: 1.5,2.5
       parent: 1
 - proto: GeneratorWallmountAPU
   entities:
-  - uid: 48
+  - uid: 51
     components:
     - type: Transform
       pos: 2.5,-0.5
       parent: 1
-  - uid: 49
+  - uid: 52
     components:
     - type: Transform
       pos: 2.5,-1.5
       parent: 1
 - proto: GravityGeneratorMini
   entities:
-  - uid: 35
+  - uid: 53
     components:
     - type: Transform
       pos: -1.5,-0.5
       parent: 1
 - proto: Grille
   entities:
-  - uid: 36
+  - uid: 54
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,1.5
       parent: 1
-  - uid: 37
+  - uid: 55
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,1.5
       parent: 1
-  - uid: 38
+  - uid: 56
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,2.5
       parent: 1
-  - uid: 39
+  - uid: 57
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,3.5
       parent: 1
-  - uid: 40
+  - uid: 58
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,2.5
       parent: 1
-  - uid: 41
+  - uid: 59
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,1.5
       parent: 1
-  - uid: 42
+  - uid: 60
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-0.5
       parent: 1
-  - uid: 43
+  - uid: 61
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-2.5
       parent: 1
-  - uid: 44
+  - uid: 62
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,-3.5
       parent: 1
-  - uid: 45
+  - uid: 63
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-2.5
       parent: 1
-- proto: LockerEvidence
+- proto: LockerNfsdEvidence
   entities:
-  - uid: 56
+  - uid: 64
     components:
     - type: Transform
       pos: 1.5,-0.5
       parent: 1
 - proto: PlastitaniumWindow
   entities:
-  - uid: 17
+  - uid: 65
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,3.5
       parent: 1
-  - uid: 18
+  - uid: 66
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,1.5
       parent: 1
-  - uid: 19
+  - uid: 67
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,2.5
       parent: 1
-  - uid: 20
+  - uid: 68
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,1.5
       parent: 1
-  - uid: 21
+  - uid: 69
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,2.5
       parent: 1
-  - uid: 22
+  - uid: 70
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-2.5
       parent: 1
-  - uid: 23
+  - uid: 71
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,-3.5
       parent: 1
-  - uid: 24
+  - uid: 72
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-2.5
       parent: 1
-  - uid: 25
+  - uid: 73
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -581,7 +573,7 @@ entities:
       parent: 1
 - proto: Poweredlight
   entities:
-  - uid: 85
+  - uid: 74
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -589,29 +581,28 @@ entities:
       parent: 1
 - proto: PoweredSmallLight
   entities:
-  - uid: 2
+  - uid: 75
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-2.5
       parent: 1
-  - uid: 78
+  - uid: 76
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,3.5
       parent: 1
-- proto: SmallGyroscopeSecurity
+- proto: SmallGyroscopeNfsd
   entities:
-  - uid: 34
+  - uid: 101
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -1.5,-1.5
       parent: 1
 - proto: Stool
   entities:
-  - uid: 46
+  - uid: 78
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -619,118 +610,118 @@ entities:
       parent: 1
 - proto: SubstationWallBasic
   entities:
-  - uid: 50
+  - uid: 79
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,-1.5
       parent: 1
-- proto: ThrusterSecurity
+- proto: ThrusterNfsd
   entities:
-  - uid: 30
-    components:
-    - type: Transform
-      pos: 1.5,4.5
-      parent: 1
-  - uid: 31
+  - uid: 77
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,4.5
       parent: 1
-  - uid: 32
+  - uid: 80
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -1.5,-2.5
+      pos: 1.5,4.5
       parent: 1
-  - uid: 33
+  - uid: 81
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-3.5
       parent: 1
+  - uid: 82
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-2.5
+      parent: 1
 - proto: WallPlastitanium
   entities:
-  - uid: 3
+  - uid: 83
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,4.5
       parent: 1
-  - uid: 4
+  - uid: 84
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,4.5
       parent: 1
-  - uid: 5
+  - uid: 85
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,3.5
       parent: 1
-  - uid: 6
+  - uid: 86
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,3.5
       parent: 1
-  - uid: 7
+  - uid: 87
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,3.5
       parent: 1
-  - uid: 8
+  - uid: 88
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,0.5
       parent: 1
-  - uid: 9
+  - uid: 89
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-0.5
       parent: 1
-  - uid: 10
+  - uid: 90
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-1.5
       parent: 1
-  - uid: 11
+  - uid: 91
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-1.5
       parent: 1
-  - uid: 12
+  - uid: 92
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,-1.5
       parent: 1
-  - uid: 13
+  - uid: 93
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-3.5
       parent: 1
-  - uid: 14
+  - uid: 94
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-3.5
       parent: 1
-  - uid: 15
+  - uid: 95
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-3.5
       parent: 1
-  - uid: 16
+  - uid: 96
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -738,7 +729,7 @@ entities:
       parent: 1
 - proto: WallPlastitaniumDiagonal
   entities:
-  - uid: 26
+  - uid: 97
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -746,7 +737,7 @@ entities:
       parent: 1
 - proto: WallWeaponCapacitorRecharger
   entities:
-  - uid: 51
+  - uid: 98
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -754,15 +745,23 @@ entities:
       parent: 1
 - proto: WarpPointShip
   entities:
-  - uid: 101
+  - uid: 99
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,0.5
       parent: 1
+- proto: WindoorSecureBrigLocked
+  entities:
+  - uid: 2
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-1.5
+      parent: 1
 - proto: WindoorSecureSecurityLocked
   entities:
-  - uid: 92
+  - uid: 100
     components:
     - type: Transform
       pos: -0.5,3.5


### PR DESCRIPTION
## About the PR
Updated the NSF Fighter to bring it in line with the new NFSD look as per #1230. 

## Why / Balance
Thrusters, gyro and evidence locker were all replaced with their new NFSD-specific sprites.
As there is no brig-locked glass airlock in the new NFSD style, the airlock was replaced with a brig-locked secure windoor.

## How to test
<!-- Describe the way it can be tested -->
Checkout the branch, loadgrid.

## Media
![2024-04-20 11_53_13-Window](https://github.com/new-frontiers-14/frontier-station-14/assets/151581207/e3967d28-e8f2-478d-b5d5-f310c1372eca)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None!

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- tweak: Updated the NSF Fighter with the new NFSD sprites.

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
