### PR TITLE
Fixes Harpy Skirt Bugs

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Uniforms/base_clothinguniforms.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/base_clothinguniforms.yml
@@ -36,6 +36,11 @@
   - type: Clothing
     slots: [innerclothing]
     femaleMask: UniformTop
+  - type: Tag
+    tags:
+    - ClothMade
+    - WhitelistChameleon
+    - Skirt #Frontier, needed for Harpies
 
 
 - type: entity

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/color_jumpskirts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/color_jumpskirts.yml
@@ -1,6 +1,6 @@
 # White Jumpskirt
 - type: entity
-  parent: CLothingUniformSkirtBase
+  parent: ClothingUniformSkirtBase
   id: ClothingUniformJumpskirtColorWhite
   name: white jumpskirt
   description: A generic white jumpskirt with no rank markings.
@@ -27,7 +27,7 @@
 
 # Grey Jumpskirt
 - type: entity
-  parent: CLothingUniformSkirtBase
+  parent: ClothingUniformSkirtBase
   id: ClothingUniformJumpskirtColorGrey
   name: grey jumpskirt
   description: A tasteful grey jumpskirt that reminds you of the good old days.
@@ -58,7 +58,7 @@
 
 # Black Jumpskirt
 - type: entity
-  parent: CLothingUniformSkirtBase
+  parent: ClothingUniformSkirtBase
   id: ClothingUniformJumpskirtColorBlack
   name: black jumpskirt
   description: A generic black jumpskirt with no rank markings.
@@ -89,7 +89,7 @@
 
 # Blue Jumpskirt
 - type: entity
-  parent: CLothingUniformSkirtBase
+  parent: ClothingUniformSkirtBase
   id: ClothingUniformJumpskirtColorBlue
   name: blue jumpskirt
   description: A generic blue jumpskirt with no rank markings.
@@ -120,7 +120,7 @@
 
 # Dark Blue Jumpskirt
 - type: entity
-  parent: CLothingUniformSkirtBase
+  parent: ClothingUniformSkirtBase
   id: ClothingUniformJumpskirtColorDarkBlue
   name: dark blue jumpskirt
   description: A generic dark blue jumpskirt with no rank markings.
@@ -151,7 +151,7 @@
 
 # Teal Jumpskirt
 - type: entity
-  parent: CLothingUniformSkirtBase
+  parent: ClothingUniformSkirtBase
   id: ClothingUniformJumpskirtColorTeal
   name: teal jumpskirt
   description: A generic teal jumpskirt with no rank markings.
@@ -182,7 +182,7 @@
 
 # Green Jumpskirt
 - type: entity
-  parent: CLothingUniformSkirtBase
+  parent: ClothingUniformSkirtBase
   id: ClothingUniformJumpskirtColorGreen
   name: green jumpskirt
   description: A generic green jumpskirt with no rank markings.
@@ -213,7 +213,7 @@
 
  # Dark Green Jumpskirt
 - type: entity
-  parent: CLothingUniformSkirtBase
+  parent: ClothingUniformSkirtBase
   id: ClothingUniformJumpskirtColorDarkGreen
   name: dark green jumpskirt
   description: A generic dark green jumpskirt with no rank markings.
@@ -244,7 +244,7 @@
 
 # Orange Jumpskirt
 - type: entity
-  parent: CLothingUniformSkirtBase
+  parent: ClothingUniformSkirtBase
   id: ClothingUniformJumpskirtColorOrange
   name: orange jumpskirt
   description: Don't wear this near paranoid security officers.
@@ -275,7 +275,7 @@
 
 # Pink Jumpskirt
 - type: entity
-  parent: CLothingUniformSkirtBase
+  parent: ClothingUniformSkirtBase
   id: ClothingUniformJumpskirtColorPink
   name: pink jumpskirt
   description: Just looking at this makes you feel <i>fabulous</i>.
@@ -306,7 +306,7 @@
 
 # Red Jumpskirt
 - type: entity
-  parent: CLothingUniformSkirtBase
+  parent: ClothingUniformSkirtBase
   id: ClothingUniformJumpskirtColorRed
   name: red jumpskirt
   description: A generic red jumpskirt with no rank markings.
@@ -337,7 +337,7 @@
 
 # Yellow Jumpskirt
 - type: entity
