### PR TITLE
No mail for pirates

### DIFF
--- a/Content.Server/Nyanotrasen/Mail/Components/MailDisabledComponent.cs
+++ b/Content.Server/Nyanotrasen/Mail/Components/MailDisabledComponent.cs
@@ -1,0 +1,6 @@
+namespace Content.Server.Mail.Components
+{
+    [RegisterComponent]
+    public sealed partial class MailDisabledComponent : Component
+    {}
+}

--- a/Content.Server/Nyanotrasen/Mail/MailSystem.cs
+++ b/Content.Server/Nyanotrasen/Mail/MailSystem.cs
@@ -74,6 +74,7 @@ namespace Content.Server.Mail
         [Dependency] private readonly ItemSystem _itemSystem = default!;
         [Dependency] private readonly MindSystem _mindSystem = default!;
         [Dependency] private readonly MetaDataSystem _metaDataSystem = default!;
+        [Dependency] private readonly IEntityManager _entManager = default!; // Frontier
 
         private ISawmill _sawmill = default!;
 
@@ -574,6 +575,12 @@ namespace Content.Server.Mail
                 }
 
                 if (!_mind.TryGetMind(receiver.Owner, out var mindId, out var mindComp))
+                {
+                    recipient = null;
+                    return false;
+                }
+
+                if (_entManager.TryGetComponent<MailDisabledComponent>(receiver.Owner, out var antag))
                 {
                     recipient = null;
                     return false;

--- a/Resources/Prototypes/_NF/Roles/Jobs/Pirates/pirate.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Pirates/pirate.yml
@@ -15,6 +15,9 @@
   accessGroups:
   - GeneralAccess
   special:
+  - !type:AddComponentSpecial
+    components:
+    - type: MailDisabled
   - !type:AddImplantSpecial
     implants: [ FreelanceTrackingImplant ]
 

--- a/Resources/Prototypes/_NF/Roles/Jobs/Pirates/pirate_captain.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Pirates/pirate_captain.yml
@@ -16,6 +16,9 @@
   accessGroups:
   - GeneralAccess
   special:
+  - !type:AddComponentSpecial
+    components:
+    - type: MailDisabled
   - !type:AddImplantSpecial
     implants: [ FreelanceTrackingImplant ]
 

--- a/Resources/Prototypes/_NF/Roles/Jobs/Pirates/pirate_first_mate.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Pirates/pirate_first_mate.yml
@@ -8,14 +8,17 @@
     - !type:OverallPlaytimeRequirement
       time: 129600 # Frontier - 36 hours
   startingGear: NFPirateFirstMateGear
-  canBeAntag: true
   alwaysUseSpawner: true
+  canBeAntag: true
   icon: "JobIconMercenary" 
   supervisors: job-supervisors-hire
   setPreference: true
   accessGroups:
   - GeneralAccess
   special:
+  - !type:AddComponentSpecial
+    components:
+    - type: MailDisabled
   - !type:AddImplantSpecial
     implants: [ FreelanceTrackingImplant ]
 


### PR DESCRIPTION
## About the PR
Disable mail from pirates.

## Why / Balance
Spy issue

## How to test
Spawn as pirate, ``mailnow`` no mail

## Media
N/A

## Breaking changes
N/A

**Changelog**
:cl: Dvir01
- tweak: NT No longer send mail to pirates.
