### PR TITLE
Hyperlink Book Restore

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -35,7 +35,7 @@
         tags:
         - Write
     bookSlot: # Frontier
-      startingItem: BookRandomStory # HyperlinkBookSpaceLaw - hyperlink books broken, needs a fix
+      startingItem: HyperlinkBookSpaceLaw
       priority: -2
       whitelist:
         tags:

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Books/hyperlinks.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Books/hyperlinks.yml
@@ -114,17 +114,17 @@
 #  - type: HyperlinkBook
 #    url: https://wiki.nyanotrasen.moe/view/Alert_Procedure
 
-- type: entity
-  parent: BaseHyperlinkBook
-  id: HyperlinkBookProcedure
-  name: standard operating procedure
-  description: A guide to normal station function.
-  components:
-  - type: Sprite
-    layers:
-    - state: book_particle_accelerator
-  - type: HyperlinkBook
-    url: https://frontierstation14.com/index.php/Space_Law
+#- type: entity
+#  parent: BaseHyperlinkBook
+#  id: HyperlinkBookProcedure
+#  name: standard operating procedure
+#  description: A guide to normal station function.
+#  components:
+#  - type: Sprite
+#    layers:
+#    - state: book_particle_accelerator
+#  - type: HyperlinkBook
+#    url: https://frontierstation14.com/index.php/Space_Law
 
 #- type: entity
 #  parent: BaseHyperlinkBook

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Books/hyperlinks.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Books/hyperlinks.yml
@@ -29,90 +29,90 @@
     - Book
     - BookSpaceLaw  #Frontier
 
-- type: entity
-  parent: BaseHyperlinkBook
-  id: HyperlinkBookSupernanny
-  name: book of unsanctioned space punishments
-  description: The ravings of a madman.
-  components:
-  - type: Sprite
-    sprite: Nyanotrasen/Objects/Misc/books.rsi
-    layers:
-    - state: law_space
-  - type: HyperlinkBook
-    url: https://supernannyfanon.fandom.com/wiki/Category:Discipline_Techniques
+#- type: entity
+#  parent: BaseHyperlinkBook
+#  id: HyperlinkBookSupernanny
+#  name: book of unsanctioned space punishments
+#  description: The ravings of a madman.
+#  components:
+#  - type: Sprite
+#    sprite: Nyanotrasen/Objects/Misc/books.rsi
+#    layers:
+#    - state: law_space
+#  - type: HyperlinkBook
+#    url: https://supernannyfanon.fandom.com/wiki/Category:Discipline_Techniques
 
-- type: entity
-  parent: BaseHyperlinkBook
-  id: HyperlinkBookChemistry
-  name: chemical recipe book
-  description: A list of chemical recipes.
-  components:
-  - type: Sprite
-    layers:
-    - state: book_chemistry
-  - type: HyperlinkBook
-    url: https://wiki.nyanotrasen.moe/view/Chemistry
+#- type: entity
+#  parent: BaseHyperlinkBook
+#  id: HyperlinkBookChemistry
+#  name: chemical recipe book
+#  description: A list of chemical recipes.
+#  components:
+#  - type: Sprite
+#    layers:
+#    - state: book_chemistry
+#  - type: HyperlinkBook
+#    url: https://wiki.nyanotrasen.moe/view/Chemistry
 
-- type: entity
-  parent: BaseHyperlinkBook
-  id: HyperlinkBookBartending
-  name: bartender's guide
-  description: A list of drink recipes.
-  components:
-  - type: Sprite
-    layers:
-    - state: book_bar
-  - type: HyperlinkBook
-    url: https://wiki.nyanotrasen.moe/view/Drinks
+#- type: entity
+#  parent: BaseHyperlinkBook
+#  id: HyperlinkBookBartending
+#  name: bartender's guide
+#  description: A list of drink recipes.
+#  components:
+#  - type: Sprite
+#    layers:
+#    - state: book_bar
+#  - type: HyperlinkBook
+#    url: https://wiki.nyanotrasen.moe/view/Drinks
 
