### PR TITLE
Fix for loadout black web vest

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/armor.yml
@@ -73,3 +73,12 @@
   - type: ExplosionResistance
     damageCoefficient: 0.60
   - type: GroupExamine
+
+- type: entity
+  parent: ClothingOuterVestWebMercenary
+  id: ClothingOuterVestWebMercenaryBlack
+  components:
+  - type: Sprite
+    sprite: Clothing/OuterClothing/Vests/webvest.rsi
+  - type: Clothing
+    sprite: Clothing/OuterClothing/Vests/webvest.rsi

--- a/Resources/Prototypes/_NF/Loadouts/Jobs/Mercenary/outer.yml
+++ b/Resources/Prototypes/_NF/Loadouts/Jobs/Mercenary/outer.yml
@@ -16,4 +16,4 @@
 - type: startingGear
   id: MercenaryClothingOuterVestWeb
   equipment:
-    outerClothing: ClothingOuterVestWeb
+    outerClothing: ClothingOuterVestWebMercenaryBlack

--- a/Resources/Prototypes/_NF/Loadouts/Jobs/Mercenary/outer.yml
+++ b/Resources/Prototypes/_NF/Loadouts/Jobs/Mercenary/outer.yml
@@ -9,11 +9,11 @@
     outerClothing: ClothingOuterVestWebMercenary
 
 - type: loadout
-  id: MercenaryClothingOuterVestWeb
-  equipment: MercenaryClothingOuterVestWeb
+  id: MercenaryClothingOuterVestWebMercenaryBlack
+  equipment: MercenaryClothingOuterVestWebMercenaryBlack
   price: 600
 
 - type: startingGear
-  id: MercenaryClothingOuterVestWeb
+  id: MercenaryClothingOuterVestWebMercenaryBlack
   equipment:
     outerClothing: ClothingOuterVestWebMercenaryBlack

--- a/Resources/Prototypes/_NF/Loadouts/mercenary_loadout_groups.yml
+++ b/Resources/Prototypes/_NF/Loadouts/mercenary_loadout_groups.yml
@@ -203,7 +203,7 @@
   minLimit: 0
   loadouts:
   - MercenaryClothingOuterVestWebMercenary
-  - MercenaryClothingOuterVestWeb
+  - MercenaryClothingOuterVestWebMercenaryBlack
   - ContractorClothingOuterSuitEmergency
   - ContractorClothingOuterHardsuitEVA
   - ContractorClothingOuterHardsuitBasic


### PR DESCRIPTION
## About the PR
Adds new web vest for mercs loadout with reasonable stats for $600.

## Why / Balance
Fixing my mistake

## How to test
Go to merc loadouts, choose black merc vest, compare it with regular merc web vest after spawn

## Media
- [x] This PR does not require an ingame showcase

## Breaking changes
none I think

**Changelog**
:cl: erhardsteinhauer
- tweak: Starting black web vest no longer come with additional armor inserts.