### PR TITLE
Thruster Nerf & Space Alterations

### DIFF
--- a/Content.Server/Shuttles/Components/ShuttleComponent.cs
+++ b/Content.Server/Shuttles/Components/ShuttleComponent.cs
@@ -66,9 +66,9 @@ namespace Content.Server.Shuttles.Components
         /// Damping applied to the shuttle's physics component when not in FTL.
         /// </summary>
         [DataField("linearDamping"), ViewVariables(VVAccess.ReadWrite)]
-        public float LinearDamping = 0.05f;
+        public float LinearDamping = 0.00f;
 
         [DataField("angularDamping"), ViewVariables(VVAccess.ReadWrite)]
-        public float AngularDamping = 0.05f;
+        public float AngularDamping = 0.6f;
     }
 }

--- a/Content.Server/Shuttles/Components/ThrusterComponent.cs
+++ b/Content.Server/Shuttles/Components/ThrusterComponent.cs
@@ -66,7 +66,7 @@ namespace Content.Server.Shuttles.Components
         public string MachinePartThrust = "Capacitor";
 
         [DataField("partRatingThrustMultiplier")]
-        public float PartRatingThrustMultiplier = 1.5f;
+        public float PartRatingThrustMultiplier = 1.15f;
 
         [DataField("thrusterIgnoreEmp")]
         public bool ThrusterIgnoreEmp = false;


### PR DESCRIPTION
## About the PR
This PR changes thrusters and space mechanics to a small degree, but significantly alters the core gameplay experience for Frontier.

Thruster Upgrades have been nerfed from being multiplied by 1.5 for each upgrade to just 1.15 instead, drastically reducing the maximum speed achievable by a vessel by current means.
- Tier 1 (Base) 20m/s
- Tier 2 23m/s
- Tier 3 26.45m/s
- Tier 4 30.4175m/s

This PR also alters linear and angular dampening. For better control, angular dampening was raised to a whopping 0.6 which means that the spin of the vessel will slow down much sooner and faster after releasing the spin button. Additionally, linear dampening was removed meaning ships will retain all linear (forward, backward, left, right) momentum until they collide with another grid or the ship is intentionally stopped.

## Why / Balance
The speeds achievable in the game caused significant issues with collision detection, so much so that it was possible to actually hit yourself with bullets, emps, or RPGs during high speed chases, 45m/s+. These speeds are not well supported by the engine and thus should not be something frequently done especially as we look towards implementing ship-fired weapons.

The linear momentum change means that players don't actually have to sit there and hold W forever, thus having a defacto cruise control of whatever their last input was. This is a significant change and will need discussion.

## How to test
Spawn in a ship, upgrade the engines if you want and give it a whirl.

**Changelog**
:cl:
- remove: Central Command removed excess drag-particles in the Frontier Sector.
- tweak: Reduced top thruster speeds.
