### PR TITLE
Expedition Balance Small Update

### DIFF
--- a/Content.Server/Salvage/SalvageSystem.Expeditions.cs
+++ b/Content.Server/Salvage/SalvageSystem.Expeditions.cs
@@ -30,7 +30,7 @@ public sealed partial class SalvageSystem
      * Handles setup / teardown of salvage expeditions.
      */
 
-    private const int MissionLimit = 4;
+    private const int MissionLimit = 5;
     [Dependency] private readonly StationSystem _stationSystem = default!;
 
     private readonly JobQueue _salvageQueue = new();

--- a/Content.Shared/Salvage/Expeditions/SalvageFactionPrototype.cs
+++ b/Content.Shared/Salvage/Expeditions/SalvageFactionPrototype.cs
@@ -5,7 +5,7 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototy
 namespace Content.Shared.Salvage.Expeditions;
 
 [Prototype("salvageFaction")]
-public sealed partial class SalvageFactionPrototype : IPrototype
+public sealed partial class SalvageFactionPrototype : IPrototype, ISalvageMod
 {
     [IdDataField] public string ID { get; } = default!;
 

--- a/Content.Shared/Salvage/SharedSalvageSystem.cs
+++ b/Content.Shared/Salvage/SharedSalvageSystem.cs
@@ -59,15 +59,15 @@ public abstract partial class SharedSalvageSystem : EntitySystem
         switch (rating)
         {
             case DifficultyRating.Minimal:
-                return 1;
-            case DifficultyRating.Minor:
-                return 2;
-            case DifficultyRating.Moderate:
                 return 4;
-            case DifficultyRating.Hazardous:
+            case DifficultyRating.Minor:
+                return 6;
+            case DifficultyRating.Moderate:
                 return 8;
+            case DifficultyRating.Hazardous:
+                return 10;
             case DifficultyRating.Extreme:
-                return 16;
+                return 12;
             default:
                 throw new ArgumentOutOfRangeException(nameof(rating), rating, null);
         }
@@ -100,12 +100,10 @@ public abstract partial class SharedSalvageSystem : EntitySystem
         // - Biome
         // - Lighting
         // - Atmos
+        var faction = GetMod<SalvageFactionPrototype>(rand, ref rating);
         var biome = GetMod<SalvageBiomeMod>(rand, ref rating);
         var air = GetBiomeMod<SalvageAirMod>(biome.ID, rand, ref rating);
         var dungeon = GetBiomeMod<SalvageDungeonModPrototype>(biome.ID, rand, ref rating);
-        var factionProtos = _proto.EnumeratePrototypes<SalvageFactionPrototype>().ToList();
-        factionProtos.Sort((x, y) => string.Compare(x.ID, y.ID, StringComparison.Ordinal));
-        var faction = factionProtos[rand.Next(factionProtos.Count)];
 
         var mods = new List<string>();
 

--- a/Resources/Prototypes/Procedural/salvage_factions.yml
+++ b/Resources/Prototypes/Procedural/salvage_factions.yml
@@ -1,5 +1,6 @@
 - type: salvageFaction
   id: Xenos
+  cost: 4
   groups:
   - entries:
     - id: MobXeno
@@ -40,6 +41,7 @@
 
 - type: salvageFaction
   id: Carps
+  cost: 1
   groups:
   - entries:
     - id: MobCarpDungeon
@@ -68,6 +70,7 @@
 # Frontier
 - type: salvageFaction
   id: Syndicate
+  cost: 9
   groups:
   - entries:
     - id: SpawnMobSyndicateNavalDeckhand
@@ -109,6 +112,7 @@
 
 - type: salvageFaction
   id: Cultists
+  cost: 7
   groups:
   - entries:
     - id: SpawnMobBloodCultLeech

--- a/Resources/Prototypes/Procedural/salvage_mods.yml
+++ b/Resources/Prototypes/Procedural/salvage_mods.yml
@@ -17,6 +17,7 @@
 - type: salvageBiomeMod
   id: Snow
   biome: Snow
+  cost: 1 # Frontier
 
 - type: salvageBiomeMod
   id: Caves
@@ -25,7 +26,7 @@
 
 - type: salvageBiomeMod
   id: Shadow
-  cost: 2
+#  cost: 2 # Frontier
   biome: Shadow
 
 #- type: salvageBiomeMod


### PR DESCRIPTION
## Why / Balance
Restore the offers to show 5 again as it used to, so you can see all offers.
Update the numbers of "cost" on expo mods.
Added missing code to make it so factions like syndicate and cultist wont be optional on lower levels at all, to avoid noob traps.

## How to test
Run, try expo.

## Media
N/A

## Breaking changes
N/A

**Changelog**
:cl: dvir01
- tweak: The cultist and syndicate migrated to the harder difficulty expeditions only. 