-  parent: CLothingUniformSkirtBase
+  parent: ClothingUniformSkirtBase
   id: ClothingUniformJumpskirtColorYellow
   name: yellow jumpskirt
   description: A generic yellow jumpskirt with no rank markings.
@@ -368,7 +368,7 @@
 
 # Purple Jumpskirt
 - type: entity
-  parent: CLothingUniformSkirtBase
+  parent: ClothingUniformSkirtBase
   id: ClothingUniformJumpskirtColorPurple
   name: purple jumpskirt
   description: A generic light purple jumpskirt with no rank markings.
@@ -399,7 +399,7 @@
 
 # Light Brown Jumpskirt
 - type: entity
-  parent: CLothingUniformSkirtBase
+  parent: ClothingUniformSkirtBase
   id: ClothingUniformJumpskirtColorLightBrown
   name: light brown jumpskirt
   description: A generic light brown jumpskirt with no rank markings.
@@ -433,7 +433,7 @@
 
 # Brown Jumpskirt
 - type: entity
-  parent: CLothingUniformSkirtBase
+  parent: ClothingUniformSkirtBase
   id: ClothingUniformJumpskirtColorBrown
   name: brown jumpskirt
   description: A generic brown jumpskirt with no rank markings.
@@ -464,7 +464,7 @@
 
 # Maroon Jumpskirt
 - type: entity
-  parent: CLothingUniformSkirtBase
+  parent: ClothingUniformSkirtBase
   id: ClothingUniformJumpskirtColorMaroon
   name: maroon jumpskirt
   description: A generic maroon jumpskirt with no rank markings.

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/color_jumpskirts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/color_jumpskirts.yml
@@ -1,6 +1,6 @@
 # White Jumpskirt
 - type: entity
-  parent: ClothingUNiformSkirtBase
+  parent: CLothingUniformSkirtBase
   id: ClothingUniformJumpskirtColorWhite
   name: white jumpskirt
   description: A generic white jumpskirt with no rank markings.
@@ -27,7 +27,7 @@
 
 # Grey Jumpskirt
 - type: entity
-  parent: ClothingUNiformSkirtBase
+  parent: CLothingUniformSkirtBase
   id: ClothingUniformJumpskirtColorGrey
   name: grey jumpskirt
   description: A tasteful grey jumpskirt that reminds you of the good old days.
@@ -58,7 +58,7 @@
 
 # Black Jumpskirt
 - type: entity
-  parent: ClothingUNiformSkirtBase
+  parent: CLothingUniformSkirtBase
   id: ClothingUniformJumpskirtColorBlack
   name: black jumpskirt
   description: A generic black jumpskirt with no rank markings.
@@ -89,7 +89,7 @@
 
 # Blue Jumpskirt
 - type: entity
-  parent: ClothingUNiformSkirtBase
+  parent: CLothingUniformSkirtBase
   id: ClothingUniformJumpskirtColorBlue
   name: blue jumpskirt
   description: A generic blue jumpskirt with no rank markings.
@@ -120,7 +120,7 @@
 
 # Dark Blue Jumpskirt
 - type: entity
-  parent: ClothingUNiformSkirtBase
+  parent: CLothingUniformSkirtBase
   id: ClothingUniformJumpskirtColorDarkBlue
   name: dark blue jumpskirt
   description: A generic dark blue jumpskirt with no rank markings.
@@ -151,7 +151,7 @@
 
 # Teal Jumpskirt
 - type: entity
-  parent: ClothingUNiformSkirtBase
+  parent: CLothingUniformSkirtBase
   id: ClothingUniformJumpskirtColorTeal
   name: teal jumpskirt
   description: A generic teal jumpskirt with no rank markings.
@@ -182,7 +182,7 @@
 
 # Green Jumpskirt
 - type: entity
-  parent: ClothingUNiformSkirtBase
+  parent: CLothingUniformSkirtBase
   id: ClothingUniformJumpskirtColorGreen
   name: green jumpskirt
   description: A generic green jumpskirt with no rank markings.
@@ -213,7 +213,7 @@
 
  # Dark Green Jumpskirt
 - type: entity
-  parent: ClothingUNiformSkirtBase
+  parent: CLothingUniformSkirtBase
   id: ClothingUniformJumpskirtColorDarkGreen
   name: dark green jumpskirt
   description: A generic dark green jumpskirt with no rank markings.
@@ -244,7 +244,7 @@
 
 # Orange Jumpskirt
 - type: entity