-- type: entity
-  parent: BaseHyperlinkBook
-  id: HyperlinkBookCooking
-  name: cookbook
-  description: A list of food recipes.
-  components:
-  - type: Sprite
-    layers:
-    - state: book_cooking
-  - type: HyperlinkBook
-    url: https://wiki.nyanotrasen.moe/view/Cooking
+#- type: entity
+#  parent: BaseHyperlinkBook
+#  id: HyperlinkBookCooking
+#  name: cookbook
+#  description: A list of food recipes.
+#  components:
+#  - type: Sprite
+#    layers:
+#    - state: book_cooking
+#  - type: HyperlinkBook
+#    url: https://wiki.nyanotrasen.moe/view/Cooking
 
-- type: entity
-  parent: BaseHyperlinkBook
-  id: HyperlinkBookBotany
-  name: botanical field guide
-  description: A guide to plants.
-  components:
-  - type: Sprite
-    layers:
-    - state: book_hydroponics_pod_people
-  - type: HyperlinkBook
-    url: https://wiki.nyanotrasen.moe/view/Hydroponics
+#- type: entity
+#  parent: BaseHyperlinkBook
+#  id: HyperlinkBookBotany
+#  name: botanical field guide
+#  description: A guide to plants.
+#  components:
+#  - type: Sprite
+#    layers:
+#    - state: book_hydroponics_pod_people
+#  - type: HyperlinkBook
+#    url: https://wiki.nyanotrasen.moe/view/Hydroponics
 
-- type: entity
-  parent: BaseHyperlinkBook
-  id: HyperlinkBookShuttle
-  name: guide to shuttle construction
-  description: A guide to building shuttles.
-  components:
-  - type: Sprite
-    layers:
-    - state: book_engineering
-  - type: HyperlinkBook
-    url: https://wiki.nyanotrasen.moe/view/Shuttle_Construction
+#- type: entity
+#  parent: BaseHyperlinkBook
+#  id: HyperlinkBookShuttle
+#  name: guide to shuttle construction
+#  description: A guide to building shuttles.
+#  components:
+#  - type: Sprite
+#    layers:
+#    - state: book_engineering
+#  - type: HyperlinkBook
+#    url: https://wiki.nyanotrasen.moe/view/Shuttle_Construction
 
-- type: entity
-  parent: BaseHyperlinkBook
-  id: HyperlinkBookAlerts
-  name: alert procedure
-  description: Procedure for when and why each alert should be put in effect, and what to do.
-  components:
-  - type: Sprite
-    layers:
-    - state: book_nuclear
-  - type: HyperlinkBook
-    url: https://wiki.nyanotrasen.moe/view/Alert_Procedure
+#- type: entity
+#  parent: BaseHyperlinkBook
+#  id: HyperlinkBookAlerts
+#  name: alert procedure
+#  description: Procedure for when and why each alert should be put in effect, and what to do.
+#  components:
+#  - type: Sprite
+#    layers:
+#    - state: book_nuclear
+#  - type: HyperlinkBook
+#    url: https://wiki.nyanotrasen.moe/view/Alert_Procedure
 
 - type: entity
   parent: BaseHyperlinkBook
@@ -126,50 +126,50 @@
   - type: HyperlinkBook
     url: https://frontierstation14.com/index.php/Space_Law
 
-- type: entity
-  parent: BaseHyperlinkBook
-  id: HyperlinkBookPower
-  name: guide to power
-  description: A guide to powering the station.
-  components:
-  - type: Sprite
-    layers:
-    - state: book_engineering2
-  - type: HyperlinkBook
-    url: https://wiki.nyanotrasen.moe/view/Power
+#- type: entity
+#  parent: BaseHyperlinkBook
+#  id: HyperlinkBookPower
+#  name: guide to power
+#  description: A guide to powering the station.
+#  components:
+#  - type: Sprite
+#    layers:
+#    - state: book_engineering2
+#  - type: HyperlinkBook
+#    url: https://wiki.nyanotrasen.moe/view/Power
 
-- type: entity
-  parent: BaseHyperlinkBook
-  id: HyperlinkBookMedical
-  name: guide to medical
-  description: A guide to the medical department.
-  components:
-  - type: Sprite
-    layers:
-    - state: book_infections
-  - type: HyperlinkBook
-    url: https://wiki.nyanotrasen.moe/view/Medical
+#- type: entity
+#  parent: BaseHyperlinkBook
+#  id: HyperlinkBookMedical
+#  name: guide to medical
+#  description: A guide to the medical department.
+#  components:
+#  - type: Sprite
+#    layers:
+#    - state: book_infections
+#  - type: HyperlinkBook
+#    url: https://wiki.nyanotrasen.moe/view/Medical
 
