### PR TITLE
Retarget space-wizards/RobustToolbox

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "RobustToolbox"]
 	path = RobustToolbox
-	url = https://github.com/DeltaV-Station/RobustToolbox.git
+	url = https://github.com/space-wizards/RobustToolbox.git
 	branch = master


### PR DESCRIPTION
## About the PR
This temporary fix isn't needed anymore, so you shouldn't keep targeting this repo.

Make sure the local watchdog origin is updated too
