### PR TITLE
Loadout Hotfix

### DIFF
--- a/Resources/Prototypes/_NF/Catalog/Fills/Items/belt.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/Items/belt.yml
@@ -63,6 +63,5 @@
       - id: Censer
       - id: Bible
       - id: Lantern
-      - id: ChaplainHolywaterBottleFilled
-      - id: WoodenStake
-        amount: 2
+      - id: ChaplainHolywaterFlaskFilled
+      - id: UrnMortuary

--- a/Resources/Prototypes/_NF/Catalog/Fills/Items/belt.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/Items/belt.yml
@@ -49,8 +49,17 @@
 
 - type: entity
   id: ClothingBeltSalvageWebbingFilledNF
-  parent: [ ClothingBeltSalvageWebbing, ClothingBeltUtility ]
-  suffix: Filled
+  parent: ClothingBeltSalvageWebbing
+  suffix: Filled, Engineering
+  components:
+  - type: StorageFill
+    contents:
+      - id: Crowbar
+      - id: Wrench
+      - id: Screwdriver
+      - id: Wirecutter
+      - id: Welder
+      - id: Multitool
 
 - type: entity
   id: ClothingBeltChaplainSashFilled

--- a/Resources/Prototypes/_NF/Catalog/Fills/Items/misc.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/Items/misc.yml
@@ -23,9 +23,9 @@
   parent: [ClothingShoesBootsNfsdCream, ClothingShoesBootsCombatFilled]
 
 - type: entity
-  parent: ChemistryEmptyBottle04
-  id: ChaplainHolywaterBottleFilled
-  name: holy water bottle
+  parent: DrinkFlaskBar
+  id: ChaplainHolywaterFlaskFilled
+  name: holy water flask
   description: Blessed be this holy water by the deity of your choosing.
   components:
   - type: SolutionContainerManager

--- a/Resources/Prototypes/_NF/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Belt/belts.yml
@@ -55,7 +55,7 @@
     mapLayers:
       book:
         whitelist:
-          tag:
+          tags:
           - Book
           components:
           - BibleComponent

--- a/Resources/Prototypes/_NF/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Belt/belts.yml
@@ -26,32 +26,47 @@
     # TODO: Fill this out more.
     whitelist:
       tags:
-        - Book
-        - Smokable
-        - Flare
-        - Matchstick
-        - Flashlight
-        - Trash
-        - CigPack
-        - Radio
-        - Crayon
-        - Bottle
-        - WeaponMeleeStake
-        - Censer
-        - ReligiousSymbol
-        - Crucifix
-        - Spear
-        - Wooden
+      - ObjectOfSpiritualSignificance
+      - Censer
+      - ReligiousSymbol
+      - Crucifix
+      - WeaponMeleeStake
+      - Book
+      - Smokable
+      - Matchstick
+      - Flashlight
+      - Trash
+      - CigPack
+      - Radio
+      - Crayon
+      - Bottle
+      - DrinkBottle
+      components:
+      - BibleComponent
+      - Drink
+      - Smokable
+      - MeleeWeapon
+      - HandheldLight
+      - ExpendableLight
+      - ToggleableLightVisuals
+      - Paper
+      - Stamp
   - type: ItemMapper
     mapLayers:
       book:
         whitelist:
-          tags:
+          tag:
           - Book
+          components:
+          - BibleComponent
+          - Paper
       bottle:
         whitelist:
           tags:
           - Bottle
+          - DrinkBottle
+          components:
+          - Drink
       censer:
         whitelist:
           tags:

--- a/Resources/Prototypes/_NF/Entities/Clothing/Neck/misc.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Neck/misc.yml
@@ -57,3 +57,6 @@
     rechargeCooldown: 440
     rechargeSound:
       path: /Audio/_NF/Effects/silence.ogg
+  - type: Tag
+    tags:
+    - ObjectOfSpiritualSignificance

--- a/Resources/Prototypes/_NF/Loadouts/Jobs/Contractor/belt.yml
+++ b/Resources/Prototypes/_NF/Loadouts/Jobs/Contractor/belt.yml
@@ -121,7 +121,7 @@
 - type: loadout
   id: ContractorClothingBeltSalvageWebbingFilledNF
   equipment: ContractorClothingBeltSalvageWebbingFilledNF
-  price: 500
+  price: 1500
 
 - type: startingGear
   id: ContractorClothingBeltSalvageWebbingFilledNF
@@ -166,7 +166,7 @@
 - type: startingGear
   id: ContractorClothingBeltPilotFilled
   equipment:
-    belt: ClothingBeltPilot
+    belt: ClothingBeltPilotFilled
 
 - type: loadout
   id: ContractorClothingBeltBandolier

--- a/Resources/Prototypes/_NF/Loadouts/Jobs/Contractor/jumpsuit.yml
+++ b/Resources/Prototypes/_NF/Loadouts/Jobs/Contractor/jumpsuit.yml
@@ -394,6 +394,19 @@
   id: ContractorClothingUniformJumpskirtColorDarkBlue
   equipment:
     jumpsuit: ClothingUniformJumpskirtColorDarkBlue
