### PR TITLE
Increase goblin damage

### DIFF
--- a/Resources/Prototypes/_NF/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_NF/Damage/modifier_sets.yml
@@ -1,7 +1,7 @@
 - type: damageModifierSet
   id: Goblin
   coefficients:
-    Blunt: 1.1
-    Slash: 1.1
-    Piercing: 1.1
-    Poison: 0.8
+    Blunt: 1.2
+    Slash: 1.2
+    Piercing: 1.2
+    Poison: 0.75

--- a/Resources/Prototypes/_NF/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_NF/Damage/modifier_sets.yml
@@ -5,3 +5,4 @@
     Slash: 1.2
     Piercing: 1.2
     Poison: 0.75
+    Caustic: 0.9


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Goblins receive 10% more damage now making them have 20% less resistance to piercing, brute and slash, also increased poison resistance by 5% and added caustic resistance by 10%.
 
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
They are even smaller than felinids and have smaller hitbox, felnids have 15% less resistance to everything so this balances out with their size.


**Changelog**

:cl: Leander
- tweak: New goblins send by the nanotrasen recycling plant are more fragile but somehow resist poison and acid much better.

