### PR TITLE
adding tramoxadone and supporting chems for post mortem brute restoration

### DIFF
--- a/Resources/Locale/en-US/_NF/reagents/meta/chemicals.ftl
+++ b/Resources/Locale/en-US/_NF/reagents/meta/chemicals.ftl
@@ -1,0 +1,2 @@
+reagent-name-salicylicacid = Salicylic Acid
+reagent-desc-salicylicacid = A powdery substence used for dermalogical treatments.

--- a/Resources/Locale/en-US/_NF/reagents/meta/chemicals.ftl
+++ b/Resources/Locale/en-US/_NF/reagents/meta/chemicals.ftl
@@ -1,2 +1,2 @@
-reagent-name-salicylicacid = Salicylic Acid
+reagent-name-salicylicacid = salicylic acid
 reagent-desc-salicylicacid = A powdery substance used for dermatological treatments.

--- a/Resources/Locale/en-US/_NF/reagents/meta/chemicals.ftl
+++ b/Resources/Locale/en-US/_NF/reagents/meta/chemicals.ftl
@@ -1,2 +1,2 @@
 reagent-name-salicylicacid = Salicylic Acid
-reagent-desc-salicylicacid = A powdery substence used for dermalogical treatments.
+reagent-desc-salicylicacid = A powdery substance used for dermatological treatments.

--- a/Resources/Locale/en-US/_NF/reagents/meta/medicine.ftl
+++ b/Resources/Locale/en-US/_NF/reagents/meta/medicine.ftl
@@ -1,2 +1,2 @@
 reagent-name-tramoxadone = tramoxadone
-reagent-desc-tramoxadone = A cryogenics chemical. Used to treat severe trama via regeneration of the damaged tissue. Works regardless of the patient being alive or dead.
+reagent-desc-tramoxadone = A cryogenics chemical. Used to treat severe trauma via regeneration of the damaged tissue. Works regardless of the patient being alive or dead.

--- a/Resources/Locale/en-US/_NF/reagents/meta/medicine.ftl
+++ b/Resources/Locale/en-US/_NF/reagents/meta/medicine.ftl
@@ -1,0 +1,2 @@
+reagent-name-tramoxadone = tramoxadone
+reagent-desc-tramoxadone = A cryogenics chemical. Used to treat severe trama via regeneration of the damaged tissue. Works regardless of the patient being alive or dead.

--- a/Resources/Prototypes/_NF/Reagents/chemicals.yml
+++ b/Resources/Prototypes/_NF/Reagents/chemicals.yml
@@ -20,3 +20,10 @@
         conditions:
         - !type:ReagentThreshold
           min: 5
+          
+- type: reagent
+  id: SalicylicAcid
+  name: reagent-name-salicylicacid
+  desc: reagent-desc-salicylicacid
+  physicalDesc: reagent-physical-desc-powdery
+  color: "#EEEEEE"

--- a/Resources/Prototypes/_NF/Reagents/medicine.yml
+++ b/Resources/Prototypes/_NF/Reagents/medicine.yml
@@ -1,0 +1,21 @@
+- type: reagent
+  id : Tramoxadone
+  name: reagent-name-tramoxadone
+  group: Medicine
+  desc: reagent-desc-tramoxadone
+  physicalDesc: reagent-physical-desc-soothing
+  flavor: medicine
+  color: "#880077"
+  worksOnTheDead: true
+  metabolisms:
+    Medicine:
+      effects:
+      - !type:HealthChange
+        conditions:
+        - !type:Temperature
+          max: 213.0
+        damage:
+          types:
+            Blunt: -2
+            Piercing: -2
+            Slash: -2

--- a/Resources/Prototypes/_NF/Recipes/Reactions/chemicals.yml
+++ b/Resources/Prototypes/_NF/Recipes/Reactions/chemicals.yml
@@ -50,3 +50,19 @@
       amount: 2
   products:
     Water: 2
+
+- type: reaction
+  id : SalicylicAcid
+  reactants:
+    Phenol:
+      amount: 1
+    Sodium:
+      amount: 1
+    Carbon:
+      amount: 1
+    Oxygen:
+      amount: 1
+    SulfuricAcid:
+      amount: 1
+  products:
+    SalicylicAcid: 3

--- a/Resources/Prototypes/_NF/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/_NF/Recipes/Reactions/medicine.yml
@@ -1,0 +1,11 @@
+- type: reaction
+  id: Tramoxadone
+  reactants:
+    Cryoxadone:
+      amount: 1
+    SalicylicAcid:
+      amount: 1
+    Lipozine:
+      amount: 1
+  products:
+    Tramoxadone: 2


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Adds 1 new chem to create a new cryo chem called Tramoxadone which restores brute damage even if dead
<!-- What did you change in this PR? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Why / Balance
This helps balance the changes from med where there are no longer re-stocks and encourage advance med rather than treating everything with brute packs.  This is the Brute version of Aloxodone
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

## How to test
take a urist,  whap it with a throngler 8 times tossed it into a cryo system and once cooled added the tramoxadone to ensure the brute was cured
<!-- Describe the way it can be tested -->


**Changelog**
:cl:
- add: new Cryo Chem