-- type: entity
-  parent: BaseHyperlinkBook
-  id: HyperlinkBookHacking
-  name: guide to hacking
-  description: For emergency use only.
-  components:
-  - type: Sprite
-    layers:
-    - state: book_hacking
-  - type: HyperlinkBook
-    url: https://wiki.nyanotrasen.moe/view/Hacking
+#- type: entity
+#  parent: BaseHyperlinkBook
+#  id: HyperlinkBookHacking
+#  name: guide to hacking
+#  description: For emergency use only.
+#  components:
+#  - type: Sprite
+#    layers:
+#    - state: book_hacking
+#  - type: HyperlinkBook
+#    url: https://wiki.nyanotrasen.moe/view/Hacking
 
-- type: entity
-  parent: BaseHyperlinkBook
-  id: HyperlinkBookAtmos
-  name: guide to atmospherics
-  description: How to make sure everyone has air to breathe.
-  components:
-  - type: Sprite
-    layers:
-    - state: book_engineering2
-  - type: HyperlinkBook
-    url: https://wiki.nyanotrasen.moe/view/Atmospheric_Science
+#- type: entity
+#  parent: BaseHyperlinkBook
+#  id: HyperlinkBookAtmos
+#  name: guide to atmospherics
+#  description: How to make sure everyone has air to breathe.
+#  components:
+#  - type: Sprite
+#    layers:
+#    - state: book_engineering2
+#  - type: HyperlinkBook
+#    url: https://wiki.nyanotrasen.moe/view/Atmospheric_Science

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Books/hyperlinks.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Books/hyperlinks.yml
@@ -1,175 +1,175 @@
 # Frontier - this needs a dedicated fix if we want to continue using it even
