### PR TITLE
Pirates Suit Sensors

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Uniforms/color_jumpskirts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/color_jumpskirts.yml
@@ -427,6 +427,9 @@
       - state: equipped-INNERCLOTHING
         color: "#c59431"
       - state: trinkets-equipped-INNERCLOTHING
+  - type: SuitSensor # Frontier
+    randomMode: false # Frontier
+    mode: SensorOff # Frontier
 
 # Brown Jumpskirt
 - type: entity

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/jumpsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/jumpsuits.yml
@@ -1052,6 +1052,9 @@
     sprite: Clothing/Uniforms/Jumpsuit/pirate.rsi
   - type: AddAccentClothing
     accent: PirateAccent
+  - type: SuitSensor # Frontier
+    randomMode: false # Frontier
+    mode: SensorOff # Frontier
 
 - type: entity
   parent: ClothingUniformBase


### PR DESCRIPTION
## About the PR
Make the pirate spawn suits no longer start with sensors on.
They can still enable them if they want to.

## Why / Balance
Skill issue

## How to test
Spawn as pirate

## Media
N/A

## Breaking changes
N/A

**Changelog**
N/A