+
+- type: loadout
+  id: ContractorClothingUniformJumpsuitColorDarkGreen
+  equipment: ContractorClothingUniformJumpsuitColorDarkGreen
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: ContractorT1
+  price: 500
+
+- type: startingGear
+  id: ContractorClothingUniformJumpsuitColorDarkGreen
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitColorDarkGreen
   
 - type: loadout
   id: ContractorClothingUniformJumpskirtColorDarkGreen

--- a/Resources/Prototypes/_NF/Loadouts/contractor_loadout_groups.yml
+++ b/Resources/Prototypes/_NF/Loadouts/contractor_loadout_groups.yml
@@ -41,7 +41,7 @@
   - ContractorClothingUniformJumpskirtColorPink
   - ContractorClothingUniformJumpsuitColorDarkBlue
   - ContractorClothingUniformJumpskirtColorDarkBlue
-  - ContractorClothingUniformJumpskirtColorDarkBlue
+  - ContractorClothingUniformJumpsuitColorDarkGreen
   - ContractorClothingUniformJumpskirtColorDarkGreen
   - ContractorClothingUniformJumpsuitColorTeal
   - ContractorClothingUniformJumpskirtColorTeal

--- a/Resources/Prototypes/_NF/Loadouts/mercenary_loadout_groups.yml
+++ b/Resources/Prototypes/_NF/Loadouts/mercenary_loadout_groups.yml
@@ -7,6 +7,7 @@
 #Second Section: Contractor list
   - ContractorClothingUniformJumpsuitColorGrey
   - ContractorClothingUniformJumpskirtColorGrey
+  - PilotClothingUniformJumpsuitPilot
   - ContractorClothingUniformJumpsuitAtmos
   - ContractorClothingUniformJumpskirtAtmos
   - ContractorClothingUniformJumpsuitBartender
@@ -44,7 +45,7 @@
   - ContractorClothingUniformJumpskirtColorPink
   - ContractorClothingUniformJumpsuitColorDarkBlue
   - ContractorClothingUniformJumpskirtColorDarkBlue
-  - ContractorClothingUniformJumpskirtColorDarkBlue
+  - ContractorClothingUniformJumpsuitColorDarkGreen
   - ContractorClothingUniformJumpskirtColorDarkGreen
   - ContractorClothingUniformJumpsuitColorTeal
   - ContractorClothingUniformJumpskirtColorTeal
@@ -139,6 +140,10 @@
   - ContractorClothingBackpackDuffelFilled
   - ContractorClothingBackpackSatchelFilled
   - ContractorClothingBackpackMessengerFilled
+  - PilotClothingBackpackPilotFilled
+  - PilotClothingBackpackDuffelPilotFilled
+  - PilotClothingBackpackSatchelPilotFilled
+  - PilotClothingBackpackMessengerPilotFilled
   - ContractorClothingBackpackCaptainFilled
   - ContractorClothingBackpackDuffelCaptainFilled
   - ContractorClothingBackpackSatchelCaptainFilled

--- a/Resources/Prototypes/_NF/Loadouts/pilot_loadout_groups.yml
+++ b/Resources/Prototypes/_NF/Loadouts/pilot_loadout_groups.yml
@@ -43,7 +43,7 @@
   - ContractorClothingUniformJumpskirtColorPink
   - ContractorClothingUniformJumpsuitColorDarkBlue
   - ContractorClothingUniformJumpskirtColorDarkBlue
-  - ContractorClothingUniformJumpskirtColorDarkBlue
+  - ContractorClothingUniformJumpsuitColorDarkGreen
   - ContractorClothingUniformJumpskirtColorDarkGreen
   - ContractorClothingUniformJumpsuitColorTeal
   - ContractorClothingUniformJumpskirtColorTeal


### PR DESCRIPTION
## About the PR
- Filled Pilot Webbing is actually filled now.
- Fixed filled variant of salvager rig (it was empty and functioned as utility belt and not like webbing).
- Fixed price tag on filled salvager rig.
- Fixed dark green jumpsuit for contractor/pilot/mercenary loadouts.
- Made pilot drip available for mercenaries.
- Changed contents of filled chaplain sash to contain: Crucifix, Censer, Bible, Lantern, Flask with Holy Water, Mortuary Urn (Frontier specific one).

## Why / Balance
Fixes.

## How to test
Choose loadout options and spawn with them.

## Media
- [x] This PR does not require an ingame showcase

## Breaking changes
none afaik

**Changelog**
:cl: erhardsteinhauer (discord)
- tweak: Changed contents of filled chaplain sash to contain: Crucifix, Censer, Bible, Lantern, Flask with Holy Water, Mortuary Urn.
- tweak: Gave mercenaries access to pilot clothes in loadouts.
- fix: Fixed filled Pilot webbing and Filled Salvager Rig in loadouts.
- fix: Enabled dark green jumpsuit.
