### PR TITLE
Flatpack Vend Edits

### DIFF
--- a/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/expeditionaryflatpackvend.yml
+++ b/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/expeditionaryflatpackvend.yml
@@ -6,4 +6,4 @@
     PowerCellRechargerFlatpack: 16
     WeaponCapacitorRechargerFlatpack: 16
     BorgChargerFlatpack: 16
-    ComputerIFFFlatpack: 3
+    ComputerIFFFlatpack: 1

--- a/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/flatpackvend.yml
+++ b/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/flatpackvend.yml
@@ -8,6 +8,7 @@
     ExosuitFabricatorFlatpack: 4
     ProtolatheFlatpack: 6
     CircuitImprinterFlatpack: 6
+    ResearchAndDevelopmentServerFlatpack: 6
     ScienceTechFabFlatpack: 4
     EngineeringTechFabFlatpack: 4
     SalvageTechfabNFFlatpack: 4
@@ -24,5 +25,3 @@
     AirlockGlassFlatpack: 20
     AirlockShuttleFlatpack: 20
     AirlockGlassShuttleFlatpack: 20
-  emaggedInventory:
-    HoverbikeFlatpack: 1


### PR DESCRIPTION
## About the PR
Lower IFF board in vend since they can be found and resold from planets, left only 1.
Added R&D Servers back, so people wont have to buy a full kit just for an extra server.
Remove the EMAG hover since they are also sold on the contravend itself now.

## Why / Balance
Cleanup

## Media
N/A

## Breaking changes
N/A

**Changelog**
:cl: dvir01
- tweak: Lower IFF amounts in Expeditionary Flatpackvend, you can now find many IFF boards on planets.
- tweak: Added R&D Server Flatpack to Flatpackvend, removed the hidden HoverBike, they can also be found on planets now.
