### PR TITLE
Loadout Fixes [Pt. 1]

### DIFF
--- a/Resources/Prototypes/_NF/Catalog/Fills/Backpacks/StarterGear/backpack.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/Backpacks/StarterGear/backpack.yml
@@ -38,6 +38,20 @@
 
 - type: entity
   noSpawn: true
+  parent: ClothingBackpackIan
+  id: ClothingBackpackIanSrFilled
+  components:
+  - type: StorageFill
+    contents:
+      - id: BoxSurvival
+      - id: Flash
+      - id: RubberStampSr
+      - id: DoorRemoteCommand
+      - id: AccessConfigurator
+      - id: PhoneInstrument
+
+- type: entity
+  noSpawn: true
   parent: ClothingBackpackNfsdBrown
   id: ClothingBackpackNfsdBrownFilled
   components:

--- a/Resources/Prototypes/_NF/Loadouts/Jobs/Contractor/belt.yml
+++ b/Resources/Prototypes/_NF/Loadouts/Jobs/Contractor/belt.yml
@@ -73,17 +73,17 @@
     belt: BoxFolderClipboard
 
 - type: loadout
-  id: ContractorClothingBeltPilotFilled
-  equipment: ContractorClothingBeltPilotFilled
+  id: ContractorClothingBeltPilot
+  equipment: ContractorClothingBeltPilot
   effects:
   - !type:GroupLoadoutEffect
     proto: ContractorT1
   price: 1500
 
 - type: startingGear
-  id: ContractorClothingBeltPilotFilled
+  id: ContractorClothingBeltPilot
   equipment:
-    belt: ClothingBeltPilotFilled
+    belt: ClothingBeltPilot
 
 - type: loadout
   id: ContractorClothingBeltBandolier

--- a/Resources/Prototypes/_NF/Loadouts/Jobs/Mercenary/belt.yml
+++ b/Resources/Prototypes/_NF/Loadouts/Jobs/Mercenary/belt.yml
@@ -7,3 +7,13 @@
   id: MercenaryClothingBeltMercenaryWebbing
   equipment:
     belt: ClothingBeltMercenaryWebbing
+
+- type: loadout
+  id: MercenaryClothingBeltMilitaryWebbing
+  equipment: MercenaryClothingBeltMilitaryWebbing
+  price: 500
+
+- type: startingGear
+  id: MercenaryClothingBeltMilitaryWebbing
+  equipment:
+    belt: ClothingBeltMilitaryWebbing

--- a/Resources/Prototypes/_NF/Loadouts/Jobs/Mercenary/gloves.yml
+++ b/Resources/Prototypes/_NF/Loadouts/Jobs/Mercenary/gloves.yml
@@ -18,3 +18,13 @@
   id: MercenaryClothingHandsMercenaryGlovesCombat
   equipment:
     gloves: ClothingHandsMercenaryGlovesCombat
+
+- type: loadout
+  id: MercenaryClothingHandsGlovesCombat
+  equipment: MercenaryClothingHandsGlovesCombat
+  price: 600
+
+- type: startingGear
+  id: MercenaryClothingHandsGlovesCombat
+  equipment:
+    gloves: ClothingHandsGlovesCombat

--- a/Resources/Prototypes/_NF/Loadouts/Jobs/Mercenary/outer.yml
+++ b/Resources/Prototypes/_NF/Loadouts/Jobs/Mercenary/outer.yml
@@ -7,3 +7,13 @@
   id: MercenaryClothingOuterVestWebMercenary
   equipment:
     outerClothing: ClothingOuterVestWebMercenary
+
+- type: loadout
+  id: MercenaryClothingOuterVestWeb
+  equipment: MercenaryClothingOuterVestWeb
+  price: 600
+
+- type: startingGear
+  id: MercenaryClothingOuterVestWeb
+  equipment:
+    outerClothing: ClothingOuterVestWeb

--- a/Resources/Prototypes/_NF/Loadouts/Jobs/Mercenary/shoes.yml
+++ b/Resources/Prototypes/_NF/Loadouts/Jobs/Mercenary/shoes.yml
@@ -7,3 +7,23 @@
   id: MercenaryClothingShoesBootsMercenary
   equipment:
     shoes: ClothingShoesBootsMercenary
+
+- type: loadout
+  id: MercenaryClothingShoesBootsCombat
+  equipment: MercenaryClothingShoesBootsCombat
+  price: 600
+
+- type: startingGear
+  id: MercenaryClothingShoesBootsCombat
+  equipment:
+    shoes: ClothingShoesBootsCombat
+
+- type: loadout
+  id: MercenaryClothingShoesBootsJack
+  equipment: MercenaryClothingShoesBootsJack
+  price: 600
+
+- type: startingGear
+  id: MercenaryClothingShoesBootsJack
+  equipment:
+    shoes: ClothingShoesBootsJack

--- a/Resources/Prototypes/_NF/Loadouts/Jobs/StationRep/bags.yml
+++ b/Resources/Prototypes/_NF/Loadouts/Jobs/StationRep/bags.yml
@@ -1,9 +1,49 @@
 - type: loadout