-#- type: entity
-#  parent: BaseItem
-#  id: BaseHyperlinkBook
-#  abstract: true
-#  components:
-#  - type: Sprite
-#    sprite: Objects/Misc/books.rsi
-#  - type: Tag
-#    tags:
-#    - Book
-#  - type: StaticPrice
-#    price: 35
-#
-#- type: entity
-#  parent: BaseHyperlinkBook
-#  id: HyperlinkBookSpaceLaw
-#  name: space law
-#  description: A big book of laws for space courts.
-#  components:
-#  - type: Sprite
-#    sprite: Nyanotrasen/Objects/Misc/books.rsi
-#    layers:
-#    - state: law_space
-#  - type: HyperlinkBook
-#    url: https://frontierstation14.com/index.php/Space_Law # Frontier
-#  - type: Tag
-#    tags:
-#    - Book
-#    - BookSpaceLaw # Frontier
-#
-#- type: entity
-#  parent: BaseHyperlinkBook
-#  id: HyperlinkBookSupernanny
-#  name: book of unsanctioned space punishments
-#  description: The ravings of a madman.
-#  components:
-#  - type: Sprite
-#    sprite: Nyanotrasen/Objects/Misc/books.rsi
-#    layers:
-#    - state: law_space
-#  - type: HyperlinkBook
-#    url: https://supernannyfanon.fandom.com/wiki/Category:Discipline_Techniques
-#
-#- type: entity
-#  parent: BaseHyperlinkBook
-#  id: HyperlinkBookChemistry
-#  name: chemical recipe book
-#  description: A list of chemical recipes.
-#  components:
-#  - type: Sprite
-#    layers:
-#    - state: book_chemistry
-#  - type: HyperlinkBook
-#    url: https://wiki.nyanotrasen.moe/view/Chemistry
-#
-#- type: entity
-#  parent: BaseHyperlinkBook
-#  id: HyperlinkBookBartending
-#  name: bartender's guide
-#  description: A list of drink recipes.
-#  components:
-#  - type: Sprite
-#    layers:
-#    - state: book_bar
-#  - type: HyperlinkBook
-#    url: https://wiki.nyanotrasen.moe/view/Drinks
-#
-#- type: entity
-#  parent: BaseHyperlinkBook
-#  id: HyperlinkBookCooking
-#  name: cookbook
-#  description: A list of food recipes.
-#  components:
-#  - type: Sprite
-#    layers:
-#    - state: book_cooking
-#  - type: HyperlinkBook
-#    url: https://wiki.nyanotrasen.moe/view/Cooking
-#
-#- type: entity
-#  parent: BaseHyperlinkBook
-#  id: HyperlinkBookBotany
-#  name: botanical field guide
-#  description: A guide to plants.
-#  components:
-#  - type: Sprite
-#    layers:
-#    - state: book_hydroponics_pod_people
-#  - type: HyperlinkBook
-#    url: https://wiki.nyanotrasen.moe/view/Hydroponics
-#
-#- type: entity
-#  parent: BaseHyperlinkBook
-#  id: HyperlinkBookShuttle
-#  name: guide to shuttle construction
-#  description: A guide to building shuttles.
-#  components:
-#  - type: Sprite
-#    layers:
-#    - state: book_engineering
-#  - type: HyperlinkBook
-#    url: https://wiki.nyanotrasen.moe/view/Shuttle_Construction
-#
-#- type: entity
-#  parent: BaseHyperlinkBook
-#  id: HyperlinkBookAlerts
-#  name: alert procedure
-#  description: Procedure for when and why each alert should be put in effect, and what to do.
-#  components:
-#  - type: Sprite
-#    layers:
-#    - state: book_nuclear
-#  - type: HyperlinkBook
-#    url: https://wiki.nyanotrasen.moe/view/Alert_Procedure
-#
-#- type: entity
-#  parent: BaseHyperlinkBook
-#  id: HyperlinkBookProcedure
-#  name: standard operating procedure
-#  description: A guide to normal station function.
-#  components:
-#  - type: Sprite
-#    layers:
-#    - state: book_particle_accelerator
-#  - type: HyperlinkBook
-#    url: https://frontierstation14.com/index.php/Space_Law
-#
-#- type: entity
-#  parent: BaseHyperlinkBook
-#  id: HyperlinkBookPower
-#  name: guide to power
-#  description: A guide to powering the station.
-#  components:
-#  - type: Sprite
-#    layers:
-#    - state: book_engineering2
-#  - type: HyperlinkBook
-#    url: https://wiki.nyanotrasen.moe/view/Power
-#
-#- type: entity
-#  parent: BaseHyperlinkBook
-#  id: HyperlinkBookMedical
-#  name: guide to medical
-#  description: A guide to the medical department.
-#  components:
-#  - type: Sprite
-#    layers:
-#    - state: book_infections
-#  - type: HyperlinkBook
-#    url: https://wiki.nyanotrasen.moe/view/Medical
-#
-#- type: entity
-#  parent: BaseHyperlinkBook
-#  id: HyperlinkBookHacking
-#  name: guide to hacking
-#  description: For emergency use only.
-#  components:
-#  - type: Sprite
-#    layers:
-#    - state: book_hacking
-#  - type: HyperlinkBook
-#    url: https://wiki.nyanotrasen.moe/view/Hacking
-#
-#- type: entity
-#  parent: BaseHyperlinkBook
-#  id: HyperlinkBookAtmos
-#  name: guide to atmospherics
-#  description: How to make sure everyone has air to breathe.
-#  components:
-#  - type: Sprite
-#    layers:
-#    - state: book_engineering2
-#  - type: HyperlinkBook
-#    url: https://wiki.nyanotrasen.moe/view/Atmospheric_Science
+- type: entity
+  parent: BaseItem
+  id: BaseHyperlinkBook
+  abstract: true
+  components:
+  - type: Sprite
+    sprite: Objects/Misc/books.rsi
+  - type: Tag
+    tags:
+    - Book
+  - type: StaticPrice
+    price: 35
+
+- type: entity
+  parent: BaseHyperlinkBook
+  id: HyperlinkBookSpaceLaw
+  name: space law
+  description: A big book of laws for space courts.
+  components:
+  - type: Sprite
+    sprite: Nyanotrasen/Objects/Misc/books.rsi
+    layers:
+    - state: law_space
+  - type: HyperlinkBook
+    url: https://frontierstation14.com/index.php/Space_Law  #Frontier
+  - type: Tag
+    tags:
+    - Book
+    - BookSpaceLaw  #Frontier
+
+- type: entity
+  parent: BaseHyperlinkBook
+  id: HyperlinkBookSupernanny
+  name: book of unsanctioned space punishments
+  description: The ravings of a madman.
+  components:
+  - type: Sprite
+    sprite: Nyanotrasen/Objects/Misc/books.rsi
+    layers:
+    - state: law_space
+  - type: HyperlinkBook
+    url: https://supernannyfanon.fandom.com/wiki/Category:Discipline_Techniques
+
+- type: entity
+  parent: BaseHyperlinkBook
+  id: HyperlinkBookChemistry
+  name: chemical recipe book
+  description: A list of chemical recipes.
+  components:
+  - type: Sprite
+    layers:
+    - state: book_chemistry
+  - type: HyperlinkBook
+    url: https://wiki.nyanotrasen.moe/view/Chemistry
+
+- type: entity
+  parent: BaseHyperlinkBook
+  id: HyperlinkBookBartending
+  name: bartender's guide
+  description: A list of drink recipes.
+  components:
+  - type: Sprite
+    layers:
+    - state: book_bar
+  - type: HyperlinkBook
+    url: https://wiki.nyanotrasen.moe/view/Drinks
+
+- type: entity
+  parent: BaseHyperlinkBook
+  id: HyperlinkBookCooking
+  name: cookbook
+  description: A list of food recipes.
+  components:
+  - type: Sprite
+    layers:
+    - state: book_cooking
+  - type: HyperlinkBook
+    url: https://wiki.nyanotrasen.moe/view/Cooking
+
+- type: entity
+  parent: BaseHyperlinkBook
+  id: HyperlinkBookBotany
+  name: botanical field guide
+  description: A guide to plants.
+  components:
+  - type: Sprite
+    layers:
+    - state: book_hydroponics_pod_people
+  - type: HyperlinkBook
+    url: https://wiki.nyanotrasen.moe/view/Hydroponics
+
+- type: entity
+  parent: BaseHyperlinkBook
+  id: HyperlinkBookShuttle
+  name: guide to shuttle construction
+  description: A guide to building shuttles.
+  components:
+  - type: Sprite
+    layers:
+    - state: book_engineering
+  - type: HyperlinkBook
+    url: https://wiki.nyanotrasen.moe/view/Shuttle_Construction
+
+- type: entity
+  parent: BaseHyperlinkBook
+  id: HyperlinkBookAlerts
+  name: alert procedure
+  description: Procedure for when and why each alert should be put in effect, and what to do.
+  components:
+  - type: Sprite
+    layers:
+    - state: book_nuclear
+  - type: HyperlinkBook
+    url: https://wiki.nyanotrasen.moe/view/Alert_Procedure
+
+- type: entity
+  parent: BaseHyperlinkBook
+  id: HyperlinkBookProcedure
+  name: standard operating procedure
+  description: A guide to normal station function.
+  components:
+  - type: Sprite
+    layers:
+    - state: book_particle_accelerator
+  - type: HyperlinkBook
+    url: https://frontierstation14.com/index.php/Space_Law
+
+- type: entity
+  parent: BaseHyperlinkBook
+  id: HyperlinkBookPower
+  name: guide to power
+  description: A guide to powering the station.
+  components:
+  - type: Sprite
+    layers:
+    - state: book_engineering2
+  - type: HyperlinkBook
+    url: https://wiki.nyanotrasen.moe/view/Power
+
+- type: entity
+  parent: BaseHyperlinkBook
+  id: HyperlinkBookMedical
+  name: guide to medical
+  description: A guide to the medical department.
+  components:
+  - type: Sprite
+    layers:
+    - state: book_infections
+  - type: HyperlinkBook
+    url: https://wiki.nyanotrasen.moe/view/Medical
+
+- type: entity
+  parent: BaseHyperlinkBook
+  id: HyperlinkBookHacking
+  name: guide to hacking
+  description: For emergency use only.
+  components:
+  - type: Sprite
+    layers:
+    - state: book_hacking
+  - type: HyperlinkBook
+    url: https://wiki.nyanotrasen.moe/view/Hacking
+
+- type: entity
+  parent: BaseHyperlinkBook
+  id: HyperlinkBookAtmos
+  name: guide to atmospherics
+  description: How to make sure everyone has air to breathe.
+  components:
+  - type: Sprite
+    layers:
+    - state: book_engineering2
+  - type: HyperlinkBook
+    url: https://wiki.nyanotrasen.moe/view/Atmospheric_Science


### PR DESCRIPTION
## About the PR
Currently the hyperlink system, Nyanocode, is still functional. Losing the spacelaw book has been a real pain for teaching cadets in NFSD so this would be a temp fix to be reverted once a guidebook is implemented for spacelaw.

**Changelog**
:cl:
- tweak: Temporarily restored Spacelaw books.