-  parent: ClothingUNiformSkirtBase
+  parent: CLothingUniformSkirtBase
   id: ClothingUniformJumpskirtColorOrange
   name: orange jumpskirt
   description: Don't wear this near paranoid security officers.
@@ -275,7 +275,7 @@
 
 # Pink Jumpskirt
 - type: entity
-  parent: ClothingUNiformSkirtBase
+  parent: CLothingUniformSkirtBase
   id: ClothingUniformJumpskirtColorPink
   name: pink jumpskirt
   description: Just looking at this makes you feel <i>fabulous</i>.
@@ -306,7 +306,7 @@
 
 # Red Jumpskirt
 - type: entity
-  parent: ClothingUNiformSkirtBase
+  parent: CLothingUniformSkirtBase
   id: ClothingUniformJumpskirtColorRed
   name: red jumpskirt
   description: A generic red jumpskirt with no rank markings.
@@ -337,7 +337,7 @@
 
 # Yellow Jumpskirt
 - type: entity
-  parent: ClothingUNiformSkirtBase
+  parent: CLothingUniformSkirtBase
   id: ClothingUniformJumpskirtColorYellow
   name: yellow jumpskirt
   description: A generic yellow jumpskirt with no rank markings.
@@ -368,7 +368,7 @@
 
 # Purple Jumpskirt
 - type: entity
-  parent: ClothingUNiformSkirtBase
+  parent: CLothingUniformSkirtBase
   id: ClothingUniformJumpskirtColorPurple
   name: purple jumpskirt
   description: A generic light purple jumpskirt with no rank markings.
@@ -399,7 +399,7 @@
 
 # Light Brown Jumpskirt
 - type: entity
-  parent: ClothingUNiformSkirtBase
+  parent: CLothingUniformSkirtBase
   id: ClothingUniformJumpskirtColorLightBrown
   name: light brown jumpskirt
   description: A generic light brown jumpskirt with no rank markings.
@@ -433,7 +433,7 @@
 
 # Brown Jumpskirt
 - type: entity
-  parent: ClothingUNiformSkirtBase
+  parent: CLothingUniformSkirtBase
   id: ClothingUniformJumpskirtColorBrown
   name: brown jumpskirt
   description: A generic brown jumpskirt with no rank markings.
@@ -464,7 +464,7 @@
 
 # Maroon Jumpskirt
 - type: entity
-  parent: ClothingUNiformSkirtBase
+  parent: CLothingUniformSkirtBase
   id: ClothingUniformJumpskirtColorMaroon
   name: maroon jumpskirt
   description: A generic maroon jumpskirt with no rank markings.

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/color_jumpskirts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/color_jumpskirts.yml
@@ -1,6 +1,6 @@
 # White Jumpskirt
 - type: entity
-  parent: ClothingUniformBase
+  parent: ClothingUNiformSkirtBase
   id: ClothingUniformJumpskirtColorWhite
   name: white jumpskirt
   description: A generic white jumpskirt with no rank markings.
@@ -27,7 +27,7 @@
 
 # Grey Jumpskirt
 - type: entity
-  parent: ClothingUniformBase
+  parent: ClothingUNiformSkirtBase
   id: ClothingUniformJumpskirtColorGrey
   name: grey jumpskirt
   description: A tasteful grey jumpskirt that reminds you of the good old days.
@@ -58,7 +58,7 @@
 
 # Black Jumpskirt
 - type: entity
-  parent: ClothingUniformBase
+  parent: ClothingUNiformSkirtBase
   id: ClothingUniformJumpskirtColorBlack
   name: black jumpskirt
   description: A generic black jumpskirt with no rank markings.
@@ -89,7 +89,7 @@
 
 # Blue Jumpskirt
 - type: entity
-  parent: ClothingUniformBase
+  parent: ClothingUNiformSkirtBase
   id: ClothingUniformJumpskirtColorBlue
   name: blue jumpskirt
   description: A generic blue jumpskirt with no rank markings.
@@ -120,7 +120,7 @@
 
 # Dark Blue Jumpskirt
 - type: entity
-  parent: ClothingUniformBase
+  parent: ClothingUNiformSkirtBase
   id: ClothingUniformJumpskirtColorDarkBlue
   name: dark blue jumpskirt
   description: A generic dark blue jumpskirt with no rank markings.
@@ -151,7 +151,7 @@
 
 # Teal Jumpskirt
 - type: entity