-  id: StationRepClothingBackpackIan
-  equipment: StationRepClothingBackpackIan
+  id: StationRepClothingBackpackSrFilled
+  equipment: StationRepClothingBackpackSrFilled
   price: 0
 
 - type: startingGear
-  id: StationRepClothingBackpackIan
+  id: StationRepClothingBackpackSrFilled
   equipment:
-    back: ClothingBackpackIan
+    back: ClothingBackpackSrFilled
+
+- type: loadout
+  id: StationRepClothingBackpackDuffelSrFilled
+  equipment: StationRepClothingBackpackDuffelSrFilled
+  price: 0
+
+- type: startingGear
+  id: StationRepClothingBackpackDuffelSrFilled
+  equipment:
+    back: ClothingBackpackDuffelSrFilled
+
+- type: loadout
+  id: StationRepClothingBackpackSatchelSrFilled
+  equipment: StationRepClothingBackpackSatchelSrFilled
+  price: 0
+
+- type: startingGear
+  id: StationRepClothingBackpackSatchelSrFilled
+  equipment:
+    back: ClothingBackpackSatchelSrFilled
+
+- type: loadout
+  id: StationRepClothingBackpackMessengerSrFilled
+  equipment: StationRepClothingBackpackMessengerSrFilled
+  price: 0
+
+- type: startingGear
+  id: StationRepClothingBackpackMessengerSrFilled
+  equipment:
+    back: ClothingBackpackMessengerSrFilled
+
+- type: loadout
+  id: StationRepClothingBackpackIanFilled
+  equipment: StationRepClothingBackpackIanFilled
+  price: 0
+
+- type: startingGear
+  id: StationRepClothingBackpackIanFilled
+  equipment:
+    back: ClothingBackpackIanSrFilled

--- a/Resources/Prototypes/_NF/Loadouts/contractor_loadout_groups.yml
+++ b/Resources/Prototypes/_NF/Loadouts/contractor_loadout_groups.yml
@@ -267,7 +267,7 @@
   - ContractorClothingBeltUtilityFilled
   - ContractorClothingBeltSalvageWebbing
   - ContractorBoxFolderClipboard
-  - ContractorClothingBeltPilotFilled
+  - ContractorClothingBeltPilot
   - ContractorClothingBeltBandolier
   - ContractorClothingBeltHolster
   - ContractorClothingBeltChaplainSash

--- a/Resources/Prototypes/_NF/Loadouts/mercenary_loadout_groups.yml
+++ b/Resources/Prototypes/_NF/Loadouts/mercenary_loadout_groups.yml
@@ -198,6 +198,7 @@
   minLimit: 0
   loadouts:
   - MercenaryClothingOuterVestWebMercenary
+  - MercenaryClothingOuterVestWeb
   - ContractorClothingOuterSuitEmergency
   - ContractorClothingOuterHardsuitEVA
   - ContractorClothingOuterHardsuitBasic
@@ -268,6 +269,8 @@
   name: loadout-group-contractor-shoes
   loadouts:
   - MercenaryClothingShoesBootsMercenary
+  - MercenaryClothingShoesBootsJack
+  - MercenaryClothingShoesBootsCombat
   - ContractorClothingShoesColorBlack
   - ContractorClothingShoesClothwarp
   - ContractorClothingShoesTourist
@@ -296,7 +299,6 @@
   - ContractorClothingShoesBootsWinterRobo
   - ContractorClothingShoesBootsWinterSci
   - ContractorClothingShoesBootsWinterViro
-  - ContractorClothingShoesBootsJack
   - ContractorClothingShoesLeather
   - ContractorClothingShoesBootsLaceup
   - ContractorClothingShoesSlippers
@@ -402,6 +404,7 @@
   loadouts:
   - MercenaryClothingHandsGlovesMercFingerless
   - MercenaryClothingHandsMercenaryGlovesCombat
+  - MercenaryClothingHandsGlovesCombat
   - ContractorClothingHandsGlovesColorYellow
   - ContractorClothingHandsGlovesLeather
   - ContractorClothingHandsGlovesFingerless
@@ -503,6 +506,7 @@
   minLimit: 0
   loadouts:
   - MercenaryClothingBeltMercenaryWebbing
+  - MercenaryClothingBeltMilitaryWebbing
   - ContractorClothingBeltPlantFilled
   - ContractorClothingBeltChefFilled
   - ContractorClothingBeltStorageWaistbag
@@ -510,7 +514,7 @@
   - ContractorClothingBeltUtilityFilled
   - ContractorClothingBeltSalvageWebbing
   - ContractorBoxFolderClipboard
-  - ContractorClothingBeltPilotFilled
+  - ContractorClothingBeltPilot
   - ContractorClothingBeltBandolier
   - ContractorClothingBeltHolster
   - ContractorClothingBeltChaplainSash

--- a/Resources/Prototypes/_NF/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_NF/Loadouts/role_loadouts.yml
@@ -33,6 +33,7 @@
   - MercenaryGlasses
   - MercenaryShoes
   - ContractorNeck
