### PR TITLE
Fix news manager consoles

### DIFF
--- a/Content.Shared/_NF/MassMedia/Component/SectorNewsComponent.cs
+++ b/Content.Shared/_NF/MassMedia/Component/SectorNewsComponent.cs
@@ -1,0 +1,9 @@
+using Content.Shared.MassMedia.Systems;
+
+namespace Content.Shared.MassMedia.Components;
+
+[RegisterComponent]
+public sealed partial class SectorNewsComponent : Component
+{
+    public static List<NewsArticle> Articles = new();
+}

--- a/Resources/Prototypes/_NF/Shipyard/base.yml
+++ b/Resources/Prototypes/_NF/Shipyard/base.yml
@@ -9,6 +9,7 @@
     - BaseStationAlertLevels
     - BaseStationSiliconLawFrontierStation
     - BaseStationEmpImmune
+    - BaseStationSectorNews
   noSpawn: true
   components:
     - type: Transform
@@ -131,3 +132,10 @@
   abstract: true
   components:
     - type: StationEmpImmune
+
+# Sector-wide news access, should be on stations with comms (radio station, telecomms)
+- type: entity
+  id: BaseStationSectorNews
+  abstract: true
+  components:
+    - type: SectorNews


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

News consoles should work now, anyone with a valid ID with a station record can publish messages on a console.  Also, you should be able to read all published news messages from your PDA wherever you are.

The following changes were made to the code:
1. **NewsSystem no longer has an onMapInit handler.**  For shuttles being purchased, this was being run before there was a station entry, and the shuttle would never receive a StationNewsComponent.  This prevented the publish/delete actions.
2. **Added a SectorNewsComponent, with a statically defined article list.**  This mimics old behaviour, but the data is accessible through a Component instead of a System.  This makes all news stories readable from anywhere.
3. **Added a SectorNewsComponent to Frontier Outpost.**  Since Frontier Outpost has that server/telecomm room, I assumed that station news would be stored there.  Since Frontier Outpost shouldn't be destroyed, there shouldn't be any lifecycle issues with the SectorNewsComponent.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

News manager consoles stopped working on Frontier after the march 2024 upstream merge, when the NewsSystem updates were pulled in.

As written, the upstream changes work alright for situations with one station, with nearly everybody working onboard the station, and when the station has a StationNewsComponent in its definition.  For Frontier, this solution is poorly suited - storing and retrieving news articles published within one shuttle is insufficient, you should have access to all news published sector-wide.

A few points to note:

1. The article set has no controllable lifecycle, being static, but the components accessing it do.
2. When the component storing the news articles is destroyed, any terminals list all cached articles, but they cannot publish new articles or delete existing ones.  **There is no UI feedback for this.**
3. The access rules for publishing and deleting news articles prevent you from publishing articles if you receive a new ID, since that new ID lacks a station record.  This seems strange.

## How to test
<!-- Describe the way it can be tested -->

1. Build, run, and connect to a local server.
4. Buy a Legman.
5. Publish a story from the Legman's news console.
6. Open the news app on your PDA aboard the Legman, your story should appear.
7. Run back onto Frontier Outpost.
8. Open the news app on your PDA aboard Frontier Outpost, your story should appear.
9. Spawn a PDA.
10. Purchase a WaveShot with the ID in your new PDA.
11. Publish a story from the WaveShot's news console with your old PDA equipped.  It should work.
12. Open the news app on your PDA aboard the Waveshot, both stories should appear.
13. Equip your new PDA, dropping your old one.
14. Try to publish a story from the WaveShot's news console with your new PDA equipped.  It should not work, as this ID does not have a station record.
15. Try to delete a story from the WaveShot's news console with your new PDA equipped.  It should not work, as this ID does not have a station record.
16. Re-equip your old PDA.
17. Try to delete your first story from the WaveShot's news console with your old PDA equipped.  It should work.
18. Open the news app on your old PDA aboard the WaveShot, only your second story should appear.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** ***this PR does not require an ingame showcase***

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->



**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl:
- fix: News consoles now publish and delete articles properly.