### PR TITLE
Revert "IonStormRule: affects cyborgs system-wide (#1314)"

### DIFF
--- a/Content.Server/StationEvents/Events/IonStormRule.cs
+++ b/Content.Server/StationEvents/Events/IonStormRule.cs
@@ -64,19 +64,15 @@ public sealed class IonStormRule : StationEventSystem<IonStormRuleComponent>
     {
         base.Started(uid, comp, gameRule, args);
 
-        // Frontier - Affect all silicon beings in the sector, not just on-station.
-        // if (!TryGetRandomStation(out var chosenStation))
-        //     return;
-        // End Frontier
+        if (!TryGetRandomStation(out var chosenStation))
+            return;
 
         var query = EntityQueryEnumerator<SiliconLawBoundComponent, TransformComponent, IonStormTargetComponent>();
         while (query.MoveNext(out var ent, out var lawBound, out var xform, out var target))
         {
-            // Frontier - Affect all silicon beings in the sector, not just on-station.
-            // // only affect law holders on the station
-            // if (CompOrNull<StationMemberComponent>(xform.GridUid)?.Station != chosenStation)
-            //     continue;
-            // End Frontier
+            // only affect law holders on the station
+            if (CompOrNull<StationMemberComponent>(xform.GridUid)?.Station != chosenStation)
+                continue;
 
             if (!RobustRandom.Prob(target.Chance))
                 continue;


### PR DESCRIPTION
This reverts commit 584f618981f463189c4eea7d8ac4374b3f1335b6.

For testing

The rule itself seem to test for silicon roles holder but I fear it might be somehow effecting stuff it should not outside of main grids