### PR TITLE
Plasteel Recipe Fix

### DIFF
--- a/Resources/Prototypes/_NF/Recipes/Lathes/eva.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/eva.yml
@@ -1,27 +1,3 @@
-
-#    Cloth: 300
-#    Steel: 50
-#    Plastic: 50
-#    Gold: 100
-#    Silver: 100
-
-# Raw mats
-- type: latheRecipe
-  id: Durathread
-  result: MaterialDurathread1
-  completetime: 0.2
-  materials:
-    Plastic: 100
-    Cloth: 100
-
-- type: latheRecipe
-  id: Plasteel
-  result: SheetPlasteel1
-  completetime: 0.2
-  materials:
-    Plastic: 100
-    Steel: 100
-
 # Softsuits
 - type: latheRecipe
   id: ClothingOuterSuitEmergency

--- a/Resources/Prototypes/_NF/Recipes/Lathes/materials.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/materials.yml
@@ -1,0 +1,16 @@
+# Raw mats
+- type: latheRecipe
+  id: Durathread
+  result: MaterialDurathread1
+  completetime: 0.2
+  materials:
+    Plastic: 100
+    Cloth: 100
+
+- type: latheRecipe
+  id: Plasteel
+  result: SheetPlasteel1
+  completetime: 0.2
+  materials:
+    Plasma: 100
+    Steel: 100


### PR DESCRIPTION
## About the PR
Fixes the plasteel recipe to be lore accurate: Plasteel = Plasma + Steel

## Why / Balance
Bug fix

## How to test
Spawn autolathe, put stack of steel and plasma, print plasteel

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
none afaik

**Changelog**
:cl: erhardsteinhauer
- fix: Fixes the plasteel recipe to be lore accurate: Plasteel = Plasma + Steel
