### PR TITLE
Add felinids/goblins/vulps to hoverbike built-in storage blacklist 

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Objects/Vehicles/vehicles.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Vehicles/vehicles.yml
@@ -66,7 +66,7 @@
     maxItemSize: Huge
     blacklist:
       components:
-      - MindContainer
+      - HumanoidAppearance
   - type: ContainerContainer
     containers:
       storagebase: !type:Container


### PR DESCRIPTION
## About the PR
Adds felinids/goblins/vulps to hoverbike built-in storage blacklist : apparently inserting felinid/goblin/vulp in hoverbike storage compartment causes weird behavior, see [dicord bug report](https://discord.com/channels/1123826877245694004/1235640787874611231) for details.

## Why / Balance
Bugfix

## How to test
Attempt to insert a felinid/goblin/vulp in mail carrier/syndie/nfsd/pirate hoverbike or skeleton bike.

## Media
- [x] This PR does not require an ingame showcase.

## Breaking changes
none afaik

**Changelog**
:cl: erhardsteinhauer (discord)
- fix: Added felinids/goblins/vulps to hoverbike built-in storage blacklist.