-  parent: ClothingUniformBase
+  parent: ClothingUNiformSkirtBase
   id: ClothingUniformJumpskirtColorTeal
   name: teal jumpskirt
   description: A generic teal jumpskirt with no rank markings.
@@ -182,7 +182,7 @@
 
 # Green Jumpskirt
 - type: entity
-  parent: ClothingUniformBase
+  parent: ClothingUNiformSkirtBase
   id: ClothingUniformJumpskirtColorGreen
   name: green jumpskirt
   description: A generic green jumpskirt with no rank markings.
@@ -213,7 +213,7 @@
 
  # Dark Green Jumpskirt
 - type: entity
-  parent: ClothingUniformBase
+  parent: ClothingUNiformSkirtBase
   id: ClothingUniformJumpskirtColorDarkGreen
   name: dark green jumpskirt
   description: A generic dark green jumpskirt with no rank markings.
@@ -244,7 +244,7 @@
 
 # Orange Jumpskirt
 - type: entity
-  parent: ClothingUniformBase
+  parent: ClothingUNiformSkirtBase
   id: ClothingUniformJumpskirtColorOrange
   name: orange jumpskirt
   description: Don't wear this near paranoid security officers.
@@ -275,7 +275,7 @@
 
 # Pink Jumpskirt
 - type: entity
-  parent: ClothingUniformBase
+  parent: ClothingUNiformSkirtBase
   id: ClothingUniformJumpskirtColorPink
   name: pink jumpskirt
   description: Just looking at this makes you feel <i>fabulous</i>.
@@ -306,7 +306,7 @@
 
 # Red Jumpskirt
 - type: entity
-  parent: ClothingUniformBase
+  parent: ClothingUNiformSkirtBase
   id: ClothingUniformJumpskirtColorRed
   name: red jumpskirt
   description: A generic red jumpskirt with no rank markings.
@@ -337,7 +337,7 @@
 
 # Yellow Jumpskirt
 - type: entity
-  parent: ClothingUniformBase
+  parent: ClothingUNiformSkirtBase
   id: ClothingUniformJumpskirtColorYellow
   name: yellow jumpskirt
   description: A generic yellow jumpskirt with no rank markings.
@@ -368,7 +368,7 @@
 
 # Purple Jumpskirt
 - type: entity
-  parent: ClothingUniformBase
+  parent: ClothingUNiformSkirtBase
   id: ClothingUniformJumpskirtColorPurple
   name: purple jumpskirt
   description: A generic light purple jumpskirt with no rank markings.
@@ -399,7 +399,7 @@
 
 # Light Brown Jumpskirt
 - type: entity
-  parent: ClothingUniformBase
+  parent: ClothingUNiformSkirtBase
   id: ClothingUniformJumpskirtColorLightBrown
   name: light brown jumpskirt
   description: A generic light brown jumpskirt with no rank markings.
@@ -433,7 +433,7 @@
 
 # Brown Jumpskirt
 - type: entity
-  parent: ClothingUniformBase
+  parent: ClothingUNiformSkirtBase
   id: ClothingUniformJumpskirtColorBrown
   name: brown jumpskirt
   description: A generic brown jumpskirt with no rank markings.
@@ -464,7 +464,7 @@
 
 # Maroon Jumpskirt
 - type: entity
-  parent: ClothingUniformBase
+  parent: ClothingUNiformSkirtBase
   id: ClothingUniformJumpskirtColorMaroon
   name: maroon jumpskirt
   description: A generic maroon jumpskirt with no rank markings.

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/jumpskirts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/jumpskirts.yml
@@ -263,7 +263,7 @@
     sprite: Clothing/Uniforms/Jumpskirt/brigmedic.rsi
 
 - type: entity
-  parent: ClothingUniformBase
+  parent: ClothingUniformSkirtBase
   id: ClothingUniformJumpskirtPrisoner
   name: prisoner jumpskirt
   description: Busted.


### PR DESCRIPTION
## About the PR
Jumpskirts were not being consistently parented to UniformJumpskirtBase, and so all of the colored jumpskirts in the game were not listed as skirts, resulting in Harpies being unable to wear them. I reparented them to the correct base, so now this works as intended.

## Why / Balance
Digitigrade Entities are fun. Tajaran are going to have the same annoyances to deal with when I port them.

**Changelog**

:cl: VMSolidus
- fix: All Jumpskirts in the game have been correctly listed as skirts, now Harpies can wear them again. 
