### PR TITLE
Fixed a typo in a blood cult NPC line

### DIFF
--- a/Resources/Locale/en-US/_NF/advertisements/mobchatter/bloodculthumanoidmob.ftl
+++ b/Resources/Locale/en-US/_NF/advertisements/mobchatter/bloodculthumanoidmob.ftl
@@ -15,6 +15,6 @@ advertisement-bloodcultisthumanoid-14 = There will be no mercy, unbeliever.
 advertisement-bloodcultisthumanoid-15 = Hey, nice jacket!
 advertisement-bloodcultisthumanoid-16 = Death to the followers of False Gods!
 advertisement-bloodcultisthumanoid-17 = Yes-yes, blood. Need more blood. More, yes.
-advertisement-bloodcultisthumanoid-18 = Void take you1
+advertisement-bloodcultisthumanoid-18 = Void take you!
 advertisement-bloodcultisthumanoid-19 = *hums*
 advertisement-bloodcultisthumanoid-20 = I will make a flute out of your collarbone!


### PR DESCRIPTION
## About the PR
Noticed one of the blood cultist NPC lines had a '1' instead of an exclamation mark. I fixed it.

## Why / Balance
Death to typos1

## How to test
It's a single character change.

## Media
- [x] PR does not require an ingame showcase

## Breaking changes
None!

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- fix: Blood cultists no longer use numerals instead of punctuation

