### PR TITLE
 Syndicate and Blackmarket shipyard changes

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers_shipyard.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers_shipyard.yml
@@ -124,7 +124,7 @@
 
 - type: entity
   id: ComputerShipyardSyndicate
-  parent: [BaseStructureDisableToolUse, BaseStructureDestructible, ComputerShipyard]
+  parent: [BaseStructureDisableToolUse, BaseStructureIndestructible, ComputerShipyard]
   name: syndicate shipyard console
   description: Used to buy ships not available through other means. Has a sticker that says SALES TAX 30%
   components:
@@ -150,7 +150,7 @@
 
 - type: entity
   id: ComputerShipyardBlackMarket
-  parent: [BaseStructureDisableToolUse, BaseStructureDestructible, ComputerShipyard]
+  parent: [BaseStructureDisableToolUse, BaseStructureIndestructible, ComputerShipyard]
   name: black market shipyard console
   description: Used to buy ships not available through other means. Has a sticker that says SALES TAX 30%
   components:


### PR DESCRIPTION
## About the PR
Syndicate and blackmarket shipyards now use `BaseStructureIndestructible` instead of `BaseStructureDestructible`

## Why / Balance
With pirates transitioning to start out on the POIs, administration shouldn't have to replace the shipyard console because NFSD decides to break everything.

They are the only shipyards to not be indestructible.

Permanently removing a shipyard listing in a round, especially early in a six hours round isn't good fun for players or mappers. It also makes an interesting scenario to try and repower the console if the POI has been sabotaged.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
:cl:
- fix: All shipyard consoles are indestructible.