+  - MercenaryGloves
   - ContractorUtility
   - ContractorFun
   - ContractorTrinkets

--- a/Resources/Prototypes/_NF/Loadouts/stationrep_loadout_groups.yml
+++ b/Resources/Prototypes/_NF/Loadouts/stationrep_loadout_groups.yml
@@ -9,63 +9,11 @@
   id: StationRepBackpack
   name: loadout-group-contractor-backpack
   loadouts:
-  - ContractorClothingBackpackFilled
-  - ContractorClothingBackpackDuffelFilled
-  - ContractorClothingBackpackSatchelFilled
-  - ContractorClothingBackpackMessengerFilled
-  - StationRepClothingBackpackIan #We put the ian bag here so its not default, we also let SR pick a bag out of drip concerns.
-  - ContractorClothingBackpackCaptainFilled
-  - ContractorClothingBackpackDuffelCaptainFilled
-  - ContractorClothingBackpackSatchelCaptainFilled
-  - ContractorClothingBackpackMessengerCaptainFilled
-  - ContractorClothingBackpackSalvageFilled
-  - ContractorClothingBackpackDuffelSalvageFilled
-  - ContractorClothingBackpackSatchelSalvageFilled
-  - ContractorClothingBackpackMessengerSalvageFilled
-  - ContractorClothingBackpackCargoFilled
-  - ContractorClothingBackpackDuffelCargoFilled
-  - ContractorClothingBackpackSatchelCargoFilled
-  - ContractorClothingBackpackMessengerCargoFilled
-  - ContractorClothingBackpackHydroponicsFilled
-  - ContractorClothingBackpackDuffelHydroponicsFilled
-  - ContractorClothingBackpackSatchelHydroponicsFilled
-  - ContractorClothingBackpackMessengerHydroponicsFilled
-  - ContractorClothingBackpackScienceFilled
-  - ContractorClothingBackpackDuffelScienceFilled
-  - ContractorClothingBackpackSatchelScienceFilled
-  - ContractorClothingBackpackMessengerScienceFilled
-  - ContractorClothingBackpackMedicalFilled
-  - ContractorClothingBackpackDuffelMedicalFilled
-  - ContractorClothingBackpackSatchelMedicalFilled
-  - ContractorClothingBackpackMessengerMedicalFilled
-  - ContractorClothingBackpackChemistryFilled
-  - ContractorClothingBackpackDuffelChemistryFilled
-  - ContractorClothingBackpackSatchelChemistryFilled
-  - ContractorClothingBackpackMessengerChemistryFilled
-  - ContractorClothingBackpackGenetics
-  - ContractorClothingBackpackDuffelGenetics
-  - ContractorClothingBackpackSatchelGenetics
-  - ContractorClothingBackpackMessengerGenetics
-  - ContractorClothingBackpackVirology
-  - ContractorClothingBackpackDuffelVirology
-  - ContractorClothingBackpackSatchelVirology
-  - ContractorClothingBackpackMessengerVirology
-  - ContractorClothingBackpackEngineeringFilled
-  - ContractorClothingBackpackDuffelEngineeringFilled
-  - ContractorClothingBackpackSatchelEngineeringFilled
-  - ContractorClothingBackpackMessengerEngineeringFilled
-  - ContractorClothingBackpackAtmosphericsFilled
-  - ContractorClothingBackpackDuffelAtmosphericsFilled
-  - ContractorClothingBackpackSatchelAtmosphericsFilled
-  - ContractorClothingBackpackMessengerAtmosphericsFilled
-  - ContractorClothingBackpackClownFilled
-  - ContractorClothingBackpackDuffelClownFilled
-  - ContractorClothingBackpackSatchelClownFilled
-  - ContractorClothingBackpackMessengerClownFilled
-  - ContractorClothingBackpackMimeFilled
-  - ContractorClothingBackpackDuffelMimeFilled
-  - ContractorClothingBackpackSatchelMimeFilled
-  - ContractorClothingBackpackMessengerMimeFilled
+  - StationRepClothingBackpackSrFilled
+  - StationRepClothingBackpackDuffelSrFilled
+  - StationRepClothingBackpackSatchelSrFilled
+  - StationRepClothingBackpackMessengerSrFilled
+  - StationRepClothingBackpackIanFilled #We put the ian bag here so its not default, we also let SR pick a bag out of drip concerns.
   
 - type: loadoutGroup
   id: StationRepOuterClothing


### PR DESCRIPTION
## About the PR
Mercs loadouts:
- Gloves!
- Added some drip options: black webvest, black combat gloves and boots, black webbing

SR loadouts:
- Backpack options should come filled with SR things.

General loadout changes:
- Pilot webbing no longer filled with standard pilot starting gear.

## Why / Balance
Fixes and tweaks

## How to test
Choose new loadout options

## Media
- [x] This PR does not require an ingame showcase

## Breaking changes
none afaik

**Changelog**
:cl: erhardsteinhauer
- fix: SR backpacks now filled with SR things (even Ian backpack).
- fix: Mercenaries have access to gloves in their loadout menu and have expanded drip selection.
- tweak: Pilot webbing on non-pilots is now empty.
