### PR TITLE
Bulk Update of Shuttles

### DIFF
--- a/Resources/Maps/_NF/Shuttles/Expedition/brigand.yml
+++ b/Resources/Maps/_NF/Shuttles/Expedition/brigand.yml
@@ -397,8 +397,7 @@ entities:
           0,0:
             0: 53757
           0,-1:
-            0: 5599
-            1: 2048
+            0: 7647
           -1,0:
             0: 65279
           0,1:
@@ -411,22 +410,22 @@ entities:
             0: 19656
             2: 16
           0,3:
-            3: 10
+            1: 10
           1,0:
             0: 12305
-            3: 1024
+            1: 1024
           1,1:
             0: 4355
-            3: 64
+            1: 64
           1,2:
             2: 16
-            3: 2
+            1: 2
           0,-4:
             0: 1808
             2: 4
           0,-5:
             2: 12288
-            3: 32768
+            1: 32768
           -1,-4:
             0: 3072
             2: 276
@@ -444,34 +443,34 @@ entities:
             2: 272
           1,-3:
             0: 272
-            3: 2
+            1: 2
           1,-2:
             0: 13073
-            3: 64
+            1: 64
           1,-1:
             0: 819
-            3: 16384
+            1: 16384
           -2,-2:
-            3: 64
+            1: 64
             0: 2048
           -2,-1:
             0: 3084
-            3: 16384
+            1: 16384
           -2,-3:
-            3: 8
+            1: 8
           -1,-5:
-            3: 8192
+            1: 8192
             2: 32768
           -2,0:
-            3: 1024
+            1: 1024
             0: 32768
           -2,1:
-            3: 64
+            1: 64
             0: 8
           -2,2:
-            3: 8
+            1: 8
           -1,3:
-            3: 10
+            1: 10
         uniqueMixes:
         - volume: 2500
           temperature: 293.15
@@ -491,8 +490,8 @@ entities:
         - volume: 2500
           temperature: 293.15
           moles:
-          - 21.813705
-          - 82.06108
+          - 0
+          - 0
           - 0
           - 0
           - 0
@@ -505,21 +504,6 @@ entities:
           - 0
         - volume: 2500
           immutable: True
-          moles:
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-        - volume: 2500
-          temperature: 293.15
           moles:
           - 0
           - 0
@@ -2031,6 +2015,13 @@ entities:
           ents:
           - 464
           - 296
+- proto: ClothingBeltSalvageWebbingFilledNF
+  entities:
+  - uid: 332
+    components:
+    - type: Transform
+      pos: 2.5809524,-2.402208
+      parent: 1
 - proto: ComputerTabletopPowerMonitoring
   entities:
   - uid: 646
@@ -2364,14 +2355,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 1.5,9.5
       parent: 1
-- proto: EncryptionKeyCommon
-  entities:
-  - uid: 226
-    components:
-    - type: Transform
-      parent: 220
-    - type: Physics
-      canCollide: False
 - proto: ExtinguisherCabinetFilled
   entities:
   - uid: 709
@@ -3613,12 +3596,12 @@ entities:
       parent: 1
     - type: Thruster
       originalPowerLoad: 1500
-- proto: HandheldHealthAnalyzerUnpowered
+- proto: HandheldHealthAnalyzer
   entities:
-  - uid: 247
+  - uid: 220
     components:
     - type: Transform
-      pos: 4.5122986,1.042957
+      pos: 4.5374136,1.0828397
       parent: 1
 - proto: HighSecCaptainLocked
   entities:
@@ -3884,8 +3867,6 @@ entities:
     - type: Transform
       pos: 2.5,-2.5
       parent: 1
-    - type: MaterialStorageMagnetPickup
-      magnetEnabled: True
 - proto: Saw
   entities:
   - uid: 698
@@ -3893,6 +3874,13 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.54243,0.6934414
+      parent: 1
+- proto: ShipyardBrigandInfo
+  entities:
+  - uid: 226
+    components:
+    - type: Transform
+      pos: 4.292027,-1.6069934
       parent: 1
 - proto: ShuttersNormalOpen
   entities:
@@ -4192,27 +4180,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 3.5,3.5
       parent: 1
-- proto: SpawnPointMercenary
-  entities:
-  - uid: 630
-    components:
-    - type: Transform
-      pos: 2.5,4.5
-      parent: 1
-- proto: SpawnPointPilot
-  entities:
-  - uid: 448
-    components:
-    - type: Transform
-      pos: 3.5,4.5
-      parent: 1
-- proto: SpawnPointSalvageSpecialist
-  entities:
-  - uid: 152
-    components:
-    - type: Transform
-      pos: 4.5,4.5
-      parent: 1
 - proto: SpawnVehicleATV
   entities:
   - uid: 474
@@ -4444,28 +4411,13 @@ entities:
     - type: Transform
       pos: -3.5,6.5
       parent: 1
-- proto: TelecomServer
+- proto: TelecomServerFilledCommon
   entities:
-  - uid: 220
+  - uid: 152
     components:
     - type: Transform
       pos: 5.5,-1.5
       parent: 1
-    - type: ContainerContainer
-      containers:
-        key_slots: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 226
-        machine_board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        machine_parts: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
 - proto: Thruster
   entities:
   - uid: 114
@@ -5283,31 +5235,27 @@ entities:
     - type: Transform
       pos: -4.5,-2.5
       parent: 1
-- proto: WallWeaponCapacitorRecharger
+- proto: WallWeaponCapacitorRechargerOmnidirectional
   entities:
-  - uid: 396
+  - uid: 239
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 2.5,-12.5
-      parent: 1
-  - uid: 397
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
       pos: 1.5,-12.5
       parent: 1
-  - uid: 398
+  - uid: 245
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 0.5,-12.5
+      pos: 2.5,-12.5
       parent: 1
-  - uid: 399
+  - uid: 247
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 3.5,-12.5
+      parent: 1
+  - uid: 248
+    components:
+    - type: Transform
+      pos: 0.5,-12.5
       parent: 1
 - proto: WarningN2
   entities:

--- a/Resources/Maps/_NF/Shuttles/Expedition/gasbender.yml
+++ b/Resources/Maps/_NF/Shuttles/Expedition/gasbender.yml
@@ -27,11 +27,11 @@ entities:
       chunks:
         0,0:
           ind: 0,0
-          tiles: HgAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfAAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfAAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfAAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfAAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfAAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfAAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAAAAawAAAAAAHgAAAAAAHgAAAAAAfQAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAAAAHgAAAAAAHgAAAAAAHgAAAAAAXgAAAAAAXgAAAAAAXgAAAAAAfQAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAAAAHgAAAAAAHgAAAAAAHgAAAAAAXgAAAAAAXgAAAAAAXgAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAAAAHgAAAAAAHgAAAAAAHgAAAAAAXgAAAAAAXgAAAAAAXgAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAAAAHgAAAAAAHgAAAAAAHgAAAAAAXgAAAAAAXgAAAAAAfQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAawAAAAAAfQAAAAAAawAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAfQAAAAAAPgAAAAAAPgAAAAAAfQAAAAAAfQAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAfQAAAAAAPgAAAAAAfQAAAAAAfQAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          tiles: fQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfAAAAAAAfQAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfAAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfAAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfAAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfAAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfAAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAAAAawAAAAAAHgAAAAAAHgAAAAAAfQAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAAAAHgAAAAAAHgAAAAAAHgAAAAAAXgAAAAAAXgAAAAAAXgAAAAAAfQAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAAAAHgAAAAAAHgAAAAAAHgAAAAAAXgAAAAAAXgAAAAAAXgAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAAAAHgAAAAAAHgAAAAAAHgAAAAAAXgAAAAAAXgAAAAAAXgAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAAAAHgAAAAAAHgAAAAAAHgAAAAAAXgAAAAAAXgAAAAAAfQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAawAAAAAAfQAAAAAAawAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAfQAAAAAAPgAAAAAAPgAAAAAAfQAAAAAAfQAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAfQAAAAAAPgAAAAAAfQAAAAAAfQAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
           version: 6
         0,-1:
           ind: 0,-1
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAfQAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAawAAAAAAawAAAAAAawAAAAAAfQAAAAAAfQAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAfQAAAAAAfQAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAfQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAHgAAAAAAHgAAAAAAHgAAAAAAawAAAAAAawAAAAAAawAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAHgAAAAAAHgAAAAAAHgAAAAAAawAAAAAAawAAAAAAawAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAawAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIwAAAAAAHgAAAAAAHgAAAAAAawAAAAAAfQAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAAAAHgAAAAAAHgAAAAAAawAAAAAAfQAAAAAAfAAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfAAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfAAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfAAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfAAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAfQAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAawAAAAAAawAAAAAAawAAAAAAfQAAAAAAfQAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAfQAAAAAAfQAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAfQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAHgAAAAAAHgAAAAAAHgAAAAAAawAAAAAAawAAAAAAawAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAHgAAAAAAHgAAAAAAHgAAAAAAawAAAAAAawAAAAAAawAAAAAAfQAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAawAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAAAAHgAAAAAAHgAAAAAAHgAAAAAAfQAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfAAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfAAAAAAAfQAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfAAAAAAAfQAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfAAAAAAAfQAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfAAAAAAAfQAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
           version: 6
         -1,-1:
           ind: -1,-1
@@ -73,12 +73,12 @@ entities:
             color: '#FFFFFFFF'
             id: Arrows
           decals:
-            113: -3,-12
-            114: -2,-12
-            115: -1,-12
-            172: -1,-14
-            173: -2,-14
-            174: -3,-14
+            102: -3,-12
+            103: -2,-12
+            104: -1,-12
+            148: -1,-14
+            149: -2,-14
+            150: -3,-14
         - node:
             angle: 4.71238898038469 rad
             color: '#FFFFFFFF'
@@ -86,8 +86,8 @@ entities:
           decals:
             9: -5,-8
             10: -5,-9
-            175: -7,-9
-            176: -7,-8
+            151: -7,-9
+            152: -7,-8
         - node:
             color: '#FFFFFFFF'
             id: Bot
@@ -102,63 +102,61 @@ entities:
             color: '#FFFFFFFF'
             id: BotGreyscale
           decals:
-            102: -8,15
-            103: -7,15
-            104: -9,14
-            105: -9,12
-            106: -6,15
-            107: -5,15
-            108: -6,11
-            132: -1,-6
-            133: 0,-6
-            137: -7,-4
-            138: -7,-5
-            139: -6,-5
-            140: -7,-11
-            141: -6,-12
-            142: -2,-8
-            143: -1,-8
-            144: -1,6
-            145: 6,-9
-            146: 6,-10
-            161: -6,6
-            162: -5,6
-            163: 5,-8
-            164: 6,-8
-            166: 4,-8
-            187: -6,-2
-            192: -1,2
-            193: -1,5
-            194: 2,-8
-            195: 3,-8
-            196: -7,-5
-            206: -3,4
+            91: -8,15
+            92: -7,15
+            93: -9,14
+            94: -9,12
+            95: -6,15
+            96: -5,15
+            97: -6,11
+            114: -7,-4
+            115: -7,-5
+            116: -6,-5
+            117: -7,-11
+            118: -6,-12
+            119: -2,-8
+            120: -1,-8
+            121: 6,-9
+            122: 6,-10
+            137: -6,6
+            138: -5,6
+            139: 5,-8
+            140: 6,-8
+            142: 4,-8
+            162: -6,-2
+            165: -1,5
+            166: 2,-8
+            167: 3,-8
+            168: -7,-5
+            178: -3,4
+            210: -1,-6
+            211: -1,6
         - node:
             angle: 4.71238898038469 rad
             color: '#FFFFFFFF'
             id: BotGreyscale
           decals:
-            177: -3,-1
-            178: -3,0
-            179: -3,1
+            153: -3,-1
+            154: -3,0
+            155: -3,1
         - node:
             color: '#FFFFFFFF'
             id: BotLeftGreyscale
           decals:
-            167: -7,-8
-            168: -7,-9
-            169: -3,-14
-            170: -2,-14
-            171: -1,-14
+            143: -7,-8
+            144: -7,-9
+            145: -3,-14
+            146: -2,-14
+            147: -1,-14
         - node:
             color: '#FFFFFFFF'
             id: BoxGreyscale
           decals:
-            98: -8,12
-            99: -9,13
-            100: -8,14
-            101: -7,14
-            109: 2,-9
+            87: -8,12
+            88: -9,13
+            89: -8,14
+            90: -7,14
+            98: 2,-9
         - node:
             angle: 4.71238898038469 rad
             color: '#FFFFFFFF'
@@ -170,10 +168,10 @@ entities:
             color: '#FFFFFFFF'
             id: BrickTileSteelLineE
           decals:
-            197: 3,8
-            198: 3,9
-            199: 3,10
-            200: 3,11
+            169: 3,8
+            170: 3,9
+            171: 3,10
+            172: 3,11
         - node:
             color: '#334E6DFF'
             id: BrickTileWhiteCornerNe
@@ -207,17 +205,11 @@ entities:
           decals:
             25: -8,12
         - node:
-            color: '#169C9CFF'
+            color: '#3EB38896'
             id: BrickTileWhiteLineE
           decals:
-            39: -3,-2
-            40: -3,-3
-        - node:
-            color: '#169C9CFF'
-            id: BrickTileWhiteLineN
-          decals:
-            127: -1,6
-            128: 0,6
+            205: -3,-2
+            206: -3,-3
         - node:
             color: '#334E6DFF'
             id: BrickTileWhiteLineN
@@ -226,28 +218,25 @@ entities:
             18: -6,15
             19: -7,15
         - node:
+            color: '#3EB38896'
+            id: BrickTileWhiteLineN
+          decals:
+            207: -1,6
+            208: 0,6
+        - node:
             color: '#EFB34196'
             id: BrickTileWhiteLineN
           decals:
-            147: -6,6
-            148: -5,6
-            149: -3,6
-            150: -4,6
-            155: 1,-8
-            156: 2,-8
-            157: 3,-8
-            158: 4,-8
-            159: 5,-8
-            160: 6,-8
-        - node:
-            color: '#169C9CFF'
-            id: BrickTileWhiteLineS
-          decals:
-            122: -1,-6
-            123: 0,-6
-            124: 1,-6
-            125: 2,-6
-            126: 3,-6
+            123: -6,6
+            124: -5,6
+            125: -3,6
+            126: -4,6
+            131: 1,-8
+            132: 2,-8
+            133: 3,-8
+            134: 4,-8
+            135: 5,-8
+            136: 6,-8
         - node:
             color: '#334E6DFF'
             id: BrickTileWhiteLineS
@@ -256,49 +245,62 @@ entities:
             14: -6,11
             15: -7,11
         - node:
+            color: '#3EB38896'
+            id: BrickTileWhiteLineS
+          decals:
+            201: 3,-6
+            202: 2,-6
+            203: 1,-6
+            204: 0,-6
+            209: -1,-6
+        - node:
             color: '#EFB34196'
             id: BrickTileWhiteLineS
           decals:
             36: -7,-5
             37: -6,-5
             38: -5,-5
-            151: -3,8
-            152: -4,8
-            153: -4,-5
-            154: -3,-5
+            127: -3,8
+            128: -4,8
+            129: -4,-5
+            130: -3,-5
         - node:
             color: '#334E6DFF'
             id: BrickTileWhiteLineW
           decals:
             16: -9,13
         - node:
+            color: '#A91409FF'
+            id: Delivery
+          decals:
+            213: 2,-5
+        - node:
             color: '#0096FFFF'
             id: DeliveryGreyscale
           decals:
-            81: -6,9
-            82: -7,9
-            83: -7,8
+            79: -6,9
+            80: -7,9
+            81: -7,8
         - node:
             color: '#3AB3DAFF'
             id: DeliveryGreyscale
           decals:
-            135: -1,-1
-        - node:
-            color: '#B02E26FF'
-            id: DeliveryGreyscale
-          decals:
-            130: 3,-5
-            131: 3,-6
+            112: -1,-1
         - node:
             color: '#F9801DFF'
             id: DeliveryGreyscale
           decals:
-            134: -1,1
+            111: -1,1
         - node:
             color: '#FF0000FF'
             id: DeliveryGreyscale
           decals:
-            136: -1,0
+            113: -1,0
+        - node:
+            color: '#FFFFFFFF'
+            id: DeliveryGreyscale
+          decals:
+            187: -1,2
         - node:
             color: '#334E6DFF'
             id: HerringboneOverlay
@@ -310,7 +312,7 @@ entities:
             color: '#FFFFFFFF'
             id: LoadingArea
           decals:
-            112: -4,-11
+            101: -4,-11
         - node:
             angle: 4.71238898038469 rad
             color: '#FFFFFFFF'
@@ -321,151 +323,148 @@ entities:
             color: '#FFFFFFFF'
             id: StandClear
           decals:
-            63: 7,5
-            116: -4,-13
-            117: -4,-15
+            61: 7,5
+            105: -4,-13
+            106: -4,-15
         - node:
             angle: 1.5707963267948966 rad
             color: '#FFFFFFFF'
             id: StandClear
           decals:
-            64: -7,0
-            65: -7,1
-            66: -7,2
-            67: -7,3
-            68: -7,4
-            69: -8,-7
-            70: -6,-7
-            71: 9,2
-            72: 9,3
-            73: 9,4
-            74: 4,6
-        - node:
-            color: '#FFFFFFFF'
-            id: WarnCornerNE
-          decals:
-            188: 0,2
+            62: -7,0
+            63: -7,1
+            64: -7,2
+            65: -7,3
+            66: -7,4
+            67: -8,-7
+            68: -6,-7
+            69: 9,2
+            70: 9,3
+            71: 9,4
+            72: 4,6
         - node:
             color: '#FFFFFFFF'
             id: WarnCornerSW
           decals:
-            77: -6,-4
+            75: -6,-4
+            188: 0,-5
         - node:
             color: '#FFFFFFFF'
             id: WarnCornerSmallNE
           decals:
-            97: 0,-5
-            185: -4,-2
-            205: -4,3
+            160: -4,-2
+            177: -4,3
         - node:
             color: '#FFFFFFFF'
             id: WarnCornerSmallNW
           decals:
-            88: 4,-10
+            86: 4,-10
         - node:
             color: '#FFFFFFFF'
             id: WarnCornerSmallSE
           decals:
-            186: -4,2
-            204: -4,5
+            161: -4,2
+            176: -4,5
         - node:
             color: '#FFFFFFFF'
             id: WarnCornerSmallSW
           decals:
-            79: -5,-4
-            80: -6,-3
+            77: -5,-4
+            78: -6,-3
+            200: 0,3
         - node:
             color: '#FFFFFFFF'
             id: WarnLineE
           decals:
-            46: -7,4
-            47: -7,3
-            48: -7,2
-            49: -7,1
-            50: -7,0
-            51: -6,-7
-            52: -8,-7
-            58: 9,4
-            59: 9,3
-            60: 9,2
-            76: 4,6
-            89: 0,1
-            90: 0,0
-            91: 0,-1
-            92: 0,-2
-            93: 0,-3
-            94: 0,-4
-            180: -4,-1
-            181: -4,0
-            182: -4,1
-            203: -4,4
+            44: -7,4
+            45: -7,3
+            46: -7,2
+            47: -7,1
+            48: -7,0
+            49: -6,-7
+            50: -8,-7
+            56: 9,4
+            57: 9,3
+            58: 9,2
+            74: 4,6
+            156: -4,-1
+            157: -4,0
+            158: -4,1
+            175: -4,4
         - node:
             color: '#FFFFFFFF'
             id: WarnLineN
           decals:
-            62: 7,5
-            120: -4,-15
-            121: -4,-13
-            184: -3,2
-            190: -1,5
-            191: 0,5
-            202: -3,5
+            60: 7,5
+            109: -4,-15
+            110: -4,-13
+            159: -3,2
+            163: -1,5
+            164: 0,5
+            174: -3,5
+            189: 1,-5
+            190: 2,-5
+            191: 3,-5
+            199: -1,3
         - node:
             color: '#FFFFFFFF'
             id: WarnLineS
           decals:
-            41: -7,0
-            42: -7,1
-            43: -7,2
-            44: -7,3
-            45: -7,4
-            53: -8,-7
-            54: -6,-7
-            55: 9,4
-            56: 9,3
-            57: 9,2
-            75: 4,6
-            78: -5,-5
-            87: 4,-9
-            110: -5,8
-            111: -5,9
-            165: 4,-8
+            39: -7,0
+            40: -7,1
+            41: -7,2
+            42: -7,3
+            43: -7,4
+            51: -8,-7
+            52: -6,-7
+            53: 9,4
+            54: 9,3
+            55: 9,2
+            73: 4,6
+            76: -5,-5
+            85: 4,-9
+            99: -5,8
+            100: -5,9
+            141: 4,-8
+            192: 0,-4
+            193: 0,-3
+            194: 0,-2
+            195: 0,-1
+            196: 0,0
+            197: 0,1
+            198: 0,2
         - node:
             color: '#FFFFFFFF'
             id: WarnLineW
           decals:
-            61: 7,5
-            84: 1,-10
-            85: 2,-10
-            86: 3,-10
-            95: 1,-5
-            96: 2,-5
-            118: -4,-13
-            119: -4,-15
-            129: 3,-5
-            183: -3,-2
-            189: -1,2
-            201: -3,3
+            59: 7,5
+            82: 1,-10
+            83: 2,-10
+            84: 3,-10
+            107: -4,-13
+            108: -4,-15
+            173: -3,3
+            212: -3,-2
         - node:
             color: '#FED83DFF'
             id: WoodTrimThinCornerNe
           decals:
-            207: 0,15
+            179: 0,15
         - node:
             color: '#FED83DFF'
             id: WoodTrimThinCornerNw
           decals:
-            208: -2,15
+            180: -2,15
         - node:
             color: '#FED83DFF'
             id: WoodTrimThinCornerSe
           decals:
-            209: 0,13
+            181: 0,13
         - node:
             color: '#FED83DFF'
             id: WoodTrimThinCornerSw
           decals:
-            210: -2,13
+            182: -2,13
         - node:
             color: '#FFFFFFFF'
             id: WoodTrimThinInnerNe
@@ -480,7 +479,7 @@ entities:
             color: '#FED83DFF'
             id: WoodTrimThinLineE
           decals:
-            211: 0,14
+            183: 0,14
         - node:
             color: '#FFFFFFFF'
             id: WoodTrimThinLineE
@@ -492,7 +491,7 @@ entities:
             color: '#FED83DFF'
             id: WoodTrimThinLineN
           decals:
-            212: -1,15
+            184: -1,15
         - node:
             color: '#FFFFFFFF'
             id: WoodTrimThinLineN
@@ -502,7 +501,7 @@ entities:
             color: '#FED83DFF'
             id: WoodTrimThinLineS
           decals:
-            214: -1,13
+            186: -1,13
         - node:
             color: '#FFFFFFFF'
             id: WoodTrimThinLineS
@@ -512,129 +511,101 @@ entities:
             color: '#FED83DFF'
             id: WoodTrimThinLineW
           decals:
-            213: -2,14
+            185: -2,14
     - type: GridAtmosphere
       version: 2
       data:
         tiles:
           0,0:
             0: 65535
-          0,1:
-            0: 65535
           0,-1:
             0: 65535
+          -1,0:
+            0: 48059
+          0,1:
+            0: 3871
+          -1,1:
+            0: 15291
           0,2:
             0: 65535
+          -1,2:
+            0: 56831
           0,3:
-            0: 65535
-          1,0:
-            0: 21973
-            1: 43554
-            2: 8
+            0: 5589
+          -1,3:
+            0: 56785
+          0,4:
+            1: 12
           1,1:
-            0: 61781
-            1: 3754
+            0: 256
+            1: 3618
+            2: 8
           1,2:
-            0: 65535
+            0: 14199
           1,3:
-            0: 311
             1: 4672
+          1,0:
+            1: 8746
+            0: 4
+            2: 34816
+          1,-1:
+            1: 43690
           2,0:
-            2: 1
-            0: 50
-            1: 13056
+            1: 3
+            2: 4352
           2,1:
-            1: 4355
-            0: 48
+            2: 1
+            1: 4352
           2,2:
             1: 1
+          2,-1:
+            1: 13107
+          -1,-4:
+            0: 61408
           0,-4:
-            0: 65328
+            0: 57344
             1: 192
           0,-3:
-            0: 65535
-          0,-2:
-            0: 65535
-          1,-4:
-            1: 16912
-            0: 12544
-          1,-3:
-            0: 65527
-            1: 8
-          1,-2:
-            0: 53759
-            1: 11776
-          1,-1:
-            0: 54741
-            1: 8738
-            3: 8
-            4: 2048
-          2,-2:
-            1: 272
-            0: 12288
-          2,-1:
-            3: 1
-            0: 12850
-            4: 256
-          -3,-3:
-            0: 52360
-          -3,-2:
-            0: 52428
-          -3,-1:
-            0: 52428
-          -2,-4:
-            1: 4672
-            0: 60544
-          -2,-3:
-            0: 65535
-          -2,-2:
-            0: 65535
-          -2,-1:
-            0: 61183
-            1: 4352
-          -1,-4:
-            0: 65520
+            0: 61166
           -1,-3:
             0: 65535
+          0,-2:
+            0: 65326
           -1,-2:
-            0: 65535
+            0: 47935
           -1,-1:
-            0: 65535
-          -3,1:
-            0: 61166
-          -3,2:
-            0: 61166
-          -3,3:
-            0: 52462
-          -3,0:
-            0: 52428
+            0: 49147
+          1,-4:
+            1: 16912
+          1,-3:
+            0: 30513
+            1: 8
+          1,-2:
+            0: 7
+            1: 11776
+          2,-2:
+            1: 785
+          -2,-4:
+            1: 4672
+          -2,-3:
+            0: 63724
+          -2,-2:
+            0: 57519
+          -2,-1:
+            0: 52430
+            2: 4352
           -2,0:
-            1: 4369
-            0: 61166
-          -2,1:
-            1: 273
-            0: 65262
+            2: 4369
+            0: 52428
+          -3,3:
+            0: 2184
           -2,2:
-            0: 65535
+            0: 61678
           -2,3:
             0: 65535
-          -1,0:
-            0: 65535
-          -1,1:
-            0: 65535
-          -1,2:
-            0: 65535
-          -1,3:
-            0: 65535
-          0,4:
-            0: 3
-            1: 12
-          -2,4:
-            0: 15
-          -1,4:
-            0: 15
-          -3,4:
-            0: 8
+          -2,1:
+            2: 273
+            0: 3276
         uniqueMixes:
         - volume: 2500
           temperature: 293.15
@@ -652,7 +623,7 @@ entities:
           - 0
           - 0
         - volume: 2500
-          temperature: 293.15
+          immutable: True
           moles:
           - 0
           - 0
@@ -671,36 +642,6 @@ entities:
           moles:
           - 0
           - 0
-          - 0
-          - 6666.982
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-        - volume: 2500
-          temperature: 293.15
-          moles:
-          - 6666.982
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-        - volume: 2500
-          temperature: 293.15
-          moles:
-          - 0
-          - 6666.982
           - 0
           - 0
           - 0
@@ -718,6 +659,23 @@ entities:
       id: gasbender
 - proto: AirAlarm
   entities:
+  - uid: 214
+    components:
+    - type: MetaData
+      name: gas collection control panel
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-6.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 261
+      - 188
+      - 144
+      - 270
+      - 153
+      - 271
+      - 279
   - uid: 317
     components:
     - type: MetaData
@@ -729,8 +687,6 @@ entities:
       devices:
       - 249
       - 250
-    - type: AtmosDevice
-      joinedGrid: 1
     - type: AccessReader
       enabled: False
     - type: Emagged
@@ -744,8 +700,6 @@ entities:
     - type: DeviceList
       devices:
       - 253
-    - type: AtmosDevice
-      joinedGrid: 1
     - type: AccessReader
       enabled: False
     - type: Emagged
@@ -762,11 +716,6 @@ entities:
       - 914
       - 913
       - 245
-      - 218
-      - 5
-      - 279
-    - type: AtmosDevice
-      joinedGrid: 1
   - uid: 479
     components:
     - type: Transform
@@ -775,11 +724,8 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 285
       - 424
       - 446
-    - type: AtmosDevice
-      joinedGrid: 1
   - uid: 480
     components:
     - type: Transform
@@ -790,9 +736,6 @@ entities:
       devices:
       - 882
       - 881
-      - 883
-    - type: AtmosDevice
-      joinedGrid: 1
   - uid: 481
     components:
     - type: Transform
@@ -801,11 +744,8 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 912
       - 910
       - 911
-    - type: AtmosDevice
-      joinedGrid: 1
   - uid: 482
     components:
     - type: Transform
@@ -814,11 +754,8 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 931
       - 929
       - 930
-    - type: AtmosDevice
-      joinedGrid: 1
   - uid: 864
     components:
     - type: Transform
@@ -827,10 +764,7 @@ entities:
     - type: DeviceList
       devices:
       - 960
-      - 966
       - 959
-    - type: AtmosDevice
-      joinedGrid: 1
 - proto: AirCanister
   entities:
   - uid: 916
@@ -838,22 +772,16 @@ entities:
     - type: Transform
       pos: -6.5,9.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
   - uid: 917
     components:
     - type: Transform
       pos: -5.5,9.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
   - uid: 928
     components:
     - type: Transform
       pos: -6.5,8.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
 - proto: Airlock
   entities:
   - uid: 496
@@ -971,6 +899,11 @@ entities:
       - 824
 - proto: AirlockExternalGlass
   entities:
+  - uid: 106
+    components:
+    - type: Transform
+      pos: 6.5,0.5
+      parent: 1
   - uid: 155
     components:
     - type: Transform
@@ -1006,48 +939,6 @@ entities:
     - type: Transform
       pos: -0.5,-14.5
       parent: 1
-- proto: AirSensor
-  entities:
-  - uid: 218
-    components:
-    - type: Transform
-      pos: 1.5,-4.5
-      parent: 1
-  - uid: 285
-    components:
-    - type: Transform
-      pos: 3.5,-8.5
-      parent: 1
-  - uid: 883
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -3.5,-8.5
-      parent: 1
-  - uid: 912
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.5,1.5
-      parent: 1
-  - uid: 931
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -5.5,14.5
-      parent: 1
-  - uid: 961
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -0.5,15.5
-      parent: 1
-  - uid: 966
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 3.5,10.5
-      parent: 1
 - proto: AmeController
   entities:
   - uid: 234
@@ -1063,8 +954,23 @@ entities:
           showEnts: False
           occludes: True
           ent: 16
+        fuelSlot: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: 5
 - proto: AmeJar
   entities:
+  - uid: 5
+    components:
+    - type: Transform
+      parent: 234
+    - type: Physics
+      canCollide: False
+  - uid: 12
+    components:
+    - type: Transform
+      pos: 5.632527,-10.400923
+      parent: 1
   - uid: 16
     components:
     - type: Transform
@@ -1074,24 +980,7 @@ entities:
   - uid: 53
     components:
     - type: Transform
-      pos: 5.274978,-10.459393
-      parent: 1
-- proto: AmePartFlatpack
-  entities:
-  - uid: 1138
-    components:
-    - type: Transform
-      pos: 5.7003665,-10.388437
-      parent: 1
-  - uid: 1139
-    components:
-    - type: Transform
-      pos: 5.7145457,-10.530349
-      parent: 1
-  - uid: 1140
-    components:
-    - type: Transform
-      pos: 5.7854433,-10.615496
+      pos: 5.413777,-10.463423
       parent: 1
 - proto: AmeShielding
   entities:
@@ -1244,15 +1133,100 @@ entities:
       parent: 1
 - proto: AtmosFixBlockerMarker
   entities:
+  - uid: 15
+    components:
+    - type: Transform
+      pos: 8.5,-0.5
+      parent: 1
+  - uid: 24
+    components:
+    - type: Transform
+      pos: 8.5,-1.5
+      parent: 1
+  - uid: 34
+    components:
+    - type: Transform
+      pos: 7.5,-0.5
+      parent: 1
+  - uid: 38
+    components:
+    - type: Transform
+      pos: 7.5,0.5
+      parent: 1
+  - uid: 46
+    components:
+    - type: Transform
+      pos: 7.5,-1.5
+      parent: 1
+  - uid: 49
+    components:
+    - type: Transform
+      pos: 7.5,-2.5
+      parent: 1
+  - uid: 50
+    components:
+    - type: Transform
+      pos: 8.5,0.5
+      parent: 1
+  - uid: 51
+    components:
+    - type: Transform
+      pos: 7.5,-3.5
+      parent: 1
+  - uid: 64
+    components:
+    - type: Transform
+      pos: 8.5,-3.5
+      parent: 1
+  - uid: 73
+    components:
+    - type: Transform
+      pos: 8.5,-2.5
+      parent: 1
+  - uid: 127
+    components:
+    - type: Transform
+      pos: 9.5,0.5
+      parent: 1
   - uid: 292
     components:
     - type: Transform
       pos: 8.5,7.5
       parent: 1
+  - uid: 365
+    components:
+    - type: Transform
+      pos: 9.5,-0.5
+      parent: 1
+  - uid: 366
+    components:
+    - type: Transform
+      pos: 9.5,-3.5
+      parent: 1
+  - uid: 375
+    components:
+    - type: Transform
+      pos: 9.5,-2.5
+      parent: 1
+  - uid: 399
+    components:
+    - type: Transform
+      pos: 8.5,-7.5
+      parent: 1
   - uid: 423
     components:
     - type: Transform
       pos: 8.5,8.5
+      parent: 1
+  - uid: 743
+    components:
+    - type: Transform
+      pos: 9.5,-1.5
+      parent: 1
+  - uid: 815
+    components:
+    - type: Transform
+      pos: 9.5,-5.5
       parent: 1
   - uid: 1071
     components:
@@ -1519,69 +1493,6 @@ entities:
     - type: Transform
       pos: 6.5,13.5
       parent: 1
-- proto: AtmosFixNitrogenMarker
-  entities:
-  - uid: 183
-    components:
-    - type: Transform
-      pos: 7.5,-1.5
-      parent: 1
-  - uid: 188
-    components:
-    - type: Transform
-      pos: 8.5,-1.5
-      parent: 1
-- proto: AtmosFixOxygenMarker
-  entities:
-  - uid: 136
-    components:
-    - type: Transform
-      pos: 7.5,-3.5
-      parent: 1
-  - uid: 168
-    components:
-    - type: Transform
-      pos: 8.5,-3.5
-      parent: 1
-  - uid: 530
-    components:
-    - type: Transform
-      pos: 8.5,-3.5
-      parent: 1
-  - uid: 1015
-    components:
-    - type: Transform
-      pos: 7.5,-3.5
-      parent: 1
-  - uid: 1016
-    components:
-    - type: Transform
-      pos: 7.5,-3.5
-      parent: 1
-  - uid: 1017
-    components:
-    - type: Transform
-      pos: 8.5,-3.5
-      parent: 1
-- proto: AtmosFixPlasmaMarker
-  entities:
-  - uid: 95
-    components:
-    - type: Transform
-      pos: 7.5,0.5
-      parent: 1
-  - uid: 127
-    components:
-    - type: Transform
-      pos: 8.5,0.5
-      parent: 1
-- proto: Autolathe
-  entities:
-  - uid: 314
-    components:
-    - type: Transform
-      pos: -6.5,-3.5
-      parent: 1
 - proto: BenchSofaCorpCorner
   entities:
   - uid: 832
@@ -1835,15 +1746,50 @@ entities:
       parent: 1
 - proto: CableApcExtension
   entities:
-  - uid: 80
+  - uid: 14
     components:
     - type: Transform
-      pos: 6.5,-0.5
+      pos: 8.5,-5.5
+      parent: 1
+  - uid: 161
+    components:
+    - type: Transform
+      pos: 8.5,-4.5
+      parent: 1
+  - uid: 174
+    components:
+    - type: Transform
+      pos: 8.5,-0.5
+      parent: 1
+  - uid: 194
+    components:
+    - type: Transform
+      pos: 8.5,-2.5
+      parent: 1
+  - uid: 262
+    components:
+    - type: Transform
+      pos: 8.5,-1.5
+      parent: 1
+  - uid: 278
+    components:
+    - type: Transform
+      pos: 8.5,-3.5
+      parent: 1
+  - uid: 285
+    components:
+    - type: Transform
+      pos: 0.5,3.5
       parent: 1
   - uid: 362
     components:
     - type: Transform
       pos: 7.5,-5.5
+      parent: 1
+  - uid: 364
+    components:
+    - type: Transform
+      pos: 0.5,2.5
       parent: 1
   - uid: 379
     components:
@@ -1855,6 +1801,11 @@ entities:
     - type: Transform
       pos: -5.5,-12.5
       parent: 1
+  - uid: 554
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
   - uid: 577
     components:
     - type: Transform
@@ -1864,6 +1815,26 @@ entities:
     components:
     - type: Transform
       pos: -4.5,-4.5
+      parent: 1
+  - uid: 592
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 1
+  - uid: 593
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 1
+  - uid: 594
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 1
+  - uid: 595
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
       parent: 1
   - uid: 619
     components:
@@ -2018,12 +1989,7 @@ entities:
   - uid: 654
     components:
     - type: Transform
-      pos: -6.5,-4.5
-      parent: 1
-  - uid: 655
-    components:
-    - type: Transform
-      pos: -6.5,-3.5
+      pos: 0.5,-5.5
       parent: 1
   - uid: 656
     components:
@@ -2185,11 +2151,6 @@ entities:
     - type: Transform
       pos: -5.5,4.5
       parent: 1
-  - uid: 689
-    components:
-    - type: Transform
-      pos: -6.5,4.5
-      parent: 1
   - uid: 690
     components:
     - type: Transform
@@ -2263,17 +2224,7 @@ entities:
   - uid: 706
     components:
     - type: Transform
-      pos: 1.5,-4.5
-      parent: 1
-  - uid: 707
-    components:
-    - type: Transform
-      pos: 1.5,-3.5
-      parent: 1
-  - uid: 708
-    components:
-    - type: Transform
-      pos: 1.5,-2.5
+      pos: 0.5,-4.5
       parent: 1
   - uid: 709
     components:
@@ -2345,41 +2296,6 @@ entities:
     - type: Transform
       pos: 4.5,4.5
       parent: 1
-  - uid: 723
-    components:
-    - type: Transform
-      pos: 1.5,-1.5
-      parent: 1
-  - uid: 724
-    components:
-    - type: Transform
-      pos: 1.5,-0.5
-      parent: 1
-  - uid: 725
-    components:
-    - type: Transform
-      pos: 1.5,0.5
-      parent: 1
-  - uid: 726
-    components:
-    - type: Transform
-      pos: 1.5,1.5
-      parent: 1
-  - uid: 727
-    components:
-    - type: Transform
-      pos: 1.5,2.5
-      parent: 1
-  - uid: 728
-    components:
-    - type: Transform
-      pos: 1.5,3.5
-      parent: 1
-  - uid: 729
-    components:
-    - type: Transform
-      pos: 1.5,4.5
-      parent: 1
   - uid: 730
     components:
     - type: Transform
@@ -2445,31 +2361,6 @@ entities:
     - type: Transform
       pos: 6.5,2.5
       parent: 1
-  - uid: 743
-    components:
-    - type: Transform
-      pos: 6.5,0.5
-      parent: 1
-  - uid: 745
-    components:
-    - type: Transform
-      pos: 6.5,-1.5
-      parent: 1
-  - uid: 746
-    components:
-    - type: Transform
-      pos: 6.5,-2.5
-      parent: 1
-  - uid: 747
-    components:
-    - type: Transform
-      pos: 6.5,-3.5
-      parent: 1
-  - uid: 748
-    components:
-    - type: Transform
-      pos: 6.5,-4.5
-      parent: 1
   - uid: 749
     components:
     - type: Transform
@@ -2484,11 +2375,6 @@ entities:
     components:
     - type: Transform
       pos: 6.5,-5.5
-      parent: 1
-  - uid: 752
-    components:
-    - type: Transform
-      pos: 6.5,-4.5
       parent: 1
   - uid: 757
     components:
@@ -2660,16 +2546,6 @@ entities:
     - type: Transform
       pos: 5.5,13.5
       parent: 1
-  - uid: 972
-    components:
-    - type: Transform
-      pos: -0.5,14.5
-      parent: 1
-  - uid: 973
-    components:
-    - type: Transform
-      pos: -1.5,14.5
-      parent: 1
   - uid: 1022
     components:
     - type: Transform
@@ -2679,11 +2555,6 @@ entities:
     components:
     - type: Transform
       pos: -5.5,6.5
-      parent: 1
-  - uid: 1039
-    components:
-    - type: Transform
-      pos: -6.5,6.5
       parent: 1
 - proto: CableHV
   entities:
@@ -2899,26 +2770,6 @@ entities:
     - type: Transform
       pos: -0.5,-2.5
       parent: 1
-  - uid: 592
-    components:
-    - type: Transform
-      pos: 0.5,-2.5
-      parent: 1
-  - uid: 593
-    components:
-    - type: Transform
-      pos: 0.5,-3.5
-      parent: 1
-  - uid: 594
-    components:
-    - type: Transform
-      pos: 0.5,-4.5
-      parent: 1
-  - uid: 595
-    components:
-    - type: Transform
-      pos: 0.5,-5.5
-      parent: 1
   - uid: 596
     components:
     - type: Transform
@@ -3024,10 +2875,30 @@ entities:
     - type: Transform
       pos: 1.5,12.5
       parent: 1
+  - uid: 625
+    components:
+    - type: Transform
+      pos: -0.5,-4.5
+      parent: 1
   - uid: 641
     components:
     - type: Transform
       pos: -4.5,-5.5
+      parent: 1
+  - uid: 707
+    components:
+    - type: Transform
+      pos: 0.5,-5.5
+      parent: 1
+  - uid: 708
+    components:
+    - type: Transform
+      pos: -0.5,-5.5
+      parent: 1
+  - uid: 723
+    components:
+    - type: Transform
+      pos: -0.5,-3.5
       parent: 1
   - uid: 841
     components:
@@ -3057,6 +2928,38 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,-8.5
+      parent: 1
+- proto: CargoPallet
+  entities:
+  - uid: 139
+    components:
+    - type: Transform
+      pos: -1.5,-8.5
+      parent: 1
+  - uid: 225
+    components:
+    - type: Transform
+      pos: -0.5,-9.5
+      parent: 1
+  - uid: 241
+    components:
+    - type: Transform
+      pos: -2.5,-8.5
+      parent: 1
+  - uid: 326
+    components:
+    - type: Transform
+      pos: -2.5,-9.5
+      parent: 1
+  - uid: 419
+    components:
+    - type: Transform
+      pos: -0.5,-8.5
+      parent: 1
+  - uid: 467
+    components:
+    - type: Transform
+      pos: -1.5,-9.5
       parent: 1
 - proto: CarpetBlack
   entities:
@@ -3134,10 +3037,23 @@ entities:
       parent: 1
 - proto: Catwalk
   entities:
-  - uid: 291
+  - uid: 77
     components:
     - type: Transform
-      pos: 8.5,8.5
+      rot: 1.5707963267948966 rad
+      pos: 8.5,6.5
+      parent: 1
+  - uid: 216
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,5.5
+      parent: 1
+  - uid: 323
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,0.5
       parent: 1
   - uid: 433
     components:
@@ -3193,6 +3109,12 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -7.5,6.5
       parent: 1
+  - uid: 468
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,-0.5
+      parent: 1
   - uid: 753
     components:
     - type: Transform
@@ -3211,10 +3133,71 @@ entities:
       rot: 3.141592653589793 rad
       pos: 7.5,6.5
       parent: 1
-  - uid: 1068
+  - uid: 812
     components:
     - type: Transform
-      pos: 8.5,-5.5
+      rot: 3.141592653589793 rad
+      pos: 8.5,-7.5
+      parent: 1
+  - uid: 819
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,-1.5
+      parent: 1
+  - uid: 822
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,0.5
+      parent: 1
+  - uid: 823
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,-3.5
+      parent: 1
+  - uid: 826
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,-0.5
+      parent: 1
+  - uid: 827
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,-2.5
+      parent: 1
+  - uid: 829
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,0.5
+      parent: 1
+  - uid: 845
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,-1.5
+      parent: 1
+  - uid: 846
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,-3.5
+      parent: 1
+  - uid: 851
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,-3.5
+      parent: 1
+  - uid: 856
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,-2.5
       parent: 1
   - uid: 1069
     components:
@@ -3377,6 +3360,14 @@ entities:
     - type: Transform
       pos: 2.5,-7.5
       parent: 1
+- proto: ComputerSalvageExpedition
+  entities:
+  - uid: 103
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,12.5
+      parent: 1
 - proto: ComputerShuttle
   entities:
   - uid: 287
@@ -3391,13 +3382,13 @@ entities:
     - type: Transform
       pos: -6.5,15.5
       parent: 1
-- proto: ComputerSurveillanceCameraMonitor
+- proto: ComputerTabletopSurveillanceCameraMonitor
   entities:
-  - uid: 544
+  - uid: 105
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -8.5,12.5
+      rot: 3.141592653589793 rad
+      pos: -7.5,11.5
       parent: 1
 - proto: ComputerWallmountWithdrawBankATM
   entities:
@@ -3607,65 +3598,6 @@ entities:
     - type: Transform
       pos: 4.5,8.5
       parent: 1
-- proto: DrinkMugMetal
-  entities:
-  - uid: 845
-    components:
-    - type: Transform
-      pos: 6.5791116,10.125744
-      parent: 1
-  - uid: 846
-    components:
-    - type: Transform
-      pos: 6.3446736,10.061763
-      parent: 1
-  - uid: 850
-    components:
-    - type: Transform
-      pos: 6.7188916,9.8477125
-      parent: 1
-  - uid: 852
-    components:
-    - type: Transform
-      pos: 6.2807355,9.741858
-      parent: 1
-  - uid: 855
-    components:
-    - type: Transform
-      pos: 6.767503,9.4310465
-      parent: 1
-  - uid: 856
-    components:
-    - type: Transform
-      pos: 6.517503,9.674102
-      parent: 1
-  - uid: 857
-    components:
-    - type: Transform
-      pos: 6.30917,9.3893795
-      parent: 1
-- proto: DrinkVacuumFlask
-  entities:
-  - uid: 844
-    components:
-    - type: Transform
-      pos: 6.2883363,10.694935
-      parent: 1
-  - uid: 851
-    components:
-    - type: Transform
-      pos: 6.607781,10.715769
-      parent: 1
-  - uid: 853
-    components:
-    - type: Transform
-      pos: 6.420281,10.43799
-      parent: 1
-  - uid: 854
-    components:
-    - type: Transform
-      pos: 6.7813916,10.4310465
-      parent: 1
 - proto: EmergencyLight
   entities:
   - uid: 272
@@ -3715,6 +3647,13 @@ entities:
       rot: 3.141592653589793 rad
       pos: -5.5,8.5
       parent: 1
+- proto: EngineeringTechFab
+  entities:
+  - uid: 74
+    components:
+    - type: Transform
+      pos: -6.5,-3.5
+      parent: 1
 - proto: ExosuitFabricator
   entities:
   - uid: 322
@@ -3729,11 +3668,6 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,-2.5
-      parent: 1
-  - uid: 1004
-    components:
-    - type: Transform
-      pos: 3.5,-6.5
       parent: 1
   - uid: 1006
     components:
@@ -3754,10 +3688,10 @@ entities:
       parent: 1
 - proto: FaxMachineShip
   entities:
-  - uid: 527
+  - uid: 852
     components:
     - type: Transform
-      pos: -7.5,11.5
+      pos: -6.5,11.5
       parent: 1
 - proto: FireAxeCabinetFilled
   entities:
@@ -3820,106 +3754,93 @@ entities:
           showEnts: False
           occludes: True
           ents: []
+- proto: GasFilterFlipped
+  entities:
+  - uid: 89
+    components:
+    - type: Transform
+      pos: 5.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 90
+    components:
+    - type: Transform
+      pos: 5.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 91
+    components:
+    - type: Transform
+      pos: 5.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 95
+    components:
+    - type: Transform
+      pos: 5.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 102
+    components:
+    - type: Transform
+      pos: 5.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 140
+    components:
+    - type: Transform
+      pos: 5.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 294
+    components:
+    - type: Transform
+      pos: 5.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 300
+    components:
+    - type: Transform
+      pos: 5.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
 - proto: GasMixer
   entities:
-  - uid: 271
+  - uid: 314
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 3.5,0.5
-      parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
-- proto: GasMixerFlipped
-  entities:
-  - uid: 261
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,-3.5
+      pos: 0.5,-0.5
       parent: 1
     - type: GasMixer
-      inletTwoConcentration: 0.22000003
-      inletOneConcentration: 0.78
-    - type: AtmosDevice
-      joinedGrid: 1
+      inletTwoConcentration: 0.20999998
+      inletOneConcentration: 0.79
     - type: AtmosPipeColor
       color: '#0055CCFF'
 - proto: GasOutletInjector
   entities:
-  - uid: 172
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 8.5,-3.5
-      parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
-  - uid: 177
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 8.5,0.5
-      parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
   - uid: 180
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,4.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
-  - uid: 820
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 8.5,-1.5
-      parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
 - proto: GasPassiveVent
   entities:
-  - uid: 263
+  - uid: 96
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 7.5,-3.5
+      pos: 8.5,8.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
-  - uid: 264
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 7.5,-1.5
-      parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
-  - uid: 265
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 7.5,0.5
-      parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
-  - uid: 335
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 7.5,-5.5
-      parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
-  - uid: 476
-    components:
-    - type: Transform
-      pos: 8.5,7.5
-      parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
 - proto: GasPipeBend
   entities:
   - uid: 48
@@ -3930,34 +3851,6 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 49
-    components:
-    - type: Transform
-      pos: 8.5,-0.5
-      parent: 1
-  - uid: 73
-    components:
-    - type: Transform
-      pos: 0.5,-0.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#449DFFFF'
-  - uid: 96
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,-0.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#F94541FF'
-  - uid: 161
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 0.5,-2.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#449DFFFF'
   - uid: 244
     components:
     - type: Transform
@@ -3972,26 +3865,28 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 270
+  - uid: 280
     components:
     - type: Transform
-      pos: 1.5,0.5
+      pos: 1.5,-4.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#F94541FF'
-  - uid: 278
+      color: '#0055CCFF'
+  - uid: 308
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 1.5,-1.5
-      parent: 1
-  - uid: 282
-    components:
-    - type: Transform
-      pos: -0.5,-4.5
+      pos: 5.5,6.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
+  - uid: 309
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 453
     components:
     - type: Transform
@@ -4000,18 +3895,6 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 781
-    components:
-    - type: Transform
-      pos: 8.5,-2.5
-      parent: 1
-  - uid: 826
-    components:
-    - type: Transform
-      pos: 0.5,-3.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 877
     components:
     - type: Transform
@@ -4102,7 +3985,21 @@ entities:
       parent: 1
 - proto: GasPipeFourway
   entities:
-  - uid: 334
+  - uid: 217
+    components:
+    - type: Transform
+      pos: 8.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 248
+    components:
+    - type: Transform
+      pos: 8.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 725
     components:
     - type: Transform
       pos: 2.5,-5.5
@@ -4118,11 +4015,17 @@ entities:
       color: '#990000FF'
 - proto: GasPipeStraight
   entities:
-  - uid: 50
+  - uid: 76
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 2.5,-0.5
+      rot: 1.5707963267948966 rad
+      pos: 4.5,2.5
+      parent: 1
+  - uid: 80
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-1.5
       parent: 1
   - uid: 86
     components:
@@ -4130,54 +4033,66 @@ entities:
       rot: 3.141592653589793 rad
       pos: 8.5,5.5
       parent: 1
-  - uid: 105
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,1.5
-      parent: 1
     - type: AtmosPipeColor
-      color: '#EB6B00FF'
-  - uid: 106
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,-3.5
-      parent: 1
+      color: '#990000FF'
   - uid: 118
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,-2.5
+      pos: 0.5,-1.5
       parent: 1
-  - uid: 144
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 142
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 0.5,0.5
+      pos: 4.5,-0.5
       parent: 1
-    - type: AtmosPipeColor
-      color: '#F94541FF'
-  - uid: 170
+  - uid: 168
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,4.5
+      rot: 3.141592653589793 rad
+      pos: 8.5,-0.5
       parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 173
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 175
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 183
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 186
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,1.5
       parent: 1
-  - uid: 189
+  - uid: 192
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 0.5,1.5
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-5.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#EB6B00FF'
+      color: '#990000FF'
   - uid: 196
     components:
     - type: Transform
@@ -4190,41 +4105,11 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 4.5,4.5
       parent: 1
-  - uid: 205
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#EB6B00FF'
-  - uid: 207
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,-0.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#F94541FF'
-  - uid: 225
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,-2.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#449DFFFF'
   - uid: 243
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,3.5
-      parent: 1
-  - uid: 248
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 3.5,-0.5
       parent: 1
   - uid: 251
     components:
@@ -4235,117 +4120,84 @@ entities:
   - uid: 252
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 3.5,-1.5
+      rot: 1.5707963267948966 rad
+      pos: 4.5,0.5
       parent: 1
-  - uid: 260
+  - uid: 264
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 7.5,-2.5
-      parent: 1
-  - uid: 266
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 6.5,0.5
+      rot: 1.5707963267948966 rad
+      pos: 4.5,1.5
       parent: 1
   - uid: 267
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 3.5,-2.5
+      rot: 1.5707963267948966 rad
+      pos: 7.5,-5.5
       parent: 1
-  - uid: 268
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,0.5
-      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 273
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 6.5,-1.5
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-2.5
       parent: 1
-  - uid: 275
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,-1.5
-      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 277
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,1.5
       parent: 1
-  - uid: 280
+  - uid: 282
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,-2.5
+      rot: 3.141592653589793 rad
+      pos: 8.5,-2.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#449DFFFF'
+      color: '#990000FF'
   - uid: 284
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 6.5,-3.5
+      rot: 3.141592653589793 rad
+      pos: 5.5,4.5
       parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 286
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,-3.5
+      pos: -4.5,-3.5
       parent: 1
-  - uid: 294
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 291
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 7.5,-0.5
+      rot: 3.141592653589793 rad
+      pos: 5.5,5.5
       parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 295
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 6.5,-2.5
+      rot: 1.5707963267948966 rad
+      pos: 6.5,6.5
       parent: 1
-  - uid: 323
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 301
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 2.5,-2.5
+      pos: -2.5,-2.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#449DFFFF'
-  - uid: 324
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#EB6B00FF'
-  - uid: 342
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 3.5,-1.5
-      parent: 1
-  - uid: 361
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 6.5,-0.5
-      parent: 1
-  - uid: 363
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,3.5
-      parent: 1
+      color: '#0055CCFF'
   - uid: 430
     components:
     - type: Transform
@@ -4398,7 +4250,7 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 4.5,-5.5
+      pos: 7.5,6.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -4410,6 +4262,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
+  - uid: 454
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 497
     components:
     - type: Transform
@@ -4438,37 +4298,24 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 0.5,3.5
       parent: 1
-  - uid: 811
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,-0.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#F94541FF'
-  - uid: 827
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,-0.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#F94541FF'
-  - uid: 828
+  - uid: 844
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 1.5,-2.5
+      pos: 4.5,-3.5
       parent: 1
-    - type: AtmosPipeColor
-      color: '#449DFFFF'
-  - uid: 829
+  - uid: 850
     components:
     - type: Transform
-      pos: 0.5,-1.5
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-4.5
       parent: 1
-    - type: AtmosPipeColor
-      color: '#449DFFFF'
+  - uid: 854
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-2.5
+      parent: 1
   - uid: 873
     components:
     - type: Transform
@@ -4510,14 +4357,6 @@ entities:
     components:
     - type: Transform
       pos: -3.5,-6.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 880
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,-3.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
@@ -4609,22 +4448,6 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 897
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -3.5,-3.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 898
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -4.5,-2.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 899
     components:
     - type: Transform
@@ -4860,14 +4683,6 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 974
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#EB6B00FF'
   - uid: 1001
     components:
     - type: Transform
@@ -4876,44 +4691,71 @@ entities:
       parent: 1
 - proto: GasPipeTJunction
   entities:
-  - uid: 226
+  - uid: 146
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 3.5,-3.5
+      pos: 5.5,-5.5
       parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 170
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 177
+    components:
+    - type: Transform
+      pos: 8.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 247
     components:
     - type: Transform
       pos: 7.5,3.5
       parent: 1
-  - uid: 262
+  - uid: 274
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 275
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 281
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 1.5,-4.5
+      pos: 0.5,-2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 289
+  - uid: 299
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -0.5,-3.5
+      rot: -1.5707963267948966 rad
+      pos: 8.5,6.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 356
+      color: '#990000FF'
+  - uid: 724
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 2.5,-1.5
-      parent: 1
-  - uid: 432
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 3.5,-5.5
+      pos: 8.5,-5.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -4925,14 +4767,6 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 872
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,-3.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 887
     components:
     - type: Transform
@@ -4983,36 +4817,20 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -0.5,0.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
     - type: AtmosPipeColor
-      color: '#F94541FF'
+      color: '#0055CCFF'
   - uid: 206
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,4.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
   - uid: 293
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,3.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
-  - uid: 308
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,-5.5
-      parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
   - uid: 354
     components:
     - type: MetaData
@@ -5021,17 +4839,13 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -0.5,1.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
     - type: AtmosPipeColor
       color: '#EB6B00FF'
-  - uid: 359
+  - uid: 655
     components:
     - type: Transform
-      pos: 3.5,-4.5
+      pos: 2.5,-4.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 825
@@ -5042,8 +4856,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -0.5,-0.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
     - type: AtmosPipeColor
       color: '#449DFFFF'
   - uid: 926
@@ -5052,72 +4864,38 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -6.5,8.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
 - proto: GasPressurePump
   entities:
-  - uid: 15
+  - uid: 141
     components:
-    - type: MetaData
-      name: waste loop pump
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 5.5,-5.5
+      rot: 3.141592653589793 rad
+      pos: 8.5,7.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 211
+  - uid: 263
     components:
-    - type: MetaData
-      name: O2 output pump
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 5.5,-3.5
-      parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
-  - uid: 214
-    components:
-    - type: MetaData
-      name: N2 output pump
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 5.5,-1.5
-      parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
-  - uid: 216
-    components:
-    - type: MetaData
-      name: ignition chamber output pump
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,3.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
-  - uid: 217
+  - uid: 289
     components:
-    - type: MetaData
-      name: plasma output pump
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 747
+    components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 5.5,0.5
+      pos: 6.5,-5.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
-  - uid: 475
-    components:
-    - type: MetaData
-      name: ignition chamber vent pump
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 8.5,6.5
-      parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
 - proto: GasThermoMachineFreezer
   entities:
   - uid: 414
@@ -5125,15 +4903,11 @@ entities:
     - type: Transform
       pos: -0.5,6.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
   - uid: 415
     components:
     - type: Transform
       pos: -0.5,5.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
 - proto: GasThermoMachineHeater
   entities:
   - uid: 369
@@ -5142,29 +4916,13 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -0.5,2.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
-- proto: GasValve
-  entities:
-  - uid: 385
-    components:
-    - type: MetaData
-      name: waste loop manual valve
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 6.5,-5.5
-      parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
 - proto: GasVentPump
   entities:
-  - uid: 279
+  - uid: 307
     components:
     - type: Transform
-      pos: -0.5,-2.5
+      pos: -0.5,-1.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 446
@@ -5173,8 +4931,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 1.5,-8.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 882
@@ -5183,8 +4939,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: -3.5,-7.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 910
@@ -5193,8 +4947,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -3.5,0.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 930
@@ -5203,8 +4955,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -6.5,12.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 960
@@ -5213,8 +4963,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 4.5,9.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 967
@@ -5222,19 +4970,41 @@ entities:
     - type: Transform
       pos: 0.5,15.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
 - proto: GasVentScrubber
   entities:
-  - uid: 5
+  - uid: 144
     components:
     - type: Transform
-      pos: 2.5,-4.5
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-1.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 214
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 153
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,-3.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 214
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 188
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,0.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 214
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 249
@@ -5243,32 +5013,70 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 8.5,3.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
   - uid: 250
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,2.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
   - uid: 253
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,4.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 261
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,0.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 214
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 270
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,-1.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 214
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 271
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-3.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 214
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 279
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-5.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 214
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 424
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-8.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 512
@@ -5276,8 +5084,13 @@ entities:
     - type: Transform
       pos: -1.5,15.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 527
+    components:
+    - type: Transform
+      pos: -0.5,-3.5
+      parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 881
@@ -5286,8 +5099,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: -2.5,-7.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 911
@@ -5296,8 +5107,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -3.5,-0.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 929
@@ -5306,8 +5115,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -6.5,13.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 959
@@ -5316,84 +5123,24 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 2.5,11.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
     - type: AtmosPipeColor
       color: '#990000FF'
 - proto: GasVolumePump
   entities:
-  - uid: 375
+  - uid: 207
     components:
-    - type: MetaData
-      name: plasma input pump
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 5.5,1.5
-      parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
-    - type: AtmosPipeColor
-      color: '#EB6B00FF'
-  - uid: 477
-    components:
-    - type: MetaData
-      name: ignition chamber input pump
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,4.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
-  - uid: 812
-    components:
-    - type: MetaData
-      name: O2 input pump
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 5.5,-2.5
-      parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
-    - type: AtmosPipeColor
-      color: '#449DFFFF'
   - uid: 927
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,8.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1018
-    components:
-    - type: MetaData
-      name: N2 input pump
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 5.5,-0.5
-      parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
-    - type: AtmosPipeColor
-      color: '#F94541FF'
-  - uid: 1144
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 1.5,4.5
-      parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
-  - uid: 1145
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 1.5,3.5
-      parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
 - proto: GravityGeneratorMini
   entities:
   - uid: 195
@@ -5438,21 +5185,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: -6.5,5.5
       parent: 1
-  - uid: 51
-    components:
-    - type: Transform
-      pos: 4.5,-3.5
-      parent: 1
-  - uid: 74
-    components:
-    - type: Transform
-      pos: 6.5,0.5
-      parent: 1
-  - uid: 76
-    components:
-    - type: Transform
-      pos: 6.5,-1.5
-      parent: 1
   - uid: 81
     components:
     - type: Transform
@@ -5464,16 +5196,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,16.5
-      parent: 1
-  - uid: 89
-    components:
-    - type: Transform
-      pos: 4.5,3.5
-      parent: 1
-  - uid: 91
-    components:
-    - type: Transform
-      pos: 4.5,4.5
       parent: 1
   - uid: 97
     components:
@@ -5499,36 +5221,17 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -7.5,8.5
       parent: 1
-  - uid: 138
-    components:
-    - type: Transform
-      pos: 6.5,-3.5
-      parent: 1
-  - uid: 139
-    components:
-    - type: Transform
-      pos: 4.5,2.5
-      parent: 1
-  - uid: 140
-    components:
-    - type: Transform
-      pos: 4.5,1.5
-      parent: 1
-  - uid: 142
-    components:
-    - type: Transform
-      pos: 4.5,0.5
-      parent: 1
-  - uid: 146
-    components:
-    - type: Transform
-      pos: 4.5,-1.5
-      parent: 1
   - uid: 149
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,-3.5
+      parent: 1
+  - uid: 176
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-3.5
       parent: 1
   - uid: 178
     components:
@@ -5540,23 +5243,49 @@ entities:
     - type: Transform
       pos: 6.5,4.5
       parent: 1
-  - uid: 192
+  - uid: 189
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 4.5,-5.5
-      parent: 1
-  - uid: 194
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
       pos: 2.5,-6.5
+      parent: 1
+  - uid: 205
+    components:
+    - type: Transform
+      pos: 8.5,-4.5
+      parent: 1
+  - uid: 221
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-2.5
+      parent: 1
+  - uid: 226
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-0.5
       parent: 1
   - uid: 256
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,5.5
+      parent: 1
+  - uid: 265
+    components:
+    - type: Transform
+      pos: 4.5,-4.5
+      parent: 1
+  - uid: 266
+    components:
+    - type: Transform
+      pos: 7.5,-4.5
+      parent: 1
+  - uid: 268
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-1.5
       parent: 1
   - uid: 288
     components:
@@ -5575,6 +5304,35 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -9.5,14.5
+      parent: 1
+  - uid: 324
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-0.5
+      parent: 1
+  - uid: 325
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-2.5
+      parent: 1
+  - uid: 330
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,1.5
+      parent: 1
+  - uid: 333
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,3.5
+      parent: 1
+  - uid: 334
+    components:
+    - type: Transform
+      pos: 4.5,-5.5
       parent: 1
   - uid: 343
     components:
@@ -5660,6 +5418,30 @@ entities:
       rot: 3.141592653589793 rad
       pos: -1.5,-4.5
       parent: 1
+  - uid: 457
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-3.5
+      parent: 1
+  - uid: 475
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,4.5
+      parent: 1
+  - uid: 476
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-1.5
+      parent: 1
+  - uid: 478
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,2.5
+      parent: 1
   - uid: 485
     components:
     - type: Transform
@@ -5670,23 +5452,11 @@ entities:
     - type: Transform
       pos: -4.5,10.5
       parent: 1
-  - uid: 1040
+  - uid: 517
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 4.5,-4.5
-      parent: 1
-  - uid: 1041
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 4.5,-2.5
-      parent: 1
-  - uid: 1042
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 4.5,-0.5
+      rot: -1.5707963267948966 rad
+      pos: 4.5,0.5
       parent: 1
 - proto: GroundTobacco
   entities:
@@ -5713,12 +5483,16 @@ entities:
       rot: 3.141592653589793 rad
       pos: 5.5,-7.5
       parent: 1
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 1037
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,6.5
       parent: 1
+    - type: Thruster
+      originalPowerLoad: 1500
 - proto: HappyHonk
   entities:
   - uid: 847
@@ -5735,10 +5509,10 @@ entities:
       parent: 1
 - proto: HolofanProjector
   entities:
-  - uid: 1057
+  - uid: 464
     components:
     - type: Transform
-      pos: -0.69590646,-3.6085553
+      pos: -0.6208673,-4.6052513
       parent: 1
 - proto: HospitalCurtainsOpen
   entities:
@@ -5760,31 +5534,26 @@ entities:
       - 45
 - proto: InflatableDoorStack
   entities:
-  - uid: 1056
+  - uid: 465
     components:
     - type: Transform
-      pos: -0.3699959,-3.5660625
+      pos: -0.28753394,-4.5427513
       parent: 1
 - proto: InflatableWallStack
   entities:
-  - uid: 1054
+  - uid: 136
     components:
     - type: Transform
-      pos: -0.6392264,-3.367762
-      parent: 1
-  - uid: 1055
-    components:
-    - type: Transform
-      pos: -0.29914552,-3.2969403
-      parent: 1
-- proto: LockerAtmosphericsFilledHardsuit
-  entities:
-  - uid: 366
-    components:
-    - type: Transform
-      pos: 0.5,-5.5
+      pos: -0.75628394,-4.365668
       parent: 1
   - uid: 447
+    components:
+    - type: Transform
+      pos: -0.24586731,-4.2823343
+      parent: 1
+- proto: LockerAtmosphericsFilled
+  entities:
+  - uid: 376
     components:
     - type: Transform
       pos: -0.5,-5.5
@@ -5796,19 +5565,9 @@ entities:
     - type: Transform
       pos: -5.5,11.5
       parent: 1
-- proto: LockerEngineerFilledHardsuit
+- proto: LockerEngineerFilled
   entities:
-  - uid: 364
-    components:
-    - type: Transform
-      pos: 3.5,-7.5
-      parent: 1
-  - uid: 365
-    components:
-    - type: Transform
-      pos: -4.5,6.5
-      parent: 1
-  - uid: 819
+  - uid: 391
     components:
     - type: Transform
       pos: -5.5,6.5
@@ -5850,28 +5609,24 @@ entities:
       parent: 1
 - proto: NitrogenCanister
   entities:
-  - uid: 1050
+  - uid: 855
     components:
     - type: Transform
-      pos: 8.5,-1.5
+      anchored: True
+      pos: -0.5,0.5
       parent: 1
-    - type: GasCanister
-      releaseValve: True
-      releasePressure: 1013.25
-    - type: AtmosDevice
-      joinedGrid: 1
+    - type: Physics
+      bodyType: Static
 - proto: OxygenCanister
   entities:
-  - uid: 1051
+  - uid: 828
     components:
     - type: Transform
-      pos: 8.5,-3.5
+      anchored: True
+      pos: -0.5,-0.5
       parent: 1
-    - type: GasCanister
-      releaseValve: True
-      releasePressure: 1013.25
-    - type: AtmosDevice
-      joinedGrid: 1
+    - type: Physics
+      bodyType: Static
 - proto: PaintingFireaxeCabinet
   entities:
   - uid: 1067
@@ -5886,111 +5641,6 @@ entities:
     - type: Transform
       pos: 1.5,14.5
       parent: 1
-- proto: Paper
-  entities:
-  - uid: 1149
-    components:
-    - type: Transform
-      pos: 2.65279,-7.404173
-      parent: 1
-    - type: Paper
-      stampState: paper_stamp-ce
-      stampedBy:
-      - stampedBorderless: False
-        stampedColor: '#C69B17FF'
-        stampedName: stamp-component-stamped-name-ce
-      - stampedBorderless: False
-        stampedColor: '#00BE00FF'
-        stampedName: stamp-component-stamped-name-approved
-      content: >-
-        [color=#1b67a5]█░░█░███[/color][color=#5b97bc]░███░█░█░█░██░░█░█░██░░██░░██░[/color]
-
-        [color=#1b67a5]██░█░░█░[/color][color=#5b97bc]██░░░█░█░█░█░█░█░█░█░█░█░█░█░█[/color]
-
-        [color=#1b67a5]█░██░░█░[/color][color=#5b97bc]░░██░███░█░██░░░█░░███░██░░█░█[/color]
-
-        [color=#1b67a5]█░░█░░█░[/color][color=#5b97bc]███░░█░█░█░█░░░░█░░█░█░█░█░██░[/color]
-
-
-        [head=1]=========================[/head]
-
-        [head=1]            Gasbender-class[/head]
-
-        [head=1]            engineering ship[/head]
-
-        [head=1] [/head]
-
-        [head=1]       PREFLIGHT CHECKLIST[/head]
-
-        [head=1]=========================[/head]
-
-
-        [head=2]1. Power supply.[/head]
-
-        [head=3]1.1. Battery units.[/head]
-
-        [bullet/][ ] Check if the SMES units are anchored to the floor.
-
-        [bullet/][ ] Check if the substation unit is anchored to the floor.
-
-        [bullet/][ ] Check if the APC units' Main Breakers are toggled on.
-
-        [bullet/][ ] Check the APC unit's current Load (W).
-
-        [head=3]1.2. AME generator unit.[/head]
-
-        [bullet/][ ] Check if the AME core is properly shielded.
-
-        [bullet/][ ] Check if the AME controller unit is anchored to the floor.
-
-        [bullet/][ ] Check the AME controller unit Fuel Status.
-
-        [bullet/][ ] Check the AME controller unit Injection Amount.
-
-        [bullet/][ ] Toggle Injection.
-
-
-        [head=2]2. Atmospherics.[/head]
-
-        [head=3]2.1. Distribution Loop.[/head]
-
-        [bullet/][ ] Check if the O2 output pump is set to normal pressure.
-
-        [bullet/][ ] Enable the O2 output pump.
-
-        [bullet/][ ] Check if the N2 output pump is set to normal pressure.
-
-        [bullet/][ ] Enable N2 output pump.
-
-        [bullet/][ ] Check if the gas mixer is set to the correct mixing ratio.
-
-        [bullet/][ ] Check if the gas mixer is set to normal pressure.
-
-        [bullet/][ ] Enable gas mixer.
-
-        [bullet/][ ] Check if the distribution pump is set to normal pressure.
-
-        [bullet/][ ] Enable distribution pump.
-
-        [head=3]2.2. Waste Loop.[/head]
-
-        [bullet/][ ] Check if waste loop manual valve is open.
-
-        [bullet/][ ] Enable waste loop pump.
-
-
-        [head=2]3. Other checks.[/head]
-
-        [bullet/][ ] Check if the gyroscope is anchored, powered, and enabled.
-
-        [bullet/][ ] Check if the mini gravity generator is anchored, powered, and enabled.
-
-        [bullet/][ ] Check if the portside blast doors are closed.
-
-
-        __________________________________________________________________
-
-        [bold]*[/bold] - Gasbender-class service ships are equipped with a five APC units that can be used to appraise the ship's total power consumption. Unmodifued Gasbender-class ship requires 38 kW of power to remain operational.
 - proto: PartRodMetal
   entities:
   - uid: 458
@@ -6008,20 +5658,6 @@ entities:
     - type: Transform
       pos: -2.4127467,3.6553578
       parent: 1
-- proto: PlasmaCanister
-  entities:
-  - uid: 1049
-    components:
-    - type: Transform
-      pos: 8.5,0.5
-      parent: 1
-    - type: GasCanister
-      releaseValve: True
-      releasePressure: 1013.25
-    - type: Lock
-      locked: False
-    - type: AtmosDevice
-      joinedGrid: 1
 - proto: PlasticFlapsAirtightClear
   entities:
   - uid: 30
@@ -6055,15 +5691,15 @@ entities:
       parent: 1
 - proto: PortableScrubber
   entities:
-  - uid: 309
+  - uid: 218
     components:
     - type: Transform
-      pos: 3.5,-4.5
+      pos: 1.5,-9.5
       parent: 1
-  - uid: 419
+  - uid: 689
     components:
     - type: Transform
-      pos: 3.5,-5.5
+      pos: 2.5,-9.5
       parent: 1
 - proto: PottedPlantRandom
   entities:
@@ -6077,13 +5713,13 @@ entities:
     - type: Transform
       pos: 0.5,15.5
       parent: 1
-  - uid: 554
-    components:
-    - type: Transform
-      pos: -6.5,11.5
-      parent: 1
 - proto: PowerCellRecharger
   entities:
+  - uid: 363
+    components:
+    - type: Transform
+      pos: -0.5,-3.5
+      parent: 1
   - uid: 462
     components:
     - type: Transform
@@ -6095,9 +5731,9 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -2.5,2.5
       parent: 1
-- proto: PoweredlightBlueInterior
+- proto: PoweredlightColoredBlack
   entities:
-  - uid: 517
+  - uid: 456
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -6105,6 +5741,11 @@ entities:
       parent: 1
 - proto: PoweredlightLED
   entities:
+  - uid: 172
+    components:
+    - type: Transform
+      pos: 8.5,0.5
+      parent: 1
   - uid: 980
     components:
     - type: Transform
@@ -6177,36 +5818,12 @@ entities:
       rot: 3.141592653589793 rad
       pos: 6.5,8.5
       parent: 1
-  - uid: 1060
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,4.5
-      parent: 1
 - proto: PoweredSmallLight
   entities:
   - uid: 473
     components:
     - type: Transform
       pos: 7.5,6.5
-      parent: 1
-  - uid: 976
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 8.5,-3.5
-      parent: 1
-  - uid: 977
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 8.5,-1.5
-      parent: 1
-  - uid: 978
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 8.5,0.5
       parent: 1
   - uid: 979
     components:
@@ -6250,10 +5867,10 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 5.5,-10.5
       parent: 1
-  - uid: 1053
+  - uid: 463
     components:
     - type: Transform
-      pos: -0.5,-3.5
+      pos: -0.5,-4.5
       parent: 1
 - proto: RandomFoodMeal
   entities:
@@ -6324,21 +5941,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 6.5,3.5
       parent: 1
-  - uid: 141
-    components:
-    - type: Transform
-      pos: 6.5,-1.5
-      parent: 1
-  - uid: 173
-    components:
-    - type: Transform
-      pos: 6.5,-3.5
-      parent: 1
-  - uid: 176
-    components:
-    - type: Transform
-      pos: 6.5,0.5
-      parent: 1
   - uid: 257
     components:
     - type: Transform
@@ -6347,11 +5949,6 @@ entities:
       parent: 1
 - proto: ReinforcedWindow
   entities:
-  - uid: 12
-    components:
-    - type: Transform
-      pos: 4.5,-1.5
-      parent: 1
   - uid: 26
     components:
     - type: Transform
@@ -6363,11 +5960,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,2.5
-      parent: 1
-  - uid: 38
-    components:
-    - type: Transform
-      pos: 4.5,-3.5
       parent: 1
   - uid: 47
     components:
@@ -6405,30 +5997,10 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -8.5,11.5
       parent: 1
-  - uid: 64
-    components:
-    - type: Transform
-      pos: 4.5,1.5
-      parent: 1
-  - uid: 90
-    components:
-    - type: Transform
-      pos: 4.5,4.5
-      parent: 1
-  - uid: 102
-    components:
-    - type: Transform
-      pos: 4.5,0.5
-      parent: 1
-  - uid: 103
-    components:
-    - type: Transform
-      pos: 4.5,2.5
-      parent: 1
   - uid: 104
     components:
     - type: Transform
-      pos: 4.5,3.5
+      pos: 2.5,-6.5
       parent: 1
   - uid: 135
     components:
@@ -6436,11 +6008,16 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -1.5,4.5
       parent: 1
-  - uid: 221
+  - uid: 240
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 2.5,-6.5
+      rot: -1.5707963267948966 rad
+      pos: 4.5,0.5
+      parent: 1
+  - uid: 260
+    components:
+    - type: Transform
+      pos: 7.5,-4.5
       parent: 1
   - uid: 312
     components:
@@ -6460,6 +6037,12 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -7.5,16.5
       parent: 1
+  - uid: 319
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,3.5
+      parent: 1
   - uid: 327
     components:
     - type: Transform
@@ -6472,6 +6055,12 @@ entities:
       rot: 3.141592653589793 rad
       pos: 5.5,7.5
       parent: 1
+  - uid: 335
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-1.5
+      parent: 1
   - uid: 340
     components:
     - type: Transform
@@ -6483,6 +6072,12 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,16.5
+      parent: 1
+  - uid: 342
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-0.5
       parent: 1
   - uid: 344
     components:
@@ -6501,11 +6096,34 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -9.5,13.5
       parent: 1
+  - uid: 356
+    components:
+    - type: Transform
+      pos: 4.5,-4.5
+      parent: 1
+  - uid: 357
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-2.5
+      parent: 1
   - uid: 358
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,3.5
+      parent: 1
+  - uid: 359
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,1.5
+      parent: 1
+  - uid: 361
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-3.5
       parent: 1
   - uid: 380
     components:
@@ -6543,6 +6161,18 @@ entities:
       rot: 3.141592653589793 rad
       pos: -1.5,-4.5
       parent: 1
+  - uid: 469
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-0.5
+      parent: 1
+  - uid: 470
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,4.5
+      parent: 1
   - uid: 519
     components:
     - type: Transform
@@ -6561,6 +6191,35 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 7.5,10.5
       parent: 1
+  - uid: 530
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,2.5
+      parent: 1
+  - uid: 544
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-2.5
+      parent: 1
+  - uid: 745
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-3.5
+      parent: 1
+  - uid: 746
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-1.5
+      parent: 1
+  - uid: 831
+    components:
+    - type: Transform
+      pos: 8.5,-4.5
+      parent: 1
   - uid: 919
     components:
     - type: Transform
@@ -6571,21 +6230,9 @@ entities:
     - type: Transform
       pos: -4.5,10.5
       parent: 1
-  - uid: 1044
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 4.5,-2.5
-      parent: 1
-  - uid: 1045
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 4.5,-0.5
-      parent: 1
 - proto: ResearchAndDevelopmentServer
   entities:
-  - uid: 46
+  - uid: 727
     components:
     - type: Transform
       pos: -5.5,15.5
@@ -6618,23 +6265,21 @@ entities:
     - type: Transform
       pos: -5.69607,-2.5081196
       parent: 1
-  - uid: 1058
+  - uid: 138
     components:
     - type: Transform
-      pos: -0.45501596,-3.3960907
+      pos: -0.45420063,-4.4385843
+      parent: 1
+- proto: ShipyardGasbenderInfo
+  entities:
+  - uid: 432
+    components:
+    - type: Transform
+      pos: 2.6811826,-7.451379
       parent: 1
 - proto: ShuttersWindow
   entities:
-  - uid: 376
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 4.5,-4.5
-      parent: 1
-    - type: DeviceLinkSink
-      links:
-      - 1052
-  - uid: 1043
+  - uid: 853
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -6642,7 +6287,7 @@ entities:
       parent: 1
     - type: DeviceLinkSink
       links:
-      - 1052
+      - 820
 - proto: SignalButton
   entities:
   - uid: 45
@@ -6756,6 +6401,17 @@ entities:
         - Pressed: Toggle
         429:
         - Pressed: Toggle
+  - uid: 820
+    components:
+    - type: MetaData
+      name: atmospherics lab emergency vent
+    - type: Transform
+      pos: 3.5,5.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        853:
+        - Pressed: Toggle
   - uid: 824
     components:
     - type: MetaData
@@ -6789,21 +6445,6 @@ entities:
         536:
         - Pressed: Toggle
         164:
-        - Pressed: Toggle
-  - uid: 1052
-    components:
-    - type: MetaData
-      name: 'emergency vent switch: main atmos lab'
-    - type: Transform
-      pos: 3.5,5.5
-      parent: 1
-    - type: SignalSwitch
-      state: True
-    - type: DeviceLinkSource
-      linkedPorts:
-        376:
-        - Pressed: Toggle
-        1043:
         - Pressed: Toggle
 - proto: SignAtmos
   entities:
@@ -6865,12 +6506,12 @@ entities:
       parent: 1
 - proto: SMESBasic
   entities:
-  - uid: 240
+  - uid: 748
     components:
     - type: Transform
       pos: 6.5,-8.5
       parent: 1
-  - uid: 241
+  - uid: 752
     components:
     - type: Transform
       pos: 6.5,-9.5
@@ -6882,55 +6523,12 @@ entities:
     - type: Transform
       pos: -3.176369,13.49504
       parent: 1
-- proto: SpawnPointAtmos
-  entities:
-  - uid: 814
-    components:
-    - type: Transform
-      pos: -0.5,-4.5
-      parent: 1
-  - uid: 815
-    components:
-    - type: Transform
-      pos: 0.5,-4.5
-      parent: 1
-- proto: SpawnPointBorg
-  entities:
-  - uid: 454
-    components:
-    - type: Transform
-      pos: -3.5,0.5
-      parent: 1
 - proto: SpawnPointLatejoin
   entities:
-  - uid: 817
+  - uid: 781
     components:
     - type: Transform
-      pos: 2.5,13.5
-      parent: 1
-- proto: SpawnPointPilot
-  entities:
-  - uid: 1146
-    components:
-    - type: Transform
-      pos: -6.5,13.5
-      parent: 1
-- proto: SpawnPointStationEngineer
-  entities:
-  - uid: 813
-    components:
-    - type: Transform
-      pos: 3.5,-8.5
-      parent: 1
-  - uid: 822
-    components:
-    - type: Transform
-      pos: -5.5,5.5
-      parent: 1
-  - uid: 823
-    components:
-    - type: Transform
-      pos: -4.5,5.5
+      pos: 5.5,10.5
       parent: 1
 - proto: SubstationBasic
   entities:
@@ -6939,6 +6537,23 @@ entities:
     - type: Transform
       pos: 6.5,-7.5
       parent: 1
+- proto: SuitStorageEngi
+  entities:
+  - uid: 388
+    components:
+    - type: Transform
+      pos: -4.5,6.5
+      parent: 1
+- proto: SuitStorageWallmountAtmos
+  entities:
+  - uid: 385
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-6.5
+      parent: 1
+    - type: Physics
+      canCollide: False
 - proto: SurveillanceCameraGeneral
   entities:
   - uid: 995
@@ -7051,6 +6666,13 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -3.5,13.5
       parent: 1
+- proto: TableCounterMetal
+  entities:
+  - uid: 466
+    components:
+    - type: Transform
+      pos: -0.5,-3.5
+      parent: 1
 - proto: TableWoodReinforced
   entities:
   - uid: 507
@@ -7076,6 +6698,13 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -1.5,11.5
       parent: 1
+- proto: TelecomServerFilledCommon
+  entities:
+  - uid: 726
+    components:
+    - type: Transform
+      pos: 3.5,-7.5
+      parent: 1
 - proto: ThermomachineFreezerMachineCircuitBoard
   entities:
   - uid: 1142
@@ -7092,97 +6721,129 @@ entities:
       parent: 1
 - proto: Thruster
   entities:
-  - uid: 330
+  - uid: 13
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 8.5,-6.5
+      pos: 8.5,-7.5
       parent: 1
-  - uid: 333
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 8.5,-5.5
-      parent: 1
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 538
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-14.5
       parent: 1
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 768
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-14.5
       parent: 1
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 769
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-14.5
       parent: 1
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 770
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,-14.5
       parent: 1
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 771
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,-13.5
       parent: 1
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 772
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,-12.5
       parent: 1
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 773
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,-13.5
       parent: 1
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 774
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,-12.5
       parent: 1
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 775
     components:
     - type: Transform
       pos: 2.5,16.5
       parent: 1
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 776
     components:
     - type: Transform
       pos: 3.5,16.5
       parent: 1
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 777
     components:
     - type: Transform
       pos: 4.5,15.5
       parent: 1
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 778
     components:
     - type: Transform
       pos: 5.5,14.5
       parent: 1
+    - type: Thruster
+      originalPowerLoad: 1500
+  - uid: 811
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-6.5
+      parent: 1
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 867
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,-11.5
       parent: 1
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 868
     components:
     - type: Transform
       pos: 6.5,13.5
       parent: 1
+    - type: Thruster
+      originalPowerLoad: 1500
 - proto: ToiletDirtyWater
   entities:
   - uid: 523
@@ -7239,6 +6900,13 @@ entities:
         - Left: Forward
         - Right: Reverse
         - Middle: Off
+- proto: VendingMachineAtmosDrobe
+  entities:
+  - uid: 817
+    components:
+    - type: Transform
+      pos: -1.5,-7.5
+      parent: 1
 - proto: VendingMachineCigs
   entities:
   - uid: 505
@@ -7248,14 +6916,7 @@ entities:
       parent: 1
 - proto: VendingMachineEngiDrobe
   entities:
-  - uid: 625
-    components:
-    - type: Transform
-      pos: -5.5,-11.5
-      parent: 1
-- proto: VendingMachineEngivend
-  entities:
-  - uid: 153
+  - uid: 814
     components:
     - type: Transform
       pos: -0.5,-7.5
@@ -7269,17 +6930,10 @@ entities:
       parent: 1
 - proto: VendingMachineTankDispenserEVA
   entities:
-  - uid: 388
+  - uid: 813
     components:
     - type: Transform
-      pos: -7.5,-1.5
-      parent: 1
-- proto: VendingMachineYouTool
-  entities:
-  - uid: 391
-    components:
-    - type: Transform
-      pos: -1.5,-7.5
+      pos: -5.5,-11.5
       parent: 1
 - proto: WallmountTelevision
   entities:
@@ -7335,20 +6989,10 @@ entities:
     - type: Transform
       pos: -0.5,16.5
       parent: 1
-  - uid: 24
-    components:
-    - type: Transform
-      pos: 9.5,-0.5
-      parent: 1
   - uid: 29
     components:
     - type: Transform
       pos: -3.5,16.5
-      parent: 1
-  - uid: 34
-    components:
-    - type: Transform
-      pos: 9.5,-4.5
       parent: 1
   - uid: 35
     components:
@@ -7434,12 +7078,6 @@ entities:
     components:
     - type: Transform
       pos: -7.5,-5.5
-      parent: 1
-  - uid: 77
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 9.5,-3.5
       parent: 1
   - uid: 78
     components:
@@ -7590,17 +7228,6 @@ entities:
     - type: Transform
       pos: 0.5,-14.5
       parent: 1
-  - uid: 174
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 9.5,-2.5
-      parent: 1
-  - uid: 175
-    components:
-    - type: Transform
-      pos: 9.5,0.5
-      parent: 1
   - uid: 184
     components:
     - type: Transform
@@ -7617,11 +7244,17 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 2.5,7.5
       parent: 1
+  - uid: 211
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-4.5
+      parent: 1
   - uid: 212
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 9.5,-1.5
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-4.5
       parent: 1
   - uid: 229
     components:
@@ -7634,36 +7267,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,7.5
-      parent: 1
-  - uid: 274
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 6.5,-4.5
-      parent: 1
-  - uid: 281
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 8.5,-0.5
-      parent: 1
-  - uid: 299
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 8.5,-2.5
-      parent: 1
-  - uid: 300
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 6.5,-2.5
-      parent: 1
-  - uid: 301
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 6.5,-0.5
       parent: 1
   - uid: 302
     components:
@@ -7689,18 +7292,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -7.5,7.5
       parent: 1
-  - uid: 319
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 8.5,-4.5
-      parent: 1
-  - uid: 357
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 7.5,-2.5
-      parent: 1
   - uid: 370
     components:
     - type: Transform
@@ -7722,12 +7313,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,-9.5
-      parent: 1
-  - uid: 399
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 7.5,-0.5
       parent: 1
   - uid: 406
     components:
@@ -7751,12 +7336,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,10.5
-      parent: 1
-  - uid: 478
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 7.5,-4.5
       parent: 1
   - uid: 782
     components:
@@ -7860,12 +7439,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -1.5,-5.5
       parent: 1
-  - uid: 307
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,-6.5
-      parent: 1
   - uid: 407
     components:
     - type: Transform
@@ -7877,6 +7450,11 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,-6.5
+      parent: 1
+  - uid: 477
+    components:
+    - type: Transform
+      pos: 3.5,-6.5
       parent: 1
   - uid: 483
     components:
@@ -7970,30 +7548,6 @@ entities:
     components:
     - type: Transform
       pos: -5.5,7.5
-      parent: 1
-- proto: WarningN2
-  entities:
-  - uid: 1046
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 6.5,-2.5
-      parent: 1
-- proto: WarningO2
-  entities:
-  - uid: 1047
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 6.5,-4.5
-      parent: 1
-- proto: WarningPlasma
-  entities:
-  - uid: 1048
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 6.5,-0.5
       parent: 1
 - proto: WarpPointShip
   entities:

--- a/Resources/Maps/_NF/Shuttles/harbormaster.yml
+++ b/Resources/Maps/_NF/Shuttles/harbormaster.yml
@@ -14,12 +14,13 @@ entities:
   entities:
   - uid: 1
     components:
-    - name: grid
-      type: MetaData
-    - pos: -0.484375,-0.5156288
+    - type: MetaData
+      name: grid
+    - type: Transform
+      pos: -0.484375,-0.5156288
       parent: invalid
-      type: Transform
-    - chunks:
+    - type: MapGrid
+      chunks:
         0,0:
           ind: 0,0
           tiles: JQAAAAAAJQAAAAAAcgAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJQAAAAAAJQAAAAAAcgAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYQAAAAAAYQAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIQAAAAAAIQAAAAAAIQAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYQAAAAAAYQAAAAAAYQAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
@@ -36,24 +37,24 @@ entities:
           ind: -1,-1
           tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAcgAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcgAAAAAAYQAAAAAAYQAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAYQAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcgAAAAAAYQAAAAAAIAAAAAAAYQAAAAAAYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAYQAAAAAAcgAAAAAAcgAAAAAA
           version: 6
-      type: MapGrid
     - type: Broadphase
-    - bodyStatus: InAir
+    - type: Physics
+      bodyStatus: InAir
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
       bodyType: Dynamic
-      type: Physics
-    - fixtures: {}
-      type: Fixtures
+    - type: Fixtures
+      fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid
     - type: Shuttle
     - type: GridPathfinding
-    - gravityShakeSound: !type:SoundPathSpecifier
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
         path: /Audio/Effects/alert.ogg
-      type: Gravity
-    - chunkCollection:
+    - type: DecalGrid
+      chunkCollection:
         version: 2
         nodes:
         - node:
@@ -63,7 +64,7 @@ entities:
           decals:
             0: 0,3
             8: 2,3
-            76: 1,3
+            70: 1,3
         - node:
             angle: 3.141592653589793 rad
             color: '#FFFFFFFF'
@@ -71,39 +72,39 @@ entities:
           decals:
             1: 0,3
             9: 2,3
-            77: 1,3
+            71: 1,3
         - node:
             color: '#D4D4D428'
             id: BrickTileWhiteCornerSe
           decals:
-            35: 1,0
+            29: 1,0
         - node:
             color: '#D4D4D428'
             id: BrickTileWhiteInnerNw
           decals:
-            36: 0,1
+            30: 0,1
         - node:
             color: '#D4D4D428'
             id: BrickTileWhiteLineE
           decals:
-            34: 1,1
+            28: 1,1
         - node:
             color: '#D4D4D428'
             id: BrickTileWhiteLineN
           decals:
-            25: -4,1
-            26: -3,1
-            27: -2,1
-            28: -1,1
+            19: -4,1
+            20: -3,1
+            21: -2,1
+            22: -1,1
         - node:
             color: '#D4D4D428'
             id: BrickTileWhiteLineS
           decals:
-            29: -4,0
-            30: -3,0
-            31: -2,0
-            32: -1,0
-            33: 0,0
+            23: -4,0
+            24: -3,0
+            25: -2,0
+            26: -1,0
+            27: 0,0
         - node:
             angle: 3.141592653589793 rad
             color: '#00FFFFFF'
@@ -127,11 +128,11 @@ entities:
             14: -7,1
             15: -6,1
             16: -6,0
-            18: -7,2
-            20: -6,3
-            70: -7,3
-            71: -6,2
-            72: -7,0
+            17: -7,2
+            18: -6,3
+            64: -7,3
+            65: -6,2
+            66: -7,0
         - node:
             color: '#EFB34196'
             id: MiniTileCheckerAOverlay
@@ -144,113 +145,105 @@ entities:
             color: '#FFFFFFFF'
             id: StandClear
           decals:
-            45: 0,4
-            46: 2,4
-            47: 0,2
-            48: 1,2
-            49: -3,2
-            75: 1,4
+            39: 0,4
+            40: 2,4
+            41: 0,2
+            42: 1,2
+            43: -3,2
+            69: 1,4
         - node:
             angle: 1.5707963267948966 rad
             color: '#FFFFFFFF'
             id: StandClear
           decals:
-            50: -5,1
-            51: -5,-3
+            44: -5,1
+            45: -5,-3
         - node:
             angle: 3.141592653589793 rad
             color: '#FFFFFFFF'
             id: StandClear
           decals:
-            52: -3,-1
-            53: 1,-4
-            54: 1,-1
+            46: -3,-1
+            47: 1,-4
+            48: 1,-1
         - node:
             angle: 4.71238898038469 rad
             color: '#FFFFFFFF'
             id: StandClear
           decals:
-            55: 2,-2
+            49: 2,-2
         - node:
             color: '#FFFFFFFF'
             id: WarnLineE
           decals:
-            58: -5,1
-            59: 2,-2
-            60: -5,-3
+            52: -5,1
+            53: 2,-2
+            54: -5,-3
         - node:
             color: '#FFFFFFFF'
             id: WarnLineN
           decals:
-            41: 0,2
-            42: 1,2
-            43: 2,4
-            44: 0,4
-            57: -3,2
-            67: -3,-1
-            68: 1,-1
-            69: 1,-4
-            74: 1,4
+            35: 0,2
+            36: 1,2
+            37: 2,4
+            38: 0,4
+            51: -3,2
+            61: -3,-1
+            62: 1,-1
+            63: 1,-4
+            68: 1,4
         - node:
             color: '#FFFFFFFF'
             id: WarnLineS
           decals:
-            61: -5,1
-            62: -5,-3
-            63: 2,-2
+            55: -5,1
+            56: -5,-3
+            57: 2,-2
         - node:
             color: '#FFFFFFFF'
             id: WarnLineW
           decals:
-            37: 0,2
-            38: 1,2
-            39: 0,4
-            40: 2,4
-            56: -3,2
-            64: 1,-1
-            65: 1,-4
-            66: -3,-1
-            73: 1,4
-      type: DecalGrid
-    - version: 2
+            31: 0,2
+            32: 1,2
+            33: 0,4
+            34: 2,4
+            50: -3,2
+            58: 1,-1
+            59: 1,-4
+            60: -3,-1
+            67: 1,4
+    - type: GridAtmosphere
+      version: 2
       data:
         tiles:
           0,0:
-            0: 65399
+            0: 29491
             1: 136
-          0,-1:
-            0: 30591
-            1: 34944
+          -1,0:
+            0: 767
+            1: 28672
           0,1:
-            0: 15
+            0: 7
+          0,-1:
+            0: 9762
+            1: 34944
           1,0:
             1: 17
+          1,-1:
+            1: 4368
           0,-2:
             1: 32512
-            0: 32768
-          1,-1:
-            0: 1
-            1: 4368
-          -2,0:
-            0: 65535
-          -2,1:
-            0: 15
-          -1,0:
-            0: 36863
-            1: 28672
-          -1,1:
-            0: 8
-          -2,-1:
-            0: 63624
-            1: 1638
-          -2,-2:
-            0: 36352
-            1: 24576
           -1,-2:
-            0: 29184
             1: 35840
           -1,-1:
-            0: 65535
+            0: 12275
+          -2,0:
+            0: 26342
+          -2,-2:
+            1: 24576
+          -2,-1:
+            1: 1638
+            0: 128
         uniqueMixes:
         - volume: 2500
           temperature: 293.15
@@ -268,7 +261,7 @@ entities:
           - 0
           - 0
         - volume: 2500
-          temperature: 293.15
+          immutable: True
           moles:
           - 0
           - 0
@@ -283,1443 +276,1343 @@ entities:
           - 0
           - 0
         chunkSize: 4
-      type: GridAtmosphere
     - type: GasTileOverlay
     - type: RadiationGridResistance
-    - id: harbormaster
-      type: BecomesStation
+    - type: BecomesStation
+      id: harbormaster
 - proto: AirAlarm
   entities:
   - uid: 118
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -1.5,-3.5
       parent: 1
-      type: Transform
-    - ShutdownSubscribers:
+    - type: DeviceList
+      devices:
       - 104
-      type: DeviceNetwork
-    - devices:
-      - 104
-      type: DeviceList
 - proto: AirCanister
   entities:
   - uid: 209
     components:
-    - anchored: True
+    - type: Transform
+      anchored: True
       pos: -3.5,-1.5
       parent: 1
-      type: Transform
-    - bodyType: Static
-      type: Physics
+    - type: Physics
+      bodyType: Static
 - proto: AirlockCommandGlass
   entities:
   - uid: 191
     components:
-    - pos: -4.5,1.5
+    - type: Transform
+      pos: -4.5,1.5
       parent: 1
-      type: Transform
 - proto: AirlockEngineeringGlass
   entities:
   - uid: 193
     components:
-    - pos: -2.5,-0.5
+    - type: Transform
+      pos: -2.5,-0.5
       parent: 1
-      type: Transform
 - proto: AirlockExternalGlass
   entities:
   - uid: 194
     components:
-    - pos: -2.5,2.5
+    - type: Transform
+      pos: -2.5,2.5
       parent: 1
-      type: Transform
   - uid: 195
     components:
-    - pos: -4.5,-2.5
+    - type: Transform
+      pos: -4.5,-2.5
       parent: 1
-      type: Transform
   - uid: 196
     components:
-    - pos: 0.5,2.5
+    - type: Transform
+      pos: 0.5,2.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 266
-      type: DeviceLinkSink
   - uid: 197
     components:
-    - pos: 1.5,2.5
+    - type: Transform
+      pos: 1.5,2.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 266
-      type: DeviceLinkSink
   - uid: 198
     components:
-    - pos: 2.5,-1.5
+    - type: Transform
+      pos: 2.5,-1.5
       parent: 1
-      type: Transform
   - uid: 199
     components:
-    - pos: 1.5,-3.5
+    - type: Transform
+      pos: 1.5,-3.5
       parent: 1
-      type: Transform
 - proto: AirlockGlassShuttle
   entities:
   - uid: 30
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 0.5,4.5
       parent: 1
-      type: Transform
   - uid: 270
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 1.5,4.5
       parent: 1
-      type: Transform
   - uid: 277
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 2.5,4.5
       parent: 1
-      type: Transform
 - proto: APCBasic
   entities:
   - uid: 185
     components:
-    - pos: -3.5,2.5
+    - type: Transform
+      pos: -3.5,2.5
       parent: 1
-      type: Transform
   - uid: 187
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 2.5,-2.5
       parent: 1
-      type: Transform
 - proto: AtmosDeviceFanTiny
   entities:
   - uid: 24
     components:
-    - pos: 2.5,-1.5
+    - type: Transform
+      pos: 2.5,-1.5
       parent: 1
-      type: Transform
   - uid: 33
     components:
-    - pos: 1.5,4.5
+    - type: Transform
+      pos: 1.5,4.5
       parent: 1
-      type: Transform
   - uid: 34
     components:
-    - pos: -4.5,-2.5
+    - type: Transform
+      pos: -4.5,-2.5
       parent: 1
-      type: Transform
   - uid: 47
     components:
-    - pos: 1.5,-3.5
+    - type: Transform
+      pos: 1.5,-3.5
       parent: 1
-      type: Transform
   - uid: 73
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 0.5,4.5
       parent: 1
-      type: Transform
   - uid: 93
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 2.5,4.5
       parent: 1
-      type: Transform
   - uid: 111
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -2.5,2.5
       parent: 1
-      type: Transform
 - proto: AtmosFixBlockerMarker
   entities:
   - uid: 217
     components:
-    - pos: 3.5,1.5
+    - type: Transform
+      pos: 3.5,1.5
       parent: 1
-      type: Transform
   - uid: 218
     components:
-    - pos: 3.5,0.5
+    - type: Transform
+      pos: 3.5,0.5
       parent: 1
-      type: Transform
   - uid: 219
     components:
-    - pos: 3.5,-0.5
+    - type: Transform
+      pos: 3.5,-0.5
       parent: 1
-      type: Transform
   - uid: 220
     components:
-    - pos: 3.5,-1.5
+    - type: Transform
+      pos: 3.5,-1.5
       parent: 1
-      type: Transform
   - uid: 221
     components:
-    - pos: 3.5,-2.5
+    - type: Transform
+      pos: 3.5,-2.5
       parent: 1
-      type: Transform
   - uid: 222
     components:
-    - pos: 4.5,1.5
+    - type: Transform
+      pos: 4.5,1.5
       parent: 1
-      type: Transform
   - uid: 223
     components:
-    - pos: 4.5,0.5
+    - type: Transform
+      pos: 4.5,0.5
       parent: 1
-      type: Transform
   - uid: 224
     components:
-    - pos: 4.5,-0.5
+    - type: Transform
+      pos: 4.5,-0.5
       parent: 1
-      type: Transform
   - uid: 225
     components:
-    - pos: 4.5,-1.5
+    - type: Transform
+      pos: 4.5,-1.5
       parent: 1
-      type: Transform
   - uid: 226
     components:
-    - pos: 4.5,-2.5
+    - type: Transform
+      pos: 4.5,-2.5
       parent: 1
-      type: Transform
   - uid: 227
     components:
-    - pos: 2.5,-5.5
+    - type: Transform
+      pos: 2.5,-5.5
       parent: 1
-      type: Transform
   - uid: 228
     components:
-    - pos: 2.5,-4.5
+    - type: Transform
+      pos: 2.5,-4.5
       parent: 1
-      type: Transform
   - uid: 229
     components:
-    - pos: 1.5,-5.5
+    - type: Transform
+      pos: 1.5,-5.5
       parent: 1
-      type: Transform
   - uid: 230
     components:
-    - pos: 1.5,-4.5
+    - type: Transform
+      pos: 1.5,-4.5
       parent: 1
-      type: Transform
   - uid: 231
     components:
-    - pos: 0.5,-5.5
+    - type: Transform
+      pos: 0.5,-5.5
       parent: 1
-      type: Transform
   - uid: 232
     components:
-    - pos: 0.5,-4.5
+    - type: Transform
+      pos: 0.5,-4.5
       parent: 1
-      type: Transform
   - uid: 233
     components:
-    - pos: -0.5,-5.5
+    - type: Transform
+      pos: -0.5,-5.5
       parent: 1
-      type: Transform
   - uid: 234
     components:
-    - pos: -0.5,-4.5
+    - type: Transform
+      pos: -0.5,-4.5
       parent: 1
-      type: Transform
   - uid: 235
     components:
-    - pos: -1.5,-5.5
+    - type: Transform
+      pos: -1.5,-5.5
       parent: 1
-      type: Transform
   - uid: 236
     components:
-    - pos: 3.5,-5.5
+    - type: Transform
+      pos: 3.5,-5.5
       parent: 1
-      type: Transform
   - uid: 237
     components:
-    - pos: -3.5,3.5
+    - type: Transform
+      pos: -3.5,3.5
       parent: 1
-      type: Transform
   - uid: 238
     components:
-    - pos: -2.5,3.5
+    - type: Transform
+      pos: -2.5,3.5
       parent: 1
-      type: Transform
   - uid: 239
     components:
-    - pos: -1.5,3.5
+    - type: Transform
+      pos: -1.5,3.5
       parent: 1
-      type: Transform
   - uid: 240
     components:
-    - pos: -5.5,-1.5
+    - type: Transform
+      pos: -5.5,-1.5
       parent: 1
-      type: Transform
   - uid: 241
     components:
-    - pos: -5.5,-2.5
+    - type: Transform
+      pos: -5.5,-2.5
       parent: 1
-      type: Transform
   - uid: 242
     components:
-    - pos: -5.5,-3.5
+    - type: Transform
+      pos: -5.5,-3.5
       parent: 1
-      type: Transform
   - uid: 243
     components:
-    - pos: -5.5,-4.5
+    - type: Transform
+      pos: -5.5,-4.5
       parent: 1
-      type: Transform
   - uid: 244
     components:
-    - pos: -6.5,-1.5
+    - type: Transform
+      pos: -6.5,-1.5
       parent: 1
-      type: Transform
   - uid: 245
     components:
-    - pos: -6.5,-2.5
+    - type: Transform
+      pos: -6.5,-2.5
       parent: 1
-      type: Transform
   - uid: 246
     components:
-    - pos: -6.5,-3.5
+    - type: Transform
+      pos: -6.5,-3.5
       parent: 1
-      type: Transform
   - uid: 247
     components:
-    - pos: -6.5,-4.5
+    - type: Transform
+      pos: -6.5,-4.5
       parent: 1
-      type: Transform
 - proto: BoxFolderBlue
   entities:
   - uid: 276
     components:
-    - pos: -5.630942,3.0957122
+    - type: Transform
+      pos: -5.630942,3.0957122
       parent: 1
-      type: Transform
 - proto: CableApcExtension
   entities:
   - uid: 122
     components:
-    - pos: -0.5,1.5
+    - type: Transform
+      pos: -0.5,1.5
       parent: 1
-      type: Transform
   - uid: 123
     components:
-    - pos: -2.5,1.5
+    - type: Transform
+      pos: -2.5,1.5
       parent: 1
-      type: Transform
   - uid: 124
     components:
-    - pos: -1.5,1.5
+    - type: Transform
+      pos: -1.5,1.5
       parent: 1
-      type: Transform
   - uid: 125
     components:
-    - pos: -2.5,0.5
+    - type: Transform
+      pos: -2.5,0.5
       parent: 1
-      type: Transform
   - uid: 126
     components:
-    - pos: 2.5,-2.5
+    - type: Transform
+      pos: 2.5,-2.5
       parent: 1
-      type: Transform
   - uid: 127
     components:
-    - pos: 3.5,-2.5
+    - type: Transform
+      pos: 3.5,-2.5
       parent: 1
-      type: Transform
   - uid: 128
     components:
-    - pos: 3.5,-1.5
+    - type: Transform
+      pos: 3.5,-1.5
       parent: 1
-      type: Transform
   - uid: 129
     components:
-    - pos: 3.5,-0.5
+    - type: Transform
+      pos: 3.5,-0.5
       parent: 1
-      type: Transform
   - uid: 130
     components:
-    - pos: 3.5,0.5
+    - type: Transform
+      pos: 3.5,0.5
       parent: 1
-      type: Transform
   - uid: 131
     components:
-    - pos: 1.5,-2.5
+    - type: Transform
+      pos: 1.5,-2.5
       parent: 1
-      type: Transform
   - uid: 132
     components:
-    - pos: 1.5,-3.5
+    - type: Transform
+      pos: 1.5,-3.5
       parent: 1
-      type: Transform
   - uid: 133
     components:
-    - pos: 1.5,-4.5
+    - type: Transform
+      pos: 1.5,-4.5
       parent: 1
-      type: Transform
   - uid: 134
     components:
-    - pos: 2.5,-4.5
+    - type: Transform
+      pos: 2.5,-4.5
       parent: 1
-      type: Transform
   - uid: 135
     components:
-    - pos: 0.5,-4.5
+    - type: Transform
+      pos: 0.5,-4.5
       parent: 1
-      type: Transform
   - uid: 136
     components:
-    - pos: -0.5,-4.5
+    - type: Transform
+      pos: -0.5,-4.5
       parent: 1
-      type: Transform
   - uid: 137
     components:
-    - pos: 0.5,1.5
+    - type: Transform
+      pos: 0.5,1.5
       parent: 1
-      type: Transform
   - uid: 138
     components:
-    - pos: 1.5,1.5
+    - type: Transform
+      pos: 1.5,1.5
       parent: 1
-      type: Transform
   - uid: 139
     components:
-    - pos: 1.5,2.5
+    - type: Transform
+      pos: 1.5,2.5
       parent: 1
-      type: Transform
   - uid: 161
     components:
-    - pos: -2.5,-0.5
+    - type: Transform
+      pos: -2.5,-0.5
       parent: 1
-      type: Transform
   - uid: 162
     components:
-    - pos: -2.5,-1.5
+    - type: Transform
+      pos: -2.5,-1.5
       parent: 1
-      type: Transform
   - uid: 163
     components:
-    - pos: -2.5,-2.5
+    - type: Transform
+      pos: -2.5,-2.5
       parent: 1
-      type: Transform
   - uid: 164
     components:
-    - pos: -3.5,-2.5
+    - type: Transform
+      pos: -3.5,-2.5
       parent: 1
-      type: Transform
   - uid: 165
     components:
-    - pos: -4.5,-2.5
+    - type: Transform
+      pos: -4.5,-2.5
       parent: 1
-      type: Transform
   - uid: 166
     components:
-    - pos: -5.5,-2.5
+    - type: Transform
+      pos: -5.5,-2.5
       parent: 1
-      type: Transform
   - uid: 167
     components:
-    - pos: -5.5,-3.5
+    - type: Transform
+      pos: -5.5,-3.5
       parent: 1
-      type: Transform
   - uid: 205
     components:
-    - pos: -4.5,1.5
+    - type: Transform
+      pos: -4.5,1.5
       parent: 1
-      type: Transform
   - uid: 206
     components:
-    - pos: 1.5,3.5
+    - type: Transform
+      pos: 1.5,3.5
       parent: 1
-      type: Transform
   - uid: 207
     components:
-    - pos: -3.5,1.5
+    - type: Transform
+      pos: -3.5,1.5
       parent: 1
-      type: Transform
   - uid: 210
     components:
-    - pos: -5.5,1.5
+    - type: Transform
+      pos: -5.5,1.5
       parent: 1
-      type: Transform
   - uid: 211
     components:
-    - pos: -3.5,2.5
+    - type: Transform
+      pos: -3.5,2.5
       parent: 1
-      type: Transform
 - proto: CableHV
   entities:
   - uid: 116
     components:
-    - pos: -3.5,-0.5
+    - type: Transform
+      pos: -3.5,-0.5
       parent: 1
-      type: Transform
   - uid: 180
     components:
-    - pos: -0.5,-2.5
+    - type: Transform
+      pos: -0.5,-2.5
       parent: 1
-      type: Transform
   - uid: 181
     components:
-    - pos: -0.5,-1.5
+    - type: Transform
+      pos: -0.5,-1.5
       parent: 1
-      type: Transform
   - uid: 182
     components:
-    - pos: -1.5,-1.5
+    - type: Transform
+      pos: -1.5,-1.5
       parent: 1
-      type: Transform
   - uid: 183
     components:
-    - pos: -2.5,-1.5
+    - type: Transform
+      pos: -2.5,-1.5
       parent: 1
-      type: Transform
   - uid: 184
     components:
-    - pos: -3.5,-1.5
+    - type: Transform
+      pos: -3.5,-1.5
       parent: 1
-      type: Transform
 - proto: CableMV
   entities:
   - uid: 143
     components:
-    - pos: -3.5,-0.5
+    - type: Transform
+      pos: -3.5,-0.5
       parent: 1
-      type: Transform
   - uid: 144
     components:
-    - pos: -3.5,0.5
+    - type: Transform
+      pos: -3.5,0.5
       parent: 1
-      type: Transform
   - uid: 146
     components:
-    - pos: -2.5,0.5
+    - type: Transform
+      pos: -2.5,0.5
       parent: 1
-      type: Transform
   - uid: 147
     components:
-    - pos: -1.5,0.5
+    - type: Transform
+      pos: -1.5,0.5
       parent: 1
-      type: Transform
   - uid: 148
     components:
-    - pos: -0.5,0.5
+    - type: Transform
+      pos: -0.5,0.5
       parent: 1
-      type: Transform
   - uid: 149
     components:
-    - pos: 0.5,0.5
+    - type: Transform
+      pos: 0.5,0.5
       parent: 1
-      type: Transform
   - uid: 150
     components:
-    - pos: 1.5,0.5
+    - type: Transform
+      pos: 1.5,0.5
       parent: 1
-      type: Transform
   - uid: 151
     components:
-    - pos: 1.5,-0.5
+    - type: Transform
+      pos: 1.5,-0.5
       parent: 1
-      type: Transform
   - uid: 152
     components:
-    - pos: 1.5,-1.5
+    - type: Transform
+      pos: 1.5,-1.5
       parent: 1
-      type: Transform
   - uid: 153
     components:
-    - pos: 1.5,-2.5
+    - type: Transform
+      pos: 1.5,-2.5
       parent: 1
-      type: Transform
   - uid: 154
     components:
-    - pos: 2.5,-2.5
+    - type: Transform
+      pos: 2.5,-2.5
       parent: 1
-      type: Transform
   - uid: 212
     components:
-    - pos: -3.5,1.5
+    - type: Transform
+      pos: -3.5,1.5
       parent: 1
-      type: Transform
   - uid: 213
     components:
-    - pos: -3.5,2.5
+    - type: Transform
+      pos: -3.5,2.5
       parent: 1
-      type: Transform
 - proto: CableTerminal
   entities:
   - uid: 269
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -0.5,-1.5
       parent: 1
-      type: Transform
 - proto: Catwalk
   entities:
   - uid: 79
     components:
-    - pos: 2.5,-4.5
+    - type: Transform
+      pos: 2.5,-4.5
       parent: 1
-      type: Transform
   - uid: 80
     components:
-    - pos: 0.5,-4.5
+    - type: Transform
+      pos: 0.5,-4.5
       parent: 1
-      type: Transform
   - uid: 81
     components:
-    - pos: 1.5,-4.5
+    - type: Transform
+      pos: 1.5,-4.5
       parent: 1
-      type: Transform
   - uid: 82
     components:
-    - pos: -0.5,-4.5
+    - type: Transform
+      pos: -0.5,-4.5
       parent: 1
-      type: Transform
   - uid: 88
     components:
-    - pos: -5.5,-1.5
+    - type: Transform
+      pos: -5.5,-1.5
       parent: 1
-      type: Transform
   - uid: 89
     components:
-    - pos: -5.5,-2.5
+    - type: Transform
+      pos: -5.5,-2.5
       parent: 1
-      type: Transform
   - uid: 90
     components:
-    - pos: -5.5,-3.5
+    - type: Transform
+      pos: -5.5,-3.5
       parent: 1
-      type: Transform
   - uid: 91
     components:
-    - pos: -5.5,-4.5
+    - type: Transform
+      pos: -5.5,-4.5
       parent: 1
-      type: Transform
   - uid: 94
     components:
-    - pos: 3.5,-2.5
+    - type: Transform
+      pos: 3.5,-2.5
       parent: 1
-      type: Transform
   - uid: 155
     components:
-    - pos: 3.5,-1.5
+    - type: Transform
+      pos: 3.5,-1.5
       parent: 1
-      type: Transform
   - uid: 156
     components:
-    - pos: 3.5,-0.5
+    - type: Transform
+      pos: 3.5,-0.5
       parent: 1
-      type: Transform
   - uid: 157
     components:
-    - pos: 3.5,0.5
+    - type: Transform
+      pos: 3.5,0.5
       parent: 1
-      type: Transform
   - uid: 179
     components:
-    - pos: 3.5,1.5
+    - type: Transform
+      pos: 3.5,1.5
       parent: 1
-      type: Transform
 - proto: ChairPilotSeat
   entities:
   - uid: 174
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -6.5,2.5
       parent: 1
-      type: Transform
 - proto: ClothingBeltUtilityFilled
   entities:
   - uid: 251
     components:
-    - pos: -1.6776748,-2.1916976
+    - type: Transform
+      pos: -1.6776748,-2.1916976
       parent: 1
-      type: Transform
 - proto: ComputerTabletopRadar
   entities:
   - uid: 273
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -5.5,2.5
       parent: 1
-      type: Transform
 - proto: ComputerTabletopShuttle
   entities:
   - uid: 272
     components:
-    - pos: -6.5,3.5
+    - type: Transform
+      pos: -6.5,3.5
       parent: 1
-      type: Transform
 - proto: ComputerTabletopStationRecords
   entities:
   - uid: 200
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -5.5,0.5
       parent: 1
-      type: Transform
 - proto: DefibrillatorCabinetFilled
   entities:
   - uid: 274
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -7.5,0.5
       parent: 1
-      type: Transform
 - proto: DrinkMugMetal
   entities:
   - uid: 216
     components:
-    - pos: -6.021567,3.4238372
+    - type: Transform
+      pos: -6.021567,3.4238372
       parent: 1
-      type: Transform
-    - solutions:
+    - type: SolutionContainerManager
+      solutions:
         drink:
           temperature: 293.15
-          canMix: True
           canReact: True
           maxVol: 20
+          name: null
           reagents:
           - data: null
             ReagentId: Coffee
             Quantity: 20
-      type: SolutionContainerManager
 - proto: ExtinguisherCabinetFilled
   entities:
   - uid: 215
     components:
-    - pos: -0.5,2.5
+    - type: Transform
+      pos: -0.5,2.5
       parent: 1
-      type: Transform
 - proto: FaxMachineShip
   entities:
   - uid: 173
     components:
-    - pos: -5.5,3.5
+    - type: Transform
+      pos: -5.5,3.5
       parent: 1
-      type: Transform
 - proto: FirelockGlass
   entities:
   - uid: 110
     components:
-    - pos: -2.5,-0.5
+    - type: Transform
+      pos: -2.5,-0.5
       parent: 1
-      type: Transform
   - uid: 186
     components:
-    - pos: -4.5,1.5
+    - type: Transform
+      pos: -4.5,1.5
       parent: 1
-      type: Transform
   - uid: 188
     components:
-    - pos: 0.5,2.5
+    - type: Transform
+      pos: 0.5,2.5
       parent: 1
-      type: Transform
   - uid: 189
     components:
-    - pos: 1.5,2.5
+    - type: Transform
+      pos: 1.5,2.5
       parent: 1
-      type: Transform
   - uid: 190
     components:
-    - pos: 1.5,-0.5
+    - type: Transform
+      pos: 1.5,-0.5
       parent: 1
-      type: Transform
 - proto: GasPassiveVent
   entities:
   - uid: 160
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -5.5,-2.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
 - proto: GasPipeBend
   entities:
   - uid: 117
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -6.5,0.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
 - proto: GasPipeStraight
   entities:
   - uid: 32
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -1.5,-0.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0000CCFF'
   - uid: 37
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 0.5,1.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0000CCFF'
   - uid: 40
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -2.5,1.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0000CCFF'
   - uid: 67
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -3.5,1.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0000CCFF'
   - uid: 98
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -4.5,-2.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 101
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -4.5,0.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 102
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -5.5,0.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 112
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -3.5,0.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 114
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -2.5,-0.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 115
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -2.5,-1.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 120
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -1.5,0.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0000CCFF'
   - uid: 140
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -0.5,1.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0000CCFF'
   - uid: 141
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 0.5,0.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 145
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -0.5,0.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 159
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -4.5,1.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0000CCFF'
   - uid: 208
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -1.5,0.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
 - proto: GasPipeTJunction
   entities:
   - uid: 29
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -1.5,-1.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0000CCFF'
   - uid: 106
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -2.5,-2.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 113
     components:
-    - pos: -2.5,0.5
+    - type: Transform
+      pos: -2.5,0.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 142
     components:
-    - pos: -1.5,1.5
+    - type: Transform
+      pos: -1.5,1.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0000CCFF'
 - proto: GasPort
   entities:
   - uid: 7
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -3.5,-1.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0000CCFF'
 - proto: GasPressurePump
   entities:
   - uid: 59
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -2.5,-1.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0000CCFF'
   - uid: 105
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -3.5,-2.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
 - proto: GasVentPump
   entities:
   - uid: 38
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 1.5,1.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0000CCFF'
   - uid: 41
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -5.5,1.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0000CCFF'
   - uid: 109
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -0.5,-1.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0000CCFF'
 - proto: GasVentScrubber
   entities:
   - uid: 28
     components:
-    - pos: -6.5,1.5
+    - type: Transform
+      pos: -6.5,1.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 104
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -1.5,-2.5
       parent: 1
-      type: Transform
-    - ShutdownSubscribers:
-      - 118
-      type: DeviceNetwork
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 121
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 1.5,0.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
 - proto: GravityGeneratorMini
   entities:
   - uid: 168
     components:
-    - pos: -2.5,-3.5
+    - type: Transform
+      pos: -2.5,-3.5
       parent: 1
-      type: Transform
 - proto: Grille
   entities:
   - uid: 27
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -0.5,3.5
       parent: 1
-      type: Transform
   - uid: 35
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 3.5,3.5
       parent: 1
-      type: Transform
   - uid: 36
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -7.5,3.5
       parent: 1
-      type: Transform
   - uid: 42
     components:
-    - pos: -7.5,2.5
+    - type: Transform
+      pos: -7.5,2.5
       parent: 1
-      type: Transform
   - uid: 44
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -5.5,4.5
       parent: 1
-      type: Transform
   - uid: 50
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -5.5,-0.5
       parent: 1
-      type: Transform
   - uid: 53
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -1.5,-0.5
       parent: 1
-      type: Transform
   - uid: 61
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -4.5,3.5
       parent: 1
-      type: Transform
   - uid: 63
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -6.5,4.5
       parent: 1
-      type: Transform
   - uid: 192
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -4.5,0.5
       parent: 1
-      type: Transform
 - proto: Gyroscope
   entities:
   - uid: 169
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -3.5,-3.5
       parent: 1
-      type: Transform
+    - type: Thruster
+      originalPowerLoad: 1500
 - proto: Lantern
   entities:
   - uid: 201
     components:
-    - pos: -6.305764,0.699216
+    - type: Transform
+      pos: -6.305764,0.699216
       parent: 1
-      type: Transform
-- proto: Paper
-  entities:
-  - uid: 268
-    components:
-    - pos: -1.4035056,-2.5020657
-      parent: 1
-      type: Transform
-    - stampState: paper_stamp-ce
-      stampedBy:
-      - stampedBorderless: False
-        stampedColor: '#C69B17FF'
-        stampedName: stamp-component-stamped-name-ce
-      - stampedBorderless: False
-        stampedColor: '#00BE00FF'
-        stampedName: stamp-component-stamped-name-approved
-      content: >-
-        [color=#1b67a5]█░░█░███[/color][color=#5b97bc]░███░█░█░█░██░░█░█░██░░██░░██░[/color]
-
-        [color=#1b67a5]██░█░░█░[/color][color=#5b97bc]██░░░█░█░█░█░█░█░█░█░█░█░█░█░█[/color]
-
-        [color=#1b67a5]█░██░░█░[/color][color=#5b97bc]░░██░███░█░██░░░█░░███░██░░█░█[/color]
-
-        [color=#1b67a5]█░░█░░█░[/color][color=#5b97bc]███░░█░█░█░█░░░░█░░█░█░█░█░██░[/color]
-
-
-        [head=1]=========================[/head]
-
-        [head=1]Harbormaster-class tugboat[/head]
-
-        [head=1] [/head]
-
-        [head=1]       PREFLIGHT CHECKLIST[/head]
-
-        [head=1] [/head]
-
-        [head=1]=========================[/head]
-
-
-        [head=2]1. Power supply.[/head]
-
-        [head=3]1.1. Battery units.[/head]
-
-        [bullet/][ ] Check if the SMES unit is anchored to the floor.
-
-        [bullet/][ ] Check if the substation unit is anchored to the floor.
-
-        [bullet/][ ] Check if the APC unit's Main Breakers are toggled on.
-
-        [bullet/][ ] Check current Load[bold]*[/bold] (W) on APC unit.
-
-        [head=3]1.2. P.A.C.M.A.N. generator units.[/head]
-
-        [bullet/][ ] Check if the P.A.C.M.A.N. generator units are anchored to the floor.
-
-        [bullet/][ ] Check if the P.A.C.M.A.N. generator units are fueled. For extended flights make sure that you have enough fuel stockpiled to sustain prolonged power generation.
-
-        [bullet/][ ] Check if the P.A.C.M.A.N. generator units are set to HV output.
-
-        [bullet/][ ] Set Target Power for 16 [bold]**[/bold] [bold]k[/bold]W.
-
-        [bullet/][ ] Start the P.A.C.M.A.N. generator units.
-
-
-        [head=2]2. Atmospherics.[/head]
-
-        [head=3]2.1. Distribution Loop.[/head]
-
-        [bullet/][ ] Check if the air canister is anchored to connector port.
-
-        [bullet/][ ] Check if the air output pump is set to normal pressure.
-
-        [bullet/][ ] Enable the air output pump.
-
-        [bullet/][ ] Check if the distribution pump is set to normal pressure.
-
-        [bullet/][ ] Enable distribution pump.
-
-        [head=3]2.2. Waste Loop.[/head]
-
-        [bullet/][ ] Enable waste loop pump.
-
-
-        [head=2]3. Other checks.[/head]
-
-        [bullet/][ ] Check if the gyroscope is anchored, powered, and enabled.
-
-        [bullet/][ ] Check if the mini gravity generator is anchored, powered, and enabled.
-
-
-        __________________________________________________________________
-
-        [bold]*[/bold] - Harbormaster-class tugboats are equipped with a two APC units that can be used to appraise the ship's total power consumption. Unmodifued Harbormaster-class tugboat requires 30 kW of power to remain operational.
-
-        [bold]**[/bold] - Harbormaster-class tugboats have higher power demand than single standard P.A.C.M.A.N. generator unit can provide at optimal settings, however the ship comes equipped with two P.A.C.M.A.N. generator units, recommended target power output for each P.A.C.M.A.N. generator unit is 16 kW.
-
-        [bold]Note:[/bold] Additional generator units can be purchased at the Frontier Station.
-      type: Paper
-- proto: PortableGeneratorPacman
+- proto: PortableGeneratorPacmanShuttle
   entities:
   - uid: 64
     components:
-    - anchored: True
+    - type: Transform
       pos: -0.5,-1.5
       parent: 1
-      type: Transform
-    - storage:
-        Plasma: 1500
-      type: MaterialStorage
-    - bodyType: Static
-      type: Physics
-    - type: InsertingMaterialStorage
-  - uid: 70
+    - type: FuelGenerator
+      on: False
+    - type: Physics
+      bodyType: Static
+  - uid: 268
     components:
-    - anchored: True
+    - type: Transform
       pos: -0.5,-2.5
       parent: 1
-      type: Transform
-    - storage:
-        Plasma: 1500
-      type: MaterialStorage
-    - bodyType: Static
-      type: Physics
-    - type: InsertingMaterialStorage
+    - type: FuelGenerator
+      on: False
+    - type: Physics
+      bodyType: Static
 - proto: PowerCellRecharger
   entities:
   - uid: 271
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -6.5,0.5
       parent: 1
-      type: Transform
 - proto: PoweredlightLED
   entities:
   - uid: 203
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 1.5,0.5
       parent: 1
-      type: Transform
   - uid: 204
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -6.5,1.5
       parent: 1
-      type: Transform
 - proto: PoweredSmallLight
   entities:
   - uid: 202
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -1.5,-2.5
       parent: 1
-      type: Transform
 - proto: ReinforcedWindow
   entities:
   - uid: 17
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -6.5,4.5
       parent: 1
-      type: Transform
   - uid: 45
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -5.5,4.5
       parent: 1
-      type: Transform
   - uid: 46
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -7.5,3.5
       parent: 1
-      type: Transform
   - uid: 60
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -4.5,3.5
       parent: 1
-      type: Transform
   - uid: 62
     components:
-    - pos: -7.5,2.5
+    - type: Transform
+      pos: -7.5,2.5
       parent: 1
-      type: Transform
   - uid: 74
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 3.5,3.5
       parent: 1
-      type: Transform
   - uid: 92
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -0.5,3.5
       parent: 1
-      type: Transform
   - uid: 107
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -1.5,-0.5
       parent: 1
-      type: Transform
   - uid: 108
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -5.5,-0.5
       parent: 1
-      type: Transform
   - uid: 119
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -4.5,0.5
       parent: 1
-      type: Transform
 - proto: SheetPlasma
   entities:
   - uid: 252
     components:
-    - pos: -0.53643143,-1.4761097
+    - type: Transform
+      pos: -0.53643143,-1.4761097
       parent: 1
-      type: Transform
-    - count: 15
-      type: Stack
-    - size: 15
-      type: Item
+    - type: Stack
+      count: 15
+    - type: Item
+      size: 15
   - uid: 253
     components:
-    - pos: -0.47393143,-2.5229847
+    - type: Transform
+      pos: -0.47393143,-2.5229847
       parent: 1
-      type: Transform
-    - count: 15
-      type: Stack
-    - size: 15
-      type: Item
+    - type: Stack
+      count: 15
+    - type: Item
+      size: 15
+- proto: ShipyardHarbormasterInfo
+  entities:
+  - uid: 70
+    components:
+    - type: Transform
+      pos: -1.1647649,-2.4062462
+      parent: 1
 - proto: ShuttersNormalOpen
   entities:
   - uid: 257
     components:
-    - pos: -5.5,-0.5
+    - type: Transform
+      pos: -5.5,-0.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 267
-      type: DeviceLinkSink
   - uid: 258
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -7.5,2.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 267
-      type: DeviceLinkSink
   - uid: 259
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -7.5,3.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 267
-      type: DeviceLinkSink
   - uid: 260
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -0.5,3.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 267
-      type: DeviceLinkSink
   - uid: 261
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -6.5,4.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 267
-      type: DeviceLinkSink
   - uid: 262
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -5.5,4.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 267
-      type: DeviceLinkSink
   - uid: 263
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -4.5,3.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 267
-      type: DeviceLinkSink
   - uid: 264
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 3.5,3.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 267
-      type: DeviceLinkSink
   - uid: 265
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -4.5,0.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 267
-      type: DeviceLinkSink
 - proto: SignalButtonDirectional
   entities:
   - uid: 266
     components:
-    - name: airlock bolts switch
-      type: MetaData
-    - rot: -1.5707963267948966 rad
+    - type: MetaData
+      name: airlock bolts switch
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 2.5,1.5
       parent: 1
-      type: Transform
-    - linkedPorts:
+    - type: DeviceLinkSource
+      linkedPorts:
         196:
         - Pressed: DoorBolt
         197:
         - Pressed: DoorBolt
-      type: DeviceLinkSource
   - uid: 267
     components:
-    - name: shutters switch
-      type: MetaData
-    - rot: -1.5707963267948966 rad
+    - type: MetaData
+      name: shutters switch
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -4.5,2.5
       parent: 1
-      type: Transform
-    - linkedPorts:
+    - type: DeviceLinkSource
+      linkedPorts:
         263:
         - Pressed: Toggle
         262:
@@ -1738,416 +1631,446 @@ entities:
         - Pressed: Toggle
         264:
         - Pressed: Toggle
-      type: DeviceLinkSource
 - proto: SignElectricalMed
   entities:
   - uid: 250
     components:
-    - pos: -0.5,-0.5
+    - type: Transform
+      pos: -0.5,-0.5
       parent: 1
-      type: Transform
 - proto: SMESBasic
   entities:
   - uid: 72
     components:
-    - pos: -1.5,-1.5
+    - type: Transform
+      pos: -1.5,-1.5
       parent: 1
-      type: Transform
 - proto: SpawnPointLatejoin
   entities:
   - uid: 248
     components:
-    - pos: -6.5,1.5
+    - type: Transform
+      pos: -6.5,1.5
       parent: 1
-      type: Transform
-- proto: SpawnPointPilot
-  entities:
-  - uid: 275
-    components:
-    - pos: -6.5,2.5
-      parent: 1
-      type: Transform
 - proto: SubstationWallBasic
   entities:
   - uid: 214
     components:
-    - pos: -3.5,-0.5
+    - type: Transform
+      pos: -3.5,-0.5
       parent: 1
-      type: Transform
 - proto: SuitStorageWallmountPilot
   entities:
   - uid: 175
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -7.5,1.5
       parent: 1
-      type: Transform
+    - type: Physics
+      canCollide: False
 - proto: Table
   entities:
   - uid: 170
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -6.5,3.5
       parent: 1
-      type: Transform
   - uid: 171
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -5.5,2.5
       parent: 1
-      type: Transform
   - uid: 172
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -5.5,3.5
       parent: 1
-      type: Transform
 - proto: TableCounterMetal
   entities:
   - uid: 254
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -5.5,0.5
       parent: 1
-      type: Transform
   - uid: 255
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -6.5,0.5
       parent: 1
-      type: Transform
 - proto: Thruster
   entities:
   - uid: 65
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 4.5,-0.5
       parent: 1
-      type: Transform
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 66
     components:
-    - pos: 4.5,1.5
+    - type: Transform
+      pos: 4.5,1.5
       parent: 1
-      type: Transform
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 68
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -6.5,-3.5
       parent: 1
-      type: Transform
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 69
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -6.5,-1.5
       parent: 1
-      type: Transform
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 71
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -6.5,-2.5
       parent: 1
-      type: Transform
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 75
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 4.5,-1.5
       parent: 1
-      type: Transform
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 76
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 4.5,-2.5
       parent: 1
-      type: Transform
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 77
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 3.5,-5.5
       parent: 1
-      type: Transform
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 78
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 2.5,-5.5
       parent: 1
-      type: Transform
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 83
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 1.5,-5.5
       parent: 1
-      type: Transform
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 84
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 0.5,-5.5
       parent: 1
-      type: Transform
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 85
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -0.5,-5.5
       parent: 1
-      type: Transform
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 86
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -1.5,-5.5
       parent: 1
-      type: Transform
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 87
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -6.5,-4.5
       parent: 1
-      type: Transform
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 158
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 4.5,0.5
       parent: 1
-      type: Transform
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 176
     components:
-    - pos: -3.5,3.5
+    - type: Transform
+      pos: -3.5,3.5
       parent: 1
-      type: Transform
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 177
     components:
-    - pos: -2.5,3.5
+    - type: Transform
+      pos: -2.5,3.5
       parent: 1
-      type: Transform
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 178
     components:
-    - pos: -1.5,3.5
+    - type: Transform
+      pos: -1.5,3.5
       parent: 1
-      type: Transform
+    - type: Thruster
+      originalPowerLoad: 1500
 - proto: WallReinforced
   entities:
   - uid: 2
     components:
-    - pos: -6.5,-5.5
+    - type: Transform
+      pos: -6.5,-5.5
       parent: 1
-      type: Transform
   - uid: 3
     components:
-    - pos: -5.5,-5.5
+    - type: Transform
+      pos: -5.5,-5.5
       parent: 1
-      type: Transform
   - uid: 4
     components:
-    - pos: -4.5,-5.5
+    - type: Transform
+      pos: -4.5,-5.5
       parent: 1
-      type: Transform
   - uid: 5
     components:
-    - pos: -4.5,-4.5
+    - type: Transform
+      pos: -4.5,-4.5
       parent: 1
-      type: Transform
   - uid: 6
     components:
-    - pos: -4.5,-3.5
+    - type: Transform
+      pos: -4.5,-3.5
       parent: 1
-      type: Transform
   - uid: 8
     components:
-    - pos: -4.5,-1.5
+    - type: Transform
+      pos: -4.5,-1.5
       parent: 1
-      type: Transform
   - uid: 9
     components:
-    - pos: -4.5,-0.5
+    - type: Transform
+      pos: -4.5,-0.5
       parent: 1
-      type: Transform
   - uid: 10
     components:
-    - pos: -3.5,-4.5
+    - type: Transform
+      pos: -3.5,-4.5
       parent: 1
-      type: Transform
   - uid: 11
     components:
-    - pos: -2.5,-4.5
+    - type: Transform
+      pos: -2.5,-4.5
       parent: 1
-      type: Transform
   - uid: 12
     components:
-    - pos: -2.5,-5.5
+    - type: Transform
+      pos: -2.5,-5.5
       parent: 1
-      type: Transform
   - uid: 13
     components:
-    - pos: -1.5,-4.5
+    - type: Transform
+      pos: -1.5,-4.5
       parent: 1
-      type: Transform
   - uid: 14
     components:
-    - pos: -1.5,-3.5
+    - type: Transform
+      pos: -1.5,-3.5
       parent: 1
-      type: Transform
   - uid: 15
     components:
-    - pos: -0.5,-3.5
+    - type: Transform
+      pos: -0.5,-3.5
       parent: 1
-      type: Transform
   - uid: 16
     components:
-    - pos: 0.5,-3.5
+    - type: Transform
+      pos: 0.5,-3.5
       parent: 1
-      type: Transform
   - uid: 18
     components:
-    - pos: 2.5,-3.5
+    - type: Transform
+      pos: 2.5,-3.5
       parent: 1
-      type: Transform
   - uid: 19
     components:
-    - pos: 3.5,-3.5
+    - type: Transform
+      pos: 3.5,-3.5
       parent: 1
-      type: Transform
   - uid: 20
     components:
-    - pos: 4.5,-3.5
+    - type: Transform
+      pos: 4.5,-3.5
       parent: 1
-      type: Transform
   - uid: 21
     components:
-    - pos: 3.5,-4.5
+    - type: Transform
+      pos: 3.5,-4.5
       parent: 1
-      type: Transform
   - uid: 22
     components:
-    - pos: 2.5,-2.5
+    - type: Transform
+      pos: 2.5,-2.5
       parent: 1
-      type: Transform
   - uid: 23
     components:
-    - pos: 2.5,-0.5
+    - type: Transform
+      pos: 2.5,-0.5
       parent: 1
-      type: Transform
   - uid: 25
     components:
-    - pos: 2.5,0.5
+    - type: Transform
+      pos: 2.5,0.5
       parent: 1
-      type: Transform
   - uid: 26
     components:
-    - pos: 2.5,1.5
+    - type: Transform
+      pos: 2.5,1.5
       parent: 1
-      type: Transform
   - uid: 31
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -0.5,4.5
       parent: 1
-      type: Transform
   - uid: 39
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 3.5,2.5
       parent: 1
-      type: Transform
   - uid: 43
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -4.5,4.5
       parent: 1
-      type: Transform
   - uid: 48
     components:
-    - pos: -7.5,-0.5
+    - type: Transform
+      pos: -7.5,-0.5
       parent: 1
-      type: Transform
   - uid: 49
     components:
-    - pos: -6.5,-0.5
+    - type: Transform
+      pos: -6.5,-0.5
       parent: 1
-      type: Transform
   - uid: 52
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -7.5,0.5
       parent: 1
-      type: Transform
   - uid: 58
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 2.5,2.5
       parent: 1
-      type: Transform
   - uid: 95
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -7.5,4.5
       parent: 1
-      type: Transform
   - uid: 96
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -1.5,2.5
       parent: 1
-      type: Transform
   - uid: 97
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -4.5,2.5
       parent: 1
-      type: Transform
   - uid: 99
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -0.5,2.5
       parent: 1
-      type: Transform
   - uid: 100
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -3.5,2.5
       parent: 1
-      type: Transform
   - uid: 103
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -7.5,1.5
       parent: 1
-      type: Transform
   - uid: 256
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 3.5,4.5
       parent: 1
-      type: Transform
 - proto: WallSolid
   entities:
   - uid: 51
     components:
-    - pos: -3.5,-0.5
+    - type: Transform
+      pos: -3.5,-0.5
       parent: 1
-      type: Transform
   - uid: 54
     components:
-    - pos: -0.5,-0.5
+    - type: Transform
+      pos: -0.5,-0.5
       parent: 1
-      type: Transform
   - uid: 55
     components:
-    - pos: 0.5,-0.5
+    - type: Transform
+      pos: 0.5,-0.5
       parent: 1
-      type: Transform
   - uid: 56
     components:
-    - pos: 0.5,-1.5
+    - type: Transform
+      pos: 0.5,-1.5
       parent: 1
-      type: Transform
   - uid: 57
     components:
-    - pos: 0.5,-2.5
+    - type: Transform
+      pos: 0.5,-2.5
       parent: 1
-      type: Transform
 - proto: WarpPointShip
   entities:
   - uid: 249
     components:
-    - pos: -1.5,0.5
+    - type: Transform
+      pos: -1.5,0.5
       parent: 1
-      type: Transform
 ...

--- a/Resources/Maps/_NF/Shuttles/kilderkin.yml
+++ b/Resources/Maps/_NF/Shuttles/kilderkin.yml
@@ -16,12 +16,13 @@ entities:
   entities:
   - uid: 1
     components:
-    - name: grid
-      type: MetaData
-    - pos: -0.5,-0.53125
+    - type: MetaData
+      name: grid
+    - type: Transform
+      pos: -0.5,-0.53125
       parent: invalid
-      type: Transform
-    - chunks:
+    - type: MapGrid
+      chunks:
         0,0:
           ind: 0,0
           tiles: cAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcgAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcgAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAIQAAAAAAIQAAAAAAHgAAAAAAHgAAAAAAHgAAAAAAIQAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYQAAAAAAHgAAAAAAHgAAAAAAHgAAAAAAHgAAAAAAHgAAAAAAIQAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAHgAAAAAAHgAAAAAAHgAAAAAAHgAAAAAAIQAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
@@ -38,24 +39,24 @@ entities:
           ind: -1,0
           tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYQAAAAAAHAAAAAAAHAAAAAAAcgAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAYQAAAAAAYQAAAAAAcgAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAIQAAAAAAHAAAAAAAcgAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAIQAAAAAAHAAAAAAAcgAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcgAAAAAAYQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAIQAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcgAAAAAAIQAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
           version: 6
-      type: MapGrid
     - type: Broadphase
-    - bodyStatus: InAir
+    - type: Physics
+      bodyStatus: InAir
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
       bodyType: Dynamic
-      type: Physics
-    - fixtures: {}
-      type: Fixtures
+    - type: Fixtures
+      fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid
     - type: Shuttle
     - type: GridPathfinding
-    - gravityShakeSound: !type:SoundPathSpecifier
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
         path: /Audio/Effects/alert.ogg
-      type: Gravity
-    - chunkCollection:
+    - type: DecalGrid
+      chunkCollection:
         version: 2
         nodes:
         - node:
@@ -77,13 +78,14 @@ entities:
             id: BotGreyscale
           decals:
             17: -6,3
-            52: 5,7
-            53: 6,6
-            54: 6,5
-            57: -4,7
-            58: -5,6
-            63: -6,2
-            64: 1,-6
+            51: 5,7
+            52: 6,6
+            53: 6,5
+            54: -4,7
+            55: -5,6
+            60: -6,2
+            61: 1,-6
+            65: -2,5
         - node:
             color: '#FFFFFFFF'
             id: BotLeftGreyscale
@@ -96,8 +98,8 @@ entities:
             color: '#FFFFFFFF'
             id: BoxGreyscale
           decals:
-            59: 2,6
-            65: -5,2
+            56: 2,6
+            62: -5,2
         - node:
             color: '#FFFFFFFF'
             id: Bushi1
@@ -113,9 +115,9 @@ entities:
             color: '#FFFFFFFF'
             id: DeliveryGreyscale
           decals:
-            60: 2,5
-            61: -3,-6
-            62: 4,5
+            57: 2,5
+            58: -3,-6
+            59: 4,5
         - node:
             angle: 4.71238898038469 rad
             color: '#FFFFFFFF'
@@ -195,126 +197,119 @@ entities:
             color: '#9D9D97FF'
             id: MiniTileCheckerAOverlay
           decals:
-            66: 6,-5
-            67: 6,-6
+            63: 6,-5
+            64: 6,-6
         - node:
             color: '#9FED5896'
             id: MiniTileWhiteCornerSe
           decals:
-            40: -1,5
+            39: -1,5
         - node:
             color: '#EFB34196'
             id: MiniTileWhiteCornerSe
           decals:
-            44: 4,-7
+            43: 4,-7
         - node:
             color: '#334E6DC8'
             id: MiniTileWhiteCornerSw
           decals:
-            30: 1,5
+            29: 1,5
         - node:
             color: '#EFB34196'
             id: MiniTileWhiteCornerSw
           decals:
-            43: -4,-7
+            42: -4,-7
         - node:
             color: '#9FED5896'
             id: MiniTileWhiteLineE
           decals:
-            41: -1,6
-            42: -1,7
+            40: -1,6
+            41: -1,7
         - node:
             color: '#334E6DC8'
             id: MiniTileWhiteLineS
           decals:
-            31: 2,5
-            32: 3,5
-            33: 4,5
-            34: 5,5
-            35: 6,5
+            30: 2,5
+            31: 3,5
+            32: 4,5
+            33: 5,5
+            34: 6,5
         - node:
             color: '#9FED5896'
             id: MiniTileWhiteLineS
           decals:
-            36: -2,5
-            37: -3,5
-            38: -4,5
-            39: -5,5
+            35: -2,5
+            36: -3,5
+            37: -4,5
+            38: -5,5
         - node:
             color: '#EFB34196'
             id: MiniTileWhiteLineS
           decals:
-            45: -3,-7
-            46: -2,-7
-            47: -1,-7
-            48: 0,-7
-            49: 1,-7
-            50: 2,-7
-            51: 3,-7
+            44: -3,-7
+            45: -2,-7
+            46: -1,-7
+            47: 0,-7
+            48: 1,-7
+            49: 2,-7
+            50: 3,-7
         - node:
             color: '#334E6DC8'
             id: MiniTileWhiteLineW
           decals:
-            29: 1,6
-      type: DecalGrid
-    - version: 2
+            28: 1,6
+    - type: GridAtmosphere
+      version: 2
       data:
         tiles:
           0,0:
-            0: 65535
+            0: 49087
           0,-1:
             0: 65535
+          -1,0:
+            0: 61166
+          -1,1:
+            0: 65528
           0,1:
-            0: 65535
-          0,2:
-            0: 15
-            1: 128
+            0: 61408
           1,0:
-            0: 65535
+            0: 65521
           1,1:
-            0: 65535
+            0: 14192
+          0,2:
+            1: 128
           1,2:
-            0: 7
-            1: 48
-          2,0:
-            0: 4369
-          2,1:
             0: 1
+            1: 48
+          1,-1:
+            0: 65489
+          2,-1:
+            0: 4112
           0,-2:
-            0: 65535
+            0: 1776
+          -1,-2:
+            0: 48114
+          -1,-1:
+            0: 65512
           0,-3:
             1: 32768
           1,-3:
             1: 12288
           1,-2:
-            0: 65527
-          1,-1:
-            0: 65535
-          2,-1:
-            0: 4369
+            0: 29713
           -2,-1:
-            0: 61166
+            0: 60640
           -2,-2:
-            0: 52424
+            0: 34816
+          -2,0:
+            0: 52236
           -1,-3:
             1: 28672
-          -1,-2:
-            0: 65535
-          -1,-1:
-            0: 65535
-          -2,0:
-            0: 61166
           -2,1:
-            0: 52430
-          -2,2:
-            0: 8
-          -1,0:
-            0: 65535
-          -1,1:
-            0: 65535
+            0: 2184
           -1,2:
-            0: 15
             1: 112
+            0: 2
         uniqueMixes:
         - volume: 2500
           temperature: 293.15
@@ -332,7 +327,7 @@ entities:
           - 0
           - 0
         - volume: 2500
-          temperature: 293.15
+          immutable: True
           moles:
           - 0
           - 0
@@ -347,2731 +342,2638 @@ entities:
           - 0
           - 0
         chunkSize: 4
-      type: GridAtmosphere
     - type: GasTileOverlay
     - type: RadiationGridResistance
-    - id: kilderkin
-      type: BecomesStation
+    - type: BecomesStation
+      id: kilderkin
 - proto: AirAlarm
   entities:
   - uid: 84
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 0.5,7.5
       parent: 1
-      type: Transform
-    - ShutdownSubscribers:
-      - 278
-      - 279
-      - 308
-      - 316
-      type: DeviceNetwork
-    - devices:
-      - 278
-      - 279
-      - 308
-      - 316
-      type: DeviceList
   - uid: 482
     components:
-    - pos: 0.5,-5.5
+    - type: Transform
+      pos: 0.5,-5.5
       parent: 1
-      type: Transform
-    - ShutdownSubscribers:
+    - type: DeviceList
+      devices:
       - 349
-      type: DeviceNetwork
-    - devices:
-      - 349
-      type: DeviceList
 - proto: AirCanister
   entities:
   - uid: 324
     components:
-    - anchored: True
+    - type: Transform
+      anchored: True
       pos: 2.5,-5.5
       parent: 1
-      type: Transform
-    - bodyType: Static
-      type: Physics
+    - type: Physics
+      bodyType: Static
 - proto: Airlock
   entities:
   - uid: 48
     components:
-    - pos: 5.5,-4.5
+    - type: Transform
+      pos: 5.5,-4.5
       parent: 1
-      type: Transform
   - uid: 178
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -0.5,4.5
       parent: 1
-      type: Transform
 - proto: AirlockCaptainGlassLocked
   entities:
   - uid: 177
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 0.5,6.5
       parent: 1
-      type: Transform
 - proto: AirlockCargoGlass
   entities:
   - uid: 335
     components:
-    - pos: -4.5,4.5
+    - type: Transform
+      pos: -4.5,4.5
       parent: 1
-      type: Transform
 - proto: AirlockEngineering
   entities:
   - uid: 169
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -0.5,-5.5
       parent: 1
-      type: Transform
 - proto: AirlockExternalGlass
   entities:
   - uid: 12
     components:
-    - pos: -2.5,8.5
+    - type: Transform
+      pos: -2.5,8.5
       parent: 1
-      type: Transform
   - uid: 13
     components:
-    - pos: 4.5,8.5
+    - type: Transform
+      pos: 4.5,8.5
       parent: 1
-      type: Transform
   - uid: 14
     components:
-    - pos: 4.5,-7.5
+    - type: Transform
+      pos: 4.5,-7.5
       parent: 1
-      type: Transform
   - uid: 15
     components:
-    - pos: -2.5,-7.5
+    - type: Transform
+      pos: -2.5,-7.5
       parent: 1
-      type: Transform
   - uid: 50
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 5.5,-1.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 512
-      type: DeviceLinkSink
   - uid: 139
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -3.5,-0.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 512
-      type: DeviceLinkSink
   - uid: 168
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 5.5,-0.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 512
-      type: DeviceLinkSink
   - uid: 170
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -3.5,-1.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 512
-      type: DeviceLinkSink
 - proto: AirlockGlassShuttle
   entities:
   - uid: 164
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -6.5,-2.5
       parent: 1
-      type: Transform
   - uid: 165
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -6.5,-0.5
       parent: 1
-      type: Transform
   - uid: 166
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 8.5,-2.5
       parent: 1
-      type: Transform
   - uid: 167
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 8.5,-0.5
       parent: 1
-      type: Transform
 - proto: APCBasic
   entities:
   - uid: 391
     components:
-    - pos: -1.5,-5.5
+    - type: Transform
+      pos: -1.5,-5.5
       parent: 1
-      type: Transform
   - uid: 392
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 0.5,5.5
       parent: 1
-      type: Transform
 - proto: AtmosDeviceFanTiny
   entities:
   - uid: 4
     components:
-    - pos: -6.5,-0.5
+    - type: Transform
+      pos: -6.5,-0.5
       parent: 1
-      type: Transform
   - uid: 5
     components:
-    - pos: -6.5,-2.5
+    - type: Transform
+      pos: -6.5,-2.5
       parent: 1
-      type: Transform
   - uid: 6
     components:
-    - pos: 8.5,-0.5
+    - type: Transform
+      pos: 8.5,-0.5
       parent: 1
-      type: Transform
   - uid: 7
     components:
-    - pos: 8.5,-2.5
+    - type: Transform
+      pos: 8.5,-2.5
       parent: 1
-      type: Transform
   - uid: 8
     components:
-    - pos: -2.5,-7.5
+    - type: Transform
+      pos: -2.5,-7.5
       parent: 1
-      type: Transform
   - uid: 9
     components:
-    - pos: 4.5,-7.5
+    - type: Transform
+      pos: 4.5,-7.5
       parent: 1
-      type: Transform
   - uid: 10
     components:
-    - pos: 4.5,8.5
+    - type: Transform
+      pos: 4.5,8.5
       parent: 1
-      type: Transform
   - uid: 11
     components:
-    - pos: -2.5,8.5
+    - type: Transform
+      pos: -2.5,8.5
       parent: 1
-      type: Transform
   - uid: 71
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -6.5,0.5
       parent: 1
-      type: Transform
 - proto: AtmosFixBlockerMarker
   entities:
   - uid: 523
     components:
-    - pos: -3.5,-8.5
+    - type: Transform
+      pos: -3.5,-8.5
       parent: 1
-      type: Transform
   - uid: 524
     components:
-    - pos: -2.5,-8.5
+    - type: Transform
+      pos: -2.5,-8.5
       parent: 1
-      type: Transform
   - uid: 525
     components:
-    - pos: -1.5,-8.5
+    - type: Transform
+      pos: -1.5,-8.5
       parent: 1
-      type: Transform
   - uid: 526
     components:
-    - pos: 3.5,-8.5
+    - type: Transform
+      pos: 3.5,-8.5
       parent: 1
-      type: Transform
   - uid: 527
     components:
-    - pos: 4.5,-8.5
+    - type: Transform
+      pos: 4.5,-8.5
       parent: 1
-      type: Transform
   - uid: 528
     components:
-    - pos: 5.5,-8.5
+    - type: Transform
+      pos: 5.5,-8.5
       parent: 1
-      type: Transform
   - uid: 529
     components:
-    - pos: -3.5,9.5
+    - type: Transform
+      pos: -3.5,9.5
       parent: 1
-      type: Transform
   - uid: 530
     components:
-    - pos: -2.5,9.5
+    - type: Transform
+      pos: -2.5,9.5
       parent: 1
-      type: Transform
   - uid: 531
     components:
-    - pos: -1.5,9.5
+    - type: Transform
+      pos: -1.5,9.5
       parent: 1
-      type: Transform
   - uid: 532
     components:
-    - pos: 3.5,9.5
+    - type: Transform
+      pos: 3.5,9.5
       parent: 1
-      type: Transform
   - uid: 533
     components:
-    - pos: 4.5,9.5
+    - type: Transform
+      pos: 4.5,9.5
       parent: 1
-      type: Transform
   - uid: 534
     components:
-    - pos: 5.5,9.5
+    - type: Transform
+      pos: 5.5,9.5
       parent: 1
-      type: Transform
 - proto: BarSign
   entities:
   - uid: 209
     components:
-    - pos: -2.5,4.5
+    - type: Transform
+      pos: -2.5,4.5
       parent: 1
-      type: Transform
 - proto: BassGuitarInstrument
   entities:
   - uid: 291
     components:
-    - pos: 4.386519,3.6216404
+    - type: Transform
+      pos: 4.386519,3.6216404
       parent: 1
-      type: Transform
 - proto: BenchSofaCorner
   entities:
   - uid: 120
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 7.5,1.5
       parent: 1
-      type: Transform
-    - canCollide: False
+    - type: Physics
+      canCollide: False
       bodyType: Static
-      type: Physics
-    - fixtures: {}
-      type: Fixtures
+    - type: Fixtures
+      fixtures: {}
 - proto: BenchSofaLeft
   entities:
   - uid: 119
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 5.5,1.5
       parent: 1
-      type: Transform
-    - bodyType: Static
-      type: Physics
+    - type: Physics
+      bodyType: Static
 - proto: BenchSofaMiddle
   entities:
   - uid: 121
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 6.5,1.5
       parent: 1
-      type: Transform
-    - bodyType: Static
-      type: Physics
+    - type: Physics
+      bodyType: Static
 - proto: BenchSofaRight
   entities:
   - uid: 122
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 7.5,2.5
       parent: 1
-      type: Transform
-    - bodyType: Static
-      type: Physics
+    - type: Physics
+      bodyType: Static
 - proto: BlastDoor
   entities:
   - uid: 179
     components:
-    - pos: -5.5,1.5
+    - type: Transform
+      pos: -5.5,1.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 493
-      type: DeviceLinkSink
   - uid: 337
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -6.5,0.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 493
-      type: DeviceLinkSink
   - uid: 345
     components:
-    - pos: -4.5,1.5
+    - type: Transform
+      pos: -4.5,1.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 493
-      type: DeviceLinkSink
 - proto: BookshelfFilled
   entities:
   - uid: 115
     components:
-    - pos: 7.5,3.5
+    - type: Transform
+      pos: 7.5,3.5
       parent: 1
-      type: Transform
   - uid: 116
     components:
-    - pos: 5.5,3.5
+    - type: Transform
+      pos: 5.5,3.5
       parent: 1
-      type: Transform
 - proto: BoozeDispenser
   entities:
   - uid: 129
     components:
-    - pos: 0.5,3.5
+    - type: Transform
+      pos: 0.5,3.5
       parent: 1
-      type: Transform
 - proto: BoxFolderBlue
   entities:
   - uid: 514
     components:
-    - pos: 2.720742,5.7433147
+    - type: Transform
+      pos: 2.720742,5.7433147
       parent: 1
-      type: Transform
 - proto: BoxFolderRed
   entities:
   - uid: 513
     components:
-    - pos: 2.330117,5.7120647
+    - type: Transform
+      pos: 2.330117,5.7120647
       parent: 1
-      type: Transform
 - proto: CableApcExtension
   entities:
-  - uid: 186
-    components:
-    - pos: 4.5,8.5
-      parent: 1
-      type: Transform
-  - uid: 195
-    components:
-    - pos: 4.5,-7.5
-      parent: 1
-      type: Transform
   - uid: 412
     components:
-    - pos: -1.5,-5.5
+    - type: Transform
+      pos: -1.5,-5.5
       parent: 1
-      type: Transform
   - uid: 413
     components:
-    - pos: -1.5,-6.5
+    - type: Transform
+      pos: -1.5,-6.5
       parent: 1
-      type: Transform
   - uid: 414
     components:
-    - pos: -2.5,-6.5
+    - type: Transform
+      pos: -2.5,-6.5
       parent: 1
-      type: Transform
-  - uid: 415
-    components:
-    - pos: -2.5,8.5
-      parent: 1
-      type: Transform
   - uid: 416
     components:
-    - pos: 6.5,-1.5
+    - type: Transform
+      pos: 6.5,-1.5
       parent: 1
-      type: Transform
   - uid: 417
     components:
-    - pos: -0.5,-6.5
+    - type: Transform
+      pos: -0.5,-6.5
       parent: 1
-      type: Transform
   - uid: 418
     components:
-    - pos: 0.5,-6.5
+    - type: Transform
+      pos: 0.5,-6.5
       parent: 1
-      type: Transform
   - uid: 419
     components:
-    - pos: 1.5,-6.5
+    - type: Transform
+      pos: 1.5,-6.5
       parent: 1
-      type: Transform
   - uid: 420
     components:
-    - pos: 2.5,-6.5
+    - type: Transform
+      pos: 2.5,-6.5
       parent: 1
-      type: Transform
   - uid: 421
     components:
-    - pos: 3.5,-6.5
+    - type: Transform
+      pos: 3.5,-6.5
       parent: 1
-      type: Transform
   - uid: 422
     components:
-    - pos: 4.5,-6.5
+    - type: Transform
+      pos: 4.5,-6.5
       parent: 1
-      type: Transform
   - uid: 423
     components:
-    - pos: 5.5,-1.5
+    - type: Transform
+      pos: 5.5,-1.5
       parent: 1
-      type: Transform
-  - uid: 424
-    components:
-    - pos: -2.5,-7.5
-      parent: 1
-      type: Transform
   - uid: 425
     components:
-    - pos: -0.5,-5.5
+    - type: Transform
+      pos: -0.5,-5.5
       parent: 1
-      type: Transform
   - uid: 426
     components:
-    - pos: -0.5,-4.5
+    - type: Transform
+      pos: -0.5,-4.5
       parent: 1
-      type: Transform
   - uid: 427
     components:
-    - pos: -0.5,-3.5
+    - type: Transform
+      pos: -0.5,-3.5
       parent: 1
-      type: Transform
   - uid: 428
     components:
-    - pos: -0.5,-2.5
+    - type: Transform
+      pos: -0.5,-2.5
       parent: 1
-      type: Transform
   - uid: 429
     components:
-    - pos: -0.5,-1.5
+    - type: Transform
+      pos: -0.5,-1.5
       parent: 1
-      type: Transform
   - uid: 430
     components:
-    - pos: -0.5,-0.5
+    - type: Transform
+      pos: -0.5,-0.5
       parent: 1
-      type: Transform
   - uid: 431
     components:
-    - pos: -1.5,-1.5
+    - type: Transform
+      pos: -1.5,-1.5
       parent: 1
-      type: Transform
   - uid: 432
     components:
-    - pos: -2.5,-1.5
+    - type: Transform
+      pos: -2.5,-1.5
       parent: 1
-      type: Transform
   - uid: 433
     components:
-    - pos: -3.5,-1.5
+    - type: Transform
+      pos: -3.5,-1.5
       parent: 1
-      type: Transform
   - uid: 434
     components:
-    - pos: -4.5,-1.5
+    - type: Transform
+      pos: -4.5,-1.5
       parent: 1
-      type: Transform
-  - uid: 435
-    components:
-    - pos: -5.5,-1.5
-      parent: 1
-      type: Transform
   - uid: 436
     components:
-    - pos: 0.5,-0.5
+    - type: Transform
+      pos: 0.5,-0.5
       parent: 1
-      type: Transform
   - uid: 437
     components:
-    - pos: 1.5,-0.5
+    - type: Transform
+      pos: 1.5,-0.5
       parent: 1
-      type: Transform
   - uid: 438
     components:
-    - pos: 2.5,-0.5
+    - type: Transform
+      pos: 2.5,-0.5
       parent: 1
-      type: Transform
   - uid: 439
     components:
-    - pos: 3.5,-0.5
+    - type: Transform
+      pos: 3.5,-0.5
       parent: 1
-      type: Transform
   - uid: 440
     components:
-    - pos: 4.5,-0.5
+    - type: Transform
+      pos: 4.5,-0.5
       parent: 1
-      type: Transform
-  - uid: 441
-    components:
-    - pos: 7.5,-1.5
-      parent: 1
-      type: Transform
   - uid: 444
     components:
-    - pos: -0.5,2.5
+    - type: Transform
+      pos: -0.5,2.5
       parent: 1
-      type: Transform
   - uid: 445
     components:
-    - pos: -0.5,3.5
+    - type: Transform
+      pos: -0.5,3.5
       parent: 1
-      type: Transform
   - uid: 446
     components:
-    - pos: -0.5,4.5
+    - type: Transform
+      pos: -0.5,4.5
       parent: 1
-      type: Transform
   - uid: 447
     components:
-    - pos: -0.5,5.5
+    - type: Transform
+      pos: -0.5,5.5
       parent: 1
-      type: Transform
   - uid: 448
     components:
-    - pos: 0.5,5.5
+    - type: Transform
+      pos: 0.5,5.5
       parent: 1
-      type: Transform
   - uid: 449
     components:
-    - pos: 1.5,5.5
+    - type: Transform
+      pos: 1.5,5.5
       parent: 1
-      type: Transform
   - uid: 450
     components:
-    - pos: 1.5,6.5
+    - type: Transform
+      pos: 1.5,6.5
       parent: 1
-      type: Transform
   - uid: 451
     components:
-    - pos: 2.5,6.5
+    - type: Transform
+      pos: 2.5,6.5
       parent: 1
-      type: Transform
   - uid: 452
     components:
-    - pos: 3.5,6.5
+    - type: Transform
+      pos: 3.5,6.5
       parent: 1
-      type: Transform
   - uid: 453
     components:
-    - pos: 4.5,6.5
+    - type: Transform
+      pos: 4.5,6.5
       parent: 1
-      type: Transform
   - uid: 454
     components:
-    - pos: 5.5,6.5
+    - type: Transform
+      pos: 5.5,6.5
       parent: 1
-      type: Transform
   - uid: 455
     components:
-    - pos: 4.5,7.5
+    - type: Transform
+      pos: 4.5,7.5
       parent: 1
-      type: Transform
   - uid: 458
     components:
-    - pos: -0.5,6.5
+    - type: Transform
+      pos: -0.5,6.5
       parent: 1
-      type: Transform
   - uid: 459
     components:
-    - pos: -1.5,6.5
+    - type: Transform
+      pos: -1.5,6.5
       parent: 1
-      type: Transform
   - uid: 460
     components:
-    - pos: -2.5,6.5
+    - type: Transform
+      pos: -2.5,6.5
       parent: 1
-      type: Transform
   - uid: 461
     components:
-    - pos: -2.5,7.5
+    - type: Transform
+      pos: -2.5,7.5
       parent: 1
-      type: Transform
   - uid: 464
     components:
-    - pos: -3.5,6.5
+    - type: Transform
+      pos: -3.5,6.5
       parent: 1
-      type: Transform
   - uid: 465
     components:
-    - pos: -4.5,6.5
+    - type: Transform
+      pos: -4.5,6.5
       parent: 1
-      type: Transform
   - uid: 466
     components:
-    - pos: -4.5,5.5
+    - type: Transform
+      pos: -4.5,5.5
       parent: 1
-      type: Transform
   - uid: 467
     components:
-    - pos: -4.5,4.5
+    - type: Transform
+      pos: -4.5,4.5
       parent: 1
-      type: Transform
   - uid: 468
     components:
-    - pos: -4.5,3.5
+    - type: Transform
+      pos: -4.5,3.5
       parent: 1
-      type: Transform
   - uid: 469
     components:
-    - pos: -4.5,2.5
+    - type: Transform
+      pos: -4.5,2.5
       parent: 1
-      type: Transform
   - uid: 471
     components:
-    - pos: 0.5,2.5
+    - type: Transform
+      pos: 0.5,2.5
       parent: 1
-      type: Transform
   - uid: 472
     components:
-    - pos: 1.5,2.5
+    - type: Transform
+      pos: 1.5,2.5
       parent: 1
-      type: Transform
   - uid: 473
     components:
-    - pos: -1.5,2.5
+    - type: Transform
+      pos: -1.5,2.5
       parent: 1
-      type: Transform
   - uid: 474
     components:
-    - pos: -2.5,2.5
+    - type: Transform
+      pos: -2.5,2.5
       parent: 1
-      type: Transform
   - uid: 475
     components:
-    - pos: 0.5,-3.5
+    - type: Transform
+      pos: 0.5,-3.5
       parent: 1
-      type: Transform
   - uid: 476
     components:
-    - pos: 1.5,-3.5
+    - type: Transform
+      pos: 1.5,-3.5
       parent: 1
-      type: Transform
   - uid: 477
     components:
-    - pos: 2.5,-3.5
+    - type: Transform
+      pos: 2.5,-3.5
       parent: 1
-      type: Transform
   - uid: 478
     components:
-    - pos: 3.5,-3.5
+    - type: Transform
+      pos: 3.5,-3.5
       parent: 1
-      type: Transform
   - uid: 479
     components:
-    - pos: 4.5,-3.5
+    - type: Transform
+      pos: 4.5,-3.5
       parent: 1
-      type: Transform
   - uid: 480
     components:
-    - pos: 4.5,-4.5
+    - type: Transform
+      pos: 4.5,-4.5
       parent: 1
-      type: Transform
   - uid: 481
     components:
-    - pos: 4.5,-1.5
+    - type: Transform
+      pos: 4.5,-1.5
       parent: 1
-      type: Transform
   - uid: 484
     components:
-    - pos: 2.5,2.5
+    - type: Transform
+      pos: 2.5,2.5
       parent: 1
-      type: Transform
   - uid: 485
     components:
-    - pos: 3.5,2.5
+    - type: Transform
+      pos: 3.5,2.5
       parent: 1
-      type: Transform
   - uid: 486
     components:
-    - pos: 4.5,2.5
+    - type: Transform
+      pos: 4.5,2.5
       parent: 1
-      type: Transform
   - uid: 487
     components:
-    - pos: 5.5,2.5
+    - type: Transform
+      pos: 5.5,2.5
       parent: 1
-      type: Transform
   - uid: 488
     components:
-    - pos: 6.5,2.5
+    - type: Transform
+      pos: 6.5,2.5
       parent: 1
-      type: Transform
 - proto: CableHV
   entities:
   - uid: 386
     components:
-    - pos: -4.5,-5.5
+    - type: Transform
+      pos: -4.5,-5.5
       parent: 1
-      type: Transform
   - uid: 387
     components:
-    - pos: -4.5,-4.5
+    - type: Transform
+      pos: -4.5,-4.5
       parent: 1
-      type: Transform
   - uid: 388
     components:
-    - pos: -3.5,-4.5
+    - type: Transform
+      pos: -3.5,-4.5
       parent: 1
-      type: Transform
   - uid: 389
     components:
-    - pos: -2.5,-4.5
+    - type: Transform
+      pos: -2.5,-4.5
       parent: 1
-      type: Transform
 - proto: CableMV
   entities:
   - uid: 393
     components:
-    - pos: -2.5,-4.5
+    - type: Transform
+      pos: -2.5,-4.5
       parent: 1
-      type: Transform
   - uid: 394
     components:
-    - pos: -2.5,-5.5
+    - type: Transform
+      pos: -2.5,-5.5
       parent: 1
-      type: Transform
   - uid: 395
     components:
-    - pos: -2.5,-6.5
+    - type: Transform
+      pos: -2.5,-6.5
       parent: 1
-      type: Transform
   - uid: 396
     components:
-    - pos: -1.5,-6.5
+    - type: Transform
+      pos: -1.5,-6.5
       parent: 1
-      type: Transform
   - uid: 397
     components:
-    - pos: -0.5,-6.5
+    - type: Transform
+      pos: -0.5,-6.5
       parent: 1
-      type: Transform
   - uid: 398
     components:
-    - pos: -0.5,-5.5
+    - type: Transform
+      pos: -0.5,-5.5
       parent: 1
-      type: Transform
   - uid: 399
     components:
-    - pos: -1.5,-5.5
+    - type: Transform
+      pos: -1.5,-5.5
       parent: 1
-      type: Transform
   - uid: 400
     components:
-    - pos: -0.5,-4.5
+    - type: Transform
+      pos: -0.5,-4.5
       parent: 1
-      type: Transform
   - uid: 401
     components:
-    - pos: -0.5,-3.5
+    - type: Transform
+      pos: -0.5,-3.5
       parent: 1
-      type: Transform
   - uid: 402
     components:
-    - pos: -0.5,-2.5
+    - type: Transform
+      pos: -0.5,-2.5
       parent: 1
-      type: Transform
   - uid: 403
     components:
-    - pos: -0.5,-1.5
+    - type: Transform
+      pos: -0.5,-1.5
       parent: 1
-      type: Transform
   - uid: 404
     components:
-    - pos: -0.5,-0.5
+    - type: Transform
+      pos: -0.5,-0.5
       parent: 1
-      type: Transform
   - uid: 405
     components:
-    - pos: -0.5,0.5
+    - type: Transform
+      pos: -0.5,0.5
       parent: 1
-      type: Transform
   - uid: 406
     components:
-    - pos: -0.5,1.5
+    - type: Transform
+      pos: -0.5,1.5
       parent: 1
-      type: Transform
   - uid: 407
     components:
-    - pos: -0.5,2.5
+    - type: Transform
+      pos: -0.5,2.5
       parent: 1
-      type: Transform
   - uid: 408
     components:
-    - pos: -0.5,3.5
+    - type: Transform
+      pos: -0.5,3.5
       parent: 1
-      type: Transform
   - uid: 409
     components:
-    - pos: -0.5,4.5
+    - type: Transform
+      pos: -0.5,4.5
       parent: 1
-      type: Transform
   - uid: 410
     components:
-    - pos: -0.5,5.5
+    - type: Transform
+      pos: -0.5,5.5
       parent: 1
-      type: Transform
   - uid: 411
     components:
-    - pos: 0.5,5.5
+    - type: Transform
+      pos: 0.5,5.5
       parent: 1
-      type: Transform
 - proto: CableTerminal
   entities:
   - uid: 390
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -4.5,-4.5
       parent: 1
-      type: Transform
 - proto: CarpetPurple
   entities:
   - uid: 210
     components:
-    - pos: 7.5,1.5
+    - type: Transform
+      pos: 7.5,1.5
       parent: 1
-      type: Transform
   - uid: 211
     components:
-    - pos: 7.5,2.5
+    - type: Transform
+      pos: 7.5,2.5
       parent: 1
-      type: Transform
   - uid: 212
     components:
-    - pos: 6.5,1.5
+    - type: Transform
+      pos: 6.5,1.5
       parent: 1
-      type: Transform
   - uid: 213
     components:
-    - pos: 6.5,2.5
+    - type: Transform
+      pos: 6.5,2.5
       parent: 1
-      type: Transform
   - uid: 214
     components:
-    - pos: 5.5,1.5
+    - type: Transform
+      pos: 5.5,1.5
       parent: 1
-      type: Transform
   - uid: 215
     components:
-    - pos: 5.5,2.5
+    - type: Transform
+      pos: 5.5,2.5
       parent: 1
-      type: Transform
 - proto: Catwalk
   entities:
   - uid: 140
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -3.5,-8.5
       parent: 1
-      type: Transform
   - uid: 141
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -2.5,-8.5
       parent: 1
-      type: Transform
   - uid: 142
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -1.5,-8.5
       parent: 1
-      type: Transform
   - uid: 143
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 3.5,-8.5
       parent: 1
-      type: Transform
   - uid: 144
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 4.5,-8.5
       parent: 1
-      type: Transform
   - uid: 145
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 5.5,-8.5
       parent: 1
-      type: Transform
   - uid: 146
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -3.5,9.5
       parent: 1
-      type: Transform
   - uid: 147
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -2.5,9.5
       parent: 1
-      type: Transform
   - uid: 148
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -1.5,9.5
       parent: 1
-      type: Transform
   - uid: 149
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 3.5,9.5
       parent: 1
-      type: Transform
   - uid: 150
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 4.5,9.5
       parent: 1
-      type: Transform
   - uid: 151
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 5.5,9.5
       parent: 1
-      type: Transform
 - proto: ChairPilotSeat
   entities:
   - uid: 197
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 2.5,6.5
       parent: 1
-      type: Transform
 - proto: ChairWood
   entities:
   - uid: 218
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -2.5,-2.5
       parent: 1
-      type: Transform
   - uid: 220
     components:
-    - pos: 1.5,-2.5
+    - type: Transform
+      pos: 1.5,-2.5
       parent: 1
-      type: Transform
   - uid: 221
     components:
-    - pos: 2.5,-2.5
+    - type: Transform
+      pos: 2.5,-2.5
       parent: 1
-      type: Transform
   - uid: 222
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 3.5,-3.5
       parent: 1
-      type: Transform
   - uid: 223
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 0.5,-3.5
       parent: 1
-      type: Transform
   - uid: 224
     components:
-    - pos: -1.5,-1.5
+    - type: Transform
+      pos: -1.5,-1.5
       parent: 1
-      type: Transform
   - uid: 225
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -0.5,-2.5
       parent: 1
-      type: Transform
 - proto: ClosetWallEmergencyFilledRandom
   entities:
   - uid: 506
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 5.5,4.5
       parent: 1
-      type: Transform
 - proto: ClothingBeltUtilityFilled
   entities:
   - uid: 346
     components:
-    - pos: 1.5155181,-5.436296
+    - type: Transform
+      pos: 1.5155181,-5.436296
       parent: 1
-      type: Transform
 - proto: ComputerSurveillanceCameraMonitor
   entities:
   - uid: 198
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 1.5,5.5
       parent: 1
-      type: Transform
 - proto: ComputerTabletopShuttle
   entities:
   - uid: 470
     components:
-    - pos: 2.5,7.5
+    - type: Transform
+      pos: 2.5,7.5
       parent: 1
-      type: Transform
 - proto: ComputerTabletopStationRecords
   entities:
   - uid: 463
     components:
-    - pos: 1.5,7.5
+    - type: Transform
+      pos: 1.5,7.5
       parent: 1
-      type: Transform
 - proto: ComputerWallmountWithdrawBankATM
   entities:
   - uid: 190
     components:
-    - pos: 2.5,1.5
+    - type: Transform
+      pos: 2.5,1.5
       parent: 1
-      type: Transform
-    - containers:
+    - type: Physics
+      canCollide: False
+    - type: ContainerContainer
+      containers:
         board: !type:Container
           ents: []
         bank-ATM-cashSlot: !type:ContainerSlot {}
-      type: ContainerContainer
     - type: ItemSlots
 - proto: ConveyorBelt
   entities:
   - uid: 180
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -6.5,0.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 502
-      type: DeviceLinkSink
   - uid: 181
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -5.5,0.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 502
-      type: DeviceLinkSink
 - proto: DefibrillatorCabinetFilled
   entities:
   - uid: 321
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 3.5,-4.5
       parent: 1
-      type: Transform
-- proto: DrinkKegSteel
-  entities:
-  - uid: 492
-    components:
-    - pos: -1.4009669,5.600147
-      parent: 1
-      type: Transform
-- proto: DrinkKegWood
-  entities:
-  - uid: 205
-    components:
-    - pos: -1.8540919,5.537647
-      parent: 1
-      type: Transform
 - proto: EmergencyLight
   entities:
   - uid: 516
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 2.5,-3.5
       parent: 1
-      type: Transform
   - uid: 517
     components:
-    - pos: 0.5,-6.5
+    - type: Transform
+      pos: 0.5,-6.5
       parent: 1
-      type: Transform
   - uid: 518
     components:
-    - pos: 3.5,7.5
+    - type: Transform
+      pos: 3.5,7.5
       parent: 1
-      type: Transform
 - proto: ExtinguisherCabinetFilled
   entities:
   - uid: 293
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -1.5,-4.5
       parent: 1
-      type: Transform
 - proto: FaxMachineShip
   entities:
   - uid: 202
     components:
-    - pos: 3.5,7.5
+    - type: Transform
+      pos: 3.5,7.5
       parent: 1
-      type: Transform
+- proto: FirelockEdge
+  entities:
+  - uid: 182
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-6.5
+      parent: 1
+  - uid: 183
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-6.5
+      parent: 1
+  - uid: 328
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,0.5
+      parent: 1
+  - uid: 415
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,0.5
+      parent: 1
+  - uid: 424
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,0.5
+      parent: 1
+  - uid: 435
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,0.5
+      parent: 1
+  - uid: 492
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,0.5
+      parent: 1
+  - uid: 497
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,2.5
+      parent: 1
 - proto: FirelockGlass
   entities:
   - uid: 356
     components:
-    - pos: 5.5,-0.5
+    - type: Transform
+      pos: 5.5,-0.5
       parent: 1
-      type: Transform
   - uid: 357
     components:
-    - pos: 5.5,-1.5
+    - type: Transform
+      pos: 5.5,-1.5
       parent: 1
-      type: Transform
   - uid: 358
     components:
-    - pos: -3.5,-1.5
+    - type: Transform
+      pos: -3.5,-1.5
       parent: 1
-      type: Transform
   - uid: 359
     components:
-    - pos: -3.5,-0.5
+    - type: Transform
+      pos: -3.5,-0.5
       parent: 1
-      type: Transform
   - uid: 360
     components:
-    - pos: -0.5,-5.5
+    - type: Transform
+      pos: -0.5,-5.5
       parent: 1
-      type: Transform
   - uid: 361
     components:
-    - pos: -5.5,1.5
+    - type: Transform
+      pos: -5.5,1.5
       parent: 1
-      type: Transform
   - uid: 362
     components:
-    - pos: -4.5,1.5
+    - type: Transform
+      pos: -4.5,1.5
       parent: 1
-      type: Transform
   - uid: 363
     components:
-    - pos: -4.5,4.5
+    - type: Transform
+      pos: -4.5,4.5
       parent: 1
-      type: Transform
   - uid: 364
     components:
-    - pos: -0.5,4.5
+    - type: Transform
+      pos: -0.5,4.5
       parent: 1
-      type: Transform
   - uid: 365
     components:
-    - pos: 0.5,6.5
+    - type: Transform
+      pos: 0.5,6.5
       parent: 1
-      type: Transform
   - uid: 366
     components:
-    - pos: 5.5,-4.5
+    - type: Transform
+      pos: 5.5,-4.5
       parent: 1
-      type: Transform
 - proto: Fireplace
   entities:
   - uid: 114
     components:
-    - pos: 6.5,3.5
+    - type: Transform
+      pos: 6.5,3.5
       parent: 1
-      type: Transform
 - proto: GasPassiveVent
   entities:
   - uid: 196
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -2.5,-8.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
 - proto: GasPipeBend
   entities:
-  - uid: 271
+  - uid: 206
     components:
-    - rot: 1.5707963267948966 rad
-      pos: -2.5,-6.5
-      parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 281
-    components:
-    - pos: -2.5,-1.5
-      parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
-  - uid: 282
-    components:
-    - rot: 3.141592653589793 rad
-      pos: -2.5,-2.5
-      parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
-  - uid: 283
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 2.5,-6.5
-      parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
-  - uid: 284
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 4.5,-6.5
-      parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
-  - uid: 318
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 1.5,0.5
-      parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
-- proto: GasPipeFourway
-  entities:
-  - uid: 238
-    components:
-    - pos: -0.5,2.5
-      parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 241
-    components:
-    - pos: -0.5,-0.5
-      parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-- proto: GasPipeStraight
-  entities:
-  - uid: 235
-    components:
-    - rot: 3.141592653589793 rad
-      pos: -0.5,5.5
-      parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 236
-    components:
-    - rot: 3.141592653589793 rad
-      pos: -0.5,4.5
-      parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 237
-    components:
-    - rot: 3.141592653589793 rad
-      pos: -0.5,3.5
-      parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 239
-    components:
-    - rot: 3.141592653589793 rad
-      pos: -0.5,1.5
-      parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 240
-    components:
-    - rot: 3.141592653589793 rad
-      pos: -0.5,0.5
-      parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 242
-    components:
-    - rot: 3.141592653589793 rad
-      pos: -0.5,-1.5
-      parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 243
-    components:
-    - rot: 3.141592653589793 rad
-      pos: -0.5,-2.5
-      parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 245
-    components:
-    - rot: 3.141592653589793 rad
-      pos: -0.5,-4.5
-      parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 246
-    components:
-    - rot: 3.141592653589793 rad
-      pos: -0.5,-5.5
-      parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 248
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -2.5,6.5
-      parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 250
-    components:
-    - pos: 4.5,-3.5
-      parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
-  - uid: 251
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -1.5,2.5
-      parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 252
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 0.5,2.5
-      parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 253
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 1.5,2.5
-      parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 254
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 2.5,2.5
-      parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 255
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 3.5,2.5
-      parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 256
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 4.5,2.5
-      parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 257
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 5.5,2.5
-      parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 260
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -1.5,-0.5
-      parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 261
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -2.5,-0.5
-      parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 262
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -3.5,-0.5
-      parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 263
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 0.5,-0.5
-      parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 264
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 1.5,-0.5
-      parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 265
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 2.5,-0.5
-      parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 266
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 3.5,0.5
-      parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
-  - uid: 267
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 4.5,-0.5
-      parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 268
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 5.5,-0.5
-      parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 272
-    components:
-    - pos: -2.5,-7.5
-      parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 274
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 0.5,6.5
-      parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 275
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 1.5,6.5
-      parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 276
-    components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 2.5,6.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 277
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 271
     components:
-    - rot: -1.5707963267948966 rad
-      pos: -1.5,6.5
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-6.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 288
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 278
     components:
-    - rot: 1.5707963267948966 rad
-      pos: 5.5,-1.5
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,6.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
-  - uid: 289
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 279
     components:
-    - pos: 4.5,-5.5
+    - type: Transform
+      pos: 4.5,7.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
-  - uid: 290
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 281
     components:
-    - pos: 4.5,-4.5
+    - type: Transform
+      pos: -2.5,-1.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
-  - uid: 292
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 282
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 3.5,-2.5
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-2.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
-  - uid: 294
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 283
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 1.5,-2.5
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-6.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
-  - uid: 295
+    - type: AtmosPipeColor
+      color: '#0000CCFF'
+  - uid: 284
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 0.5,-2.5
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-6.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
-  - uid: 296
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 318
     components:
-    - rot: -1.5707963267948966 rad
-      pos: -0.5,-2.5
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,0.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
-  - uid: 297
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasPipeFourway
+  entities:
+  - uid: 241
     components:
-    - rot: -1.5707963267948966 rad
-      pos: -1.5,-2.5
+    - type: Transform
+      pos: -0.5,-0.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
-  - uid: 298
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPipeStraight
+  entities:
+  - uid: 205
     components:
-    - rot: 3.141592653589793 rad
-      pos: 4.5,-0.5
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,2.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
-  - uid: 301
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 235
     components:
-    - rot: 3.141592653589793 rad
-      pos: 4.5,2.5
-      parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
-  - uid: 302
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 4.5,3.5
-      parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
-  - uid: 303
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 4.5,4.5
-      parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
-  - uid: 307
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -3.5,-1.5
-      parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
-  - uid: 309
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 3.5,5.5
-      parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
-  - uid: 310
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 2.5,5.5
-      parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
-  - uid: 311
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 1.5,5.5
-      parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
-  - uid: 312
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 0.5,5.5
-      parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
-  - uid: 313
-    components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -0.5,5.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 236
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 238
+    components:
+    - type: Transform
+      pos: 4.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 239
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 240
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 242
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 243
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 245
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 246
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 248
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 250
+    components:
+    - type: Transform
+      pos: 4.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 252
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 253
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 254
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 255
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 256
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 257
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 260
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 261
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 262
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 263
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 264
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 265
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 266
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 267
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 268
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 272
+    components:
+    - type: Transform
+      pos: -2.5,-7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 274
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 275
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 277
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 288
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 289
+    components:
+    - type: Transform
+      pos: 4.5,-5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 290
+    components:
+    - type: Transform
+      pos: 4.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 292
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 294
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 295
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 296
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 297
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 298
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 301
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 302
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 303
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 307
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 309
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 310
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 311
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 312
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 313
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 314
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -1.5,5.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
-  - uid: 315
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -2.5,5.5
-      parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 317
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 2.5,0.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 325
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 5.5,1.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 327
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 1.5,1.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 329
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 0.5,-3.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 333
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 3.5,-0.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
 - proto: GasPipeTJunction
   entities:
+  - uid: 186
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 195
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 244
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -0.5,-3.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 247
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -0.5,-6.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 273
     components:
-    - pos: -0.5,6.5
+    - type: Transform
+      pos: -0.5,6.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 280
     components:
-    - pos: 2.5,-2.5
+    - type: Transform
+      pos: 2.5,-2.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 286
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 4.5,-2.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 287
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 4.5,-1.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 299
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 4.5,0.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 300
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 4.5,1.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 304
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 4.5,5.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
 - proto: GasPort
   entities:
   - uid: 319
     components:
-    - pos: 2.5,-5.5
+    - type: Transform
+      pos: 2.5,-5.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0000CCFF'
 - proto: GasPressurePump
   entities:
   - uid: 194
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -1.5,-6.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 285
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 3.5,-6.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
 - proto: GasVentPump
   entities:
   - uid: 249
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 2.5,-3.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 251
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 276
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 305
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 6.5,-1.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 306
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -4.5,-1.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
-  - uid: 308
-    components:
-    - pos: 4.5,6.5
-      parent: 1
-      type: Transform
-    - ShutdownSubscribers:
-      - 84
-      type: DeviceNetwork
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
-  - uid: 316
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -3.5,5.5
-      parent: 1
-      type: Transform
-    - ShutdownSubscribers:
-      - 84
-      type: DeviceNetwork
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 326
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 6.5,1.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
-  - uid: 328
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 498
     components:
-    - pos: 1.5,2.5
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,7.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
 - proto: GasVentScrubber
   entities:
+  - uid: 237
+    components:
+    - type: Transform
+      pos: -3.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 258
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 6.5,2.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 259
     components:
-    - rot: 1.5707963267948966 rad
-      pos: -2.5,2.5
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,3.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 269
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -4.5,-0.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 270
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 6.5,-0.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 278
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -3.5,6.5
-      parent: 1
-      type: Transform
-    - ShutdownSubscribers:
-      - 84
-      type: DeviceNetwork
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 279
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 3.5,6.5
-      parent: 1
-      type: Transform
-    - ShutdownSubscribers:
-      - 84
-      type: DeviceNetwork
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 331
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 1.5,-3.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 349
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 0.5,-6.5
       parent: 1
-      type: Transform
-    - ShutdownSubscribers:
-      - 482
-      type: DeviceNetwork
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 507
+    components:
+    - type: Transform
+      pos: 2.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
 - proto: GravityGeneratorMini
   entities:
   - uid: 320
     components:
-    - pos: -2.5,-5.5
+    - type: Transform
+      pos: -2.5,-5.5
       parent: 1
-      type: Transform
 - proto: Grille
   entities:
   - uid: 64
     components:
-    - pos: -5.5,5.5
+    - type: Transform
+      pos: -5.5,5.5
       parent: 1
-      type: Transform
   - uid: 65
     components:
-    - pos: -0.5,8.5
+    - type: Transform
+      pos: -0.5,8.5
       parent: 1
-      type: Transform
   - uid: 68
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -6.5,2.5
       parent: 1
-      type: Transform
   - uid: 69
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -6.5,3.5
       parent: 1
-      type: Transform
   - uid: 82
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 2.5,-7.5
       parent: 1
-      type: Transform
   - uid: 85
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -0.5,-7.5
       parent: 1
-      type: Transform
   - uid: 97
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 8.5,1.5
       parent: 1
-      type: Transform
   - uid: 98
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 8.5,2.5
       parent: 1
-      type: Transform
   - uid: 99
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 8.5,3.5
       parent: 1
-      type: Transform
   - uid: 102
     components:
-    - pos: 7.5,6.5
+    - type: Transform
+      pos: 7.5,6.5
       parent: 1
-      type: Transform
   - uid: 103
     components:
-    - pos: 7.5,5.5
+    - type: Transform
+      pos: 7.5,5.5
       parent: 1
-      type: Transform
   - uid: 109
     components:
-    - pos: 1.5,8.5
+    - type: Transform
+      pos: 1.5,8.5
       parent: 1
-      type: Transform
   - uid: 110
     components:
-    - pos: 2.5,8.5
+    - type: Transform
+      pos: 2.5,8.5
       parent: 1
-      type: Transform
   - uid: 112
     components:
-    - pos: -5.5,6.5
+    - type: Transform
+      pos: -5.5,6.5
       parent: 1
-      type: Transform
   - uid: 332
     components:
-    - pos: 1.5,-7.5
+    - type: Transform
+      pos: 1.5,-7.5
       parent: 1
-      type: Transform
 - proto: Gyroscope
   entities:
   - uid: 334
     components:
-    - pos: 4.5,5.5
+    - type: Transform
+      pos: 4.5,5.5
       parent: 1
-      type: Transform
+    - type: Thruster
+      originalPowerLoad: 1500
 - proto: HospitalCurtainsOpen
   entities:
   - uid: 229
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 6.5,-5.5
       parent: 1
-      type: Transform
 - proto: hydroponicsTrayAnchored
   entities:
   - uid: 192
     components:
-    - pos: -0.5,7.5
+    - type: Transform
+      pos: -0.5,7.5
       parent: 1
-      type: Transform
   - uid: 193
     components:
-    - pos: -1.5,7.5
+    - type: Transform
+      pos: -1.5,7.5
       parent: 1
-      type: Transform
 - proto: KitchenReagentGrinder
   entities:
   - uid: 494
     components:
-    - pos: -2.5,5.5
+    - type: Transform
+      pos: -2.5,5.5
       parent: 1
-      type: Transform
 - proto: LampGold
   entities:
   - uid: 515
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 4.638707,3.853603
       parent: 1
-      type: Transform
 - proto: LockerCaptainFilled
   entities:
   - uid: 204
     components:
-    - pos: 6.5,6.5
+    - type: Transform
+      pos: 6.5,6.5
       parent: 1
-      type: Transform
 - proto: MinimoogInstrument
   entities:
   - uid: 323
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 3.5,3.5
       parent: 1
-      type: Transform
 - proto: Paper
   entities:
   - uid: 519
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -0.7506112,1.56815
       parent: 1
-      type: Transform
   - uid: 520
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -0.4693612,1.63065
       parent: 1
-      type: Transform
-  - uid: 521
-    components:
-    - pos: -3.7583714,-5.2648873
-      parent: 1
-      type: Transform
-    - stampState: paper_stamp-ce
-      stampedBy:
-      - stampedBorderless: False
-        stampedColor: '#C69B17FF'
-        stampedName: stamp-component-stamped-name-ce
-      - stampedBorderless: False
-        stampedColor: '#00BE00FF'
-        stampedName: stamp-component-stamped-name-approved
-      content: >-
-        [color=#1b67a5]█░░█░███[/color][color=#5b97bc]░███░█░█░█░██░░█░█░██░░██░░██░[/color]
-
-        [color=#1b67a5]██░█░░█░[/color][color=#5b97bc]██░░░█░█░█░█░█░█░█░█░█░█░█░█░█[/color]
-
-        [color=#1b67a5]█░██░░█░[/color][color=#5b97bc]░░██░███░█░██░░░█░░███░██░░█░█[/color]
-
-        [color=#1b67a5]█░░█░░█░[/color][color=#5b97bc]███░░█░█░█░█░░░░█░░█░█░█░█░██░[/color]
-
-
-        [head=1]=========================[/head]
-
-        [head=1]    Kilderkin-class service ship[/head]
-
-        [head=1] [/head]
-
-        [head=1]       PREFLIGHT CHECKLIST[/head]
-
-        [head=1] [/head]
-
-        [head=1]=========================[/head]
-
-
-        [head=2]1. Power supply.[/head]
-
-        [head=3]1.1. Battery units.[/head]
-
-        [bullet/][ ] Check if the SMES unit is anchored to the floor.
-
-        [bullet/][ ] Check if the substation unit is anchored to the floor.
-
-        [bullet/][ ] Check if the APC unit's Main Breakers are toggled on.
-
-        [bullet/][ ] Check current Load[bold]*[/bold] (W) on APC unit.
-
-        [head=3]1.2. P.A.C.M.A.N. generator units.[/head]
-
-        [bullet/][ ] Check if the P.A.C.M.A.N. generator units are anchored to the floor.
-
-        [bullet/][ ] Check if the P.A.C.M.A.N. generator units are fueled. For extended flights make sure that you have enough fuel stockpiled to sustain prolonged power generation.
-
-        [bullet/][ ] Check if the P.A.C.M.A.N. generator units are set to HV output.
-
-        [bullet/][ ] Set Target Power for 13 [bold]**[/bold] [bold]k[/bold]W.
-
-        [bullet/][ ] Start the P.A.C.M.A.N. generator units.
-
-
-        [head=2]2. Atmospherics.[/head]
-
-        [head=3]2.1. Distribution Loop.[/head]
-
-        [bullet/][ ] Check if the air canister is anchored to connector port.
-
-        [bullet/][ ] Check if the air output pump is set to normal pressure.
-
-        [bullet/][ ] Enable the air output pump.
-
-        [bullet/][ ] Check if the distribution pump is set to normal pressure.
-
-        [bullet/][ ] Enable distribution pump.
-
-        [head=3]2.2. Waste Loop.[/head]
-
-        [bullet/][ ] Enable waste loop pump.
-
-
-        [head=2]3. Other checks.[/head]
-
-        [bullet/][ ] Check if the gyroscope is anchored, powered, and enabled.
-
-        [bullet/][ ] Check if the mini gravity generator is anchored, powered, and enabled.
-
-
-        __________________________________________________________________
-
-        [bold]*[/bold] - Kilderkin-class service ships are equipped with a two APC units that can be used to appraise the ship's total power consumption. Unmodifued Kilderkin-class ship requires 24.2 kW of power to remain operational.
-
-        [bold]**[/bold] - Kilderkin-class service ships have higher power demand than single standard P.A.C.M.A.N. generator unit can provide at optimal settings, however the ship comes equipped with two P.A.C.M.A.N. generator units, recommended target power output for each P.A.C.M.A.N. generator unit is 13 kW.
-
-        [bold]Note:[/bold] Additional generator units can be purchased at the Frontier Station.
-      type: Paper
 - proto: PlasticFlapsClear
   entities:
   - uid: 336
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -6.5,0.5
       parent: 1
-      type: Transform
-- proto: PortableGeneratorPacman
+- proto: PortableGeneratorPacmanShuttle
   entities:
-  - uid: 182
+  - uid: 315
     components:
-    - anchored: True
+    - type: Transform
       pos: -4.5,-5.5
       parent: 1
-      type: Transform
-    - storage:
-        Plasma: 1500
-      type: MaterialStorage
-    - bodyType: Static
-      type: Physics
-    - type: InsertingMaterialStorage
-  - uid: 183
+    - type: FuelGenerator
+      on: False
+    - type: Physics
+      bodyType: Static
+  - uid: 316
     components:
-    - anchored: True
+    - type: Transform
       pos: -4.5,-4.5
       parent: 1
-      type: Transform
-    - storage:
-        Plasma: 1500
-      type: MaterialStorage
-    - bodyType: Static
-      type: Physics
-    - type: InsertingMaterialStorage
+    - type: FuelGenerator
+      on: False
+    - type: Physics
+      bodyType: Static
 - proto: PowerCellRecharger
   entities:
   - uid: 203
     components:
-    - pos: 3.5,5.5
+    - type: Transform
+      pos: 3.5,5.5
       parent: 1
-      type: Transform
 - proto: Poweredlight
   entities:
   - uid: 340
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 1.5,-3.5
       parent: 1
-      type: Transform
   - uid: 341
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -5.5,-1.5
       parent: 1
-      type: Transform
   - uid: 342
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 7.5,-1.5
       parent: 1
-      type: Transform
   - uid: 343
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 4.5,5.5
       parent: 1
-      type: Transform
   - uid: 344
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -2.5,5.5
       parent: 1
-      type: Transform
   - uid: 353
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -4.5,-2.5
       parent: 1
-      type: Transform
   - uid: 355
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 6.5,-2.5
       parent: 1
-      type: Transform
   - uid: 522
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -2.5,2.5
       parent: 1
-      type: Transform
 - proto: PoweredlightLED
   entities:
   - uid: 542
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 0.5,-6.5
       parent: 1
-      type: Transform
 - proto: PoweredSmallLight
   entities:
   - uid: 352
     components:
-    - pos: 6.5,-4.5
+    - type: Transform
+      pos: 6.5,-4.5
       parent: 1
-      type: Transform
   - uid: 354
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -4.5,3.5
       parent: 1
-      type: Transform
 - proto: Rack
   entities:
   - uid: 462
     components:
-    - pos: 1.5,-5.5
+    - type: Transform
+      pos: 1.5,-5.5
       parent: 1
-      type: Transform
 - proto: RandomPainting
   entities:
   - uid: 499
     components:
-    - pos: 2.5,3.5
+    - type: Transform
+      pos: 2.5,3.5
       parent: 1
-      type: Transform
   - uid: 500
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 6.5,0.5
       parent: 1
-      type: Transform
   - uid: 501
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 1.5,-4.5
       parent: 1
-      type: Transform
 - proto: ReinforcedWindow
   entities:
   - uid: 132
     components:
-    - pos: 7.5,6.5
+    - type: Transform
+      pos: 7.5,6.5
       parent: 1
-      type: Transform
   - uid: 133
     components:
-    - pos: 7.5,5.5
+    - type: Transform
+      pos: 7.5,5.5
       parent: 1
-      type: Transform
   - uid: 134
     components:
-    - pos: 2.5,8.5
+    - type: Transform
+      pos: 2.5,8.5
       parent: 1
-      type: Transform
   - uid: 135
     components:
-    - pos: 1.5,8.5
+    - type: Transform
+      pos: 1.5,8.5
       parent: 1
-      type: Transform
   - uid: 136
     components:
-    - pos: -0.5,8.5
+    - type: Transform
+      pos: -0.5,8.5
       parent: 1
-      type: Transform
   - uid: 137
     components:
-    - pos: -5.5,6.5
+    - type: Transform
+      pos: -5.5,6.5
       parent: 1
-      type: Transform
   - uid: 138
     components:
-    - pos: -5.5,5.5
+    - type: Transform
+      pos: -5.5,5.5
       parent: 1
-      type: Transform
   - uid: 230
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 8.5,3.5
       parent: 1
-      type: Transform
   - uid: 231
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 8.5,2.5
       parent: 1
-      type: Transform
   - uid: 232
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 8.5,1.5
       parent: 1
-      type: Transform
   - uid: 233
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -0.5,-7.5
       parent: 1
-      type: Transform
   - uid: 234
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 2.5,-7.5
       parent: 1
-      type: Transform
   - uid: 338
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -6.5,3.5
       parent: 1
-      type: Transform
   - uid: 339
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -6.5,2.5
       parent: 1
-      type: Transform
   - uid: 510
     components:
-    - pos: 1.5,-7.5
+    - type: Transform
+      pos: 1.5,-7.5
       parent: 1
-      type: Transform
+- proto: ServiceTechFab
+  entities:
+  - uid: 442
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 1
 - proto: ShadowTree01
   entities:
   - uid: 189
     components:
-    - pos: 1.5,-1.5
+    - type: Transform
+      pos: 1.5,-1.5
       parent: 1
-      type: Transform
 - proto: SheetPlasma
   entities:
   - uid: 347
     components:
-    - pos: -4.2716427,-5.469825
+    - type: Transform
+      pos: -4.2716427,-5.469825
       parent: 1
-      type: Transform
-    - count: 15
-      type: Stack
-    - size: 15
-      type: Item
+    - type: Stack
+      count: 15
+    - type: Item
+      size: 15
   - uid: 348
     components:
-    - pos: -4.280203,-4.4959035
+    - type: Transform
+      pos: -4.280203,-4.4959035
       parent: 1
-      type: Transform
-    - count: 15
-      type: Stack
-    - size: 15
-      type: Item
+    - type: Stack
+      count: 15
+    - type: Item
+      size: 15
+- proto: ShipyardKilderkinInfo
+  entities:
+  - uid: 308
+    components:
+    - type: Transform
+      pos: -3.790268,-5.336355
+      parent: 1
 - proto: ShuttersNormalOpen
   entities:
   - uid: 367
     components:
-    - pos: -2.5,1.5
+    - type: Transform
+      pos: -2.5,1.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 490
-      type: DeviceLinkSink
   - uid: 368
     components:
-    - pos: -1.5,1.5
+    - type: Transform
+      pos: -1.5,1.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 490
-      type: DeviceLinkSink
   - uid: 369
     components:
-    - pos: -0.5,1.5
+    - type: Transform
+      pos: -0.5,1.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 490
-      type: DeviceLinkSink
   - uid: 370
     components:
-    - pos: 0.5,1.5
+    - type: Transform
+      pos: 0.5,1.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 490
-      type: DeviceLinkSink
   - uid: 371
     components:
-    - pos: -0.5,-7.5
+    - type: Transform
+      pos: -0.5,-7.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 489
-      type: DeviceLinkSink
   - uid: 372
     components:
-    - pos: 2.5,-7.5
+    - type: Transform
+      pos: 2.5,-7.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 489
-      type: DeviceLinkSink
   - uid: 373
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -6.5,2.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 537
-      type: DeviceLinkSink
   - uid: 374
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -6.5,3.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 537
-      type: DeviceLinkSink
   - uid: 375
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -5.5,5.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 508
-      type: DeviceLinkSink
   - uid: 376
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -5.5,6.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 508
-      type: DeviceLinkSink
   - uid: 377
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -0.5,8.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 508
-      type: DeviceLinkSink
   - uid: 378
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 1.5,8.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 491
-      type: DeviceLinkSink
   - uid: 379
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 2.5,8.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 491
-      type: DeviceLinkSink
   - uid: 380
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 7.5,6.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 491
-      type: DeviceLinkSink
   - uid: 381
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 7.5,5.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 491
-      type: DeviceLinkSink
   - uid: 382
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 8.5,3.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 483
-      type: DeviceLinkSink
   - uid: 383
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 8.5,2.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 483
-      type: DeviceLinkSink
   - uid: 384
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 8.5,1.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 483
-      type: DeviceLinkSink
   - uid: 385
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 2.5,2.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 490
-      type: DeviceLinkSink
   - uid: 495
     components:
-    - pos: 1.5,1.5
+    - type: Transform
+      pos: 1.5,1.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 490
-      type: DeviceLinkSink
   - uid: 511
     components:
-    - pos: 1.5,-7.5
+    - type: Transform
+      pos: 1.5,-7.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 489
-      type: DeviceLinkSink
 - proto: SignalButtonDirectional
   entities:
   - uid: 483
     components:
-    - name: shutters switch
-      type: MetaData
-    - rot: 3.141592653589793 rad
+    - type: MetaData
+      name: shutters switch
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 7.5,0.5
       parent: 1
-      type: Transform
-    - linkedPorts:
+    - type: DeviceLinkSource
+      linkedPorts:
         384:
         - Pressed: Toggle
         383:
         - Pressed: Toggle
         382:
         - Pressed: Toggle
-      type: DeviceLinkSource
   - uid: 489
     components:
-    - name: shutters switch
-      type: MetaData
-    - rot: 3.141592653589793 rad
+    - type: MetaData
+      name: shutters switch
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 0.5,-7.5
       parent: 1
-      type: Transform
-    - linkedPorts:
+    - type: DeviceLinkSource
+      linkedPorts:
         371:
         - Pressed: Toggle
         372:
         - Pressed: Toggle
         511:
         - Pressed: Toggle
-      type: DeviceLinkSource
   - uid: 490
     components:
-    - name: bar shutters switch
-      type: MetaData
-    - pos: 0.5,4.5
+    - type: MetaData
+      name: bar shutters switch
+    - type: Transform
+      pos: 0.5,4.5
       parent: 1
-      type: Transform
-    - linkedPorts:
+    - type: DeviceLinkSource
+      linkedPorts:
         385:
         - Pressed: Toggle
         370:
@@ -3084,14 +2986,14 @@ entities:
         - Pressed: Toggle
         495:
         - Pressed: Toggle
-      type: DeviceLinkSource
   - uid: 491
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 0.5,7.5
       parent: 1
-      type: Transform
-    - linkedPorts:
+    - type: DeviceLinkSource
+      linkedPorts:
         378:
         - Pressed: Toggle
         379:
@@ -3100,46 +3002,46 @@ entities:
         - Pressed: Toggle
         381:
         - Pressed: Toggle
-      type: DeviceLinkSource
   - uid: 493
     components:
-    - name: blastdoors switch
-      type: MetaData
-    - rot: -1.5707963267948966 rad
+    - type: MetaData
+      name: blastdoors switch
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -3.5,2.5
       parent: 1
-      type: Transform
-    - linkedPorts:
+    - type: DeviceLinkSource
+      linkedPorts:
         345:
         - Pressed: Toggle
         179:
         - Pressed: Toggle
         337:
         - Pressed: Toggle
-      type: DeviceLinkSource
   - uid: 508
     components:
-    - name: shutters switch
-      type: MetaData
-    - pos: -1.5,8.5
+    - type: MetaData
+      name: shutters switch
+    - type: Transform
+      pos: -1.5,8.5
       parent: 1
-      type: Transform
-    - linkedPorts:
+    - type: DeviceLinkSource
+      linkedPorts:
         377:
         - Pressed: Toggle
         376:
         - Pressed: Toggle
         375:
         - Pressed: Toggle
-      type: DeviceLinkSource
   - uid: 512
     components:
-    - name: bar entrance door bolts switch
-      type: MetaData
-    - pos: -1.5,4.5
+    - type: MetaData
+      name: bar entrance door bolts switch
+    - type: Transform
+      pos: -1.5,4.5
       parent: 1
-      type: Transform
-    - linkedPorts:
+    - type: DeviceLinkSource
+      linkedPorts:
         139:
         - Pressed: DoorBolt
         170:
@@ -3148,380 +3050,372 @@ entities:
         - Pressed: DoorBolt
         168:
         - Pressed: DoorBolt
-      type: DeviceLinkSource
   - uid: 537
     components:
-    - name: shutters switch
-      type: MetaData
-    - pos: -5.5,4.5
+    - type: MetaData
+      name: shutters switch
+    - type: Transform
+      pos: -5.5,4.5
       parent: 1
-      type: Transform
-    - linkedPorts:
+    - type: DeviceLinkSource
+      linkedPorts:
         374:
         - Pressed: Toggle
         373:
         - Pressed: Toggle
-      type: DeviceLinkSource
 - proto: SignBar
   entities:
   - uid: 540
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -6.5,-1.5
       parent: 1
-      type: Transform
   - uid: 541
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 8.5,-1.5
       parent: 1
-      type: Transform
 - proto: SignDirectionalBar
   entities:
   - uid: 538
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 5.5,-2.5
       parent: 1
-      type: Transform
   - uid: 539
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -3.5,-2.5
       parent: 1
-      type: Transform
 - proto: Sink
   entities:
   - uid: 227
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 6.5,-4.5
       parent: 1
-      type: Transform
 - proto: SMESBasic
   entities:
   - uid: 184
     components:
-    - pos: -3.5,-4.5
+    - type: Transform
+      pos: -3.5,-4.5
       parent: 1
-      type: Transform
 - proto: soda_dispenser
   entities:
   - uid: 128
     components:
-    - pos: 1.5,3.5
+    - type: Transform
+      pos: 1.5,3.5
       parent: 1
-      type: Transform
-- proto: SpawnPointBartender
-  entities:
-  - uid: 498
-    components:
-    - pos: -0.5,2.5
-      parent: 1
-      type: Transform
-- proto: SpawnPointBotanist
-  entities:
-  - uid: 535
-    components:
-    - pos: -2.5,6.5
-      parent: 1
-      type: Transform
 - proto: SpawnPointLatejoin
   entities:
-  - uid: 497
+  - uid: 441
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 6.5,-5.5
+    - type: Transform
+      pos: -2.5,6.5
       parent: 1
-      type: Transform
-- proto: SpawnPointMercenary
-  entities:
-  - uid: 536
-    components:
-    - pos: 5.5,5.5
-      parent: 1
-      type: Transform
-- proto: SpawnPointPilot
-  entities:
-  - uid: 442
-    components:
-    - pos: 2.5,6.5
-      parent: 1
-      type: Transform
 - proto: StoolBar
   entities:
   - uid: 172
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -2.5,0.5
       parent: 1
-      type: Transform
   - uid: 173
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -1.5,0.5
       parent: 1
-      type: Transform
   - uid: 174
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -0.5,0.5
       parent: 1
-      type: Transform
   - uid: 175
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 0.5,0.5
       parent: 1
-      type: Transform
   - uid: 176
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 3.5,2.5
       parent: 1
-      type: Transform
 - proto: SubstationBasic
   entities:
   - uid: 185
     components:
-    - pos: -2.5,-4.5
+    - type: Transform
+      pos: -2.5,-4.5
       parent: 1
-      type: Transform
 - proto: SuitStorageEVAAlternate
   entities:
   - uid: 509
     components:
-    - pos: 6.5,5.5
+    - type: Transform
+      pos: 6.5,5.5
       parent: 1
-      type: Transform
 - proto: SuitStorageWallmountEVAAlternate
   entities:
   - uid: 443
     components:
-    - pos: 3.5,-5.5
+    - type: Transform
+      pos: 3.5,-5.5
       parent: 1
-      type: Transform
+    - type: Physics
+      canCollide: False
 - proto: SurveillanceCameraRouterService
   entities:
   - uid: 199
     components:
-    - pos: 2.5,5.5
+    - type: Transform
+      pos: 2.5,5.5
       parent: 1
-      type: Transform
 - proto: SurveillanceCameraService
   entities:
   - uid: 503
     components:
-    - pos: 2.5,-3.5
+    - type: Transform
+      pos: 2.5,-3.5
       parent: 1
-      type: Transform
   - uid: 504
     components:
-    - pos: -4.5,-2.5
+    - type: Transform
+      pos: -4.5,-2.5
       parent: 1
-      type: Transform
   - uid: 505
     components:
-    - pos: 7.5,-2.5
+    - type: Transform
+      pos: 7.5,-2.5
       parent: 1
-      type: Transform
 - proto: Table
   entities:
   - uid: 200
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 3.5,7.5
       parent: 1
-      type: Transform
   - uid: 456
     components:
-    - pos: 1.5,7.5
+    - type: Transform
+      pos: 1.5,7.5
       parent: 1
-      type: Transform
   - uid: 457
     components:
-    - pos: 2.5,7.5
+    - type: Transform
+      pos: 2.5,7.5
       parent: 1
-      type: Transform
 - proto: TableCarpet
   entities:
   - uid: 117
     components:
-    - pos: 6.5,2.5
+    - type: Transform
+      pos: 6.5,2.5
       parent: 1
-      type: Transform
   - uid: 118
     components:
-    - pos: 5.5,2.5
+    - type: Transform
+      pos: 5.5,2.5
       parent: 1
-      type: Transform
 - proto: TableCounterMetal
   entities:
   - uid: 201
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 3.5,5.5
       parent: 1
-      type: Transform
-  - uid: 206
-    components:
-    - pos: -1.5,5.5
-      parent: 1
-      type: Transform
   - uid: 207
     components:
-    - pos: -2.5,5.5
+    - type: Transform
+      pos: -2.5,5.5
       parent: 1
-      type: Transform
 - proto: TableCounterWood
   entities:
   - uid: 123
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 0.5,3.5
       parent: 1
-      type: Transform
   - uid: 124
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 1.5,3.5
       parent: 1
-      type: Transform
   - uid: 322
     components:
-    - pos: 4.5,3.5
+    - type: Transform
+      pos: 4.5,3.5
       parent: 1
-      type: Transform
 - proto: TableWood
   entities:
   - uid: 216
     components:
-    - pos: 1.5,-3.5
+    - type: Transform
+      pos: 1.5,-3.5
       parent: 1
-      type: Transform
   - uid: 217
     components:
-    - pos: 2.5,-3.5
+    - type: Transform
+      pos: 2.5,-3.5
       parent: 1
-      type: Transform
   - uid: 219
     components:
-    - pos: -1.5,-2.5
+    - type: Transform
+      pos: -1.5,-2.5
       parent: 1
-      type: Transform
 - proto: TableWoodReinforced
   entities:
   - uid: 17
     components:
-    - pos: 0.5,1.5
+    - type: Transform
+      pos: 0.5,1.5
       parent: 1
-      type: Transform
   - uid: 18
     components:
-    - pos: -0.5,1.5
+    - type: Transform
+      pos: -0.5,1.5
       parent: 1
-      type: Transform
   - uid: 19
     components:
-    - pos: -1.5,1.5
+    - type: Transform
+      pos: -1.5,1.5
       parent: 1
-      type: Transform
   - uid: 20
     components:
-    - pos: -2.5,1.5
+    - type: Transform
+      pos: -2.5,1.5
       parent: 1
-      type: Transform
   - uid: 21
     components:
-    - pos: 2.5,2.5
+    - type: Transform
+      pos: 2.5,2.5
       parent: 1
-      type: Transform
 - proto: Thruster
   entities:
   - uid: 152
     components:
-    - pos: 3.5,9.5
+    - type: Transform
+      pos: 3.5,9.5
       parent: 1
-      type: Transform
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 153
     components:
-    - pos: 4.5,9.5
+    - type: Transform
+      pos: 4.5,9.5
       parent: 1
-      type: Transform
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 154
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 5.5,9.5
       parent: 1
-      type: Transform
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 155
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 5.5,-8.5
       parent: 1
-      type: Transform
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 156
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 4.5,-8.5
       parent: 1
-      type: Transform
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 157
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 3.5,-8.5
       parent: 1
-      type: Transform
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 158
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -1.5,-8.5
       parent: 1
-      type: Transform
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 159
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -2.5,-8.5
       parent: 1
-      type: Transform
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 160
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -3.5,-8.5
       parent: 1
-      type: Transform
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 161
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -3.5,9.5
       parent: 1
-      type: Transform
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 162
     components:
-    - pos: -2.5,9.5
+    - type: Transform
+      pos: -2.5,9.5
       parent: 1
-      type: Transform
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 163
     components:
-    - pos: -1.5,9.5
+    - type: Transform
+      pos: -1.5,9.5
       parent: 1
-      type: Transform
+    - type: Thruster
+      originalPowerLoad: 1500
 - proto: ToiletEmpty
   entities:
   - uid: 228
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 6.5,-5.5
       parent: 1
-      type: Transform
 - proto: TwoWayLever
   entities:
   - uid: 502
     components:
-    - pos: -4.5,2.5
+    - type: Transform
+      pos: -4.5,2.5
       parent: 1
-      type: Transform
-    - linkedPorts:
+    - type: DeviceLinkSource
+      linkedPorts:
         181:
         - Left: Forward
         - Right: Reverse
@@ -3530,500 +3424,499 @@ entities:
         - Left: Forward
         - Right: Reverse
         - Middle: Off
-      type: DeviceLinkSource
 - proto: VendingBarDrobe
   entities:
   - uid: 208
     components:
-    - pos: 5.5,7.5
+    - type: Transform
+      pos: 5.5,7.5
       parent: 1
-      type: Transform
 - proto: VendingMachineBooze
   entities:
   - uid: 130
     components:
-    - pos: -1.5,3.5
+    - type: Transform
+      pos: -1.5,3.5
       parent: 1
-      type: Transform
 - proto: VendingMachineCigs
   entities:
   - uid: 131
     components:
-    - pos: -2.5,3.5
+    - type: Transform
+      pos: -2.5,3.5
       parent: 1
-      type: Transform
 - proto: VendingMachineNutri
   entities:
   - uid: 330
     components:
-    - pos: -4.5,6.5
+    - type: Transform
+      pos: -4.5,6.5
       parent: 1
-      type: Transform
 - proto: VendingMachineSeeds
   entities:
   - uid: 191
     components:
-    - pos: -3.5,7.5
+    - type: Transform
+      pos: -3.5,7.5
       parent: 1
-      type: Transform
 - proto: WallReinforced
   entities:
   - uid: 60
     components:
-    - pos: -3.5,8.5
+    - type: Transform
+      pos: -3.5,8.5
       parent: 1
-      type: Transform
   - uid: 61
     components:
-    - pos: -4.5,8.5
+    - type: Transform
+      pos: -4.5,8.5
       parent: 1
-      type: Transform
   - uid: 62
     components:
-    - pos: -4.5,7.5
+    - type: Transform
+      pos: -4.5,7.5
       parent: 1
-      type: Transform
   - uid: 63
     components:
-    - pos: -5.5,7.5
+    - type: Transform
+      pos: -5.5,7.5
       parent: 1
-      type: Transform
   - uid: 66
     components:
-    - pos: -5.5,4.5
+    - type: Transform
+      pos: -5.5,4.5
       parent: 1
-      type: Transform
   - uid: 67
     components:
-    - pos: -6.5,4.5
+    - type: Transform
+      pos: -6.5,4.5
       parent: 1
-      type: Transform
   - uid: 70
     components:
-    - pos: -6.5,1.5
+    - type: Transform
+      pos: -6.5,1.5
       parent: 1
-      type: Transform
   - uid: 72
     components:
-    - pos: -6.5,-1.5
+    - type: Transform
+      pos: -6.5,-1.5
       parent: 1
-      type: Transform
   - uid: 73
     components:
-    - pos: -6.5,-3.5
+    - type: Transform
+      pos: -6.5,-3.5
       parent: 1
-      type: Transform
   - uid: 74
     components:
-    - pos: -5.5,-3.5
+    - type: Transform
+      pos: -5.5,-3.5
       parent: 1
-      type: Transform
   - uid: 75
     components:
-    - pos: -5.5,-4.5
+    - type: Transform
+      pos: -5.5,-4.5
       parent: 1
-      type: Transform
   - uid: 76
     components:
-    - pos: -5.5,-5.5
+    - type: Transform
+      pos: -5.5,-5.5
       parent: 1
-      type: Transform
   - uid: 77
     components:
-    - pos: -5.5,-6.5
+    - type: Transform
+      pos: -5.5,-6.5
       parent: 1
-      type: Transform
   - uid: 78
     components:
-    - pos: -4.5,-6.5
+    - type: Transform
+      pos: -4.5,-6.5
       parent: 1
-      type: Transform
   - uid: 79
     components:
-    - pos: -4.5,-7.5
+    - type: Transform
+      pos: -4.5,-7.5
       parent: 1
-      type: Transform
   - uid: 80
     components:
-    - pos: -3.5,-7.5
+    - type: Transform
+      pos: -3.5,-7.5
       parent: 1
-      type: Transform
   - uid: 81
     components:
-    - pos: -1.5,-7.5
+    - type: Transform
+      pos: -1.5,-7.5
       parent: 1
-      type: Transform
   - uid: 83
     components:
-    - pos: 0.5,-7.5
+    - type: Transform
+      pos: 0.5,-7.5
       parent: 1
-      type: Transform
   - uid: 86
     components:
-    - pos: 3.5,-7.5
+    - type: Transform
+      pos: 3.5,-7.5
       parent: 1
-      type: Transform
   - uid: 87
     components:
-    - pos: 5.5,-7.5
+    - type: Transform
+      pos: 5.5,-7.5
       parent: 1
-      type: Transform
   - uid: 88
     components:
-    - pos: 6.5,-7.5
+    - type: Transform
+      pos: 6.5,-7.5
       parent: 1
-      type: Transform
   - uid: 89
     components:
-    - pos: 6.5,-6.5
+    - type: Transform
+      pos: 6.5,-6.5
       parent: 1
-      type: Transform
   - uid: 90
     components:
-    - pos: 7.5,-6.5
+    - type: Transform
+      pos: 7.5,-6.5
       parent: 1
-      type: Transform
   - uid: 91
     components:
-    - pos: 7.5,-5.5
+    - type: Transform
+      pos: 7.5,-5.5
       parent: 1
-      type: Transform
   - uid: 92
     components:
-    - pos: 7.5,-4.5
+    - type: Transform
+      pos: 7.5,-4.5
       parent: 1
-      type: Transform
   - uid: 93
     components:
-    - pos: 7.5,-3.5
+    - type: Transform
+      pos: 7.5,-3.5
       parent: 1
-      type: Transform
   - uid: 94
     components:
-    - pos: 8.5,-3.5
+    - type: Transform
+      pos: 8.5,-3.5
       parent: 1
-      type: Transform
   - uid: 95
     components:
-    - pos: 8.5,-1.5
+    - type: Transform
+      pos: 8.5,-1.5
       parent: 1
-      type: Transform
   - uid: 96
     components:
-    - pos: 8.5,0.5
+    - type: Transform
+      pos: 8.5,0.5
       parent: 1
-      type: Transform
   - uid: 100
     components:
-    - pos: 8.5,4.5
+    - type: Transform
+      pos: 8.5,4.5
       parent: 1
-      type: Transform
   - uid: 101
     components:
-    - pos: 7.5,4.5
+    - type: Transform
+      pos: 7.5,4.5
       parent: 1
-      type: Transform
   - uid: 104
     components:
-    - pos: 7.5,7.5
+    - type: Transform
+      pos: 7.5,7.5
       parent: 1
-      type: Transform
   - uid: 105
     components:
-    - pos: 6.5,7.5
+    - type: Transform
+      pos: 6.5,7.5
       parent: 1
-      type: Transform
   - uid: 106
     components:
-    - pos: 6.5,8.5
+    - type: Transform
+      pos: 6.5,8.5
       parent: 1
-      type: Transform
   - uid: 107
     components:
-    - pos: 5.5,8.5
+    - type: Transform
+      pos: 5.5,8.5
       parent: 1
-      type: Transform
   - uid: 108
     components:
-    - pos: 3.5,8.5
+    - type: Transform
+      pos: 3.5,8.5
       parent: 1
-      type: Transform
   - uid: 111
     components:
-    - pos: 0.5,8.5
+    - type: Transform
+      pos: 0.5,8.5
       parent: 1
-      type: Transform
   - uid: 113
     components:
-    - pos: -1.5,8.5
+    - type: Transform
+      pos: -1.5,8.5
       parent: 1
-      type: Transform
 - proto: WallSolid
   entities:
   - uid: 2
     components:
-    - pos: 2.5,3.5
+    - type: Transform
+      pos: 2.5,3.5
       parent: 1
-      type: Transform
   - uid: 3
     components:
-    - pos: 2.5,1.5
+    - type: Transform
+      pos: 2.5,1.5
       parent: 1
-      type: Transform
   - uid: 22
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -1.5,-4.5
       parent: 1
-      type: Transform
   - uid: 23
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -1.5,-3.5
       parent: 1
-      type: Transform
   - uid: 24
     components:
-    - pos: -3.5,0.5
+    - type: Transform
+      pos: -3.5,0.5
       parent: 1
-      type: Transform
   - uid: 25
     components:
-    - pos: -3.5,1.5
+    - type: Transform
+      pos: -3.5,1.5
       parent: 1
-      type: Transform
   - uid: 26
     components:
-    - pos: -3.5,2.5
+    - type: Transform
+      pos: -3.5,2.5
       parent: 1
-      type: Transform
   - uid: 27
     components:
-    - pos: -3.5,3.5
+    - type: Transform
+      pos: -3.5,3.5
       parent: 1
-      type: Transform
   - uid: 28
     components:
-    - pos: -3.5,4.5
+    - type: Transform
+      pos: -3.5,4.5
       parent: 1
-      type: Transform
   - uid: 29
     components:
-    - pos: -2.5,4.5
+    - type: Transform
+      pos: -2.5,4.5
       parent: 1
-      type: Transform
   - uid: 30
     components:
-    - pos: -1.5,4.5
+    - type: Transform
+      pos: -1.5,4.5
       parent: 1
-      type: Transform
   - uid: 31
     components:
-    - pos: 0.5,4.5
+    - type: Transform
+      pos: 0.5,4.5
       parent: 1
-      type: Transform
   - uid: 32
     components:
-    - pos: 1.5,4.5
+    - type: Transform
+      pos: 1.5,4.5
       parent: 1
-      type: Transform
   - uid: 33
     components:
-    - pos: 2.5,4.5
+    - type: Transform
+      pos: 2.5,4.5
       parent: 1
-      type: Transform
   - uid: 34
     components:
-    - pos: 3.5,4.5
+    - type: Transform
+      pos: 3.5,4.5
       parent: 1
-      type: Transform
   - uid: 35
     components:
-    - pos: 4.5,4.5
+    - type: Transform
+      pos: 4.5,4.5
       parent: 1
-      type: Transform
   - uid: 36
     components:
-    - pos: 5.5,4.5
+    - type: Transform
+      pos: 5.5,4.5
       parent: 1
-      type: Transform
   - uid: 37
     components:
-    - pos: 6.5,4.5
+    - type: Transform
+      pos: 6.5,4.5
       parent: 1
-      type: Transform
   - uid: 38
     components:
-    - pos: -4.5,-3.5
+    - type: Transform
+      pos: -4.5,-3.5
       parent: 1
-      type: Transform
   - uid: 39
     components:
-    - pos: -3.5,-3.5
+    - type: Transform
+      pos: -3.5,-3.5
       parent: 1
-      type: Transform
   - uid: 40
     components:
-    - pos: -2.5,-3.5
+    - type: Transform
+      pos: -2.5,-3.5
       parent: 1
-      type: Transform
   - uid: 41
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 4.5,-5.5
       parent: 1
-      type: Transform
   - uid: 42
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 5.5,-5.5
       parent: 1
-      type: Transform
   - uid: 43
     components:
-    - pos: -1.5,-5.5
+    - type: Transform
+      pos: -1.5,-5.5
       parent: 1
-      type: Transform
   - uid: 44
     components:
-    - pos: 0.5,-5.5
+    - type: Transform
+      pos: 0.5,-5.5
       parent: 1
-      type: Transform
   - uid: 45
     components:
-    - pos: 1.5,-4.5
+    - type: Transform
+      pos: 1.5,-4.5
       parent: 1
-      type: Transform
   - uid: 46
     components:
-    - pos: 0.5,-4.5
+    - type: Transform
+      pos: 0.5,-4.5
       parent: 1
-      type: Transform
   - uid: 47
     components:
-    - pos: 3.5,-5.5
+    - type: Transform
+      pos: 3.5,-5.5
       parent: 1
-      type: Transform
   - uid: 49
     components:
-    - pos: 5.5,-6.5
+    - type: Transform
+      pos: 5.5,-6.5
       parent: 1
-      type: Transform
   - uid: 51
     components:
-    - pos: 5.5,-3.5
+    - type: Transform
+      pos: 5.5,-3.5
       parent: 1
-      type: Transform
   - uid: 52
     components:
-    - pos: 6.5,-3.5
+    - type: Transform
+      pos: 6.5,-3.5
       parent: 1
-      type: Transform
   - uid: 53
     components:
-    - pos: 5.5,-2.5
+    - type: Transform
+      pos: 5.5,-2.5
       parent: 1
-      type: Transform
   - uid: 54
     components:
-    - pos: 5.5,0.5
+    - type: Transform
+      pos: 5.5,0.5
       parent: 1
-      type: Transform
   - uid: 55
     components:
-    - pos: 6.5,0.5
+    - type: Transform
+      pos: 6.5,0.5
       parent: 1
-      type: Transform
   - uid: 56
     components:
-    - pos: 7.5,0.5
+    - type: Transform
+      pos: 7.5,0.5
       parent: 1
-      type: Transform
   - uid: 57
     components:
-    - pos: -3.5,-2.5
+    - type: Transform
+      pos: -3.5,-2.5
       parent: 1
-      type: Transform
   - uid: 58
     components:
-    - pos: 0.5,5.5
+    - type: Transform
+      pos: 0.5,5.5
       parent: 1
-      type: Transform
   - uid: 59
     components:
-    - pos: 0.5,7.5
+    - type: Transform
+      pos: 0.5,7.5
       parent: 1
-      type: Transform
   - uid: 187
     components:
-    - pos: 2.5,-4.5
+    - type: Transform
+      pos: 2.5,-4.5
       parent: 1
-      type: Transform
   - uid: 188
     components:
-    - pos: 3.5,-4.5
+    - type: Transform
+      pos: 3.5,-4.5
       parent: 1
-      type: Transform
 - proto: WarpPointShip
   entities:
   - uid: 496
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 1.5,-1.5
       parent: 1
-      type: Transform
 - proto: Windoor
   entities:
   - uid: 226
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 6.5,-5.5
       parent: 1
-      type: Transform
 - proto: WindoorSecure
   entities:
   - uid: 126
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 4.5,2.5
       parent: 1
-      type: Transform
   - uid: 127
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 4.5,1.5
       parent: 1
-      type: Transform
   - uid: 171
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 1.5,1.5
       parent: 1
-      type: Transform
   - uid: 350
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -3.5,-6.5
       parent: 1
-      type: Transform
 - proto: WindowReinforcedDirectional
   entities:
   - uid: 16
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 1.5,1.5
       parent: 1
-      type: Transform
   - uid: 125
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 4.5,3.5
       parent: 1
-      type: Transform
   - uid: 351
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -2.5,-6.5
       parent: 1
-      type: Transform
 ...

--- a/Resources/Maps/_NF/Shuttles/lantern.yml
+++ b/Resources/Maps/_NF/Shuttles/lantern.yml
@@ -16,12 +16,13 @@ entities:
   entities:
   - uid: 1
     components:
-    - name: grid
-      type: MetaData
-    - pos: -0.484375,-0.515625
+    - type: MetaData
+      name: grid
+    - type: Transform
+      pos: -0.484375,-0.515625
       parent: invalid
-      type: Transform
-    - chunks:
+    - type: MapGrid
+      chunks:
         0,0:
           ind: 0,0
           tiles: cAAAAAAAcAAAAAAAcAAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcgAAAAAAcAAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPQAAAAAAcgAAAAAAcAAAAAAAcgAAAAAAcgAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPQAAAAAAPQAAAAAAPQAAAAAAPQAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPQAAAAAAPQAAAAAAPQAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
@@ -46,24 +47,24 @@ entities:
           ind: 0,-2
           tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIQAAAAAAIQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcgAAAAAAHgAAAAAAHgAAAAAAHgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
           version: 6
-      type: MapGrid
     - type: Broadphase
-    - bodyStatus: InAir
+    - type: Physics
+      bodyStatus: InAir
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
       bodyType: Dynamic
-      type: Physics
-    - fixtures: {}
-      type: Fixtures
+    - type: Fixtures
+      fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid
     - type: Shuttle
     - type: GridPathfinding
-    - gravityShakeSound: !type:SoundPathSpecifier
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
         path: /Audio/Effects/alert.ogg
-      type: Gravity
-    - chunkCollection:
+    - type: DecalGrid
+      chunkCollection:
         version: 2
         nodes:
         - node:
@@ -261,94 +262,103 @@ entities:
             5: 1,-19
             14: -3,-18
             15: 4,-18
-      type: DecalGrid
-    - version: 2
+    - type: GridAtmosphere
+      version: 2
       data:
         tiles:
           0,0:
-            0: 65535
+            0: 20599
           0,-1:
             0: 65535
           -1,0:
+            0: 34952
             1: 4096
-            0: 60622
-          -1,-1:
-            0: 61183
           0,1:
-            0: 65535
+            0: 2033
+          -1,1:
+            0: 2252
+            1: 1
           1,0:
-            0: 4097
             1: 27776
           1,1:
-            0: 273
             1: 6
           2,0:
             1: 17
+          2,-1:
+            1: 4369
           0,-4:
-            0: 65535
+            0: 3067
+          0,-5:
+            0: 45872
+            2: 128
+          -1,-4:
+            0: 1783
           0,-3:
             0: 65535
+          -1,-3:
+            0: 65228
           0,-2:
             0: 65535
+          -1,-2:
+            0: 61439
+          -1,-1:
+            0: 52430
           1,-4:
-            0: 14199
+            0: 311
             1: 136
           1,-3:
-            0: 30513
+            0: 12544
           1,-2:
-            0: 30583
+            0: 4915
             1: 128
           1,-1:
-            0: 4403
+            0: 1
+          1,-5:
+            0: 12544
+            2: 48
           2,-4:
             1: 4368
-          2,-3:
-            1: 4369
           2,-2:
             1: 4369
-          2,-1:
+          2,-3:
             1: 4369
           -2,0:
             1: 35938
-          -2,1:
-            1: 8
-          -1,1:
-            1: 1
-            0: 52974
-          -2,-4:
-            1: 8804
-            0: 2184
-          -2,-3:
-            1: 8738
-            0: 34816
-          -2,-2:
-            1: 8802
-            0: 34952
           -2,-1:
             1: 8738
-          -1,-4:
-            0: 65535
-          -1,-3:
-            0: 65534
-          -1,-2:
-            0: 65535
-          -2,-5:
-            0: 34816
+          -2,1:
+            1: 8
+          -2,-4:
+            1: 8804
+            0: 8
+          -2,-3:
+            1: 8738
+          -2,-2:
+            1: 8802
           -1,-5:
-            1: 112
-            0: 65408
-          0,-5:
-            0: 65392
-            1: 128
-          1,-5:
-            1: 48
-            0: 30464
+            0: 29184
+            2: 112
         uniqueMixes:
         - volume: 2500
           temperature: 293.15
           moles:
           - 21.824879
           - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          immutable: True
+          moles:
+          - 0
+          - 0
           - 0
           - 0
           - 0
@@ -375,36 +385,31 @@ entities:
           - 0
           - 0
         chunkSize: 4
-      type: GridAtmosphere
     - type: GasTileOverlay
     - type: RadiationGridResistance
-    - id: lantern
-      type: BecomesStation
+    - type: BecomesStation
+      id: lantern
 - proto: AirAlarm
   entities:
   - uid: 738
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -1.5,3.5
       parent: 1
-      type: Transform
-    - ShutdownSubscribers:
+    - type: DeviceList
+      devices:
       - 539
       - 538
       - 540
-      type: DeviceNetwork
-    - devices:
-      - 539
-      - 538
-      - 540
-      type: DeviceList
   - uid: 739
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -0.5,-12.5
       parent: 1
-      type: Transform
-    - ShutdownSubscribers:
+    - type: DeviceList
+      devices:
       - 516
       - 517
       - 528
@@ -413,2878 +418,2853 @@ entities:
       - 742
       - 540
       - 541
-      type: DeviceNetwork
-    - devices:
-      - 516
-      - 517
-      - 528
-      - 527
-      - 743
-      - 742
-      - 540
-      - 541
-      type: DeviceList
   - uid: 741
     components:
-    - name: engine room air alarm
-      type: MetaData
-    - rot: 3.141592653589793 rad
+    - type: MetaData
+      name: engine room air alarm
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -1.5,-17.5
       parent: 1
-      type: Transform
-    - ShutdownSubscribers:
+    - type: DeviceList
+      devices:
       - 518
       - 542
-      type: DeviceNetwork
-    - devices:
-      - 518
-      - 542
-      type: DeviceList
   - uid: 801
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 6.5,-14.5
       parent: 1
-      type: Transform
-    - ShutdownSubscribers:
+    - type: DeviceList
+      devices:
       - 530
       - 543
-      type: DeviceNetwork
-    - devices:
-      - 530
-      - 543
-      type: DeviceList
 - proto: AirCanister
   entities:
   - uid: 345
     components:
-    - anchored: True
+    - type: Transform
+      anchored: True
       pos: -1.5,-16.5
       parent: 1
-      type: Transform
-    - bodyType: Static
-      type: Physics
+    - type: Physics
+      bodyType: Static
 - proto: Airlock
   entities:
   - uid: 406
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 2.5,-14.5
       parent: 1
-      type: Transform
 - proto: AirlockCommand
   entities:
   - uid: 198
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -0.5,2.5
       parent: 1
-      type: Transform
 - proto: AirlockEngineering
   entities:
   - uid: 405
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -0.5,-14.5
       parent: 1
-      type: Transform
 - proto: AirlockExternalGlass
   entities:
   - uid: 396
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 0.5,-15.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 901
-      type: DeviceLinkSink
   - uid: 397
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 1.5,-15.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 901
-      type: DeviceLinkSink
   - uid: 398
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 6.5,-15.5
       parent: 1
-      type: Transform
   - uid: 399
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -4.5,-15.5
       parent: 1
-      type: Transform
   - uid: 400
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -2.5,-17.5
       parent: 1
-      type: Transform
   - uid: 401
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 4.5,-17.5
       parent: 1
-      type: Transform
 - proto: AirlockGlassShuttle
   entities:
   - uid: 402
     components:
-    - pos: 0.5,-18.5
+    - type: Transform
+      pos: 0.5,-18.5
       parent: 1
-      type: Transform
   - uid: 403
     components:
-    - pos: 1.5,-18.5
+    - type: Transform
+      pos: 1.5,-18.5
       parent: 1
-      type: Transform
 - proto: AltarSpawner
   entities:
   - uid: 327
     components:
-    - pos: 0.5,3.5
+    - type: Transform
+      pos: 0.5,3.5
       parent: 1
-      type: Transform
 - proto: APCBasic
   entities:
   - uid: 493
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -2.5,4.5
       parent: 1
-      type: Transform
   - uid: 797
     components:
-    - pos: -3.5,-13.5
+    - type: Transform
+      pos: -3.5,-13.5
       parent: 1
-      type: Transform
   - uid: 798
     components:
-    - pos: 4.5,-12.5
+    - type: Transform
+      pos: 4.5,-12.5
       parent: 1
-      type: Transform
 - proto: AtmosDeviceFanTiny
   entities:
   - uid: 61
     components:
-    - pos: 6.5,-6.5
+    - type: Transform
+      pos: 6.5,-6.5
       parent: 1
-      type: Transform
   - uid: 69
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -4.5,-15.5
       parent: 1
-      type: Transform
   - uid: 71
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 0.5,-18.5
       parent: 1
-      type: Transform
   - uid: 111
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 6.5,-15.5
       parent: 1
-      type: Transform
   - uid: 113
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 1.5,-18.5
       parent: 1
-      type: Transform
   - uid: 304
     components:
-    - pos: -2.5,-17.5
+    - type: Transform
+      pos: -2.5,-17.5
       parent: 1
-      type: Transform
   - uid: 305
     components:
-    - pos: 4.5,-17.5
+    - type: Transform
+      pos: 4.5,-17.5
       parent: 1
-      type: Transform
 - proto: AtmosFixBlockerMarker
   entities:
   - uid: 805
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -5.5,-15.5
       parent: 1
-      type: Transform
   - uid: 806
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -5.5,-14.5
       parent: 1
-      type: Transform
   - uid: 807
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -6.5,-14.5
       parent: 1
-      type: Transform
   - uid: 808
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -6.5,-13.5
       parent: 1
-      type: Transform
   - uid: 809
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -6.5,-12.5
       parent: 1
-      type: Transform
   - uid: 810
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -6.5,-11.5
       parent: 1
-      type: Transform
   - uid: 811
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -6.5,-10.5
       parent: 1
-      type: Transform
   - uid: 812
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -6.5,-9.5
       parent: 1
-      type: Transform
   - uid: 813
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -6.5,-8.5
       parent: 1
-      type: Transform
   - uid: 814
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -6.5,-7.5
       parent: 1
-      type: Transform
   - uid: 815
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -6.5,-6.5
       parent: 1
-      type: Transform
   - uid: 816
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -6.5,-5.5
       parent: 1
-      type: Transform
   - uid: 817
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -6.5,-4.5
       parent: 1
-      type: Transform
   - uid: 818
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -6.5,-3.5
       parent: 1
-      type: Transform
   - uid: 819
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -6.5,-2.5
       parent: 1
-      type: Transform
   - uid: 820
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -6.5,-1.5
       parent: 1
-      type: Transform
   - uid: 821
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -6.5,-0.5
       parent: 1
-      type: Transform
   - uid: 822
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -6.5,0.5
       parent: 1
-      type: Transform
   - uid: 823
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -6.5,1.5
       parent: 1
-      type: Transform
   - uid: 824
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -5.5,1.5
       parent: 1
-      type: Transform
   - uid: 825
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -5.5,2.5
       parent: 1
-      type: Transform
   - uid: 826
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -4.5,2.5
       parent: 1
-      type: Transform
   - uid: 827
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -4.5,3.5
       parent: 1
-      type: Transform
   - uid: 828
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -4.5,4.5
       parent: 1
-      type: Transform
   - uid: 829
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -3.5,3.5
       parent: 1
-      type: Transform
   - uid: 830
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -3.5,4.5
       parent: 1
-      type: Transform
   - uid: 831
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 5.5,4.5
       parent: 1
-      type: Transform
   - uid: 832
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 5.5,3.5
       parent: 1
-      type: Transform
   - uid: 833
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 6.5,4.5
       parent: 1
-      type: Transform
   - uid: 834
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 6.5,3.5
       parent: 1
-      type: Transform
   - uid: 835
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 6.5,2.5
       parent: 1
-      type: Transform
   - uid: 836
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 7.5,2.5
       parent: 1
-      type: Transform
   - uid: 837
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 7.5,1.5
       parent: 1
-      type: Transform
   - uid: 838
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 8.5,1.5
       parent: 1
-      type: Transform
   - uid: 839
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 8.5,0.5
       parent: 1
-      type: Transform
   - uid: 840
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 8.5,-0.5
       parent: 1
-      type: Transform
   - uid: 841
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 8.5,-1.5
       parent: 1
-      type: Transform
   - uid: 842
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 8.5,-2.5
       parent: 1
-      type: Transform
   - uid: 843
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 8.5,-3.5
       parent: 1
-      type: Transform
   - uid: 844
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 8.5,-4.5
       parent: 1
-      type: Transform
   - uid: 845
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 8.5,-5.5
       parent: 1
-      type: Transform
   - uid: 846
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 8.5,-6.5
       parent: 1
-      type: Transform
   - uid: 847
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 8.5,-7.5
       parent: 1
-      type: Transform
   - uid: 848
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 8.5,-8.5
       parent: 1
-      type: Transform
   - uid: 849
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 8.5,-9.5
       parent: 1
-      type: Transform
   - uid: 850
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 8.5,-10.5
       parent: 1
-      type: Transform
   - uid: 851
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 8.5,-11.5
       parent: 1
-      type: Transform
   - uid: 852
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 8.5,-12.5
       parent: 1
-      type: Transform
   - uid: 853
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 8.5,-13.5
       parent: 1
-      type: Transform
   - uid: 854
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 8.5,-14.5
       parent: 1
-      type: Transform
   - uid: 855
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 7.5,-14.5
       parent: 1
-      type: Transform
   - uid: 856
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 7.5,-15.5
       parent: 1
-      type: Transform
   - uid: 857
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 5.5,-18.5
       parent: 1
-      type: Transform
   - uid: 858
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 4.5,-18.5
       parent: 1
-      type: Transform
   - uid: 859
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 3.5,-18.5
       parent: 1
-      type: Transform
   - uid: 860
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -3.5,-18.5
       parent: 1
-      type: Transform
   - uid: 861
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -2.5,-18.5
       parent: 1
-      type: Transform
   - uid: 862
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -1.5,-18.5
       parent: 1
-      type: Transform
   - uid: 863
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -5.5,-6.5
       parent: 1
-      type: Transform
   - uid: 864
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 7.5,-6.5
       parent: 1
-      type: Transform
 - proto: BenchPewLeft
   entities:
   - uid: 489
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 2.5,-5.5
       parent: 1
-      type: Transform
-    - bodyType: Static
-      type: Physics
+    - type: Physics
+      bodyType: Static
   - uid: 490
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 2.5,-3.5
       parent: 1
-      type: Transform
-    - bodyType: Static
-      type: Physics
+    - type: Physics
+      bodyType: Static
   - uid: 495
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 2.5,-7.5
       parent: 1
-      type: Transform
-    - bodyType: Static
-      type: Physics
+    - type: Physics
+      bodyType: Static
   - uid: 504
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -1.5,-3.5
       parent: 1
-      type: Transform
-    - bodyType: Static
-      type: Physics
+    - type: Physics
+      bodyType: Static
   - uid: 505
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -2.5,-5.5
       parent: 1
-      type: Transform
-    - bodyType: Static
-      type: Physics
+    - type: Physics
+      bodyType: Static
   - uid: 506
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -2.5,-7.5
       parent: 1
-      type: Transform
-    - bodyType: Static
-      type: Physics
+    - type: Physics
+      bodyType: Static
 - proto: BenchPewMiddle
   entities:
   - uid: 496
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -1.5,-5.5
       parent: 1
-      type: Transform
-    - bodyType: Static
-      type: Physics
+    - type: Physics
+      bodyType: Static
   - uid: 497
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -1.5,-7.5
       parent: 1
-      type: Transform
-    - bodyType: Static
-      type: Physics
+    - type: Physics
+      bodyType: Static
 - proto: BenchPewRight
   entities:
   - uid: 498
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 3.5,-5.5
       parent: 1
-      type: Transform
-    - bodyType: Static
-      type: Physics
+    - type: Physics
+      bodyType: Static
   - uid: 499
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 3.5,-7.5
       parent: 1
-      type: Transform
-    - bodyType: Static
-      type: Physics
+    - type: Physics
+      bodyType: Static
   - uid: 500
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 3.5,-3.5
       parent: 1
-      type: Transform
-    - bodyType: Static
-      type: Physics
+    - type: Physics
+      bodyType: Static
   - uid: 501
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -0.5,-7.5
       parent: 1
-      type: Transform
-    - bodyType: Static
-      type: Physics
+    - type: Physics
+      bodyType: Static
   - uid: 502
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -0.5,-5.5
       parent: 1
-      type: Transform
-    - bodyType: Static
-      type: Physics
+    - type: Physics
+      bodyType: Static
   - uid: 503
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -0.5,-3.5
       parent: 1
-      type: Transform
-    - bodyType: Static
-      type: Physics
+    - type: Physics
+      bodyType: Static
 - proto: Bible
   entities:
-  - uid: 511
+  - uid: 323
     components:
-    - rot: 3.141592653589793 rad
-      pos: 1.015625,-0.40625
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.03125,-0.421875
       parent: 1
-      type: Transform
-    - storageUsed: 10
-      type: Storage
-    - containers:
-        storagebase: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 512
-      type: ContainerContainer
 - proto: BlastDoor
   entities:
   - uid: 762
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 6.5,-6.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 905
-      type: DeviceLinkSink
 - proto: BoxBodyBag
   entities:
   - uid: 907
     components:
-    - pos: 4.303397,-13.613676
+    - type: Transform
+      pos: 4.303397,-13.613676
       parent: 1
-      type: Transform
 - proto: BoxFolderBlack
   entities:
   - uid: 763
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -1.6598933,-10.886158
       parent: 1
-      type: Transform
   - uid: 764
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -1.4411433,-11.042408
       parent: 1
-      type: Transform
 - proto: CableApcExtension
   entities:
   - uid: 614
     components:
-    - pos: -3.5,-18.5
+    - type: Transform
+      pos: -3.5,-18.5
       parent: 1
-      type: Transform
   - uid: 615
     components:
-    - pos: -2.5,-18.5
+    - type: Transform
+      pos: -2.5,-18.5
       parent: 1
-      type: Transform
   - uid: 616
     components:
-    - pos: -1.5,-18.5
+    - type: Transform
+      pos: -1.5,-18.5
       parent: 1
-      type: Transform
   - uid: 617
     components:
-    - pos: -2.5,-17.5
+    - type: Transform
+      pos: -2.5,-17.5
       parent: 1
-      type: Transform
   - uid: 618
     components:
-    - pos: -2.5,-16.5
+    - type: Transform
+      pos: -2.5,-16.5
       parent: 1
-      type: Transform
   - uid: 619
     components:
-    - pos: -2.5,-15.5
+    - type: Transform
+      pos: -2.5,-15.5
       parent: 1
-      type: Transform
   - uid: 620
     components:
-    - pos: -3.5,-15.5
+    - type: Transform
+      pos: -3.5,-15.5
       parent: 1
-      type: Transform
   - uid: 621
     components:
-    - pos: -3.5,-14.5
+    - type: Transform
+      pos: -3.5,-14.5
       parent: 1
-      type: Transform
   - uid: 622
     components:
-    - pos: 4.5,-13.5
+    - type: Transform
+      pos: 4.5,-13.5
       parent: 1
-      type: Transform
   - uid: 623
     components:
-    - pos: 4.5,-14.5
+    - type: Transform
+      pos: 4.5,-14.5
       parent: 1
-      type: Transform
   - uid: 624
     components:
-    - pos: 4.5,-15.5
+    - type: Transform
+      pos: 4.5,-15.5
       parent: 1
-      type: Transform
   - uid: 625
     components:
-    - pos: 4.5,-16.5
+    - type: Transform
+      pos: 4.5,-16.5
       parent: 1
-      type: Transform
   - uid: 626
     components:
-    - pos: 4.5,-17.5
+    - type: Transform
+      pos: 4.5,-17.5
       parent: 1
-      type: Transform
   - uid: 627
     components:
-    - pos: 4.5,-18.5
+    - type: Transform
+      pos: 4.5,-18.5
       parent: 1
-      type: Transform
   - uid: 628
     components:
-    - pos: 3.5,-18.5
+    - type: Transform
+      pos: 3.5,-18.5
       parent: 1
-      type: Transform
   - uid: 629
     components:
-    - pos: 5.5,-18.5
+    - type: Transform
+      pos: 5.5,-18.5
       parent: 1
-      type: Transform
   - uid: 630
     components:
-    - pos: 5.5,-15.5
+    - type: Transform
+      pos: 5.5,-15.5
       parent: 1
-      type: Transform
   - uid: 631
     components:
-    - pos: 6.5,-15.5
+    - type: Transform
+      pos: 6.5,-15.5
       parent: 1
-      type: Transform
   - uid: 632
     components:
-    - pos: 3.5,-14.5
+    - type: Transform
+      pos: 3.5,-14.5
       parent: 1
-      type: Transform
   - uid: 633
     components:
-    - pos: 2.5,-14.5
+    - type: Transform
+      pos: 2.5,-14.5
       parent: 1
-      type: Transform
   - uid: 634
     components:
-    - pos: 1.5,-14.5
+    - type: Transform
+      pos: 1.5,-14.5
       parent: 1
-      type: Transform
   - uid: 635
     components:
-    - pos: 1.5,-15.5
+    - type: Transform
+      pos: 1.5,-15.5
       parent: 1
-      type: Transform
   - uid: 636
     components:
-    - pos: 1.5,-16.5
+    - type: Transform
+      pos: 1.5,-16.5
       parent: 1
-      type: Transform
   - uid: 637
     components:
-    - pos: 1.5,-17.5
+    - type: Transform
+      pos: 1.5,-17.5
       parent: 1
-      type: Transform
   - uid: 638
     components:
-    - pos: 1.5,-18.5
+    - type: Transform
+      pos: 1.5,-18.5
       parent: 1
-      type: Transform
   - uid: 639
     components:
-    - pos: -1.5,-15.5
+    - type: Transform
+      pos: -1.5,-15.5
       parent: 1
-      type: Transform
   - uid: 640
     components:
-    - pos: -1.5,-14.5
+    - type: Transform
+      pos: -1.5,-14.5
       parent: 1
-      type: Transform
   - uid: 641
     components:
-    - pos: -0.5,-14.5
+    - type: Transform
+      pos: -0.5,-14.5
       parent: 1
-      type: Transform
   - uid: 642
     components:
-    - pos: -2.5,4.5
+    - type: Transform
+      pos: -2.5,4.5
       parent: 1
-      type: Transform
   - uid: 643
     components:
-    - pos: -3.5,4.5
+    - type: Transform
+      pos: -3.5,4.5
       parent: 1
-      type: Transform
   - uid: 644
     components:
-    - pos: -4.5,4.5
+    - type: Transform
+      pos: -4.5,4.5
       parent: 1
-      type: Transform
   - uid: 645
     components:
-    - pos: -4.5,3.5
+    - type: Transform
+      pos: -4.5,3.5
       parent: 1
-      type: Transform
   - uid: 646
     components:
-    - pos: -1.5,4.5
+    - type: Transform
+      pos: -1.5,4.5
       parent: 1
-      type: Transform
   - uid: 647
     components:
-    - pos: -0.5,4.5
+    - type: Transform
+      pos: -0.5,4.5
       parent: 1
-      type: Transform
   - uid: 648
     components:
-    - pos: 0.5,4.5
+    - type: Transform
+      pos: 0.5,4.5
       parent: 1
-      type: Transform
   - uid: 649
     components:
-    - pos: 0.5,5.5
+    - type: Transform
+      pos: 0.5,5.5
       parent: 1
-      type: Transform
   - uid: 650
     components:
-    - pos: 1.5,5.5
+    - type: Transform
+      pos: 1.5,5.5
       parent: 1
-      type: Transform
   - uid: 651
     components:
-    - pos: 2.5,5.5
+    - type: Transform
+      pos: 2.5,5.5
       parent: 1
-      type: Transform
   - uid: 652
     components:
-    - pos: 3.5,5.5
+    - type: Transform
+      pos: 3.5,5.5
       parent: 1
-      type: Transform
   - uid: 653
     components:
-    - pos: 3.5,4.5
+    - type: Transform
+      pos: 3.5,4.5
       parent: 1
-      type: Transform
   - uid: 654
     components:
-    - pos: 4.5,4.5
+    - type: Transform
+      pos: 4.5,4.5
       parent: 1
-      type: Transform
   - uid: 655
     components:
-    - pos: 5.5,4.5
+    - type: Transform
+      pos: 5.5,4.5
       parent: 1
-      type: Transform
   - uid: 656
     components:
-    - pos: 6.5,4.5
+    - type: Transform
+      pos: 6.5,4.5
       parent: 1
-      type: Transform
   - uid: 657
     components:
-    - pos: 6.5,3.5
+    - type: Transform
+      pos: 6.5,3.5
       parent: 1
-      type: Transform
   - uid: 658
     components:
-    - pos: -0.5,3.5
+    - type: Transform
+      pos: -0.5,3.5
       parent: 1
-      type: Transform
   - uid: 659
     components:
-    - pos: -0.5,2.5
+    - type: Transform
+      pos: -0.5,2.5
       parent: 1
-      type: Transform
   - uid: 660
     components:
-    - pos: -0.5,1.5
+    - type: Transform
+      pos: -0.5,1.5
       parent: 1
-      type: Transform
   - uid: 661
     components:
-    - pos: -0.5,0.5
+    - type: Transform
+      pos: -0.5,0.5
       parent: 1
-      type: Transform
   - uid: 662
     components:
-    - pos: -0.5,-0.5
+    - type: Transform
+      pos: -0.5,-0.5
       parent: 1
-      type: Transform
   - uid: 663
     components:
-    - pos: -0.5,-1.5
+    - type: Transform
+      pos: -0.5,-1.5
       parent: 1
-      type: Transform
   - uid: 664
     components:
-    - pos: -0.5,-2.5
+    - type: Transform
+      pos: -0.5,-2.5
       parent: 1
-      type: Transform
   - uid: 665
     components:
-    - pos: -0.5,-3.5
+    - type: Transform
+      pos: -0.5,-3.5
       parent: 1
-      type: Transform
   - uid: 666
     components:
-    - pos: -0.5,-4.5
+    - type: Transform
+      pos: -0.5,-4.5
       parent: 1
-      type: Transform
   - uid: 667
     components:
-    - pos: -0.5,-5.5
+    - type: Transform
+      pos: -0.5,-5.5
       parent: 1
-      type: Transform
   - uid: 668
     components:
-    - pos: -0.5,-6.5
+    - type: Transform
+      pos: -0.5,-6.5
       parent: 1
-      type: Transform
   - uid: 669
     components:
-    - pos: -0.5,-7.5
+    - type: Transform
+      pos: -0.5,-7.5
       parent: 1
-      type: Transform
   - uid: 670
     components:
-    - pos: -0.5,-8.5
+    - type: Transform
+      pos: -0.5,-8.5
       parent: 1
-      type: Transform
   - uid: 671
     components:
-    - pos: -0.5,-9.5
+    - type: Transform
+      pos: -0.5,-9.5
       parent: 1
-      type: Transform
   - uid: 672
     components:
-    - pos: -0.5,-10.5
+    - type: Transform
+      pos: -0.5,-10.5
       parent: 1
-      type: Transform
   - uid: 673
     components:
-    - pos: -0.5,-11.5
+    - type: Transform
+      pos: -0.5,-11.5
       parent: 1
-      type: Transform
   - uid: 674
     components:
-    - pos: 0.5,-8.5
+    - type: Transform
+      pos: 0.5,-8.5
       parent: 1
-      type: Transform
   - uid: 675
     components:
-    - pos: 1.5,-8.5
+    - type: Transform
+      pos: 1.5,-8.5
       parent: 1
-      type: Transform
   - uid: 676
     components:
-    - pos: 2.5,-8.5
+    - type: Transform
+      pos: 2.5,-8.5
       parent: 1
-      type: Transform
   - uid: 677
     components:
-    - pos: 3.5,-8.5
+    - type: Transform
+      pos: 3.5,-8.5
       parent: 1
-      type: Transform
   - uid: 678
     components:
-    - pos: 4.5,-8.5
+    - type: Transform
+      pos: 4.5,-8.5
       parent: 1
-      type: Transform
   - uid: 679
     components:
-    - pos: 5.5,-8.5
+    - type: Transform
+      pos: 5.5,-8.5
       parent: 1
-      type: Transform
   - uid: 680
     components:
-    - pos: -1.5,-8.5
+    - type: Transform
+      pos: -1.5,-8.5
       parent: 1
-      type: Transform
   - uid: 681
     components:
-    - pos: -2.5,-8.5
+    - type: Transform
+      pos: -2.5,-8.5
       parent: 1
-      type: Transform
   - uid: 682
     components:
-    - pos: -3.5,-8.5
+    - type: Transform
+      pos: -3.5,-8.5
       parent: 1
-      type: Transform
   - uid: 683
     components:
-    - pos: -2.5,-4.5
+    - type: Transform
+      pos: -2.5,-4.5
       parent: 1
-      type: Transform
   - uid: 684
     components:
-    - pos: -1.5,-4.5
+    - type: Transform
+      pos: -1.5,-4.5
       parent: 1
-      type: Transform
   - uid: 685
     components:
-    - pos: 0.5,-4.5
+    - type: Transform
+      pos: 0.5,-4.5
       parent: 1
-      type: Transform
   - uid: 686
     components:
-    - pos: 1.5,-4.5
+    - type: Transform
+      pos: 1.5,-4.5
       parent: 1
-      type: Transform
   - uid: 687
     components:
-    - pos: 2.5,-4.5
+    - type: Transform
+      pos: 2.5,-4.5
       parent: 1
-      type: Transform
   - uid: 688
     components:
-    - pos: 3.5,-4.5
+    - type: Transform
+      pos: 3.5,-4.5
       parent: 1
-      type: Transform
   - uid: 689
     components:
-    - pos: 4.5,-4.5
+    - type: Transform
+      pos: 4.5,-4.5
       parent: 1
-      type: Transform
   - uid: 690
     components:
-    - pos: 3.5,-1.5
+    - type: Transform
+      pos: 3.5,-1.5
       parent: 1
-      type: Transform
   - uid: 691
     components:
-    - pos: 2.5,-1.5
+    - type: Transform
+      pos: 2.5,-1.5
       parent: 1
-      type: Transform
   - uid: 692
     components:
-    - pos: 1.5,-1.5
+    - type: Transform
+      pos: 1.5,-1.5
       parent: 1
-      type: Transform
   - uid: 693
     components:
-    - pos: 0.5,-1.5
+    - type: Transform
+      pos: 0.5,-1.5
       parent: 1
-      type: Transform
   - uid: 694
     components:
-    - pos: -1.5,-1.5
+    - type: Transform
+      pos: -1.5,-1.5
       parent: 1
-      type: Transform
   - uid: 695
     components:
-    - pos: 0.5,0.5
+    - type: Transform
+      pos: 0.5,0.5
       parent: 1
-      type: Transform
   - uid: 696
     components:
-    - pos: 1.5,0.5
+    - type: Transform
+      pos: 1.5,0.5
       parent: 1
-      type: Transform
   - uid: 697
     components:
-    - pos: 2.5,0.5
+    - type: Transform
+      pos: 2.5,0.5
       parent: 1
-      type: Transform
   - uid: 750
     components:
-    - pos: 0.5,-6.5
+    - type: Transform
+      pos: 0.5,-6.5
       parent: 1
-      type: Transform
   - uid: 751
     components:
-    - pos: 1.5,-6.5
+    - type: Transform
+      pos: 1.5,-6.5
       parent: 1
-      type: Transform
   - uid: 752
     components:
-    - pos: 2.5,-6.5
+    - type: Transform
+      pos: 2.5,-6.5
       parent: 1
-      type: Transform
   - uid: 753
     components:
-    - pos: 3.5,-6.5
+    - type: Transform
+      pos: 3.5,-6.5
       parent: 1
-      type: Transform
   - uid: 754
     components:
-    - pos: 4.5,-6.5
+    - type: Transform
+      pos: 4.5,-6.5
       parent: 1
-      type: Transform
   - uid: 755
     components:
-    - pos: 5.5,-6.5
+    - type: Transform
+      pos: 5.5,-6.5
       parent: 1
-      type: Transform
   - uid: 756
     components:
-    - pos: 6.5,-6.5
+    - type: Transform
+      pos: 6.5,-6.5
       parent: 1
-      type: Transform
   - uid: 792
     components:
-    - pos: 7.5,-6.5
+    - type: Transform
+      pos: 7.5,-6.5
       parent: 1
-      type: Transform
   - uid: 793
     components:
-    - pos: 8.5,-6.5
+    - type: Transform
+      pos: 8.5,-6.5
       parent: 1
-      type: Transform
   - uid: 795
     components:
-    - pos: 4.5,-12.5
+    - type: Transform
+      pos: 4.5,-12.5
       parent: 1
-      type: Transform
   - uid: 796
     components:
-    - pos: -3.5,-13.5
+    - type: Transform
+      pos: -3.5,-13.5
       parent: 1
-      type: Transform
 - proto: CableHV
   entities:
   - uid: 2
     components:
-    - pos: 7.5,-15.5
+    - type: Transform
+      pos: 7.5,-15.5
       parent: 1
-      type: Transform
   - uid: 110
     components:
-    - pos: -1.5,-15.5
+    - type: Transform
+      pos: -1.5,-15.5
       parent: 1
-      type: Transform
   - uid: 247
     components:
-    - pos: -4.5,3.5
+    - type: Transform
+      pos: -4.5,3.5
       parent: 1
-      type: Transform
   - uid: 248
     components:
-    - pos: -4.5,2.5
+    - type: Transform
+      pos: -4.5,2.5
       parent: 1
-      type: Transform
   - uid: 249
     components:
-    - pos: -5.5,2.5
+    - type: Transform
+      pos: -5.5,2.5
       parent: 1
-      type: Transform
   - uid: 250
     components:
-    - pos: -5.5,1.5
+    - type: Transform
+      pos: -5.5,1.5
       parent: 1
-      type: Transform
   - uid: 251
     components:
-    - pos: -6.5,1.5
+    - type: Transform
+      pos: -6.5,1.5
       parent: 1
-      type: Transform
   - uid: 252
     components:
-    - pos: -6.5,0.5
+    - type: Transform
+      pos: -6.5,0.5
       parent: 1
-      type: Transform
   - uid: 253
     components:
-    - pos: -6.5,-0.5
+    - type: Transform
+      pos: -6.5,-0.5
       parent: 1
-      type: Transform
   - uid: 254
     components:
-    - pos: -6.5,-1.5
+    - type: Transform
+      pos: -6.5,-1.5
       parent: 1
-      type: Transform
   - uid: 255
     components:
-    - pos: -6.5,-2.5
+    - type: Transform
+      pos: -6.5,-2.5
       parent: 1
-      type: Transform
   - uid: 256
     components:
-    - pos: -6.5,-3.5
+    - type: Transform
+      pos: -6.5,-3.5
       parent: 1
-      type: Transform
   - uid: 257
     components:
-    - pos: -6.5,-4.5
+    - type: Transform
+      pos: -6.5,-4.5
       parent: 1
-      type: Transform
   - uid: 258
     components:
-    - pos: -6.5,-5.5
+    - type: Transform
+      pos: -6.5,-5.5
       parent: 1
-      type: Transform
   - uid: 259
     components:
-    - pos: -6.5,-6.5
+    - type: Transform
+      pos: -6.5,-6.5
       parent: 1
-      type: Transform
   - uid: 260
     components:
-    - pos: -6.5,-7.5
+    - type: Transform
+      pos: -6.5,-7.5
       parent: 1
-      type: Transform
   - uid: 261
     components:
-    - pos: -6.5,-8.5
+    - type: Transform
+      pos: -6.5,-8.5
       parent: 1
-      type: Transform
   - uid: 262
     components:
-    - pos: -6.5,-9.5
+    - type: Transform
+      pos: -6.5,-9.5
       parent: 1
-      type: Transform
   - uid: 263
     components:
-    - pos: -6.5,-10.5
+    - type: Transform
+      pos: -6.5,-10.5
       parent: 1
-      type: Transform
   - uid: 264
     components:
-    - pos: -6.5,-11.5
+    - type: Transform
+      pos: -6.5,-11.5
       parent: 1
-      type: Transform
   - uid: 265
     components:
-    - pos: -6.5,-12.5
+    - type: Transform
+      pos: -6.5,-12.5
       parent: 1
-      type: Transform
   - uid: 266
     components:
-    - pos: -6.5,-13.5
+    - type: Transform
+      pos: -6.5,-13.5
       parent: 1
-      type: Transform
   - uid: 267
     components:
-    - pos: -6.5,-14.5
+    - type: Transform
+      pos: -6.5,-14.5
       parent: 1
-      type: Transform
   - uid: 268
     components:
-    - pos: -5.5,-14.5
+    - type: Transform
+      pos: -5.5,-14.5
       parent: 1
-      type: Transform
   - uid: 269
     components:
-    - pos: -5.5,-15.5
+    - type: Transform
+      pos: -5.5,-15.5
       parent: 1
-      type: Transform
   - uid: 270
     components:
-    - pos: 7.5,-14.5
+    - type: Transform
+      pos: 7.5,-14.5
       parent: 1
-      type: Transform
   - uid: 271
     components:
-    - pos: 8.5,-14.5
+    - type: Transform
+      pos: 8.5,-14.5
       parent: 1
-      type: Transform
   - uid: 272
     components:
-    - pos: 8.5,-13.5
+    - type: Transform
+      pos: 8.5,-13.5
       parent: 1
-      type: Transform
   - uid: 273
     components:
-    - pos: 8.5,-12.5
+    - type: Transform
+      pos: 8.5,-12.5
       parent: 1
-      type: Transform
   - uid: 274
     components:
-    - pos: 8.5,-11.5
+    - type: Transform
+      pos: 8.5,-11.5
       parent: 1
-      type: Transform
   - uid: 275
     components:
-    - pos: 8.5,-10.5
+    - type: Transform
+      pos: 8.5,-10.5
       parent: 1
-      type: Transform
   - uid: 276
     components:
-    - pos: 8.5,-9.5
+    - type: Transform
+      pos: 8.5,-9.5
       parent: 1
-      type: Transform
   - uid: 277
     components:
-    - pos: 8.5,-8.5
+    - type: Transform
+      pos: 8.5,-8.5
       parent: 1
-      type: Transform
   - uid: 278
     components:
-    - pos: 8.5,-7.5
+    - type: Transform
+      pos: 8.5,-7.5
       parent: 1
-      type: Transform
   - uid: 279
     components:
-    - pos: 8.5,-6.5
+    - type: Transform
+      pos: 8.5,-6.5
       parent: 1
-      type: Transform
   - uid: 280
     components:
-    - pos: 8.5,-5.5
+    - type: Transform
+      pos: 8.5,-5.5
       parent: 1
-      type: Transform
   - uid: 281
     components:
-    - pos: 8.5,-4.5
+    - type: Transform
+      pos: 8.5,-4.5
       parent: 1
-      type: Transform
   - uid: 282
     components:
-    - pos: 8.5,-3.5
+    - type: Transform
+      pos: 8.5,-3.5
       parent: 1
-      type: Transform
   - uid: 283
     components:
-    - pos: 8.5,-2.5
+    - type: Transform
+      pos: 8.5,-2.5
       parent: 1
-      type: Transform
   - uid: 284
     components:
-    - pos: 8.5,-1.5
+    - type: Transform
+      pos: 8.5,-1.5
       parent: 1
-      type: Transform
   - uid: 285
     components:
-    - pos: 8.5,-0.5
+    - type: Transform
+      pos: 8.5,-0.5
       parent: 1
-      type: Transform
   - uid: 286
     components:
-    - pos: 8.5,0.5
+    - type: Transform
+      pos: 8.5,0.5
       parent: 1
-      type: Transform
   - uid: 287
     components:
-    - pos: 8.5,1.5
+    - type: Transform
+      pos: 8.5,1.5
       parent: 1
-      type: Transform
   - uid: 288
     components:
-    - pos: 7.5,1.5
+    - type: Transform
+      pos: 7.5,1.5
       parent: 1
-      type: Transform
   - uid: 289
     components:
-    - pos: 7.5,2.5
+    - type: Transform
+      pos: 7.5,2.5
       parent: 1
-      type: Transform
   - uid: 290
     components:
-    - pos: 6.5,2.5
+    - type: Transform
+      pos: 6.5,2.5
       parent: 1
-      type: Transform
   - uid: 291
     components:
-    - pos: 6.5,3.5
+    - type: Transform
+      pos: 6.5,3.5
       parent: 1
-      type: Transform
   - uid: 324
     components:
-    - pos: -2.5,-15.5
+    - type: Transform
+      pos: -2.5,-15.5
       parent: 1
-      type: Transform
   - uid: 329
     components:
-    - pos: -0.5,-14.5
+    - type: Transform
+      pos: -0.5,-14.5
       parent: 1
-      type: Transform
   - uid: 330
     components:
-    - pos: 0.5,-14.5
+    - type: Transform
+      pos: 0.5,-14.5
       parent: 1
-      type: Transform
   - uid: 331
     components:
-    - pos: 1.5,-14.5
+    - type: Transform
+      pos: 1.5,-14.5
       parent: 1
-      type: Transform
   - uid: 332
     components:
-    - pos: 2.5,-14.5
+    - type: Transform
+      pos: 2.5,-14.5
       parent: 1
-      type: Transform
   - uid: 333
     components:
-    - pos: 3.5,-14.5
+    - type: Transform
+      pos: 3.5,-14.5
       parent: 1
-      type: Transform
   - uid: 334
     components:
-    - pos: 4.5,-14.5
+    - type: Transform
+      pos: 4.5,-14.5
       parent: 1
-      type: Transform
   - uid: 335
     components:
-    - pos: 4.5,-15.5
+    - type: Transform
+      pos: 4.5,-15.5
       parent: 1
-      type: Transform
   - uid: 336
     components:
-    - pos: 5.5,-15.5
+    - type: Transform
+      pos: 5.5,-15.5
       parent: 1
-      type: Transform
   - uid: 337
     components:
-    - pos: 6.5,-15.5
+    - type: Transform
+      pos: 6.5,-15.5
       parent: 1
-      type: Transform
   - uid: 338
     components:
-    - pos: -4.5,-15.5
+    - type: Transform
+      pos: -4.5,-15.5
       parent: 1
-      type: Transform
   - uid: 339
     components:
-    - pos: -3.5,-15.5
+    - type: Transform
+      pos: -3.5,-15.5
       parent: 1
-      type: Transform
   - uid: 342
     components:
-    - pos: -1.5,-13.5
+    - type: Transform
+      pos: -1.5,-13.5
       parent: 1
-      type: Transform
   - uid: 343
     components:
-    - pos: -2.5,-13.5
+    - type: Transform
+      pos: -2.5,-13.5
       parent: 1
-      type: Transform
   - uid: 383
     components:
-    - pos: -3.5,-16.5
+    - type: Transform
+      pos: -3.5,-16.5
       parent: 1
-      type: Transform
   - uid: 408
     components:
-    - pos: -0.5,6.5
+    - type: Transform
+      pos: -0.5,6.5
       parent: 1
-      type: Transform
   - uid: 410
     components:
-    - pos: -0.5,5.5
+    - type: Transform
+      pos: -0.5,5.5
       parent: 1
-      type: Transform
   - uid: 411
     components:
-    - pos: -0.5,4.5
+    - type: Transform
+      pos: -0.5,4.5
       parent: 1
-      type: Transform
   - uid: 412
     components:
-    - pos: -1.5,4.5
+    - type: Transform
+      pos: -1.5,4.5
       parent: 1
-      type: Transform
   - uid: 413
     components:
-    - pos: -2.5,4.5
+    - type: Transform
+      pos: -2.5,4.5
       parent: 1
-      type: Transform
   - uid: 414
     components:
-    - pos: -3.5,4.5
+    - type: Transform
+      pos: -3.5,4.5
       parent: 1
-      type: Transform
   - uid: 415
     components:
-    - pos: -4.5,4.5
+    - type: Transform
+      pos: -4.5,4.5
       parent: 1
-      type: Transform
   - uid: 582
     components:
-    - pos: -1.5,-14.5
+    - type: Transform
+      pos: -1.5,-14.5
       parent: 1
-      type: Transform
   - uid: 783
     components:
-    - pos: 0.5,5.5
+    - type: Transform
+      pos: 0.5,5.5
       parent: 1
-      type: Transform
   - uid: 784
     components:
-    - pos: 1.5,5.5
+    - type: Transform
+      pos: 1.5,5.5
       parent: 1
-      type: Transform
   - uid: 785
     components:
-    - pos: 2.5,5.5
+    - type: Transform
+      pos: 2.5,5.5
       parent: 1
-      type: Transform
   - uid: 786
     components:
-    - pos: 3.5,5.5
+    - type: Transform
+      pos: 3.5,5.5
       parent: 1
-      type: Transform
   - uid: 787
     components:
-    - pos: 4.5,5.5
+    - type: Transform
+      pos: 4.5,5.5
       parent: 1
-      type: Transform
   - uid: 788
     components:
-    - pos: 4.5,4.5
+    - type: Transform
+      pos: 4.5,4.5
       parent: 1
-      type: Transform
   - uid: 789
     components:
-    - pos: 5.5,4.5
+    - type: Transform
+      pos: 5.5,4.5
       parent: 1
-      type: Transform
   - uid: 790
     components:
-    - pos: 6.5,4.5
+    - type: Transform
+      pos: 6.5,4.5
       parent: 1
-      type: Transform
 - proto: CableMV
   entities:
   - uid: 341
     components:
-    - pos: -3.5,-13.5
+    - type: Transform
+      pos: -3.5,-13.5
       parent: 1
-      type: Transform
   - uid: 579
     components:
-    - pos: -3.5,-14.5
+    - type: Transform
+      pos: -3.5,-14.5
       parent: 1
-      type: Transform
   - uid: 583
     components:
-    - pos: -1.5,-14.5
+    - type: Transform
+      pos: -1.5,-14.5
       parent: 1
-      type: Transform
   - uid: 584
     components:
-    - pos: -2.5,-14.5
+    - type: Transform
+      pos: -2.5,-14.5
       parent: 1
-      type: Transform
   - uid: 585
     components:
-    - pos: -0.5,-14.5
+    - type: Transform
+      pos: -0.5,-14.5
       parent: 1
-      type: Transform
   - uid: 586
     components:
-    - pos: 0.5,-14.5
+    - type: Transform
+      pos: 0.5,-14.5
       parent: 1
-      type: Transform
   - uid: 587
     components:
-    - pos: 1.5,-14.5
+    - type: Transform
+      pos: 1.5,-14.5
       parent: 1
-      type: Transform
   - uid: 588
     components:
-    - pos: 2.5,-14.5
+    - type: Transform
+      pos: 2.5,-14.5
       parent: 1
-      type: Transform
   - uid: 589
     components:
-    - pos: 3.5,-14.5
+    - type: Transform
+      pos: 3.5,-14.5
       parent: 1
-      type: Transform
   - uid: 590
     components:
-    - pos: 4.5,-14.5
+    - type: Transform
+      pos: 4.5,-14.5
       parent: 1
-      type: Transform
   - uid: 591
     components:
-    - pos: 4.5,-13.5
+    - type: Transform
+      pos: 4.5,-13.5
       parent: 1
-      type: Transform
   - uid: 592
     components:
-    - pos: 0.5,-13.5
+    - type: Transform
+      pos: 0.5,-13.5
       parent: 1
-      type: Transform
   - uid: 593
     components:
-    - pos: 0.5,-12.5
+    - type: Transform
+      pos: 0.5,-12.5
       parent: 1
-      type: Transform
   - uid: 594
     components:
-    - pos: 0.5,-11.5
+    - type: Transform
+      pos: 0.5,-11.5
       parent: 1
-      type: Transform
   - uid: 595
     components:
-    - pos: 0.5,-10.5
+    - type: Transform
+      pos: 0.5,-10.5
       parent: 1
-      type: Transform
   - uid: 596
     components:
-    - pos: 0.5,-9.5
+    - type: Transform
+      pos: 0.5,-9.5
       parent: 1
-      type: Transform
   - uid: 597
     components:
-    - pos: 0.5,-8.5
+    - type: Transform
+      pos: 0.5,-8.5
       parent: 1
-      type: Transform
   - uid: 598
     components:
-    - pos: 0.5,-7.5
+    - type: Transform
+      pos: 0.5,-7.5
       parent: 1
-      type: Transform
   - uid: 599
     components:
-    - pos: 0.5,-6.5
+    - type: Transform
+      pos: 0.5,-6.5
       parent: 1
-      type: Transform
   - uid: 600
     components:
-    - pos: 0.5,-5.5
+    - type: Transform
+      pos: 0.5,-5.5
       parent: 1
-      type: Transform
   - uid: 601
     components:
-    - pos: 0.5,-4.5
+    - type: Transform
+      pos: 0.5,-4.5
       parent: 1
-      type: Transform
   - uid: 602
     components:
-    - pos: 0.5,-3.5
+    - type: Transform
+      pos: 0.5,-3.5
       parent: 1
-      type: Transform
   - uid: 603
     components:
-    - pos: 0.5,-2.5
+    - type: Transform
+      pos: 0.5,-2.5
       parent: 1
-      type: Transform
   - uid: 604
     components:
-    - pos: 0.5,-1.5
+    - type: Transform
+      pos: 0.5,-1.5
       parent: 1
-      type: Transform
   - uid: 605
     components:
-    - pos: 0.5,-0.5
+    - type: Transform
+      pos: 0.5,-0.5
       parent: 1
-      type: Transform
   - uid: 606
     components:
-    - pos: 0.5,0.5
+    - type: Transform
+      pos: 0.5,0.5
       parent: 1
-      type: Transform
   - uid: 607
     components:
-    - pos: 0.5,1.5
+    - type: Transform
+      pos: 0.5,1.5
       parent: 1
-      type: Transform
   - uid: 608
     components:
-    - pos: -0.5,1.5
+    - type: Transform
+      pos: -0.5,1.5
       parent: 1
-      type: Transform
   - uid: 609
     components:
-    - pos: -0.5,2.5
+    - type: Transform
+      pos: -0.5,2.5
       parent: 1
-      type: Transform
   - uid: 610
     components:
-    - pos: -0.5,3.5
+    - type: Transform
+      pos: -0.5,3.5
       parent: 1
-      type: Transform
   - uid: 611
     components:
-    - pos: -0.5,4.5
+    - type: Transform
+      pos: -0.5,4.5
       parent: 1
-      type: Transform
   - uid: 612
     components:
-    - pos: -1.5,4.5
+    - type: Transform
+      pos: -1.5,4.5
       parent: 1
-      type: Transform
   - uid: 613
     components:
-    - pos: -2.5,4.5
+    - type: Transform
+      pos: -2.5,4.5
       parent: 1
-      type: Transform
   - uid: 713
     components:
-    - pos: -2.5,-13.5
+    - type: Transform
+      pos: -2.5,-13.5
       parent: 1
-      type: Transform
   - uid: 782
     components:
-    - pos: 4.5,-12.5
+    - type: Transform
+      pos: 4.5,-12.5
       parent: 1
-      type: Transform
 - proto: CableTerminal
   entities:
   - uid: 340
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -1.5,-14.5
       parent: 1
-      type: Transform
 - proto: Carpet
   entities:
   - uid: 544
     components:
-    - pos: 0.5,-13.5
+    - type: Transform
+      pos: 0.5,-13.5
       parent: 1
-      type: Transform
   - uid: 545
     components:
-    - pos: 0.5,-12.5
+    - type: Transform
+      pos: 0.5,-12.5
       parent: 1
-      type: Transform
   - uid: 546
     components:
-    - pos: 0.5,-11.5
+    - type: Transform
+      pos: 0.5,-11.5
       parent: 1
-      type: Transform
   - uid: 547
     components:
-    - pos: 0.5,-10.5
+    - type: Transform
+      pos: 0.5,-10.5
       parent: 1
-      type: Transform
   - uid: 548
     components:
-    - pos: 0.5,-9.5
+    - type: Transform
+      pos: 0.5,-9.5
       parent: 1
-      type: Transform
   - uid: 549
     components:
-    - pos: 0.5,-8.5
+    - type: Transform
+      pos: 0.5,-8.5
       parent: 1
-      type: Transform
   - uid: 550
     components:
-    - pos: 0.5,-7.5
+    - type: Transform
+      pos: 0.5,-7.5
       parent: 1
-      type: Transform
   - uid: 551
     components:
-    - pos: 0.5,-6.5
+    - type: Transform
+      pos: 0.5,-6.5
       parent: 1
-      type: Transform
   - uid: 552
     components:
-    - pos: 0.5,-5.5
+    - type: Transform
+      pos: 0.5,-5.5
       parent: 1
-      type: Transform
   - uid: 553
     components:
-    - pos: 0.5,-4.5
+    - type: Transform
+      pos: 0.5,-4.5
       parent: 1
-      type: Transform
   - uid: 554
     components:
-    - pos: 0.5,-3.5
+    - type: Transform
+      pos: 0.5,-3.5
       parent: 1
-      type: Transform
   - uid: 555
     components:
-    - pos: 0.5,-2.5
+    - type: Transform
+      pos: 0.5,-2.5
       parent: 1
-      type: Transform
   - uid: 556
     components:
-    - pos: 0.5,-1.5
+    - type: Transform
+      pos: 0.5,-1.5
       parent: 1
-      type: Transform
   - uid: 557
     components:
-    - pos: 0.5,-0.5
+    - type: Transform
+      pos: 0.5,-0.5
       parent: 1
-      type: Transform
   - uid: 558
     components:
-    - pos: 1.5,-13.5
+    - type: Transform
+      pos: 1.5,-13.5
       parent: 1
-      type: Transform
   - uid: 559
     components:
-    - pos: 1.5,-12.5
+    - type: Transform
+      pos: 1.5,-12.5
       parent: 1
-      type: Transform
   - uid: 560
     components:
-    - pos: 1.5,-11.5
+    - type: Transform
+      pos: 1.5,-11.5
       parent: 1
-      type: Transform
   - uid: 561
     components:
-    - pos: 1.5,-10.5
+    - type: Transform
+      pos: 1.5,-10.5
       parent: 1
-      type: Transform
   - uid: 562
     components:
-    - pos: 1.5,-9.5
+    - type: Transform
+      pos: 1.5,-9.5
       parent: 1
-      type: Transform
   - uid: 563
     components:
-    - pos: 1.5,-8.5
+    - type: Transform
+      pos: 1.5,-8.5
       parent: 1
-      type: Transform
   - uid: 564
     components:
-    - pos: 1.5,-7.5
+    - type: Transform
+      pos: 1.5,-7.5
       parent: 1
-      type: Transform
   - uid: 565
     components:
-    - pos: 1.5,-6.5
+    - type: Transform
+      pos: 1.5,-6.5
       parent: 1
-      type: Transform
   - uid: 566
     components:
-    - pos: 1.5,-5.5
+    - type: Transform
+      pos: 1.5,-5.5
       parent: 1
-      type: Transform
   - uid: 567
     components:
-    - pos: 1.5,-4.5
+    - type: Transform
+      pos: 1.5,-4.5
       parent: 1
-      type: Transform
   - uid: 568
     components:
-    - pos: 1.5,-3.5
+    - type: Transform
+      pos: 1.5,-3.5
       parent: 1
-      type: Transform
   - uid: 569
     components:
-    - pos: 1.5,-2.5
+    - type: Transform
+      pos: 1.5,-2.5
       parent: 1
-      type: Transform
   - uid: 570
     components:
-    - pos: 1.5,-1.5
+    - type: Transform
+      pos: 1.5,-1.5
       parent: 1
-      type: Transform
   - uid: 571
     components:
-    - pos: 1.5,-0.5
+    - type: Transform
+      pos: 1.5,-0.5
       parent: 1
-      type: Transform
 - proto: CarpetChapel
   entities:
   - uid: 384
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 1.5,-16.5
       parent: 1
-      type: Transform
   - uid: 385
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 1.5,-17.5
       parent: 1
-      type: Transform
   - uid: 386
     components:
-    - pos: 0.5,-17.5
+    - type: Transform
+      pos: 0.5,-17.5
       parent: 1
-      type: Transform
   - uid: 387
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 0.5,-16.5
       parent: 1
-      type: Transform
   - uid: 388
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -1.5,-0.5
       parent: 1
-      type: Transform
   - uid: 389
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 2.5,-0.5
       parent: 1
-      type: Transform
   - uid: 390
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 3.5,-0.5
       parent: 1
-      type: Transform
   - uid: 391
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 3.5,-1.5
       parent: 1
-      type: Transform
   - uid: 392
     components:
-    - pos: 2.5,-1.5
+    - type: Transform
+      pos: 2.5,-1.5
       parent: 1
-      type: Transform
   - uid: 393
     components:
-    - pos: -1.5,-1.5
+    - type: Transform
+      pos: -1.5,-1.5
       parent: 1
-      type: Transform
   - uid: 394
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -0.5,-1.5
       parent: 1
-      type: Transform
   - uid: 395
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -0.5,-0.5
       parent: 1
-      type: Transform
   - uid: 417
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -1.5,-2.5
       parent: 1
-      type: Transform
   - uid: 419
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -1.5,-4.5
       parent: 1
-      type: Transform
   - uid: 420
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -1.5,-6.5
       parent: 1
-      type: Transform
   - uid: 421
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -1.5,-8.5
       parent: 1
-      type: Transform
   - uid: 422
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -3.5,-6.5
       parent: 1
-      type: Transform
   - uid: 423
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -3.5,-8.5
       parent: 1
-      type: Transform
   - uid: 424
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 2.5,-2.5
       parent: 1
-      type: Transform
   - uid: 425
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 2.5,-4.5
       parent: 1
-      type: Transform
   - uid: 426
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 2.5,-6.5
       parent: 1
-      type: Transform
   - uid: 427
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 2.5,-8.5
       parent: 1
-      type: Transform
   - uid: 428
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -1.5,-10.5
       parent: 1
-      type: Transform
   - uid: 429
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -0.5,-10.5
       parent: 1
-      type: Transform
   - uid: 430
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -0.5,-8.5
       parent: 1
-      type: Transform
   - uid: 431
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -2.5,-8.5
       parent: 1
-      type: Transform
   - uid: 432
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -2.5,-6.5
       parent: 1
-      type: Transform
   - uid: 433
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -0.5,-6.5
       parent: 1
-      type: Transform
   - uid: 434
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -0.5,-4.5
       parent: 1
-      type: Transform
   - uid: 435
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -0.5,-2.5
       parent: 1
-      type: Transform
   - uid: 436
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 3.5,-2.5
       parent: 1
-      type: Transform
   - uid: 437
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 3.5,-4.5
       parent: 1
-      type: Transform
   - uid: 438
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 3.5,-6.5
       parent: 1
-      type: Transform
   - uid: 439
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 3.5,-8.5
       parent: 1
-      type: Transform
   - uid: 440
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 3.5,-10.5
       parent: 1
-      type: Transform
   - uid: 441
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 5.5,-8.5
       parent: 1
-      type: Transform
   - uid: 443
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -2.5,-4.5
       parent: 1
-      type: Transform
   - uid: 444
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -0.5,-5.5
       parent: 1
-      type: Transform
   - uid: 445
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 3.5,-5.5
       parent: 1
-      type: Transform
   - uid: 446
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 3.5,-7.5
       parent: 1
-      type: Transform
   - uid: 447
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 3.5,-9.5
       parent: 1
-      type: Transform
   - uid: 448
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 3.5,-11.5
       parent: 1
-      type: Transform
   - uid: 449
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -0.5,-11.5
       parent: 1
-      type: Transform
   - uid: 451
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 3.5,-3.5
       parent: 1
-      type: Transform
   - uid: 452
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -0.5,-3.5
       parent: 1
-      type: Transform
   - uid: 453
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -2.5,-5.5
       parent: 1
-      type: Transform
   - uid: 454
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -2.5,-7.5
       parent: 1
-      type: Transform
   - uid: 455
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -2.5,-9.5
       parent: 1
-      type: Transform
   - uid: 456
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -0.5,-9.5
       parent: 1
-      type: Transform
   - uid: 457
     components:
-    - pos: -1.5,-9.5
+    - type: Transform
+      pos: -1.5,-9.5
       parent: 1
-      type: Transform
   - uid: 458
     components:
-    - pos: -1.5,-11.5
+    - type: Transform
+      pos: -1.5,-11.5
       parent: 1
-      type: Transform
   - uid: 459
     components:
-    - pos: -3.5,-7.5
+    - type: Transform
+      pos: -3.5,-7.5
       parent: 1
-      type: Transform
   - uid: 460
     components:
-    - pos: -3.5,-5.5
+    - type: Transform
+      pos: -3.5,-5.5
       parent: 1
-      type: Transform
   - uid: 461
     components:
-    - pos: -1.5,-5.5
+    - type: Transform
+      pos: -1.5,-5.5
       parent: 1
-      type: Transform
   - uid: 462
     components:
-    - pos: -1.5,-7.5
+    - type: Transform
+      pos: -1.5,-7.5
       parent: 1
-      type: Transform
   - uid: 463
     components:
-    - pos: 2.5,-9.5
+    - type: Transform
+      pos: 2.5,-9.5
       parent: 1
-      type: Transform
   - uid: 464
     components:
-    - pos: 2.5,-7.5
+    - type: Transform
+      pos: 2.5,-7.5
       parent: 1
-      type: Transform
   - uid: 465
     components:
-    - pos: 2.5,-5.5
+    - type: Transform
+      pos: 2.5,-5.5
       parent: 1
-      type: Transform
   - uid: 466
     components:
-    - pos: 2.5,-3.5
+    - type: Transform
+      pos: 2.5,-3.5
       parent: 1
-      type: Transform
   - uid: 467
     components:
-    - pos: -1.5,-3.5
+    - type: Transform
+      pos: -1.5,-3.5
       parent: 1
-      type: Transform
   - uid: 468
     components:
-    - pos: 4.5,-7.5
+    - type: Transform
+      pos: 4.5,-7.5
       parent: 1
-      type: Transform
   - uid: 469
     components:
-    - pos: 4.5,-9.5
+    - type: Transform
+      pos: 4.5,-9.5
       parent: 1
-      type: Transform
   - uid: 470
     components:
-    - pos: 2.5,-11.5
+    - type: Transform
+      pos: 2.5,-11.5
       parent: 1
-      type: Transform
   - uid: 471
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 2.5,-10.5
       parent: 1
-      type: Transform
   - uid: 472
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 4.5,-8.5
       parent: 1
-      type: Transform
   - uid: 473
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 4.5,-6.5
       parent: 1
-      type: Transform
   - uid: 474
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 4.5,-4.5
       parent: 1
-      type: Transform
   - uid: 475
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -2.5,-3.5
       parent: 1
-      type: Transform
   - uid: 476
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -0.5,-7.5
       parent: 1
-      type: Transform
   - uid: 478
     components:
-    - pos: 4.5,-5.5
+    - type: Transform
+      pos: 4.5,-5.5
       parent: 1
-      type: Transform
   - uid: 479
     components:
-    - pos: 4.5,-3.5
+    - type: Transform
+      pos: 4.5,-3.5
       parent: 1
-      type: Transform
   - uid: 482
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 2.5,1.5
       parent: 1
-      type: Transform
   - uid: 572
     components:
-    - pos: 1.5,0.5
+    - type: Transform
+      pos: 1.5,0.5
       parent: 1
-      type: Transform
   - uid: 573
     components:
-    - pos: -0.5,0.5
+    - type: Transform
+      pos: -0.5,0.5
       parent: 1
-      type: Transform
   - uid: 574
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -0.5,1.5
       parent: 1
-      type: Transform
   - uid: 575
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 1.5,1.5
       parent: 1
-      type: Transform
   - uid: 576
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 0.5,1.5
       parent: 1
-      type: Transform
   - uid: 577
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 0.5,0.5
       parent: 1
-      type: Transform
   - uid: 781
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 2.5,0.5
       parent: 1
-      type: Transform
 - proto: CarpetPurple
   entities:
   - uid: 442
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 5.5,-7.5
       parent: 1
-      type: Transform
   - uid: 450
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 5.5,-6.5
       parent: 1
-      type: Transform
   - uid: 477
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 5.5,-5.5
       parent: 1
-      type: Transform
 - proto: Catwalk
   entities:
   - uid: 16
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -6.5,-4.5
       parent: 1
-      type: Transform
   - uid: 20
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -6.5,-5.5
       parent: 1
-      type: Transform
   - uid: 27
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -6.5,0.5
       parent: 1
-      type: Transform
   - uid: 28
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -6.5,-2.5
       parent: 1
-      type: Transform
   - uid: 29
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -6.5,-10.5
       parent: 1
-      type: Transform
   - uid: 36
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -5.5,-15.5
       parent: 1
-      type: Transform
   - uid: 37
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -6.5,-13.5
       parent: 1
-      type: Transform
   - uid: 91
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -5.5,-14.5
       parent: 1
-      type: Transform
   - uid: 94
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -6.5,-11.5
       parent: 1
-      type: Transform
   - uid: 97
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -6.5,-14.5
       parent: 1
-      type: Transform
   - uid: 99
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -6.5,-12.5
       parent: 1
-      type: Transform
   - uid: 104
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -6.5,-3.5
       parent: 1
-      type: Transform
   - uid: 105
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -6.5,-0.5
       parent: 1
-      type: Transform
   - uid: 106
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -6.5,-1.5
       parent: 1
-      type: Transform
   - uid: 109
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -6.5,1.5
       parent: 1
-      type: Transform
   - uid: 115
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -4.5,3.5
       parent: 1
-      type: Transform
   - uid: 116
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -5.5,1.5
       parent: 1
-      type: Transform
   - uid: 117
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -5.5,2.5
       parent: 1
-      type: Transform
   - uid: 118
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -4.5,2.5
       parent: 1
-      type: Transform
   - uid: 121
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -6.5,-8.5
       parent: 1
-      type: Transform
   - uid: 124
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -6.5,-7.5
       parent: 1
-      type: Transform
   - uid: 130
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -6.5,-9.5
       parent: 1
-      type: Transform
   - uid: 132
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -6.5,-6.5
       parent: 1
-      type: Transform
   - uid: 137
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 6.5,3.5
       parent: 1
-      type: Transform
   - uid: 138
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 6.5,2.5
       parent: 1
-      type: Transform
   - uid: 139
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 7.5,2.5
       parent: 1
-      type: Transform
   - uid: 140
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 7.5,1.5
       parent: 1
-      type: Transform
   - uid: 141
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 8.5,1.5
       parent: 1
-      type: Transform
   - uid: 142
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 8.5,0.5
       parent: 1
-      type: Transform
   - uid: 143
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 8.5,-0.5
       parent: 1
-      type: Transform
   - uid: 144
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 8.5,-1.5
       parent: 1
-      type: Transform
   - uid: 145
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 8.5,-2.5
       parent: 1
-      type: Transform
   - uid: 146
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 8.5,-3.5
       parent: 1
-      type: Transform
   - uid: 147
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 8.5,-4.5
       parent: 1
-      type: Transform
   - uid: 148
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 8.5,-5.5
       parent: 1
-      type: Transform
   - uid: 149
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 8.5,-6.5
       parent: 1
-      type: Transform
   - uid: 150
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 8.5,-7.5
       parent: 1
-      type: Transform
   - uid: 151
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 8.5,-8.5
       parent: 1
-      type: Transform
   - uid: 152
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 8.5,-9.5
       parent: 1
-      type: Transform
   - uid: 153
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 8.5,-10.5
       parent: 1
-      type: Transform
   - uid: 154
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 8.5,-11.5
       parent: 1
-      type: Transform
   - uid: 155
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 8.5,-12.5
       parent: 1
-      type: Transform
   - uid: 156
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 8.5,-13.5
       parent: 1
-      type: Transform
   - uid: 157
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 8.5,-14.5
       parent: 1
-      type: Transform
   - uid: 158
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 7.5,-14.5
       parent: 1
-      type: Transform
   - uid: 159
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 7.5,-15.5
       parent: 1
-      type: Transform
   - uid: 306
     components:
-    - pos: 5.5,3.5
+    - type: Transform
+      pos: 5.5,3.5
       parent: 1
-      type: Transform
   - uid: 307
     components:
-    - pos: 5.5,4.5
+    - type: Transform
+      pos: 5.5,4.5
       parent: 1
-      type: Transform
   - uid: 308
     components:
-    - pos: 6.5,4.5
+    - type: Transform
+      pos: 6.5,4.5
       parent: 1
-      type: Transform
   - uid: 309
     components:
-    - pos: -3.5,3.5
+    - type: Transform
+      pos: -3.5,3.5
       parent: 1
-      type: Transform
   - uid: 310
     components:
-    - pos: -3.5,4.5
+    - type: Transform
+      pos: -3.5,4.5
       parent: 1
-      type: Transform
   - uid: 311
     components:
-    - pos: -4.5,4.5
+    - type: Transform
+      pos: -4.5,4.5
       parent: 1
-      type: Transform
   - uid: 312
     components:
-    - pos: -3.5,-18.5
+    - type: Transform
+      pos: -3.5,-18.5
       parent: 1
-      type: Transform
   - uid: 313
     components:
-    - pos: -2.5,-18.5
+    - type: Transform
+      pos: -2.5,-18.5
       parent: 1
-      type: Transform
   - uid: 314
     components:
-    - pos: 4.5,-18.5
+    - type: Transform
+      pos: 4.5,-18.5
       parent: 1
-      type: Transform
   - uid: 315
     components:
-    - pos: 5.5,-18.5
+    - type: Transform
+      pos: 5.5,-18.5
       parent: 1
-      type: Transform
   - uid: 368
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 3.5,-18.5
       parent: 1
-      type: Transform
   - uid: 407
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -1.5,-18.5
       parent: 1
-      type: Transform
 - proto: ChairPilotSeat
   entities:
   - uid: 488
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 0.5,5.5
       parent: 1
-      type: Transform
 - proto: ChairWood
   entities:
   - uid: 704
     components:
-    - pos: 2.5,5.5
+    - type: Transform
+      pos: 2.5,5.5
       parent: 1
-      type: Transform
 - proto: ChurchOrganInstrument
   entities:
   - uid: 717
     components:
-    - anchored: True
+    - type: Transform
+      anchored: True
       rot: 3.141592653589793 rad
       pos: 3.5,-0.5
       parent: 1
-      type: Transform
-    - bodyType: Static
-      type: Physics
+    - type: Physics
+      bodyType: Static
 - proto: ClosetL3Filled
   entities:
   - uid: 322
     components:
-    - pos: 3.5,-13.5
+    - type: Transform
+      pos: 3.5,-13.5
       parent: 1
-      type: Transform
 - proto: ClosetWallEmergencyFilledRandom
   entities:
   - uid: 747
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -0.5,-15.5
       parent: 1
-      type: Transform
 - proto: ComputerStationRecords
   entities:
   - uid: 246
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 3.5,5.5
       parent: 1
-      type: Transform
 - proto: ComputerTabletopCrewMonitoring
   entities:
   - uid: 910
     components:
-    - pos: 1.5,6.5
+    - type: Transform
+      pos: 1.5,6.5
       parent: 1
-      type: Transform
 - proto: ComputerTabletopShuttle
   entities:
   - uid: 909
     components:
-    - pos: 0.5,6.5
+    - type: Transform
+      pos: 0.5,6.5
       parent: 1
-      type: Transform
 - proto: ComputerTabletopSolarControl
   entities:
   - uid: 908
     components:
-    - pos: -0.5,6.5
+    - type: Transform
+      pos: -0.5,6.5
       parent: 1
-      type: Transform
 - proto: ComputerWallmountWithdrawBankATM
   entities:
   - uid: 404
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 2.5,-16.5
       parent: 1
-      type: Transform
-    - containers:
+    - type: Physics
+      canCollide: False
+    - type: ContainerContainer
+      containers:
         board: !type:Container
           ents: []
         bank-ATM-cashSlot: !type:ContainerSlot {}
-      type: ContainerContainer
     - type: ItemSlots
 - proto: ConveyorBelt
   entities:
   - uid: 186
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 5.5,-6.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 494
-      type: DeviceLinkSink
   - uid: 757
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 6.5,-6.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 494
-      type: DeviceLinkSink
   - uid: 758
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 7.5,-6.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 494
-      type: DeviceLinkSink
   - uid: 759
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 8.5,-6.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 494
-      type: DeviceLinkSink
 - proto: CrateCoffin
   entities:
   - uid: 492
     components:
-    - pos: 5.5,-5.5
+    - type: Transform
+      pos: 5.5,-5.5
       parent: 1
-      type: Transform
   - uid: 799
     components:
-    - pos: 4.5,-13.5
+    - type: Transform
+      pos: 4.5,-13.5
       parent: 1
-      type: Transform
-    - fixtures:
+    - type: Fixtures
+      fixtures:
         fix1:
           shape: !type:PolygonShape
             radius: 0.01
@@ -3303,8 +3283,8 @@ entities:
           hard: True
           restitution: 0
           friction: 0.4
-      type: Fixtures
-    - air:
+    - type: EntityStorage
+      air:
         volume: 200
         immutable: False
         temperature: 293.1496
@@ -3323,1956 +3303,1811 @@ entities:
         - 0
       open: True
       removedMasks: 20
-      type: EntityStorage
-    - isPlaceable: True
-      type: PlaceableSurface
+    - type: PlaceableSurface
+      isPlaceable: True
 - proto: Crematorium
   entities:
   - uid: 316
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 5.5,-16.5
       parent: 1
-      type: Transform
 - proto: CrowbarRed
   entities:
   - uid: 749
     components:
-    - pos: -2.6306262,-16.448538
+    - type: Transform
+      pos: -2.6306262,-16.448538
       parent: 1
-      type: Transform
 - proto: DrinkMugMetal
   entities:
   - uid: 773
     components:
-    - pos: -0.945055,-11.282531
+    - type: Transform
+      pos: -0.945055,-11.282531
       parent: 1
-      type: Transform
   - uid: 774
     components:
-    - pos: -1.17943,-11.454406
+    - type: Transform
+      pos: -1.17943,-11.454406
       parent: 1
-      type: Transform
   - uid: 775
     components:
-    - pos: -0.89818,-11.563781
+    - type: Transform
+      pos: -0.89818,-11.563781
       parent: 1
-      type: Transform
   - uid: 776
     components:
-    - pos: -1.49193,-11.595031
+    - type: Transform
+      pos: -1.49193,-11.595031
       parent: 1
-      type: Transform
   - uid: 777
     components:
-    - pos: -1.788805,-11.391906
+    - type: Transform
+      pos: -1.788805,-11.391906
       parent: 1
-      type: Transform
 - proto: DrinkWineBottleFull
   entities:
   - uid: 721
     components:
-    - pos: 3.6576126,-10.21217
+    - type: Transform
+      pos: 3.6576126,-10.21217
       parent: 1
-      type: Transform
   - uid: 722
     components:
-    - pos: 3.3763626,-10.321545
+    - type: Transform
+      pos: 3.3763626,-10.321545
       parent: 1
-      type: Transform
 - proto: DrinkWineGlass
   entities:
   - uid: 723
     components:
-    - pos: 3.6732373,-10.86842
+    - type: Transform
+      pos: 3.6732373,-10.86842
       parent: 1
-      type: Transform
   - uid: 724
     components:
-    - pos: 3.3138623,-10.86842
+    - type: Transform
+      pos: 3.3138623,-10.86842
       parent: 1
-      type: Transform
   - uid: 725
     components:
-    - pos: 3.4544873,-11.196545
+    - type: Transform
+      pos: 3.4544873,-11.196545
       parent: 1
-      type: Transform
   - uid: 726
     components:
-    - pos: 3.6732373,-11.36842
+    - type: Transform
+      pos: 3.6732373,-11.36842
       parent: 1
-      type: Transform
 - proto: EmergencyLight
   entities:
   - uid: 744
     components:
-    - pos: 0.5,1.5
+    - type: Transform
+      pos: 0.5,1.5
       parent: 1
-      type: Transform
   - uid: 746
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 1.5,5.5
       parent: 1
-      type: Transform
   - uid: 802
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 5.5,-16.5
       parent: 1
-      type: Transform
   - uid: 803
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -3.5,-16.5
       parent: 1
-      type: Transform
 - proto: EncryptionKeyMedical
   entities:
   - uid: 791
     components:
-    - pos: 1.2815478,6.4196587
+    - type: Transform
+      pos: 1.2815478,6.4196587
       parent: 1
-      type: Transform
 - proto: FaxMachineShip
   entities:
   - uid: 245
     components:
-    - pos: 2.5,6.5
+    - type: Transform
+      pos: 2.5,6.5
       parent: 1
-      type: Transform
 - proto: FirelockGlass
   entities:
   - uid: 540
     components:
-    - pos: -0.5,2.5
+    - type: Transform
+      pos: -0.5,2.5
       parent: 1
-      type: Transform
-    - ShutdownSubscribers:
-      - 739
-      - 738
-      type: DeviceNetwork
   - uid: 541
     components:
-    - pos: 2.5,2.5
+    - type: Transform
+      pos: 2.5,2.5
       parent: 1
-      type: Transform
-    - ShutdownSubscribers:
-      - 739
-      type: DeviceNetwork
   - uid: 542
     components:
-    - pos: -0.5,-14.5
+    - type: Transform
+      pos: -0.5,-14.5
       parent: 1
-      type: Transform
-    - ShutdownSubscribers:
-      - 741
-      type: DeviceNetwork
   - uid: 543
     components:
-    - pos: 2.5,-14.5
+    - type: Transform
+      pos: 2.5,-14.5
       parent: 1
-      type: Transform
-    - ShutdownSubscribers:
-      - 801
-      type: DeviceNetwork
   - uid: 742
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 0.5,-12.5
       parent: 1
-      type: Transform
-    - ShutdownSubscribers:
-      - 739
-      type: DeviceNetwork
   - uid: 743
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 1.5,-12.5
       parent: 1
-      type: Transform
-    - ShutdownSubscribers:
-      - 739
-      type: DeviceNetwork
   - uid: 766
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 0.5,-15.5
       parent: 1
-      type: Transform
   - uid: 906
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 1.5,-15.5
       parent: 1
-      type: Transform
 - proto: FoodBreadPlain
   entities:
   - uid: 728
     components:
-    - pos: 2.720112,-11.290295
+    - type: Transform
+      pos: 2.720112,-11.290295
       parent: 1
-      type: Transform
 - proto: FoodBreadPlainSlice
   entities:
   - uid: 729
     components:
-    - pos: 2.2826123,-11.33717
+    - type: Transform
+      pos: 2.2826123,-11.33717
       parent: 1
-      type: Transform
   - uid: 730
     components:
-    - pos: 2.345112,-11.43092
+    - type: Transform
+      pos: 2.345112,-11.43092
       parent: 1
-      type: Transform
   - uid: 731
     components:
-    - pos: 2.376362,-11.46217
+    - type: Transform
+      pos: 2.376362,-11.46217
       parent: 1
-      type: Transform
   - uid: 732
     components:
-    - pos: 2.485737,-11.477795
+    - type: Transform
+      pos: 2.485737,-11.477795
       parent: 1
-      type: Transform
 - proto: FoodPlate
   entities:
   - uid: 727
     components:
-    - pos: 2.641987,-11.227795
+    - type: Transform
+      pos: 2.641987,-11.227795
       parent: 1
-      type: Transform
 - proto: GasPassiveVent
   entities:
   - uid: 367
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 7.5,-15.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
 - proto: GasPipeBend
   entities:
   - uid: 409
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 4.5,-15.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 480
     components:
-    - pos: 0.5,0.5
+    - type: Transform
+      pos: 0.5,0.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0000CCFF'
   - uid: 481
     components:
-    - pos: 1.5,1.5
+    - type: Transform
+      pos: 1.5,1.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 485
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -0.5,0.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0000CCFF'
   - uid: 487
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 0.5,1.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 491
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 0.5,-14.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0000CCFF'
   - uid: 523
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 1.5,-16.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 533
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -2.5,-14.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0000CCFF'
 - proto: GasPipeStraight
   entities:
   - uid: 136
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 6.5,-15.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 346
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 1.5,-12.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 354
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 1.5,-13.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 355
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 1.5,-11.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 356
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 1.5,-7.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 357
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 1.5,-6.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 358
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 1.5,-3.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 359
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 1.5,-1.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 360
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 0.5,-0.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0000CCFF'
   - uid: 361
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 0.5,-3.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0000CCFF'
   - uid: 362
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 0.5,-6.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0000CCFF'
   - uid: 363
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 0.5,-7.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0000CCFF'
   - uid: 364
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 0.5,-11.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0000CCFF'
   - uid: 366
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 0.5,-12.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0000CCFF'
   - uid: 370
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 1.5,-10.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 371
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 1.5,-8.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 372
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 1.5,-5.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 373
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 1.5,-4.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 374
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 1.5,-0.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 375
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 0.5,-1.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0000CCFF'
   - uid: 376
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 0.5,-4.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0000CCFF'
   - uid: 377
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 0.5,-5.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0000CCFF'
   - uid: 378
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 0.5,-8.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0000CCFF'
   - uid: 379
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 0.5,-10.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0000CCFF'
   - uid: 381
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 2.5,-13.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0000CCFF'
   - uid: 484
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -0.5,1.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0000CCFF'
   - uid: 486
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -0.5,2.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0000CCFF'
   - uid: 515
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 1.5,-13.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0000CCFF'
   - uid: 519
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -1.5,-16.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 520
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -0.5,-16.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 521
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 0.5,-16.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 522
     components:
-    - pos: 1.5,-15.5
+    - type: Transform
+      pos: 1.5,-15.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 524
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -0.5,-14.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0000CCFF'
   - uid: 529
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 3.5,-14.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 534
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -0.5,3.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0000CCFF'
   - uid: 535
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 0.5,2.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 536
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 0.5,3.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 537
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 1.5,0.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 716
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 2.5,-14.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
 - proto: GasPipeTJunction
   entities:
   - uid: 292
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 4.5,-14.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 347
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 0.5,-2.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0000CCFF'
   - uid: 369
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 0.5,-9.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0000CCFF'
   - uid: 380
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 0.5,-13.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0000CCFF'
   - uid: 509
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 1.5,-14.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 513
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 1.5,-9.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 514
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 1.5,-2.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 718
     components:
-    - pos: -1.5,-14.5
+    - type: Transform
+      pos: -1.5,-14.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0000CCFF'
 - proto: GasPort
   entities:
   - uid: 344
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -1.5,-16.5
       parent: 1
-      type: Transform
-    - color: '#03FCD3FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#03FCD3FF'
 - proto: GasPressurePump
   entities:
   - uid: 532
     components:
-    - name: waste loop pump
-      type: MetaData
-    - rot: 1.5707963267948966 rad
+    - type: MetaData
+      name: waste loop pump
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 5.5,-15.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 748
     components:
-    - name: distribution pump
-      type: MetaData
-    - rot: 3.141592653589793 rad
+    - type: MetaData
+      name: distribution pump
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -1.5,-15.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0000CCFF'
 - proto: GasVentPump
   entities:
   - uid: 527
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -0.5,-9.5
       parent: 1
-      type: Transform
-    - ShutdownSubscribers:
-      - 739
-      type: DeviceNetwork
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0000CCFF'
   - uid: 528
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -0.5,-2.5
       parent: 1
-      type: Transform
-    - ShutdownSubscribers:
-      - 739
-      type: DeviceNetwork
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0000CCFF'
   - uid: 530
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 3.5,-13.5
       parent: 1
-      type: Transform
-    - ShutdownSubscribers:
-      - 801
-      type: DeviceNetwork
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0000CCFF'
   - uid: 538
     components:
-    - pos: -0.5,4.5
+    - type: Transform
+      pos: -0.5,4.5
       parent: 1
-      type: Transform
-    - ShutdownSubscribers:
-      - 738
-      type: DeviceNetwork
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0000CCFF'
   - uid: 760
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -2.5,-15.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0000CCFF'
 - proto: GasVentScrubber
   entities:
   - uid: 17
     components:
-    - pos: 4.5,-13.5
+    - type: Transform
+      pos: 4.5,-13.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 516
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 2.5,-9.5
       parent: 1
-      type: Transform
-    - ShutdownSubscribers:
-      - 739
-      type: DeviceNetwork
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 517
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 2.5,-2.5
       parent: 1
-      type: Transform
-    - ShutdownSubscribers:
-      - 739
-      type: DeviceNetwork
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 518
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -2.5,-16.5
       parent: 1
-      type: Transform
-    - ShutdownSubscribers:
-      - 741
-      type: DeviceNetwork
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 539
     components:
-    - pos: 0.5,4.5
+    - type: Transform
+      pos: 0.5,4.5
       parent: 1
-      type: Transform
-    - ShutdownSubscribers:
-      - 738
-      type: DeviceNetwork
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
 - proto: GravityGeneratorMini
   entities:
   - uid: 525
     components:
-    - pos: -2.5,-14.5
+    - type: Transform
+      pos: -2.5,-14.5
       parent: 1
-      type: Transform
 - proto: Grille
   entities:
   - uid: 5
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -4.5,-8.5
       parent: 1
-      type: Transform
   - uid: 6
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 4.5,-11.5
       parent: 1
-      type: Transform
   - uid: 7
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -4.5,-7.5
       parent: 1
-      type: Transform
   - uid: 9
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -1.5,7.5
       parent: 1
-      type: Transform
   - uid: 12
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 2.5,4.5
       parent: 1
-      type: Transform
   - uid: 13
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -2.5,5.5
       parent: 1
-      type: Transform
   - uid: 19
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 0.5,2.5
       parent: 1
-      type: Transform
   - uid: 42
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -1.5,1.5
       parent: 1
-      type: Transform
   - uid: 44
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 1.5,7.5
       parent: 1
-      type: Transform
   - uid: 47
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 4.5,5.5
       parent: 1
-      type: Transform
   - uid: 49
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 5.5,-3.5
       parent: 1
-      type: Transform
   - uid: 50
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 6.5,-8.5
       parent: 1
-      type: Transform
   - uid: 57
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -4.5,-5.5
       parent: 1
-      type: Transform
   - uid: 58
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -2.5,-0.5
       parent: 1
-      type: Transform
   - uid: 65
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -2.5,-1.5
       parent: 1
-      type: Transform
   - uid: 66
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 6.5,-5.5
       parent: 1
-      type: Transform
   - uid: 68
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -4.5,-6.5
       parent: 1
-      type: Transform
   - uid: 79
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 0.5,7.5
       parent: 1
-      type: Transform
   - uid: 80
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -0.5,7.5
       parent: 1
-      type: Transform
   - uid: 81
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -2.5,-11.5
       parent: 1
-      type: Transform
   - uid: 82
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 3.5,1.5
       parent: 1
-      type: Transform
   - uid: 84
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 6.5,-7.5
       parent: 1
-      type: Transform
   - uid: 85
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 3.5,7.5
       parent: 1
-      type: Transform
   - uid: 86
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 2.5,7.5
       parent: 1
-      type: Transform
   - uid: 125
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 4.5,-0.5
       parent: 1
-      type: Transform
   - uid: 126
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 4.5,-1.5
       parent: 1
-      type: Transform
   - uid: 134
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -3.5,-3.5
       parent: 1
-      type: Transform
 - proto: GroundCannabis
   entities:
   - uid: 318
     components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 317
-      type: Transform
-    - canCollide: False
-      type: Physics
+    - type: Transform
+      parent: 317
+    - type: Physics
+      canCollide: False
     - type: InsideEntityStorage
 - proto: Gyroscope
   entities:
   - uid: 734
     components:
-    - pos: -3.5,-14.5
+    - type: Transform
+      pos: -3.5,-14.5
       parent: 1
-      type: Transform
+    - type: Thruster
+      originalPowerLoad: 1500
 - proto: KnifePlastic
   entities:
   - uid: 45
     components:
-    - pos: 3.00555,-11.372589
+    - type: Transform
+      pos: 3.00555,-11.372589
       parent: 1
-      type: Transform
 - proto: Lantern
   entities:
   - uid: 702
     components:
-    - pos: 1.5706598,-0.2999968
+    - type: Transform
+      pos: 1.5706598,-0.2999968
       parent: 1
-      type: Transform
   - uid: 703
     components:
-    - pos: 0.44565976,-0.2999966
+    - type: Transform
+      pos: 0.44565976,-0.2999966
       parent: 1
-      type: Transform
 - proto: Matchbox
   entities:
   - uid: 737
     components:
-    - pos: 2.5131764,5.5507874
+    - type: Transform
+      pos: 2.5131764,5.5507874
       parent: 1
-      type: Transform
 - proto: MaterialWoodPlank
   entities:
   - uid: 483
     components:
-    - pos: 4.5,-13.5
+    - type: Transform
+      pos: 4.5,-13.5
       parent: 1
-      type: Transform
   - uid: 526
     components:
-    - pos: 4.5,-13.5
+    - type: Transform
+      pos: 4.5,-13.5
       parent: 1
-      type: Transform
 - proto: Morgue
   entities:
   - uid: 317
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 3.5,-16.5
       parent: 1
-      type: Transform
-    - containers:
+    - type: ContainerContainer
+      containers:
         entity_storage: !type:Container
           showEnts: False
           occludes: True
           ents:
           - 318
-      type: ContainerContainer
   - uid: 319
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 3.5,-15.5
       parent: 1
-      type: Transform
-- proto: Paper
-  entities:
-  - uid: 911
-    components:
-    - pos: -3.144133,-16.32435
-      parent: 1
-      type: Transform
-    - stampState: paper_stamp-chaplain
-      stampedBy:
-      - stampedBorderless: False
-        stampedColor: '#D70601FF'
-        stampedName: stamp-component-stamped-name-chaplain
-      - stampedBorderless: False
-        stampedColor: '#C69B17FF'
-        stampedName: stamp-component-stamped-name-ce
-      - stampedBorderless: False
-        stampedColor: '#00BE00FF'
-        stampedName: stamp-component-stamped-name-approved
-      content: >-
-        [color=#1b67a5]█░░█░███[/color][color=#5b97bc]░███░█░█░█░██░░█░█░██░░██░░██░[/color]
-
-        [color=#1b67a5]██░█░░█░[/color][color=#5b97bc]██░░░█░█░█░█░█░█░█░█░█░█░█░█░█[/color]
-
-        [color=#1b67a5]█░██░░█░[/color][color=#5b97bc]░░██░███░█░██░░░█░░███░██░░█░█[/color]
-
-        [color=#1b67a5]█░░█░░█░[/color][color=#5b97bc]███░░█░█░█░█░░░░█░░█░█░█░█░██░[/color]
-
-
-        [head=1]=========================[/head]
-
-        [head=1]Lantern-class service ship[/head]
-
-        [head=1] [/head]
-
-        [head=1]     PREFLIGHT CHECKLIST[/head]
-
-        [head=1]=========================[/head]
-
-
-        [head=2]1. Power supply.[/head]
-
-        [head=3]1.1. Battery units.[/head]
-
-        [bullet/][ ] Check if the SMES unit is anchored to the floor.
-
-        [bullet/][ ] Check if the substation unit is anchored to the floor.
-
-        [bullet/][ ] Check if the APC unit's Main Breaker is toggled on.
-
-        [bullet/][ ] Check the APC unit's current Load[bold]*[/bold] (W).
-
-        [head=3]1.2. P.A.C.M.A.N. generator unit.[/head]
-
-        [bullet/][ ] Check if the P.A.C.M.A.N. generator unit is anchored to the floor.
-
-        [bullet/][ ] Check if the P.A.C.M.A.N. generator unit has fuel. For extended flights make sure that you have enough fuel stockpiled to sustain prolonged power generation.
-
-        [bullet/][ ] Check if the P.A.C.M.A.N. generator unit is set to HV output.
-
-        [bullet/][ ] Set Target Power for 10-15[bold]**[/bold] [bold]k[/bold]W.
-
-        [bullet/][ ] Start the P.A.C.M.A.N. generator unit.
-
-        [head=3]1.3. Solar panels.[/head]
-
-        [bullet/][ ] Inspect solar control computer (located at ship's cocpit).
-
-        [bullet/][ ] Adjust panel angular velocity.
-
-        [bullet/][ ] Adjust panel angle.
-
-
-        [head=2]2. Atmospherics.[/head]
-
-        [head=3]2.1. Distribution Loop.[/head]
-
-        [bullet/][ ] Check if the air canister is anchored to connector port.
-
-        [bullet/][ ] Check if the distribution pump is set to normal pressure.
-
-        [bullet/][ ] Enable the distribution pump.
-
-        [head=3]2.2. Waste Loop.[/head]
-
-        [bullet/][ ] Enable the waste loop pump.
-
-        [bullet/][ ] Disable Auto Mode on the Air Alarm in the Engine Room.
-
-        [bullet/][ ] Set the Air Alarm in the Engine Room to Filtering (Wide).
-
-
-        [head=2]3. Other checks.[/head]
-
-        [bullet/][ ] Check if the gyroscope is anchored, powered, and enabled.
-
-        [bullet/][ ] Check if the mini gravity generator is anchored, powered, and enabled.
-
-
-        __________________________________________________________________
-
-        [bold]*[/bold] - Lantern-class service ships are equipped with a three APC units that can be used to appraise the ship's total power consumption. Unmodifued Lantern-class ship requires 22.5 kW of power to remain operational.
-
-        [bold]**[/bold] - Lantern-class service ships have higher power demand than standard P.A.C.M.A.N. generator unit can provide at optimal settings, however the ship comes equipped with 38 solar panels that can provide up to 28.5 kW of power under the ideal circumstances: assuming that on average properly maintained solar array will provide one third of maximum output power, recommended target power output for P.A.C.M.A.N. generator unit is 14 kW.
-
-        [bold]Note:[/bold] Additional generator units can be purchased at the Frontier Station.
-      type: Paper
 - proto: PaperBin10
   entities:
   - uid: 765
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -0.5,-11.5
       parent: 1
-      type: Transform
 - proto: PlasticFlapsAirtightClear
   entities:
   - uid: 580
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 6.5,-6.5
       parent: 1
-      type: Transform
-- proto: PortableGeneratorPacman
+- proto: PortableGeneratorPacmanShuttle
   entities:
-  - uid: 323
+  - uid: 511
     components:
-    - anchored: True
+    - type: Transform
       pos: -3.5,-16.5
       parent: 1
-      type: Transform
-    - storage:
-        Plasma: 1500
-      type: MaterialStorage
-    - bodyType: Static
-      type: Physics
-    - type: InsertingMaterialStorage
+    - type: FuelGenerator
+      on: False
+    - type: Physics
+      bodyType: Static
 - proto: PottedPlantRandom
   entities:
   - uid: 719
     components:
-    - pos: 4.5,-9.5
+    - type: Transform
+      pos: 4.5,-9.5
       parent: 1
-      type: Transform
   - uid: 720
     components:
-    - pos: -2.5,-9.5
+    - type: Transform
+      pos: -2.5,-9.5
       parent: 1
-      type: Transform
 - proto: PowerCellRecharger
   entities:
   - uid: 709
     components:
-    - pos: -1.5,-10.5
+    - type: Transform
+      pos: -1.5,-10.5
       parent: 1
-      type: Transform
 - proto: Poweredlight
   entities:
   - uid: 161
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 3.5,-2.5
       parent: 1
-      type: Transform
   - uid: 162
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -1.5,-2.5
       parent: 1
-      type: Transform
   - uid: 714
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 4.5,-9.5
       parent: 1
-      type: Transform
   - uid: 715
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -2.5,-9.5
       parent: 1
-      type: Transform
 - proto: PoweredSmallLight
   entities:
   - uid: 581
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 1.5,5.5
       parent: 1
-      type: Transform
   - uid: 710
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 0.5,-13.5
       parent: 1
-      type: Transform
   - uid: 711
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -1.5,-15.5
       parent: 1
-      type: Transform
   - uid: 712
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 3.5,-15.5
       parent: 1
-      type: Transform
   - uid: 778
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 2.5,3.5
       parent: 1
-      type: Transform
 - proto: Railing
   entities:
   - uid: 804
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -6.5,-13.5
       parent: 1
-      type: Transform
   - uid: 871
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -6.5,-12.5
       parent: 1
-      type: Transform
   - uid: 872
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -6.5,-11.5
       parent: 1
-      type: Transform
   - uid: 873
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -6.5,-10.5
       parent: 1
-      type: Transform
   - uid: 874
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -6.5,-9.5
       parent: 1
-      type: Transform
   - uid: 875
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -6.5,-8.5
       parent: 1
-      type: Transform
   - uid: 876
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -6.5,-7.5
       parent: 1
-      type: Transform
   - uid: 877
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -6.5,-6.5
       parent: 1
-      type: Transform
   - uid: 878
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -6.5,-5.5
       parent: 1
-      type: Transform
   - uid: 879
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -6.5,-4.5
       parent: 1
-      type: Transform
   - uid: 880
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -6.5,-3.5
       parent: 1
-      type: Transform
   - uid: 881
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -6.5,-2.5
       parent: 1
-      type: Transform
   - uid: 882
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -6.5,-1.5
       parent: 1
-      type: Transform
   - uid: 883
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -6.5,-0.5
       parent: 1
-      type: Transform
   - uid: 884
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -6.5,0.5
       parent: 1
-      type: Transform
   - uid: 886
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 8.5,-13.5
       parent: 1
-      type: Transform
   - uid: 887
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 8.5,-12.5
       parent: 1
-      type: Transform
   - uid: 888
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 8.5,-11.5
       parent: 1
-      type: Transform
   - uid: 889
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 8.5,-10.5
       parent: 1
-      type: Transform
   - uid: 890
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 8.5,-9.5
       parent: 1
-      type: Transform
   - uid: 891
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 8.5,-8.5
       parent: 1
-      type: Transform
   - uid: 892
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 8.5,-4.5
       parent: 1
-      type: Transform
   - uid: 893
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 8.5,-3.5
       parent: 1
-      type: Transform
   - uid: 894
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 8.5,-2.5
       parent: 1
-      type: Transform
   - uid: 895
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 8.5,-1.5
       parent: 1
-      type: Transform
   - uid: 896
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 8.5,-0.5
       parent: 1
-      type: Transform
   - uid: 897
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 8.5,0.5
       parent: 1
-      type: Transform
 - proto: RailingCorner
   entities:
   - uid: 705
     components:
-    - pos: 7.5,-15.5
+    - type: Transform
+      pos: 7.5,-15.5
       parent: 1
-      type: Transform
   - uid: 706
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -5.5,-15.5
       parent: 1
-      type: Transform
   - uid: 761
     components:
-    - pos: 8.5,-5.5
+    - type: Transform
+      pos: 8.5,-5.5
       parent: 1
-      type: Transform
   - uid: 794
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 8.5,-7.5
       parent: 1
-      type: Transform
   - uid: 865
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -6.5,-14.5
       parent: 1
-      type: Transform
   - uid: 866
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -6.5,1.5
       parent: 1
-      type: Transform
   - uid: 867
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -5.5,2.5
       parent: 1
-      type: Transform
   - uid: 868
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 7.5,2.5
       parent: 1
-      type: Transform
   - uid: 869
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 8.5,1.5
       parent: 1
-      type: Transform
   - uid: 870
     components:
-    - pos: 8.5,-14.5
+    - type: Transform
+      pos: 8.5,-14.5
       parent: 1
-      type: Transform
 - proto: RailingCornerSmall
   entities:
   - uid: 707
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 7.5,-14.5
       parent: 1
-      type: Transform
   - uid: 708
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -5.5,-14.5
       parent: 1
-      type: Transform
   - uid: 885
     components:
-    - pos: -5.5,1.5
+    - type: Transform
+      pos: -5.5,1.5
       parent: 1
-      type: Transform
   - uid: 898
     components:
-    - pos: -4.5,2.5
+    - type: Transform
+      pos: -4.5,2.5
       parent: 1
-      type: Transform
   - uid: 899
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 6.5,2.5
       parent: 1
-      type: Transform
   - uid: 900
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 7.5,1.5
       parent: 1
-      type: Transform
 - proto: RandomPosterAny
   entities:
   - uid: 770
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -1.5,-12.5
       parent: 1
-      type: Transform
   - uid: 771
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 3.5,-12.5
       parent: 1
-      type: Transform
 - proto: ReinforcedWindow
   entities:
   - uid: 26
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -0.5,7.5
       parent: 1
-      type: Transform
   - uid: 32
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 1.5,7.5
       parent: 1
-      type: Transform
   - uid: 34
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 3.5,7.5
       parent: 1
-      type: Transform
   - uid: 35
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 0.5,7.5
       parent: 1
-      type: Transform
   - uid: 39
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -1.5,7.5
       parent: 1
-      type: Transform
   - uid: 41
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -2.5,5.5
       parent: 1
-      type: Transform
   - uid: 76
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 2.5,7.5
       parent: 1
-      type: Transform
   - uid: 114
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 4.5,5.5
       parent: 1
-      type: Transform
   - uid: 160
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -1.5,1.5
       parent: 1
-      type: Transform
   - uid: 163
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -2.5,-0.5
       parent: 1
-      type: Transform
   - uid: 164
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -2.5,-1.5
       parent: 1
-      type: Transform
   - uid: 167
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -3.5,-3.5
       parent: 1
-      type: Transform
   - uid: 170
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -4.5,-5.5
       parent: 1
-      type: Transform
   - uid: 171
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -4.5,-6.5
       parent: 1
-      type: Transform
   - uid: 172
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -4.5,-7.5
       parent: 1
-      type: Transform
   - uid: 173
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -4.5,-8.5
       parent: 1
-      type: Transform
   - uid: 178
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -2.5,-11.5
       parent: 1
-      type: Transform
   - uid: 179
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 4.5,-11.5
       parent: 1
-      type: Transform
   - uid: 184
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 6.5,-8.5
       parent: 1
-      type: Transform
   - uid: 185
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 6.5,-7.5
       parent: 1
-      type: Transform
   - uid: 187
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 6.5,-5.5
       parent: 1
-      type: Transform
   - uid: 190
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 5.5,-3.5
       parent: 1
-      type: Transform
   - uid: 193
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 4.5,-1.5
       parent: 1
-      type: Transform
   - uid: 194
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 4.5,-0.5
       parent: 1
-      type: Transform
   - uid: 197
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 3.5,1.5
       parent: 1
-      type: Transform
 - proto: SheetPlasma
   entities:
   - uid: 736
     components:
-    - pos: -3.5859509,-16.448538
+    - type: Transform
+      pos: -3.5859509,-16.448538
       parent: 1
-      type: Transform
-    - count: 15
-      type: Stack
-    - size: 15
-      type: Item
+    - type: Stack
+      count: 15
+    - type: Item
+      size: 15
+- proto: ShipyardLanternInfo
+  entities:
+  - uid: 510
+    components:
+    - type: Transform
+      pos: -2.9330585,-16.16902
+      parent: 1
 - proto: ShuttersNormalOpen
   entities:
   - uid: 55
     components:
-    - pos: 2.5,7.5
+    - type: Transform
+      pos: 2.5,7.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 904
-      type: DeviceLinkSink
   - uid: 62
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 6.5,-8.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 903
-      type: DeviceLinkSink
   - uid: 75
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -4.5,-8.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 903
-      type: DeviceLinkSink
   - uid: 77
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 4.5,-0.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 903
-      type: DeviceLinkSink
   - uid: 90
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -4.5,-6.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 903
-      type: DeviceLinkSink
   - uid: 93
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -1.5,1.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 903
-      type: DeviceLinkSink
   - uid: 96
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -2.5,-1.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 903
-      type: DeviceLinkSink
   - uid: 100
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -2.5,5.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 904
-      type: DeviceLinkSink
   - uid: 101
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 6.5,-5.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 903
-      type: DeviceLinkSink
   - uid: 122
     components:
-    - pos: 0.5,7.5
+    - type: Transform
+      pos: 0.5,7.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 904
-      type: DeviceLinkSink
   - uid: 133
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 4.5,-11.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 903
-      type: DeviceLinkSink
   - uid: 166
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -4.5,-5.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 903
-      type: DeviceLinkSink
   - uid: 168
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -4.5,-7.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 903
-      type: DeviceLinkSink
   - uid: 176
     components:
-    - pos: 1.5,7.5
+    - type: Transform
+      pos: 1.5,7.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 904
-      type: DeviceLinkSink
   - uid: 177
     components:
-    - pos: -0.5,7.5
+    - type: Transform
+      pos: -0.5,7.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 904
-      type: DeviceLinkSink
   - uid: 180
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -2.5,-0.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 903
-      type: DeviceLinkSink
   - uid: 181
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -3.5,-3.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 903
-      type: DeviceLinkSink
   - uid: 188
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 5.5,-3.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 903
-      type: DeviceLinkSink
   - uid: 189
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 6.5,-7.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 903
-      type: DeviceLinkSink
   - uid: 191
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 3.5,1.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 903
-      type: DeviceLinkSink
   - uid: 192
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 4.5,-1.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 903
-      type: DeviceLinkSink
   - uid: 365
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -2.5,-11.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 903
-      type: DeviceLinkSink
   - uid: 382
     components:
-    - pos: 3.5,7.5
+    - type: Transform
+      pos: 3.5,7.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 904
-      type: DeviceLinkSink
   - uid: 780
     components:
-    - pos: -1.5,7.5
+    - type: Transform
+      pos: -1.5,7.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 904
-      type: DeviceLinkSink
   - uid: 902
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 4.5,5.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 904
-      type: DeviceLinkSink
 - proto: SignalButtonDirectional
   entities:
   - uid: 901
     components:
-    - name: airlock bolts switch
-      type: MetaData
-    - rot: 1.5707963267948966 rad
+    - type: MetaData
+      name: airlock bolts switch
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -0.5,-13.5
       parent: 1
-      type: Transform
-    - linkedPorts:
+    - type: DeviceLinkSource
+      linkedPorts:
         396:
         - Pressed: DoorBolt
         397:
         - Pressed: DoorBolt
-      type: DeviceLinkSource
   - uid: 903
     components:
-    - name: shutters switch
-      type: MetaData
-    - pos: 1.5,2.5
+    - type: MetaData
+      name: shutters switch
+    - type: Transform
+      pos: 1.5,2.5
       parent: 1
-      type: Transform
-    - linkedPorts:
+    - type: DeviceLinkSource
+      linkedPorts:
         93:
         - Pressed: Toggle
         191:
@@ -5307,16 +5142,16 @@ entities:
         - Pressed: Toggle
         365:
         - Pressed: Toggle
-      type: DeviceLinkSource
   - uid: 904
     components:
-    - name: cockpit shutters switch
-      type: MetaData
-    - rot: 1.5707963267948966 rad
+    - type: MetaData
+      name: cockpit shutters switch
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -1.5,6.5
       parent: 1
-      type: Transform
-    - linkedPorts:
+    - type: DeviceLinkSource
+      linkedPorts:
         100:
         - Pressed: Toggle
         780:
@@ -5333,521 +5168,533 @@ entities:
         - Pressed: Toggle
         902:
         - Pressed: Toggle
-      type: DeviceLinkSource
   - uid: 905
     components:
-    - name: blastdoor switch
-      type: MetaData
-    - rot: 3.141592653589793 rad
+    - type: MetaData
+      name: blastdoor switch
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 5.5,-9.5
       parent: 1
-      type: Transform
-    - linkedPorts:
+    - type: DeviceLinkSource
+      linkedPorts:
         762:
         - Pressed: Toggle
-      type: DeviceLinkSource
 - proto: SignChapel
   entities:
   - uid: 767
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 2.5,-18.5
       parent: 1
-      type: Transform
   - uid: 768
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -0.5,-18.5
       parent: 1
-      type: Transform
 - proto: SignDirectionalChapel
   entities:
   - uid: 769
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 2.5,-13.5
       parent: 1
-      type: Transform
 - proto: SinkWide
   entities:
   - uid: 800
     components:
-    - pos: 5.5,-14.5
+    - type: Transform
+      pos: 5.5,-14.5
       parent: 1
-      type: Transform
 - proto: SMESBasic
   entities:
   - uid: 15
     components:
-    - pos: -1.5,-13.5
+    - type: Transform
+      pos: -1.5,-13.5
       parent: 1
-      type: Transform
 - proto: SmokingPipeFilledCannabis
   entities:
   - uid: 733
     components:
-    - pos: 2.4819264,5.5507874
+    - type: Transform
+      pos: 2.4819264,5.5507874
       parent: 1
-      type: Transform
 - proto: SolarPanel
   entities:
   - uid: 204
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -6.5,0.5
       parent: 1
-      type: Transform
   - uid: 205
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -6.5,-0.5
       parent: 1
-      type: Transform
   - uid: 206
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -6.5,-1.5
       parent: 1
-      type: Transform
   - uid: 207
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -6.5,-2.5
       parent: 1
-      type: Transform
   - uid: 208
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -6.5,-3.5
       parent: 1
-      type: Transform
   - uid: 209
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -6.5,-4.5
       parent: 1
-      type: Transform
   - uid: 210
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -6.5,-5.5
       parent: 1
-      type: Transform
   - uid: 211
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -6.5,-6.5
       parent: 1
-      type: Transform
   - uid: 212
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -6.5,-7.5
       parent: 1
-      type: Transform
   - uid: 213
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -6.5,-8.5
       parent: 1
-      type: Transform
   - uid: 214
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -6.5,-9.5
       parent: 1
-      type: Transform
   - uid: 215
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -6.5,-10.5
       parent: 1
-      type: Transform
   - uid: 216
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -6.5,-11.5
       parent: 1
-      type: Transform
   - uid: 217
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -6.5,-12.5
       parent: 1
-      type: Transform
   - uid: 218
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -6.5,-13.5
       parent: 1
-      type: Transform
   - uid: 219
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -6.5,-14.5
       parent: 1
-      type: Transform
   - uid: 220
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 8.5,-14.5
       parent: 1
-      type: Transform
   - uid: 221
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 8.5,-13.5
       parent: 1
-      type: Transform
   - uid: 222
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 8.5,-12.5
       parent: 1
-      type: Transform
   - uid: 223
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 8.5,-11.5
       parent: 1
-      type: Transform
   - uid: 224
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 8.5,-10.5
       parent: 1
-      type: Transform
   - uid: 225
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 8.5,-9.5
       parent: 1
-      type: Transform
   - uid: 226
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 8.5,-8.5
       parent: 1
-      type: Transform
   - uid: 227
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 8.5,-7.5
       parent: 1
-      type: Transform
   - uid: 229
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 8.5,-5.5
       parent: 1
-      type: Transform
   - uid: 230
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 8.5,-4.5
       parent: 1
-      type: Transform
   - uid: 231
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 8.5,-3.5
       parent: 1
-      type: Transform
   - uid: 232
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 8.5,-2.5
       parent: 1
-      type: Transform
   - uid: 233
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 8.5,-1.5
       parent: 1
-      type: Transform
   - uid: 234
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 8.5,-0.5
       parent: 1
-      type: Transform
   - uid: 235
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 8.5,0.5
       parent: 1
-      type: Transform
   - uid: 236
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 7.5,1.5
       parent: 1
-      type: Transform
   - uid: 237
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 7.5,2.5
       parent: 1
-      type: Transform
   - uid: 238
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 6.5,2.5
       parent: 1
-      type: Transform
   - uid: 241
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -5.5,1.5
       parent: 1
-      type: Transform
   - uid: 242
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -5.5,2.5
       parent: 1
-      type: Transform
   - uid: 243
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -4.5,2.5
       parent: 1
-      type: Transform
 - proto: SolarTracker
   entities:
   - uid: 201
     components:
-    - pos: 8.5,1.5
+    - type: Transform
+      pos: 8.5,1.5
       parent: 1
-      type: Transform
   - uid: 203
     components:
-    - pos: -6.5,1.5
+    - type: Transform
+      pos: -6.5,1.5
       parent: 1
-      type: Transform
-- proto: SpawnPointChaplain
-  entities:
-  - uid: 510
-    components:
-    - pos: 0.5,4.5
-      parent: 1
-      type: Transform
 - proto: SpawnPointLatejoin
   entities:
   - uid: 416
     components:
-    - pos: 2.5,3.5
+    - type: Transform
+      pos: 2.5,3.5
       parent: 1
-      type: Transform
-- proto: SpawnPointPilot
-  entities:
-  - uid: 912
-    components:
-    - pos: 0.5,5.5
-      parent: 1
-      type: Transform
 - proto: Stool
   entities:
   - uid: 98
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 2.5,3.5
       parent: 1
-      type: Transform
   - uid: 745
     components:
-    - anchored: True
+    - type: Transform
+      anchored: True
       rot: 3.141592653589793 rad
       pos: 3.5,-1.5
       parent: 1
-      type: Transform
-    - bodyType: Static
-      type: Physics
+    - type: Physics
+      bodyType: Static
 - proto: SubstationBasic
   entities:
   - uid: 328
     components:
-    - pos: -2.5,-13.5
+    - type: Transform
+      pos: -2.5,-13.5
       parent: 1
-      type: Transform
 - proto: SuitStorageWallmountEVAAlternate
   entities:
   - uid: 4
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 1.5,4.5
       parent: 1
-      type: Transform
+    - type: Physics
+      canCollide: False
 - proto: TableCounterWood
   entities:
   - uid: 698
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 0.5,-0.5
       parent: 1
-      type: Transform
   - uid: 699
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 1.5,-0.5
       parent: 1
-      type: Transform
 - proto: TableWood
   entities:
   - uid: 348
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 2.5,-11.5
       parent: 1
-      type: Transform
   - uid: 349
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 3.5,-11.5
       parent: 1
-      type: Transform
   - uid: 350
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 3.5,-10.5
       parent: 1
-      type: Transform
   - uid: 351
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -0.5,-11.5
       parent: 1
-      type: Transform
   - uid: 352
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -1.5,-11.5
       parent: 1
-      type: Transform
   - uid: 507
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -1.5,-10.5
       parent: 1
-      type: Transform
 - proto: TableWoodReinforced
   entities:
   - uid: 22
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 1.5,6.5
       parent: 1
-      type: Transform
   - uid: 23
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 0.5,6.5
       parent: 1
-      type: Transform
   - uid: 119
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 2.5,6.5
       parent: 1
-      type: Transform
   - uid: 120
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -0.5,6.5
       parent: 1
-      type: Transform
 - proto: Thruster
   entities:
   - uid: 239
     components:
-    - pos: 5.5,4.5
+    - type: Transform
+      pos: 5.5,4.5
       parent: 1
-      type: Transform
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 244
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 6.5,3.5
       parent: 1
-      type: Transform
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 293
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -2.5,-18.5
       parent: 1
-      type: Transform
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 294
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 4.5,-18.5
       parent: 1
-      type: Transform
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 295
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 5.5,-18.5
       parent: 1
-      type: Transform
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 296
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -3.5,-18.5
       parent: 1
-      type: Transform
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 297
     components:
-    - pos: -4.5,4.5
+    - type: Transform
+      pos: -4.5,4.5
       parent: 1
-      type: Transform
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 298
     components:
-    - pos: -3.5,4.5
+    - type: Transform
+      pos: -3.5,4.5
       parent: 1
-      type: Transform
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 299
     components:
-    - pos: 6.5,4.5
+    - type: Transform
+      pos: 6.5,4.5
       parent: 1
-      type: Transform
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 300
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -4.5,3.5
       parent: 1
-      type: Transform
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 301
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -1.5,-18.5
       parent: 1
-      type: Transform
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 302
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 3.5,-18.5
       parent: 1
-      type: Transform
+    - type: Thruster
+      originalPowerLoad: 1500
 - proto: TintedWindow
   entities:
   - uid: 700
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 0.5,2.5
       parent: 1
-      type: Transform
   - uid: 701
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 2.5,4.5
       parent: 1
-      type: Transform
 - proto: TwoWayLever
   entities:
   - uid: 494
     components:
-    - pos: 5.5,-7.5
+    - type: Transform
+      pos: 5.5,-7.5
       parent: 1
-      type: Transform
-    - linkedPorts:
+    - type: DeviceLinkSource
+      linkedPorts:
         186:
         - Middle: Off
         - Left: Forward
@@ -5864,441 +5711,430 @@ entities:
         - Middle: Off
         - Left: Forward
         - Right: Forward
-      type: DeviceLinkSource
 - proto: VendingMachineChapel
   entities:
   - uid: 325
     components:
-    - pos: -1.5,5.5
+    - type: Transform
+      pos: -1.5,5.5
       parent: 1
-      type: Transform
 - proto: WallReinforced
   entities:
   - uid: 3
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -1.5,2.5
       parent: 1
-      type: Transform
   - uid: 8
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 4.5,4.5
       parent: 1
-      type: Transform
   - uid: 11
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -2.5,3.5
       parent: 1
-      type: Transform
   - uid: 18
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -3.5,-13.5
       parent: 1
-      type: Transform
   - uid: 25
     components:
-    - pos: -4.5,-4.5
+    - type: Transform
+      pos: -4.5,-4.5
       parent: 1
-      type: Transform
   - uid: 30
     components:
-    - pos: 4.5,-2.5
+    - type: Transform
+      pos: 4.5,-2.5
       parent: 1
-      type: Transform
   - uid: 31
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -4.5,-16.5
       parent: 1
-      type: Transform
   - uid: 33
     components:
-    - pos: -1.5,6.5
+    - type: Transform
+      pos: -1.5,6.5
       parent: 1
-      type: Transform
   - uid: 40
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 5.5,-13.5
       parent: 1
-      type: Transform
   - uid: 43
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -4.5,-14.5
       parent: 1
-      type: Transform
   - uid: 46
     components:
-    - pos: -3.5,-10.5
+    - type: Transform
+      pos: -3.5,-10.5
       parent: 1
-      type: Transform
   - uid: 48
     components:
-    - pos: -4.5,-9.5
+    - type: Transform
+      pos: -4.5,-9.5
       parent: 1
-      type: Transform
   - uid: 51
     components:
-    - pos: 2.5,-17.5
+    - type: Transform
+      pos: 2.5,-17.5
       parent: 1
-      type: Transform
   - uid: 52
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 6.5,-16.5
       parent: 1
-      type: Transform
   - uid: 53
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -0.5,-17.5
       parent: 1
-      type: Transform
   - uid: 54
     components:
-    - pos: 2.5,-18.5
+    - type: Transform
+      pos: 2.5,-18.5
       parent: 1
-      type: Transform
   - uid: 56
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 5.5,-17.5
       parent: 1
-      type: Transform
   - uid: 64
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -2.5,4.5
       parent: 1
-      type: Transform
   - uid: 67
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 3.5,3.5
       parent: 1
-      type: Transform
   - uid: 70
     components:
-    - pos: 5.5,-2.5
+    - type: Transform
+      pos: 5.5,-2.5
       parent: 1
-      type: Transform
   - uid: 72
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 6.5,-14.5
       parent: 1
-      type: Transform
   - uid: 73
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -3.5,-17.5
       parent: 1
-      type: Transform
   - uid: 74
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 6.5,-17.5
       parent: 1
-      type: Transform
   - uid: 78
     components:
-    - pos: 3.5,0.5
+    - type: Transform
+      pos: 3.5,0.5
       parent: 1
-      type: Transform
   - uid: 87
     components:
-    - pos: 5.5,-10.5
+    - type: Transform
+      pos: 5.5,-10.5
       parent: 1
-      type: Transform
   - uid: 89
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -2.5,-12.5
       parent: 1
-      type: Transform
   - uid: 92
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 5.5,-12.5
       parent: 1
-      type: Transform
   - uid: 95
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -1.5,3.5
       parent: 1
-      type: Transform
   - uid: 102
     components:
-    - pos: -2.5,0.5
+    - type: Transform
+      pos: -2.5,0.5
       parent: 1
-      type: Transform
   - uid: 107
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -4.5,-17.5
       parent: 1
-      type: Transform
   - uid: 108
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 4.5,-12.5
       parent: 1
-      type: Transform
   - uid: 112
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -0.5,-18.5
       parent: 1
-      type: Transform
   - uid: 123
     components:
-    - pos: 3.5,6.5
+    - type: Transform
+      pos: 3.5,6.5
       parent: 1
-      type: Transform
   - uid: 128
     components:
-    - pos: 5.5,-9.5
+    - type: Transform
+      pos: 5.5,-9.5
       parent: 1
-      type: Transform
   - uid: 129
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 4.5,3.5
       parent: 1
-      type: Transform
   - uid: 131
     components:
-    - pos: 5.5,-4.5
+    - type: Transform
+      pos: 5.5,-4.5
       parent: 1
-      type: Transform
   - uid: 135
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 3.5,2.5
       parent: 1
-      type: Transform
   - uid: 165
     components:
-    - pos: -2.5,6.5
+    - type: Transform
+      pos: -2.5,6.5
       parent: 1
-      type: Transform
   - uid: 169
     components:
-    - pos: 4.5,6.5
+    - type: Transform
+      pos: 4.5,6.5
       parent: 1
-      type: Transform
   - uid: 174
     components:
-    - pos: 4.5,0.5
+    - type: Transform
+      pos: 4.5,0.5
       parent: 1
-      type: Transform
   - uid: 175
     components:
-    - pos: -1.5,0.5
+    - type: Transform
+      pos: -1.5,0.5
       parent: 1
-      type: Transform
   - uid: 182
     components:
-    - pos: -3.5,-9.5
+    - type: Transform
+      pos: -3.5,-9.5
       parent: 1
-      type: Transform
   - uid: 183
     components:
-    - pos: 6.5,-9.5
+    - type: Transform
+      pos: 6.5,-9.5
       parent: 1
-      type: Transform
   - uid: 195
     components:
-    - pos: -3.5,-2.5
+    - type: Transform
+      pos: -3.5,-2.5
       parent: 1
-      type: Transform
   - uid: 196
     components:
-    - pos: 4.5,-10.5
+    - type: Transform
+      pos: 4.5,-10.5
       parent: 1
-      type: Transform
   - uid: 202
     components:
-    - pos: -2.5,-2.5
+    - type: Transform
+      pos: -2.5,-2.5
       parent: 1
-      type: Transform
   - uid: 228
     components:
-    - pos: -2.5,-10.5
+    - type: Transform
+      pos: -2.5,-10.5
       parent: 1
-      type: Transform
   - uid: 240
     components:
-    - pos: -1.5,-17.5
+    - type: Transform
+      pos: -1.5,-17.5
       parent: 1
-      type: Transform
   - uid: 303
     components:
-    - pos: 3.5,-17.5
+    - type: Transform
+      pos: 3.5,-17.5
       parent: 1
-      type: Transform
   - uid: 508
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -4.5,-13.5
       parent: 1
-      type: Transform
   - uid: 531
     components:
-    - pos: 6.5,-4.5
+    - type: Transform
+      pos: 6.5,-4.5
       parent: 1
-      type: Transform
   - uid: 578
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -3.5,-12.5
       parent: 1
-      type: Transform
   - uid: 740
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 6.5,-13.5
       parent: 1
-      type: Transform
   - uid: 779
     components:
-    - pos: -3.5,-4.5
+    - type: Transform
+      pos: -3.5,-4.5
       parent: 1
-      type: Transform
 - proto: WallSolid
   entities:
   - uid: 10
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 2.5,-16.5
       parent: 1
-      type: Transform
   - uid: 21
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 2.5,-15.5
       parent: 1
-      type: Transform
   - uid: 24
     components:
-    - pos: 1.5,2.5
+    - type: Transform
+      pos: 1.5,2.5
       parent: 1
-      type: Transform
   - uid: 38
     components:
-    - pos: 3.5,4.5
+    - type: Transform
+      pos: 3.5,4.5
       parent: 1
-      type: Transform
   - uid: 59
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -0.5,-16.5
       parent: 1
-      type: Transform
   - uid: 60
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -0.5,-15.5
       parent: 1
-      type: Transform
   - uid: 63
     components:
-    - pos: 3.5,-12.5
+    - type: Transform
+      pos: 3.5,-12.5
       parent: 1
-      type: Transform
   - uid: 83
     components:
-    - pos: 1.5,3.5
+    - type: Transform
+      pos: 1.5,3.5
       parent: 1
-      type: Transform
   - uid: 88
     components:
-    - pos: 1.5,4.5
+    - type: Transform
+      pos: 1.5,4.5
       parent: 1
-      type: Transform
   - uid: 103
     components:
-    - pos: 2.5,-12.5
+    - type: Transform
+      pos: 2.5,-12.5
       parent: 1
-      type: Transform
   - uid: 127
     components:
-    - pos: -1.5,-12.5
+    - type: Transform
+      pos: -1.5,-12.5
       parent: 1
-      type: Transform
   - uid: 200
     components:
-    - pos: -0.5,-12.5
+    - type: Transform
+      pos: -0.5,-12.5
       parent: 1
-      type: Transform
   - uid: 320
     components:
-    - pos: -0.5,-13.5
+    - type: Transform
+      pos: -0.5,-13.5
       parent: 1
-      type: Transform
   - uid: 321
     components:
-    - pos: 2.5,-13.5
+    - type: Transform
+      pos: 2.5,-13.5
       parent: 1
-      type: Transform
 - proto: WardrobeChapelFilled
   entities:
   - uid: 326
     components:
-    - pos: -1.5,4.5
+    - type: Transform
+      pos: -1.5,4.5
       parent: 1
-      type: Transform
 - proto: WarpPointShip
   entities:
   - uid: 418
     components:
-    - pos: 1.5,-6.5
+    - type: Transform
+      pos: 1.5,-6.5
       parent: 1
-      type: Transform
 - proto: WaterCooler
   entities:
   - uid: 772
     components:
-    - pos: -1.5,-9.5
+    - type: Transform
+      pos: -1.5,-9.5
       parent: 1
-      type: Transform
-- proto: WeaponRevolverArgenti
-  entities:
-  - uid: 512
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 511
-      type: Transform
-    - canCollide: False
-      type: Physics
 - proto: WoodDoor
   entities:
   - uid: 14
     components:
-    - pos: 0.5,-12.5
+    - type: Transform
+      pos: 0.5,-12.5
       parent: 1
-      type: Transform
   - uid: 199
     components:
-    - pos: 2.5,2.5
+    - type: Transform
+      pos: 2.5,2.5
       parent: 1
-      type: Transform
   - uid: 353
     components:
-    - pos: 1.5,-12.5
+    - type: Transform
+      pos: 1.5,-12.5
       parent: 1
-      type: Transform
 - proto: Wrench
   entities:
   - uid: 735
     components:
-    - pos: -2.5772095,-16.503101
+    - type: Transform
+      pos: -2.5772095,-16.503101
       parent: 1
-      type: Transform
 ...

--- a/Resources/Maps/_NF/Shuttles/legman.yml
+++ b/Resources/Maps/_NF/Shuttles/legman.yml
@@ -153,23 +153,21 @@ entities:
       data:
         tiles:
           0,0:
-            0: 32767
+            0: 2047
             1: 32768
-          1,0:
-            0: 17
-            1: 4352
-          -1,0:
-            0: 52974
-            1: 8192
           0,-1:
-            0: 65527
+            0: 65330
             1: 8
+          -1,0:
+            0: 3276
+            1: 8192
+          1,0:
+            1: 4352
+          -1,-1:
+            0: 51336
+            1: 546
           1,-1:
             1: 16
-            0: 4352
-          -1,-1:
-            1: 546
-            0: 60620
         uniqueMixes:
         - volume: 2500
           temperature: 293.15
@@ -187,7 +185,7 @@ entities:
           - 0
           - 0
         - volume: 2500
-          temperature: 293.15
+          immutable: True
           moles:
           - 0
           - 0
@@ -219,8 +217,6 @@ entities:
       - 122
       - 114
       - 121
-    - type: AtmosDevice
-      joinedGrid: 1
 - proto: AirCanister
   entities:
   - uid: 148
@@ -231,8 +227,6 @@ entities:
       parent: 1
     - type: Physics
       bodyType: Static
-    - type: AtmosDevice
-      joinedGrid: 1
 - proto: AirlockGlassShuttle
   entities:
   - uid: 61
@@ -617,7 +611,6 @@ entities:
       solutions:
         drink:
           temperature: 293.15
-          canMix: True
           canReact: True
           maxVol: 20
           name: null
@@ -671,8 +664,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -2.5,-2.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
     - type: AtmosPipeColor
       color: '#990000FF'
 - proto: GasPipeBend
@@ -710,8 +701,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -1.5,0.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
     - type: AtmosPipeColor
       color: '#0000CCFF'
 - proto: GasPressurePump
@@ -724,8 +713,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -0.5,0.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
     - type: AtmosPipeColor
       color: '#0000CCFF'
   - uid: 133
@@ -735,8 +722,6 @@ entities:
     - type: Transform
       pos: -0.5,-1.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
     - type: AtmosPipeColor
       color: '#990000FF'
 - proto: GasVentPump
@@ -747,8 +732,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 0.5,-0.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
     - type: AtmosPipeColor
       color: '#0000CCFF'
 - proto: GasVentScrubber
@@ -758,8 +741,6 @@ entities:
     - type: Transform
       pos: -0.5,-0.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
 - proto: GravityGeneratorMini
   entities:
   - uid: 78
@@ -862,127 +843,26 @@ entities:
   entities:
   - uid: 57
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 74
     - type: Physics
       canCollide: False
   - uid: 71
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 74
     - type: Physics
       canCollide: False
   - uid: 88
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 74
     - type: Physics
       canCollide: False
-  - uid: 159
-    components:
-    - type: Transform
-      pos: -0.90263844,-0.4524182
-      parent: 1
-    - type: Paper
-      stampState: paper_stamp-ce
-      stampedBy:
-      - stampedBorderless: False
-        stampedColor: '#C69B17FF'
-        stampedName: stamp-component-stamped-name-ce
-      - stampedBorderless: False
-        stampedColor: '#00BE00FF'
-        stampedName: stamp-component-stamped-name-approved
-      content: >-
-        [color=#1b67a5]█░░█░███[/color][color=#5b97bc]░███░█░█░█░██░░█░█░██░░██░░██░[/color]
-
-        [color=#1b67a5]██░█░░█░[/color][color=#5b97bc]██░░░█░█░█░█░█░█░█░█░█░█░█░█░█[/color]
-
-        [color=#1b67a5]█░██░░█░[/color][color=#5b97bc]░░██░███░█░██░░░█░░███░██░░█░█[/color]
-
-        [color=#1b67a5]█░░█░░█░[/color][color=#5b97bc]███░░█░█░█░█░░░░█░░█░█░█░█░██░[/color]
-
-
-        [head=1]=========================[/head]
-
-        [head=1]    Legman-class service ship[/head]
-
-        [head=1] [/head]
-
-        [head=1]       PREFLIGHT CHECKLIST[/head]
-
-        [head=1] [/head]
-
-        [head=1]=========================[/head]
-
-
-        [head=2]1. Power supply.[/head]
-
-        [head=3]1.1. Battery units.[/head]
-
-        [bullet/][ ] Check if the substation unit is anchored to the floor.
-
-        [bullet/][ ] Check if the APC unit's Main Breaker is toggled on.
-
-        [bullet/][ ] Check the APC unit's current Load[bold]*[/bold] (W).
-
-        [head=3]1.2. P.A.C.M.A.N. generator unit.[/head]
-
-        [bullet/][ ] Check if the P.A.C.M.A.N. generator unit is anchored to the floor.
-
-        [bullet/][ ] Check if the P.A.C.M.A.N. generator unit has fuel. For extended flights make sure that you have enough fuel stockpiled to sustain prolonged power generation.
-
-        [bullet/][ ] Check if the P.A.C.M.A.N. generator unit is set to HV output.
-
-        [bullet/][ ] Set Target Power for 9-10[bold]**[/bold] [bold]k[/bold]W.
-
-        [bullet/][ ] Start the P.A.C.M.A.N. generator unit.
-
-
-        [head=2]2. Atmospherics.[/head]
-
-        [head=3]2.1. Distribution Loop.[/head]
-
-        [bullet/][ ] Check if the air canister is anchored to connector port.
-
-        [bullet/][ ] Check if the distribution pump is set to normal pressure.
-
-        [bullet/][ ] Enable the distribution pump.
-
-        [head=3]2.2. Waste Loop.[/head]
-
-        [bullet/][ ] Enable the waste loop pump.
-
-        [bullet/][ ] Disable Auto Mode on the Air Alarm in the Engine Room.
-
-        [bullet/][ ] Set the Air Alarm in the Engine Room to Filtering (Wide).
-
-
-        [head=2]3. Other checks.[/head]
-
-        [bullet/][ ] Check if the gyroscope is anchored, powered, and enabled.
-
-        [bullet/][ ] Check if the mini gravity generator is anchored, powered, and enabled.
-
-        [bullet/][ ] Check if the bow window shutters are closed.
-
-
-        __________________________________________________________________
-
-        [bold]*[/bold] - Legman-class service ships are equipped with a single APC unit that can be used to appraise the ship's total power consumption. One can check the ship's total power consumption against the P.A.C.M.A.N. generator unit Target Power output: to keep substation and APC fully charged, P.A.C.M.A.N. generator unit Target Power output should exceed APC's Load. Remember to check APC Load and adjust the generator unit Target Power after connecting new power-consuming machines.
-
-        [bold]**[/bold] - Legman-class service ships have low power demand meaning that standard P.A.C.M.A.N. generator unit's Target Power value can be lowered as low as 10 kW. Please note, that recommended Target Power value to avoid blackouts during Gravity Generator charging sequence is 11 kW.
 - proto: PaperWrittenAMEScribbles
   entities:
   - uid: 134
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 132
     - type: Physics
@@ -1020,7 +900,6 @@ entities:
   - uid: 150
     components:
     - type: MetaData
-      flags: InContainer
       name: heart medication
     - type: Transform
       parent: 149
@@ -1029,7 +908,6 @@ entities:
   - uid: 151
     components:
     - type: MetaData
-      flags: InContainer
       name: heart medication
     - type: Transform
       parent: 149
@@ -1038,7 +916,6 @@ entities:
   - uid: 152
     components:
     - type: MetaData
-      flags: InContainer
       name: heart medication
     - type: Transform
       parent: 149
@@ -1047,7 +924,6 @@ entities:
   - uid: 153
     components:
     - type: MetaData
-      flags: InContainer
       name: heart medication
     - type: Transform
       parent: 149
@@ -1056,7 +932,6 @@ entities:
   - uid: 154
     components:
     - type: MetaData
-      flags: InContainer
       name: heart medication
     - type: Transform
       parent: 149
@@ -1065,26 +940,22 @@ entities:
   - uid: 156
     components:
     - type: MetaData
-      flags: InContainer
       name: heart medication
     - type: Transform
       parent: 149
     - type: Physics
       canCollide: False
-- proto: PortableGeneratorPacman
+- proto: PortableGeneratorPacmanShuttle
   entities:
-  - uid: 3
+  - uid: 26
     components:
     - type: Transform
-      anchored: True
       pos: -1.5,-0.5
       parent: 1
-    - type: MaterialStorage
-      storage:
-        Plasma: 1500
+    - type: FuelGenerator
+      on: False
     - type: Physics
       bodyType: Static
-    - type: InsertingMaterialStorage
 - proto: PottedPlantRandom
   entities:
   - uid: 162
@@ -1096,16 +967,12 @@ entities:
   entities:
   - uid: 81
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-1.5
       parent: 1
   - uid: 82
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,0.5
@@ -1121,6 +988,13 @@ entities:
       count: 15
     - type: Item
       size: 15
+- proto: ShipyardLegmanInfo
+  entities:
+  - uid: 3
+    components:
+    - type: Transform
+      pos: -0.6833,-0.24577266
+      parent: 1
 - proto: ShuttleWindow
   entities:
   - uid: 6
@@ -1191,6 +1065,33 @@ entities:
     - type: Transform
       pos: -0.5,2.5
       parent: 1
+    - type: Thruster
+      originalPowerLoad: 200
+- proto: SmallThruster
+  entities:
+  - uid: 27
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-2.5
+      parent: 1
+    - type: Thruster
+      originalPowerLoad: 500
+  - uid: 29
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-3.5
+      parent: 1
+    - type: Thruster
+      originalPowerLoad: 500
+  - uid: 135
+    components:
+    - type: Transform
+      pos: 4.5,3.5
+      parent: 1
+    - type: Thruster
+      originalPowerLoad: 500
 - proto: SpawnPointLatejoin
   entities:
   - uid: 142
@@ -1198,26 +1099,11 @@ entities:
     - type: Transform
       pos: 1.5,0.5
       parent: 1
-- proto: SpawnPointPilot
-  entities:
-  - uid: 144
-    components:
-    - type: Transform
-      pos: -1.5,1.5
-      parent: 1
-- proto: SpawnPointReporter
-  entities:
-  - uid: 135
-    components:
-    - type: Transform
-      pos: 3.5,0.5
-      parent: 1
 - proto: StrangePill
   entities:
   - uid: 155
     components:
     - type: MetaData
-      flags: InContainer
       name: heart medication
     - type: Transform
       parent: 149
@@ -1274,116 +1160,77 @@ entities:
       parent: 1
 - proto: Thruster
   entities:
-  - uid: 26
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -2.5,-2.5
-      parent: 1
-  - uid: 27
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,-3.5
-      parent: 1
   - uid: 28
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-3.5
       parent: 1
-  - uid: 29
-    components:
-    - type: Transform
-      pos: 4.5,3.5
-      parent: 1
+    - type: Thruster
+      originalPowerLoad: 1500
 - proto: WallShuttle
   entities:
   - uid: 2
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,-3.5
       parent: 1
   - uid: 13
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 2.5,-3.5
       parent: 1
   - uid: 18
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 1.5,3.5
       parent: 1
   - uid: 46
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 2.5,3.5
       parent: 1
   - uid: 68
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-0.5
       parent: 1
   - uid: 69
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 4.5,-1.5
       parent: 1
   - uid: 76
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,0.5
       parent: 1
   - uid: 83
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-3.5
       parent: 1
   - uid: 112
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 2.5,-2.5
       parent: 1
   - uid: 129
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -1.5,-2.5
       parent: 1
   - uid: 146
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -1.5,-1.5
       parent: 1
   - uid: 147
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 3.5,2.5
       parent: 1
@@ -1444,6 +1291,11 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 1.5,1.5
       parent: 1
+  - uid: 144
+    components:
+    - type: Transform
+      pos: -0.5,-1.5
+      parent: 1
 - proto: WindowReinforcedDirectional
   entities:
   - uid: 17
@@ -1463,6 +1315,11 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-1.5
+      parent: 1
+  - uid: 159
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
       parent: 1
 - proto: Wrench
   entities:

--- a/Resources/Maps/_NF/Shuttles/liquidator.yml
+++ b/Resources/Maps/_NF/Shuttles/liquidator.yml
@@ -16,12 +16,13 @@ entities:
   entities:
   - uid: 1
     components:
-    - name: grid
-      type: MetaData
-    - pos: -0.4999962,-0.4928913
+    - type: MetaData
+      name: grid
+    - type: Transform
+      pos: -0.4999962,-0.4928913
       parent: invalid
-      type: Transform
-    - chunks:
+    - type: MapGrid
+      chunks:
         0,0:
           ind: 0,0
           tiles: HAAAAAAAHAAAAAAAHAAAAAAAHAAAAAAAYQAAAAAAYQAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHAAAAAAAHAAAAAAAHAAAAAAAHAAAAAAAYQAAAAAAYQAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHAAAAAAAHAAAAAAAHAAAAAAAHAAAAAAAYQAAAAAAYQAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYQAAAAAAYQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
@@ -38,24 +39,24 @@ entities:
           ind: -1,-1
           tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAPwAAAAAAcgAAAAAAPwAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAXQAAAAAAXQAAAAAAXQAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAYQAAAAAAcgAAAAAAYQAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAHAAAAAAAHAAAAAAAHAAAAAAAYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAHAAAAAAAHAAAAAAAHAAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAHAAAAAAAHAAAAAAAHAAAAAAAYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAHAAAAAAAHAAAAAAAHAAAAAAAYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAYQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAA
           version: 6
-      type: MapGrid
     - type: Broadphase
-    - bodyStatus: InAir
+    - type: Physics
+      bodyStatus: InAir
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
       bodyType: Dynamic
-      type: Physics
-    - fixtures: {}
-      type: Fixtures
+    - type: Fixtures
+      fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid
     - type: Shuttle
     - type: GridPathfinding
-    - gravityShakeSound: !type:SoundPathSpecifier
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
         path: /Audio/Effects/alert.ogg
-      type: Gravity
-    - chunkCollection:
+    - type: DecalGrid
+      chunkCollection:
         version: 2
         nodes:
         - node:
@@ -65,6 +66,17 @@ entities:
             23: -2,-5
             24: -4,-7
             25: -4,-5
+        - node:
+            color: '#FFFFFFFF'
+            id: BotGreyscale
+          decals:
+            54: 2,2
+            55: 1,-3
+        - node:
+            color: '#FFFFFFFF'
+            id: BotLeftGreyscale
+          decals:
+            52: 5,0
         - node:
             color: '#0096FFFF'
             id: BotRightGreyscale
@@ -197,7 +209,7 @@ entities:
             color: '#FFFFFFFF'
             id: DeliveryGreyscale
           decals:
-            48: 5,0
+            56: 3,2
         - node:
             color: '#0096FFFF'
             id: LoadingAreaGreyscale
@@ -215,55 +227,53 @@ entities:
           decals:
             49: 4,2
             50: 4,1
-            51: 4,0
+            53: 4,0
         - node:
             color: '#FFFFFFFF'
             id: WarnLineW
           decals:
             35: 0,2
             36: 1,2
-      type: DecalGrid
-    - version: 2
+    - type: GridAtmosphere
+      version: 2
       data:
         tiles:
           0,0:
-            0: 65535
+            0: 4095
           0,-1:
-            0: 65535
-          -1,0:
-            0: 65535
-          -1,-1:
-            0: 65535
+            0: 65520
           0,1:
-            1: 255
+            1: 15
+            2: 240
+          -1,1:
+            1: 15
+            2: 240
           1,0:
-            0: 30583
-            1: 32768
+            0: 819
+            2: 32768
           1,1:
-            1: 2303
+            1: 143
+            2: 2160
           2,1:
             1: 4369
           0,-2:
-            0: 65520
-            1: 14
-          1,-2:
-            1: 1
-            0: 4368
-          1,-1:
-            0: 30583
-          -2,1:
-            1: 9966
-          -2,0:
-            1: 16384
-            0: 34952
-          -1,1:
-            1: 255
-          -2,-2:
-            0: 34952
-          -2,-1:
-            0: 34952
+            0: 65280
+            2: 14
           -1,-2:
-            0: 65535
+            0: 62837
+          -1,-1:
+            0: 8183
+          1,-2:
+            2: 1
+          1,-1:
+            0: 816
+          -2,1:
+            1: 8814
+            2: 1152
+          -2,0:
+            2: 16384
+          -1,0:
+            0: 1911
         uniqueMixes:
         - volume: 2500
           temperature: 293.15
@@ -295,51 +305,47 @@ entities:
           - 0
           - 0
           - 0
+        - volume: 2500
+          immutable: True
+          moles:
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
         chunkSize: 4
-      type: GridAtmosphere
     - type: GasTileOverlay
     - type: RadiationGridResistance
-    - id: liquidator
-      type: BecomesStation
+    - type: BecomesStation
+      id: liquidator
 - proto: AirAlarm
   entities:
   - uid: 4
     components:
-    - name: engine room air alarm
-      type: MetaData
-    - pos: 3.5,-3.5
+    - type: MetaData
+      name: engine room air alarm
+    - type: Transform
+      pos: 3.5,-3.5
       parent: 1
-      type: Transform
-    - ShutdownSubscribers:
-      - 162
-      - 234
-      - 328
-      type: DeviceNetwork
-    - devices:
-      - 328
+    - type: DeviceList
+      devices:
       - 234
       - 162
-      type: DeviceList
   - uid: 396
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 4.5,-0.5
       parent: 1
-      type: Transform
-    - ShutdownSubscribers:
-      - 335
-      - 295
-      - 69
-      - 278
-      - 460
-      - 173
-      - 249
-      - 457
-      - 22
-      type: DeviceNetwork
-    - devices:
-      - 457
-      - 249
+    - type: DeviceList
+      devices:
       - 460
       - 278
       - 69
@@ -347,2686 +353,2371 @@ entities:
       - 335
       - 173
       - 22
-      type: DeviceList
-- proto: AirCanister
-  entities:
-  - uid: 235
-    components:
-    - anchored: True
-      pos: 5.5,0.5
-      parent: 1
-      type: Transform
-    - bodyType: Static
-      type: Physics
 - proto: AirlockCommandGlass
   entities:
   - uid: 8
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -3.5,-0.5
       parent: 1
-      type: Transform
 - proto: AirlockEngineeringGlass
   entities:
   - uid: 281
     components:
-    - pos: -0.5,-4.5
+    - type: Transform
+      pos: -0.5,-4.5
       parent: 1
-      type: Transform
 - proto: AirlockExternalGlass
   entities:
   - uid: 9
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -1.5,-5.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 107
-      type: DeviceLinkSink
   - uid: 11
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -3.5,-5.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 107
-      type: DeviceLinkSink
 - proto: AirlockGlassShuttle
   entities:
   - uid: 111
     components:
-    - pos: -1.5,-7.5
+    - type: Transform
+      pos: -1.5,-7.5
       parent: 1
-      type: Transform
   - uid: 125
     components:
-    - pos: -3.5,-7.5
+    - type: Transform
+      pos: -3.5,-7.5
       parent: 1
-      type: Transform
 - proto: AirlockMaintGlass
   entities:
   - uid: 35
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -0.5,-1.5
       parent: 1
-      type: Transform
   - uid: 214
     components:
-    - pos: -0.5,-2.5
+    - type: Transform
+      pos: -0.5,-2.5
       parent: 1
-      type: Transform
 - proto: AirSensor
   entities:
-  - uid: 249
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -2.5,-3.5
-      parent: 1
-      type: Transform
-    - ShutdownSubscribers:
-      - 396
-      type: DeviceNetwork
-  - uid: 328
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 0.5,-4.5
-      parent: 1
-      type: Transform
-    - ShutdownSubscribers:
-      - 4
-      type: DeviceNetwork
-  - uid: 366
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -2.5,1.5
-      parent: 1
-      type: Transform
-  - uid: 457
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 1.5,-1.5
-      parent: 1
-      type: Transform
-    - ShutdownSubscribers:
-      - 396
-      type: DeviceNetwork
   - uid: 460
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -1.5,2.5
       parent: 1
-      type: Transform
-    - ShutdownSubscribers:
-      - 396
-      type: DeviceNetwork
 - proto: APCBasic
   entities:
   - uid: 19
     components:
-    - desc: Only one APC? Dang.
-      type: MetaData
-    - pos: 0.5,-3.5
+    - type: MetaData
+      desc: Only one APC? Dang.
+    - type: Transform
+      pos: 0.5,-3.5
       parent: 1
-      type: Transform
 - proto: AtmosDeviceFanTiny
   entities:
   - uid: 215
     components:
-    - pos: 1.5,3.5
+    - type: Transform
+      pos: 1.5,3.5
       parent: 1
-      type: Transform
   - uid: 241
     components:
-    - pos: 0.5,3.5
+    - type: Transform
+      pos: 0.5,3.5
       parent: 1
-      type: Transform
   - uid: 246
     components:
-    - pos: -3.5,-7.5
+    - type: Transform
+      pos: -3.5,-7.5
       parent: 1
-      type: Transform
   - uid: 247
     components:
-    - pos: -1.5,-7.5
+    - type: Transform
+      pos: -1.5,-7.5
       parent: 1
-      type: Transform
 - proto: AtmosFixBlockerMarker
   entities:
   - uid: 389
     components:
-    - pos: -6.5,7.5
+    - type: Transform
+      pos: -6.5,7.5
       parent: 1
-      type: Transform
   - uid: 391
     components:
-    - pos: -6.5,6.5
+    - type: Transform
+      pos: -6.5,6.5
       parent: 1
-      type: Transform
   - uid: 392
     components:
-    - pos: -6.5,5.5
+    - type: Transform
+      pos: -6.5,5.5
       parent: 1
-      type: Transform
   - uid: 410
     components:
-    - pos: -6.5,4.5
+    - type: Transform
+      pos: -6.5,4.5
       parent: 1
-      type: Transform
   - uid: 411
     components:
-    - pos: -5.5,6.5
+    - type: Transform
+      pos: -5.5,6.5
       parent: 1
-      type: Transform
   - uid: 412
     components:
-    - pos: 7.5,6.5
+    - type: Transform
+      pos: 7.5,6.5
       parent: 1
-      type: Transform
   - uid: 413
     components:
-    - pos: 8.5,7.5
+    - type: Transform
+      pos: 8.5,7.5
       parent: 1
-      type: Transform
   - uid: 414
     components:
-    - pos: 8.5,6.5
+    - type: Transform
+      pos: 8.5,6.5
       parent: 1
-      type: Transform
   - uid: 415
     components:
-    - pos: 8.5,4.5
+    - type: Transform
+      pos: 8.5,4.5
       parent: 1
-      type: Transform
   - uid: 416
     components:
-    - pos: 8.5,5.5
+    - type: Transform
+      pos: 8.5,5.5
       parent: 1
-      type: Transform
   - uid: 417
     components:
-    - pos: 7.5,4.5
+    - type: Transform
+      pos: 7.5,4.5
       parent: 1
-      type: Transform
   - uid: 418
     components:
-    - pos: 7.5,5.5
+    - type: Transform
+      pos: 7.5,5.5
       parent: 1
-      type: Transform
   - uid: 419
     components:
-    - pos: 6.5,4.5
+    - type: Transform
+      pos: 6.5,4.5
       parent: 1
-      type: Transform
   - uid: 420
     components:
-    - pos: 6.5,5.5
+    - type: Transform
+      pos: 6.5,5.5
       parent: 1
-      type: Transform
   - uid: 421
     components:
-    - pos: 5.5,4.5
+    - type: Transform
+      pos: 5.5,4.5
       parent: 1
-      type: Transform
   - uid: 422
     components:
-    - pos: 5.5,5.5
+    - type: Transform
+      pos: 5.5,5.5
       parent: 1
-      type: Transform
   - uid: 423
     components:
-    - pos: 4.5,4.5
+    - type: Transform
+      pos: 4.5,4.5
       parent: 1
-      type: Transform
   - uid: 424
     components:
-    - pos: 4.5,5.5
+    - type: Transform
+      pos: 4.5,5.5
       parent: 1
-      type: Transform
   - uid: 425
     components:
-    - pos: 3.5,4.5
+    - type: Transform
+      pos: 3.5,4.5
       parent: 1
-      type: Transform
   - uid: 426
     components:
-    - pos: 3.5,5.5
+    - type: Transform
+      pos: 3.5,5.5
       parent: 1
-      type: Transform
   - uid: 427
     components:
-    - pos: 2.5,4.5
+    - type: Transform
+      pos: 2.5,4.5
       parent: 1
-      type: Transform
   - uid: 428
     components:
-    - pos: 2.5,5.5
+    - type: Transform
+      pos: 2.5,5.5
       parent: 1
-      type: Transform
   - uid: 429
     components:
-    - pos: 1.5,4.5
+    - type: Transform
+      pos: 1.5,4.5
       parent: 1
-      type: Transform
   - uid: 430
     components:
-    - pos: 1.5,5.5
+    - type: Transform
+      pos: 1.5,5.5
       parent: 1
-      type: Transform
   - uid: 431
     components:
-    - pos: 0.5,4.5
+    - type: Transform
+      pos: 0.5,4.5
       parent: 1
-      type: Transform
   - uid: 432
     components:
-    - pos: 0.5,5.5
+    - type: Transform
+      pos: 0.5,5.5
       parent: 1
-      type: Transform
   - uid: 433
     components:
-    - pos: -0.5,4.5
+    - type: Transform
+      pos: -0.5,4.5
       parent: 1
-      type: Transform
   - uid: 434
     components:
-    - pos: -0.5,5.5
+    - type: Transform
+      pos: -0.5,5.5
       parent: 1
-      type: Transform
   - uid: 435
     components:
-    - pos: -1.5,4.5
+    - type: Transform
+      pos: -1.5,4.5
       parent: 1
-      type: Transform
   - uid: 436
     components:
-    - pos: -1.5,5.5
+    - type: Transform
+      pos: -1.5,5.5
       parent: 1
-      type: Transform
   - uid: 437
     components:
-    - pos: -2.5,4.5
+    - type: Transform
+      pos: -2.5,4.5
       parent: 1
-      type: Transform
   - uid: 438
     components:
-    - pos: -2.5,5.5
+    - type: Transform
+      pos: -2.5,5.5
       parent: 1
-      type: Transform
   - uid: 439
     components:
-    - pos: -3.5,4.5
+    - type: Transform
+      pos: -3.5,4.5
       parent: 1
-      type: Transform
   - uid: 440
     components:
-    - pos: -3.5,5.5
+    - type: Transform
+      pos: -3.5,5.5
       parent: 1
-      type: Transform
   - uid: 441
     components:
-    - pos: -4.5,4.5
+    - type: Transform
+      pos: -4.5,4.5
       parent: 1
-      type: Transform
   - uid: 442
     components:
-    - pos: -4.5,5.5
+    - type: Transform
+      pos: -4.5,5.5
       parent: 1
-      type: Transform
   - uid: 443
     components:
-    - pos: -5.5,4.5
+    - type: Transform
+      pos: -5.5,4.5
       parent: 1
-      type: Transform
   - uid: 444
     components:
-    - pos: -5.5,5.5
+    - type: Transform
+      pos: -5.5,5.5
       parent: 1
-      type: Transform
   - uid: 445
     components:
-    - pos: -5.5,3.5
+    - type: Transform
+      pos: -5.5,3.5
       parent: 1
-      type: Transform
   - uid: 446
     components:
-    - pos: 7.5,3.5
+    - type: Transform
+      pos: 7.5,3.5
       parent: 1
-      type: Transform
   - uid: 447
     components:
-    - pos: 1.5,-7.5
+    - type: Transform
+      pos: 1.5,-7.5
       parent: 1
-      type: Transform
   - uid: 448
     components:
-    - pos: 2.5,-7.5
+    - type: Transform
+      pos: 2.5,-7.5
       parent: 1
-      type: Transform
   - uid: 449
     components:
-    - pos: 3.5,-7.5
+    - type: Transform
+      pos: 3.5,-7.5
       parent: 1
-      type: Transform
   - uid: 450
     components:
-    - pos: 4.5,-7.5
+    - type: Transform
+      pos: 4.5,-7.5
       parent: 1
-      type: Transform
 - proto: BiomassReclaimer
   entities:
   - uid: 36
     components:
-    - pos: 2.5,-2.5
+    - type: Transform
+      pos: 2.5,-2.5
       parent: 1
-      type: Transform
 - proto: BlastDoor
   entities:
   - uid: 186
     components:
-    - pos: 1.5,3.5
+    - type: Transform
+      pos: 1.5,3.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 188
-      type: DeviceLinkSink
   - uid: 326
     components:
-    - pos: 0.5,3.5
+    - type: Transform
+      pos: 0.5,3.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 188
-      type: DeviceLinkSink
 - proto: BoxBeaker
   entities:
   - uid: 205
     components:
-    - pos: 5.735236,-1.2296951
+    - type: Transform
+      pos: 5.5545774,-1.3291509
       parent: 1
-      type: Transform
 - proto: BoxBodyBag
   entities:
   - uid: 72
     components:
-    - pos: 0.7108896,1.719961
+    - type: Transform
+      pos: 0.7108896,1.719961
       parent: 1
-      type: Transform
-- proto: BoxCardboard
+- proto: BoxCleanerGrenades
   entities:
-  - uid: 285
+  - uid: 71
     components:
-    - name: external light tube box
-      type: MetaData
-    - pos: 0.26414788,1.5837543
+    - type: Transform
+      pos: 0.7541566,0.7489741
       parent: 1
-      type: Transform
-    - storageUsed: 30
-      type: Storage
-    - containers:
-        storagebase: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 288
-          - 289
-          - 290
-          - 299
-          - 60
-          - 463
-      type: ContainerContainer
+- proto: BoxExteriorLightTube
+  entities:
+  - uid: 60
+    components:
+    - type: Transform
+      pos: 0.3010316,1.7333491
+      parent: 1
 - proto: BoxFolderRed
   entities:
   - uid: 15
     components:
-    - pos: -1.6538084,1.929544
+    - type: Transform
+      pos: -1.6538084,1.929544
       parent: 1
-      type: Transform
 - proto: BoxLightbulb
   entities:
   - uid: 183
     components:
-    - pos: 0.3708086,1.3091961
+    - type: Transform
+      pos: 0.3708086,1.3091961
       parent: 1
-      type: Transform
 - proto: BoxLighttube
   entities:
   - uid: 357
     components:
-    - pos: 0.76756954,1.2525389
+    - type: Transform
+      pos: 0.76756954,1.2525389
       parent: 1
-      type: Transform
 - proto: Bucket
   entities:
   - uid: 64
     components:
-    - pos: 0.9776434,-0.16575927
+    - type: Transform
+      pos: 0.9776434,-0.16575927
       parent: 1
-      type: Transform
 - proto: CableApcExtension
   entities:
   - uid: 10
     components:
-    - pos: -3.5,-0.5
+    - type: Transform
+      pos: -3.5,-0.5
       parent: 1
-      type: Transform
   - uid: 54
     components:
-    - pos: 0.5,3.5
+    - type: Transform
+      pos: 0.5,3.5
       parent: 1
-      type: Transform
   - uid: 56
     components:
-    - pos: -2.5,-1.5
+    - type: Transform
+      pos: -2.5,-1.5
       parent: 1
-      type: Transform
   - uid: 96
     components:
-    - pos: 2.5,0.5
+    - type: Transform
+      pos: 2.5,0.5
       parent: 1
-      type: Transform
   - uid: 99
     components:
-    - pos: 0.5,4.5
+    - type: Transform
+      pos: 0.5,4.5
       parent: 1
-      type: Transform
   - uid: 115
     components:
-    - pos: 0.5,0.5
+    - type: Transform
+      pos: 0.5,0.5
       parent: 1
-      type: Transform
   - uid: 116
     components:
-    - pos: 0.5,-1.5
+    - type: Transform
+      pos: 0.5,-1.5
       parent: 1
-      type: Transform
   - uid: 119
     components:
-    - pos: 1.5,-2.5
+    - type: Transform
+      pos: 1.5,-2.5
       parent: 1
-      type: Transform
   - uid: 133
     components:
-    - pos: 1.5,0.5
+    - type: Transform
+      pos: 1.5,0.5
       parent: 1
-      type: Transform
   - uid: 138
     components:
-    - pos: -3.5,0.5
+    - type: Transform
+      pos: -3.5,0.5
       parent: 1
-      type: Transform
   - uid: 141
     components:
-    - pos: 3.5,0.5
+    - type: Transform
+      pos: 3.5,0.5
       parent: 1
-      type: Transform
   - uid: 144
     components:
-    - pos: -0.5,-1.5
+    - type: Transform
+      pos: -0.5,-1.5
       parent: 1
-      type: Transform
   - uid: 177
     components:
-    - pos: 3.5,-7.5
+    - type: Transform
+      pos: 3.5,-7.5
       parent: 1
-      type: Transform
   - uid: 213
     components:
-    - pos: 1.5,-4.5
+    - type: Transform
+      pos: 1.5,-4.5
       parent: 1
-      type: Transform
   - uid: 257
     components:
-    - pos: 0.5,2.5
+    - type: Transform
+      pos: 0.5,2.5
       parent: 1
-      type: Transform
   - uid: 259
     components:
-    - pos: 2.5,-4.5
+    - type: Transform
+      pos: 2.5,-4.5
       parent: 1
-      type: Transform
   - uid: 261
     components:
-    - pos: 0.5,-0.5
+    - type: Transform
+      pos: 0.5,-0.5
       parent: 1
-      type: Transform
   - uid: 269
     components:
-    - pos: 0.5,-4.5
+    - type: Transform
+      pos: 0.5,-4.5
       parent: 1
-      type: Transform
   - uid: 270
     components:
-    - pos: -1.5,-1.5
+    - type: Transform
+      pos: -1.5,-1.5
       parent: 1
-      type: Transform
   - uid: 291
     components:
-    - pos: 3.5,-6.5
+    - type: Transform
+      pos: 3.5,-6.5
       parent: 1
-      type: Transform
   - uid: 300
     components:
-    - pos: 3.5,-5.5
+    - type: Transform
+      pos: 3.5,-5.5
       parent: 1
-      type: Transform
   - uid: 301
     components:
-    - pos: -0.5,-4.5
+    - type: Transform
+      pos: -0.5,-4.5
       parent: 1
-      type: Transform
   - uid: 303
     components:
-    - pos: 0.5,4.5
+    - type: Transform
+      pos: 0.5,4.5
       parent: 1
-      type: Transform
   - uid: 304
     components:
-    - pos: 1.5,4.5
+    - type: Transform
+      pos: 1.5,4.5
       parent: 1
-      type: Transform
   - uid: 305
     components:
-    - pos: 2.5,4.5
+    - type: Transform
+      pos: 2.5,4.5
       parent: 1
-      type: Transform
   - uid: 306
     components:
-    - pos: 4.5,4.5
+    - type: Transform
+      pos: 4.5,4.5
       parent: 1
-      type: Transform
   - uid: 307
     components:
-    - pos: 3.5,4.5
+    - type: Transform
+      pos: 3.5,4.5
       parent: 1
-      type: Transform
   - uid: 309
     components:
-    - pos: 0.5,1.5
+    - type: Transform
+      pos: 0.5,1.5
       parent: 1
-      type: Transform
   - uid: 320
     components:
-    - pos: -3.5,1.5
+    - type: Transform
+      pos: -3.5,1.5
       parent: 1
-      type: Transform
   - uid: 323
     components:
-    - pos: -1.5,-5.5
+    - type: Transform
+      pos: -1.5,-5.5
       parent: 1
-      type: Transform
   - uid: 333
     components:
-    - pos: 5.5,4.5
+    - type: Transform
+      pos: 5.5,4.5
       parent: 1
-      type: Transform
   - uid: 336
     components:
-    - pos: -0.5,4.5
+    - type: Transform
+      pos: -0.5,4.5
       parent: 1
-      type: Transform
   - uid: 337
     components:
-    - pos: -1.5,4.5
+    - type: Transform
+      pos: -1.5,4.5
       parent: 1
-      type: Transform
   - uid: 338
     components:
-    - pos: -2.5,4.5
+    - type: Transform
+      pos: -2.5,4.5
       parent: 1
-      type: Transform
   - uid: 339
     components:
-    - pos: -3.5,4.5
+    - type: Transform
+      pos: -3.5,4.5
       parent: 1
-      type: Transform
   - uid: 344
     components:
-    - pos: 2.5,-2.5
+    - type: Transform
+      pos: 2.5,-2.5
       parent: 1
-      type: Transform
   - uid: 349
     components:
-    - pos: 3.5,-2.5
+    - type: Transform
+      pos: 3.5,-2.5
       parent: 1
-      type: Transform
   - uid: 351
     components:
-    - pos: 0.5,-2.5
+    - type: Transform
+      pos: 0.5,-2.5
       parent: 1
-      type: Transform
   - uid: 353
     components:
-    - pos: -1.5,-4.5
+    - type: Transform
+      pos: -1.5,-4.5
       parent: 1
-      type: Transform
   - uid: 362
     components:
-    - pos: 0.5,-3.5
+    - type: Transform
+      pos: 0.5,-3.5
       parent: 1
-      type: Transform
   - uid: 365
     components:
-    - pos: 3.5,-4.5
+    - type: Transform
+      pos: 3.5,-4.5
       parent: 1
-      type: Transform
   - uid: 370
     components:
-    - pos: -3.5,-1.5
+    - type: Transform
+      pos: -3.5,-1.5
       parent: 1
-      type: Transform
   - uid: 395
     components:
-    - pos: -1.5,-6.5
+    - type: Transform
+      pos: -1.5,-6.5
       parent: 1
-      type: Transform
 - proto: CableHV
   entities:
   - uid: 42
     components:
-    - pos: 2.5,-5.5
+    - type: Transform
+      pos: 2.5,-5.5
       parent: 1
-      type: Transform
   - uid: 44
     components:
-    - pos: 1.5,-5.5
+    - type: Transform
+      pos: 1.5,-5.5
       parent: 1
-      type: Transform
   - uid: 45
     components:
-    - pos: 0.5,-5.5
+    - type: Transform
+      pos: 0.5,-5.5
       parent: 1
-      type: Transform
   - uid: 394
     components:
-    - pos: 2.5,-4.5
+    - type: Transform
+      pos: 2.5,-4.5
       parent: 1
-      type: Transform
 - proto: CableMV
   entities:
   - uid: 142
     components:
-    - pos: 0.5,-5.5
+    - type: Transform
+      pos: 0.5,-5.5
       parent: 1
-      type: Transform
   - uid: 187
     components:
-    - pos: 0.5,-5.5
+    - type: Transform
+      pos: 0.5,-5.5
       parent: 1
-      type: Transform
   - uid: 212
     components:
-    - pos: 0.5,-3.5
+    - type: Transform
+      pos: 0.5,-3.5
       parent: 1
-      type: Transform
   - uid: 352
     components:
-    - pos: 0.5,-4.5
+    - type: Transform
+      pos: 0.5,-4.5
       parent: 1
-      type: Transform
 - proto: CableTerminal
   entities:
   - uid: 102
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 2.5,-5.5
       parent: 1
-      type: Transform
 - proto: Catwalk
   entities:
   - uid: 18
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 2.5,4.5
       parent: 1
-      type: Transform
   - uid: 37
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 7.5,5.5
       parent: 1
-      type: Transform
   - uid: 38
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -6.5,7.5
       parent: 1
-      type: Transform
   - uid: 57
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -6.5,6.5
       parent: 1
-      type: Transform
   - uid: 58
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -6.5,5.5
       parent: 1
-      type: Transform
   - uid: 59
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -5.5,5.5
       parent: 1
-      type: Transform
   - uid: 62
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 4.5,4.5
       parent: 1
-      type: Transform
   - uid: 73
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 8.5,5.5
       parent: 1
-      type: Transform
   - uid: 74
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 8.5,6.5
       parent: 1
-      type: Transform
   - uid: 75
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 8.5,7.5
       parent: 1
-      type: Transform
   - uid: 87
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -2.5,4.5
       parent: 1
-      type: Transform
   - uid: 89
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -0.5,4.5
       parent: 1
-      type: Transform
   - uid: 90
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -1.5,4.5
       parent: 1
-      type: Transform
   - uid: 91
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -3.5,4.5
       parent: 1
-      type: Transform
   - uid: 113
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -4.5,4.5
       parent: 1
-      type: Transform
   - uid: 158
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 3.5,4.5
       parent: 1
-      type: Transform
   - uid: 181
     components:
-    - pos: 0.5,4.5
+    - type: Transform
+      pos: 0.5,4.5
       parent: 1
-      type: Transform
   - uid: 204
     components:
-    - pos: 0.5,-4.5
+    - type: Transform
+      pos: 0.5,-4.5
       parent: 1
-      type: Transform
   - uid: 263
     components:
-    - pos: 2.5,-4.5
+    - type: Transform
+      pos: 2.5,-4.5
       parent: 1
-      type: Transform
   - uid: 312
     components:
-    - pos: 1.5,-4.5
+    - type: Transform
+      pos: 1.5,-4.5
       parent: 1
-      type: Transform
   - uid: 313
     components:
-    - pos: -6.5,4.5
+    - type: Transform
+      pos: -6.5,4.5
       parent: 1
-      type: Transform
   - uid: 314
     components:
-    - pos: -5.5,4.5
+    - type: Transform
+      pos: -5.5,4.5
       parent: 1
-      type: Transform
   - uid: 317
     components:
-    - pos: 7.5,4.5
+    - type: Transform
+      pos: 7.5,4.5
       parent: 1
-      type: Transform
   - uid: 318
     components:
-    - pos: 8.5,4.5
+    - type: Transform
+      pos: 8.5,4.5
       parent: 1
-      type: Transform
   - uid: 354
     components:
-    - pos: 1.5,4.5
+    - type: Transform
+      pos: 1.5,4.5
       parent: 1
-      type: Transform
   - uid: 405
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 6.5,4.5
       parent: 1
-      type: Transform
   - uid: 407
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 5.5,4.5
       parent: 1
-      type: Transform
 - proto: ChairOfficeLight
   entities:
   - uid: 355
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 4.5,-1.5
       parent: 1
-      type: Transform
 - proto: ChairWood
   entities:
   - uid: 277
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -3.5,1.5
       parent: 1
-      type: Transform
   - uid: 297
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -2.5,1.5
       parent: 1
-      type: Transform
 - proto: chem_master
   entities:
   - uid: 348
     components:
-    - pos: 4.5,-2.5
+    - type: Transform
+      pos: 4.5,-2.5
       parent: 1
-      type: Transform
-- proto: ChemicalPayload
-  entities:
-  - uid: 132
-    components:
-    - pos: 5.5085144,-1.3571733
-      parent: 1
-      type: Transform
-  - uid: 223
-    components:
-    - pos: 5.2959647,-1.1305447
-      parent: 1
-      type: Transform
 - proto: ClosetRadiationSuitFilled
   entities:
   - uid: 273
     components:
-    - pos: 1.5,-2.5
+    - type: Transform
+      pos: 1.5,-2.5
       parent: 1
-      type: Transform
 - proto: ClothingBeltUtilityEngineering
   entities:
   - uid: 308
     components:
-    - pos: 0.3708086,0.88426673
+    - type: Transform
+      pos: 0.3708086,0.88426673
       parent: 1
-      type: Transform
 - proto: ClothingEyesGlassesChemical
   entities:
   - uid: 88
     components:
-    - pos: 5.3809843,-1.4846523
+    - type: Transform
+      pos: 5.2889524,-1.2197759
       parent: 1
-      type: Transform
-- proto: ClothingHandsGlovesColorYellow
-  entities:
-  - uid: 76
-    components:
-    - pos: 0.54084945,0.600981
-      parent: 1
-      type: Transform
 - proto: ClothingNeckCloakJanitorFilled
   entities:
   - uid: 458
     components:
-    - pos: -1.3020872,1.440808
+    - type: Transform
+      pos: -1.3020872,1.440808
       parent: 1
-      type: Transform
 - proto: ClothingOuterCoatLabChem
   entities:
   - uid: 13
     components:
-    - pos: 4.5874624,-1.5838027
+    - type: Transform
+      pos: 4.5874624,-1.5838027
       parent: 1
-      type: Transform
-- proto: ClothingShoesBootsMag
-  entities:
-  - uid: 262
-    components:
-    - pos: 0.6400392,0.78511643
-      parent: 1
-      type: Transform
 - proto: ClothingShoesGaloshes
   entities:
   - uid: 98
     components:
-    - pos: 0.3991487,0.4451735
+    - type: Transform
+      pos: 0.3991487,0.4451735
       parent: 1
-      type: Transform
 - proto: ClothingShoeSlippersDuck
   entities:
   - uid: 377
     components:
-    - pos: 0.4846384,0.38614094
+    - type: Transform
+      pos: 0.4846384,0.38614094
       parent: 1
-      type: Transform
 - proto: ComputerTabletopShuttle
   entities:
   - uid: 464
     components:
-    - pos: -3.5,2.5
+    - type: Transform
+      pos: -3.5,2.5
       parent: 1
-      type: Transform
 - proto: ComputerTabletopStationRecords
   entities:
   - uid: 459
     components:
-    - pos: -2.5,2.5
+    - type: Transform
+      pos: -2.5,2.5
       parent: 1
-      type: Transform
 - proto: ComputerWallmountWithdrawBankATM
   entities:
   - uid: 20
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -0.5,-6.5
       parent: 1
-      type: Transform
-    - containers:
+    - type: Physics
+      canCollide: False
+    - type: ContainerContainer
+      containers:
         board: !type:Container
           ents: []
         bank-ATM-cashSlot: !type:ContainerSlot {}
-      type: ContainerContainer
     - type: ItemSlots
 - proto: DefibrillatorCabinetFilled
   entities:
   - uid: 406
     components:
-    - pos: 5.5,-0.5
+    - type: Transform
+      pos: 5.5,-0.5
       parent: 1
-      type: Transform
 - proto: DisposalBend
   entities:
   - uid: 206
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -2.5,-1.5
       parent: 1
-      type: Transform
   - uid: 211
     components:
-    - pos: 3.5,-1.5
+    - type: Transform
+      pos: 3.5,-1.5
       parent: 1
-      type: Transform
   - uid: 376
     components:
-    - pos: 0.5,4.5
+    - type: Transform
+      pos: 0.5,4.5
       parent: 1
-      type: Transform
 - proto: DisposalJunctionFlipped
   entities:
   - uid: 171
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 0.5,-1.5
       parent: 1
-      type: Transform
 - proto: DisposalPipe
   entities:
   - uid: 12
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -0.5,4.5
       parent: 1
-      type: Transform
   - uid: 21
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -1.5,4.5
       parent: 1
-      type: Transform
   - uid: 66
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -0.5,-1.5
       parent: 1
-      type: Transform
   - uid: 131
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 2.5,-1.5
       parent: 1
-      type: Transform
   - uid: 136
     components:
-    - pos: 0.5,1.5
+    - type: Transform
+      pos: 0.5,1.5
       parent: 1
-      type: Transform
   - uid: 145
     components:
-    - pos: 0.5,-0.5
+    - type: Transform
+      pos: 0.5,-0.5
       parent: 1
-      type: Transform
   - uid: 146
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -1.5,-1.5
       parent: 1
-      type: Transform
   - uid: 160
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -4.5,4.5
       parent: 1
-      type: Transform
   - uid: 164
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -3.5,4.5
       parent: 1
-      type: Transform
   - uid: 176
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -2.5,-3.5
       parent: 1
-      type: Transform
   - uid: 191
     components:
-    - pos: -2.5,-2.5
+    - type: Transform
+      pos: -2.5,-2.5
       parent: 1
-      type: Transform
   - uid: 200
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 1.5,-1.5
       parent: 1
-      type: Transform
   - uid: 245
     components:
-    - pos: 0.5,3.5
+    - type: Transform
+      pos: 0.5,3.5
       parent: 1
-      type: Transform
   - uid: 334
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -2.5,4.5
       parent: 1
-      type: Transform
   - uid: 367
     components:
-    - pos: 0.5,0.5
+    - type: Transform
+      pos: 0.5,0.5
       parent: 1
-      type: Transform
   - uid: 368
     components:
-    - pos: 0.5,2.5
+    - type: Transform
+      pos: 0.5,2.5
       parent: 1
-      type: Transform
   - uid: 403
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -5.5,4.5
       parent: 1
-      type: Transform
 - proto: DisposalTrunk
   entities:
   - uid: 163
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -6.5,4.5
       parent: 1
-      type: Transform
   - uid: 350
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -2.5,-4.5
       parent: 1
-      type: Transform
 - proto: DisposalUnit
   entities:
   - uid: 196
     components:
-    - pos: -2.5,-4.5
+    - type: Transform
+      pos: -2.5,-4.5
       parent: 1
-      type: Transform
   - uid: 332
     components:
-    - pos: -6.5,4.5
+    - type: Transform
+      pos: -6.5,4.5
       parent: 1
-      type: Transform
 - proto: Dropper
   entities:
   - uid: 255
     components:
-    - pos: 5.480175,-1.6262951
+    - type: Transform
+      pos: 5.480175,-1.6262951
       parent: 1
-      type: Transform
 - proto: EmergencyLight
   entities:
   - uid: 6
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -2.5,-6.5
       parent: 1
-      type: Transform
+  - uid: 95
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,4.5
+      parent: 1
   - uid: 379
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 0.5,-5.5
       parent: 1
-      type: Transform
   - uid: 380
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -1.5,-3.5
       parent: 1
-      type: Transform
   - uid: 381
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -1.5,1.5
       parent: 1
-      type: Transform
   - uid: 382
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 3.5,-0.5
       parent: 1
-      type: Transform
-  - uid: 385
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 3.5,4.5
-      parent: 1
-      type: Transform
 - proto: ExteriorLightTube
   entities:
-  - uid: 60
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 285
-      type: Transform
-    - canCollide: False
-      type: Physics
-  - uid: 288
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 285
-      type: Transform
-    - canCollide: False
-      type: Physics
-  - uid: 289
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 285
-      type: Transform
-    - canCollide: False
-      type: Physics
-  - uid: 290
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 285
-      type: Transform
-    - canCollide: False
-      type: Physics
-  - uid: 299
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 285
-      type: Transform
-    - canCollide: False
-      type: Physics
   - uid: 341
     components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 340
-      type: Transform
-    - canCollide: False
-      type: Physics
-  - uid: 463
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 285
-      type: Transform
-    - canCollide: False
-      type: Physics
+    - type: Transform
+      parent: 340
+    - type: Physics
+      canCollide: False
 - proto: ExtinguisherCabinetFilled
   entities:
   - uid: 65
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -0.5,-0.5
       parent: 1
-      type: Transform
 - proto: FaxMachineShip
   entities:
   - uid: 330
     components:
-    - pos: -1.5,2.5
+    - type: Transform
+      pos: -1.5,2.5
       parent: 1
-      type: Transform
 - proto: FirelockGlass
   entities:
   - uid: 451
     components:
-    - pos: -3.5,-0.5
+    - type: Transform
+      pos: -3.5,-0.5
       parent: 1
-      type: Transform
   - uid: 452
     components:
-    - pos: -0.5,-1.5
+    - type: Transform
+      pos: -0.5,-1.5
       parent: 1
-      type: Transform
   - uid: 453
     components:
-    - pos: -0.5,-2.5
+    - type: Transform
+      pos: -0.5,-2.5
       parent: 1
-      type: Transform
   - uid: 454
     components:
-    - pos: -0.5,-4.5
+    - type: Transform
+      pos: -0.5,-4.5
       parent: 1
-      type: Transform
   - uid: 455
     components:
-    - pos: -3.5,-5.5
+    - type: Transform
+      pos: -3.5,-5.5
       parent: 1
-      type: Transform
   - uid: 456
     components:
-    - pos: -1.5,-5.5
+    - type: Transform
+      pos: -1.5,-5.5
       parent: 1
-      type: Transform
 - proto: FloorDrain
   entities:
   - uid: 2
     components:
-    - pos: 0.5,-0.5
+    - type: Transform
+      pos: 0.5,-0.5
       parent: 1
-      type: Transform
-    - fixtures: {}
-      type: Fixtures
+    - type: Fixtures
+      fixtures: {}
 - proto: GasAnalyzer
   entities:
   - uid: 26
     components:
-    - pos: 0.35859585,0.46067148
+    - type: Transform
+      pos: 0.35859585,0.46067148
       parent: 1
-      type: Transform
 - proto: GasMixer
   entities:
   - uid: 224
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 3.5,1.5
       parent: 1
-      type: Transform
-    - inletTwoConcentration: 0.20999998
+    - type: GasMixer
+      inletTwoConcentration: 0.20999998
       inletOneConcentration: 0.79
-      type: GasMixer
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0000CCFF'
 - proto: GasPassiveVent
   entities:
   - uid: 324
     components:
-    - pos: 0.5,5.5
+    - type: Transform
+      pos: 0.5,5.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
 - proto: GasPipeBend
   entities:
   - uid: 150
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 0.5,-1.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 254
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 3.5,-0.5
-      parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 256
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 2.5,1.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0000CCFF'
   - uid: 293
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -2.5,0.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 327
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 3.5,0.5
-      parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 369
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -2.5,-1.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 409
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 3.5,2.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0000CCFF'
 - proto: GasPipeFourway
   entities:
   - uid: 195
     components:
-    - pos: 0.5,0.5
+    - type: Transform
+      pos: 0.5,0.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 237
-    components:
-    - pos: 2.5,-0.5
-      parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
 - proto: GasPipeStraight
   entities:
   - uid: 7
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -0.5,-1.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 31
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -1.5,0.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 32
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -0.5,0.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 50
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 1.5,-2.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 68
     components:
-    - pos: -2.5,1.5
+    - type: Transform
+      pos: -2.5,1.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 92
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -1.5,-2.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 124
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 0.5,-4.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 129
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -0.5,-4.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 130
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 0.5,-2.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 148
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 2.5,-1.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 153
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 2.5,-3.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 184
     components:
-    - pos: 0.5,3.5
+    - type: Transform
+      pos: 0.5,3.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 192
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 0.5,1.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 232
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 0.5,-0.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 251
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -1.5,-1.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 253
     components:
-    - pos: -2.5,-2.5
-      parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 258
-    components:
-    - pos: -3.5,0.5
-      parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
-  - uid: 266
-    components:
-    - pos: -3.5,-1.5
-      parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
-  - uid: 271
-    components:
-    - pos: 0.5,4.5
-      parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 272
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -1.5,-4.5
-      parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 292
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -0.5,-2.5
-      parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
-  - uid: 310
-    components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
       pos: -2.5,-2.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 258
+    components:
+    - type: Transform
+      pos: -3.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 266
+    components:
+    - type: Transform
+      pos: -3.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 271
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 272
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 292
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 310
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 311
     components:
-    - pos: -3.5,-0.5
+    - type: Transform
+      pos: -3.5,-0.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 343
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -2.5,-5.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 361
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -3.5,1.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
 - proto: GasPipeTJunction
   entities:
+  - uid: 132
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 178
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 2.5,-2.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 180
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -2.5,-4.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 287
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -2.5,-3.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 321
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -3.5,-2.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
 - proto: GasPort
   entities:
   - uid: 61
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -2.5,-6.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 166
-    components:
-    - name: air mix connector port
-      type: MetaData
-    - rot: -1.5707963267948966 rad
-      pos: 5.5,0.5
-      parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 167
     components:
-    - name: O2 connector port
-      type: MetaData
-    - rot: -1.5707963267948966 rad
+    - type: MetaData
+      name: O2 connector port
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 5.5,2.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0000CCFF'
   - uid: 399
     components:
-    - name: N2 connector port
-      type: MetaData
-    - rot: -1.5707963267948966 rad
+    - type: MetaData
+      name: N2 connector port
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 5.5,1.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0000CCFF'
 - proto: GasPressurePump
   entities:
   - uid: 222
     components:
-    - name: waste loop pump
-      type: MetaData
-    - rot: 3.141592653589793 rad
+    - type: MetaData
+      name: waste loop pump
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 0.5,2.5
       parent: 1
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 226
     components:
-    - name: N2 pump
-      type: MetaData
-    - rot: -1.5707963267948966 rad
+    - type: MetaData
+      name: N2 pump
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 4.5,1.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0000CCFF'
   - uid: 230
     components:
-    - name: distribution pump
-      type: MetaData
-    - pos: 2.5,0.5
+    - type: MetaData
+      name: distribution pump
+    - type: Transform
+      pos: 2.5,0.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 279
     components:
-    - name: O2 pump
-      type: MetaData
-    - rot: -1.5707963267948966 rad
+    - type: MetaData
+      name: O2 pump
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 4.5,2.5
       parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0000CCFF'
 - proto: GasVentPump
   entities:
   - uid: 22
     components:
-    - pos: -3.5,2.5
+    - type: Transform
+      pos: -3.5,2.5
       parent: 1
-      type: Transform
-    - ShutdownSubscribers:
-      - 396
-      type: DeviceNetwork
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 162
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 2.5,-4.5
       parent: 1
-      type: Transform
-    - ShutdownSubscribers:
-      - 4
-      type: DeviceNetwork
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 173
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -3.5,-3.5
       parent: 1
-      type: Transform
-    - ShutdownSubscribers:
-      - 396
-      type: DeviceNetwork
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 335
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 1.5,-0.5
       parent: 1
-      type: Transform
-    - ShutdownSubscribers:
-      - 396
-      type: DeviceNetwork
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
 - proto: GasVentScrubber
   entities:
   - uid: 69
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -1.5,-3.5
       parent: 1
-      type: Transform
-    - ShutdownSubscribers:
-      - 396
-      type: DeviceNetwork
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 234
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 1.5,-4.5
       parent: 1
-      type: Transform
-    - ShutdownSubscribers:
-      - 4
-      type: DeviceNetwork
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 278
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 1.5,0.5
       parent: 1
-      type: Transform
-    - ShutdownSubscribers:
-      - 396
-      type: DeviceNetwork
-    - color: '#990000FF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 295
     components:
-    - pos: -2.5,2.5
+    - type: Transform
+      pos: -2.5,2.5
       parent: 1
-      type: Transform
-    - ShutdownSubscribers:
-      - 396
-      type: DeviceNetwork
-    - color: '#990000FF'
-      type: AtmosPipeColor
-- proto: GasVolumePump
-  entities:
-  - uid: 274
-    components:
-    - name: air mix pump
-      type: MetaData
-    - rot: 1.5707963267948966 rad
-      pos: 4.5,0.5
-      parent: 1
-      type: Transform
-    - color: '#0000CCFF'
-      type: AtmosPipeColor
+    - type: AtmosPipeColor
+      color: '#990000FF'
 - proto: GravityGeneratorMini
   entities:
   - uid: 319
     components:
-    - pos: 3.5,-5.5
+    - type: Transform
+      pos: 3.5,-5.5
       parent: 1
-      type: Transform
 - proto: Grille
   entities:
   - uid: 14
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 4.5,-4.5
       parent: 1
-      type: Transform
   - uid: 16
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -4.5,-6.5
       parent: 1
-      type: Transform
   - uid: 17
     components:
-    - pos: 1.5,-3.5
+    - type: Transform
+      pos: 1.5,-3.5
       parent: 1
-      type: Transform
   - uid: 25
     components:
-    - pos: -0.5,0.5
+    - type: Transform
+      pos: -0.5,0.5
       parent: 1
-      type: Transform
   - uid: 27
     components:
-    - pos: 3.5,-6.5
+    - type: Transform
+      pos: 3.5,-6.5
       parent: 1
-      type: Transform
   - uid: 34
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -2.5,3.5
       parent: 1
-      type: Transform
   - uid: 39
     components:
-    - pos: 2.5,-3.5
+    - type: Transform
+      pos: 2.5,-3.5
       parent: 1
-      type: Transform
   - uid: 41
     components:
-    - pos: 6.5,-2.5
+    - type: Transform
+      pos: 6.5,-2.5
       parent: 1
-      type: Transform
   - uid: 46
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 4.5,-5.5
       parent: 1
-      type: Transform
   - uid: 47
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 0.5,-6.5
       parent: 1
-      type: Transform
   - uid: 103
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 2.5,-6.5
       parent: 1
-      type: Transform
   - uid: 108
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -4.5,-2.5
       parent: 1
-      type: Transform
   - uid: 126
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -3.5,3.5
       parent: 1
-      type: Transform
   - uid: 127
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -4.5,0.5
       parent: 1
-      type: Transform
   - uid: 170
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 1.5,-6.5
       parent: 1
-      type: Transform
   - uid: 190
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -4.5,-3.5
       parent: 1
-      type: Transform
   - uid: 220
     components:
-    - pos: -2.5,-5.5
+    - type: Transform
+      pos: -2.5,-5.5
       parent: 1
-      type: Transform
   - uid: 240
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -4.5,2.5
       parent: 1
-      type: Transform
   - uid: 242
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -4.5,1.5
       parent: 1
-      type: Transform
   - uid: 243
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -1.5,3.5
       parent: 1
-      type: Transform
   - uid: 294
     components:
-    - pos: 5.5,-3.5
+    - type: Transform
+      pos: 5.5,-3.5
       parent: 1
-      type: Transform
   - uid: 298
     components:
-    - pos: 6.5,-1.5
+    - type: Transform
+      pos: 6.5,-1.5
       parent: 1
-      type: Transform
   - uid: 384
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 3.5,3.5
       parent: 1
-      type: Transform
 - proto: Gyroscope
   entities:
   - uid: 260
     components:
-    - pos: 3.5,-4.5
+    - type: Transform
+      pos: 3.5,-4.5
       parent: 1
-      type: Transform
+    - type: Thruster
+      originalPowerLoad: 1500
 - proto: HandLabeler
   entities:
   - uid: 40
     components:
-    - pos: 5.6751294,-1.3722651
+    - type: Transform
+      pos: 5.6751294,-1.3722651
       parent: 1
-      type: Transform
 - proto: JanitorialTrolley
   entities:
   - uid: 284
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 0.5,-0.5
       parent: 1
-      type: Transform
 - proto: Jug
   entities:
   - uid: 375
     components:
-    - name: jug (space cleaner)
-      type: MetaData
-    - pos: 4.543024,-1.5893128
+    - type: MetaData
+      name: jug (space cleaner)
+    - type: Transform
+      pos: 4.543024,-1.5893128
       parent: 1
-      type: Transform
-    - solutions:
+    - type: SolutionContainerManager
+      solutions:
         beaker:
           temperature: 293.15
-          canMix: True
           canReact: True
           maxVol: 200
+          name: null
           reagents:
           - data: null
             ReagentId: SpaceCleaner
             Quantity: 200
-      type: SolutionContainerManager
 - proto: Lamp
   entities:
   - uid: 182
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -1.3161628,2.3328702
       parent: 1
-      type: Transform
-- proto: LargeBeaker
-  entities:
-  - uid: 95
-    components:
-    - pos: 5.678556,-1.5271454
-      parent: 1
-      type: Transform
-  - uid: 143
-    components:
-    - pos: 5.2817945,-1.2155304
-      parent: 1
-      type: Transform
 - proto: LockerJanitorFilled
   entities:
   - uid: 208
     components:
-    - pos: 2.5,2.5
+    - type: Transform
+      pos: 2.5,2.5
       parent: 1
-      type: Transform
 - proto: MaterialReclaimer
   entities:
   - uid: 203
     components:
-    - pos: 3.5,-2.5
+    - type: Transform
+      pos: 3.5,-2.5
       parent: 1
-      type: Transform
 - proto: MopItem
   entities:
   - uid: 101
     components:
-    - pos: 0.8607421,-0.6631228
+    - type: Transform
+      pos: 0.8607421,-0.6631228
       parent: 1
-      type: Transform
 - proto: NitrogenCanister
   entities:
   - uid: 210
     components:
-    - anchored: True
+    - type: Transform
+      anchored: True
       pos: 5.5,1.5
       parent: 1
-      type: Transform
-    - bodyType: Static
-      type: Physics
+    - type: Physics
+      bodyType: Static
 - proto: OxygenCanister
   entities:
   - uid: 168
     components:
-    - anchored: True
+    - type: Transform
+      anchored: True
       pos: 5.5,2.5
       parent: 1
-      type: Transform
-    - bodyType: Static
-      type: Physics
+    - type: Physics
+      bodyType: Static
 - proto: PaintingFireaxeCabinet
   entities:
   - uid: 229
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -0.5,1.5
       parent: 1
-      type: Transform
 - proto: Paper
   entities:
-  - uid: 71
-    components:
-    - pos: -1.3445798,1.5508795
-      parent: 1
-      type: Transform
   - uid: 390
     components:
-    - pos: -1.5008717,1.6219696
+    - type: Transform
+      pos: -1.5008717,1.6219696
       parent: 1
-      type: Transform
-  - uid: 462
-    components:
-    - pos: 2.2410665,-5.2790337
-      parent: 1
-      type: Transform
-    - stampState: paper_stamp-ce
-      stampedBy:
-      - stampedBorderless: False
-        stampedColor: '#C69B17FF'
-        stampedName: stamp-component-stamped-name-ce
-      - stampedBorderless: False
-        stampedColor: '#00BE00FF'
-        stampedName: stamp-component-stamped-name-approved
-      content: >-
-        [color=#1b67a5]█░░█░███[/color][color=#5b97bc]░███░█░█░█░██░░█░█░██░░██░░██░[/color]
-
-        [color=#1b67a5]██░█░░█░[/color][color=#5b97bc]██░░░█░█░█░█░█░█░█░█░█░█░█░█░█[/color]
-
-        [color=#1b67a5]█░██░░█░[/color][color=#5b97bc]░░██░███░█░██░░░█░░███░██░░█░█[/color]
-
-        [color=#1b67a5]█░░█░░█░[/color][color=#5b97bc]███░░█░█░█░█░░░░█░░█░█░█░█░██░[/color]
-
-
-        [head=1]=========================[/head]
-
-        [head=1]Liquidator-class service ship[/head]
-
-        [head=1] [/head]
-
-        [head=1]     PREFLIGHT CHECKLIST[/head]
-
-        [head=1]=========================[/head]
-
-
-        [head=2]1. Power supply.[/head]
-
-        [head=3]1.1. Battery units.[/head]
-
-        [bullet/][ ] Check if the SMES unit is anchored to the floor.
-
-        [bullet/][ ] Check if the substation unit is anchored to the floor.
-
-        [bullet/][ ] Check if the APC unit's Main Breaker is toggled on.
-
-        [bullet/][ ] Check the APC unit's current Load[bold]*[/bold] (W).
-
-        [head=3]1.2. S.U.P.E.R.P.A.C.M.A.N. generator unit.[/head]
-
-        [bullet/][ ] Check if the S.U.P.E.R.P.A.C.M.A.N. generator unit is anchored to the floor.
-
-        [bullet/][ ] Check if the S.U.P.E.R.P.A.C.M.A.N. generator unit has fuel. For extended flights make sure that you have enough fuel stockpiled to sustain prolonged power generation.
-
-        [bullet/][ ] Check if the S.U.P.E.R.P.A.C.M.A.N. generator unit is set to HV output.
-
-        [bullet/][ ] Set Target Power for 18-19[bold]**[/bold] [bold]k[/bold]W.
-
-        [bullet/][ ] Start the S.U.P.E.R.P.A.C.M.A.N. generator unit.
-
-
-        [head=2]2. Atmospherics.[/head]
-
-        [head=3]2.1. Distribution Loop.[/head]
-
-        [bullet/][ ] Check if the O2 output pump is set to normal pressure.
-
-        [bullet/][ ] Enable the O2 output pump.
-
-        [bullet/][ ] Check if the N2 output pump is set to normal pressure.
-
-        [bullet/][ ] Enable N2 output pump.
-
-        [bullet/][ ] Check if the gas mixer is set to the correct mixing ratio.
-
-        [bullet/][ ] Check if the gas mixer is set to normal pressure.
-
-        [bullet/][ ] Enable gas mixer.
-
-        [bullet/][ ] Check if the distribution pump is set to normal pressure.
-
-        [bullet/][ ] Enable distribution pump.
-
-        [head=3]2.2. Waste Loop.[/head]
-
-        [bullet/][ ] Enable waste loop pump.
-
-        [bullet/][ ] Set engine room air alarm filtering to wide.
-
-
-        [head=2]3. Other checks.[/head]
-
-        [bullet/][ ] Check if the gyroscope is anchored, powered, and enabled.
-
-        [bullet/][ ] Check if the mini gravity generator is anchored, powered, and enabled.
-
-        [bullet/][ ] Check if the bow blast doors are closed.
-
-
-        __________________________________________________________________
-
-        [bold]*[/bold] - Liquidator-class service ships are equipped with a single APC unit that can be used to appraise the ship's total power consumption. One can check the ship's total power consumption against the S.U.P.E.R.P.A.C.M.A.N. generator unit Target Power output: to keep SMES, substation, and APC fully charged, S.U.P.E.R.P.A.C.M.A.N. generator unit Target Power output should exceed APC's Load. Remember to check APC Load and adjust the generator unit Target Power after connecting new power-consuming machines.
-
-        [bold]**[/bold] - Liquidator-class service ships have higher power demand than standard P.A.C.M.A.N. generator unit can provide at optimal settings, so the standard P.A.C.M.A.N. was replaced with S.U.P.E.R.P.A.C.M.A.N.: recommended Target Power value to avoid blackouts during Gravity Generator charging sequence is 19 kW. Furthermore, while the portable scrubber unit is online, changing the Target Power value to 20 kW might be advisable.
-
-        [bold]Note:[/bold] Without a working generator, fully charged battery units (SMES and substation) in unmodified Liquidator-class service ships can provide power for approximately 10 minutes before fully depleting their charge.
-
-        [bold]Note:[/bold] Additional generator units can be purchased at the Frontier Station.
-
-        [bold]Note:[/bold] Be sure to take all necessary protective measures when working with radioactive materials: use a radiation suit, engage internals, make sure to enable Geiger's counter, wash your hands after, and keep radiation shutters closed at all times.
-      type: Paper
-- proto: PortableGeneratorSuperPacman
+- proto: PortableGeneratorSuperPacmanShuttle
   entities:
-  - uid: 386
+  - uid: 166
     components:
-    - anchored: True
+    - type: Transform
       pos: 2.5,-5.5
       parent: 1
-      type: Transform
-    - storage:
-        Uranium: 3000
-      type: MaterialStorage
-    - bodyType: Static
-      type: Physics
-    - type: InsertingMaterialStorage
+    - type: FuelGenerator
+      on: False
+    - type: Physics
+      bodyType: Static
 - proto: PortableScrubber
   entities:
   - uid: 5
     components:
-    - pos: -2.5,-6.5
+    - type: Transform
+      pos: -2.5,-6.5
       parent: 1
-      type: Transform
 - proto: PosterLegitCleanliness
   entities:
   - uid: 296
     components:
-    - pos: -4.5,-4.5
+    - type: Transform
+      pos: -4.5,-4.5
       parent: 1
-      type: Transform
 - proto: PottedPlantRandom
   entities:
   - uid: 23
     components:
-    - pos: -2.5,0.5
+    - type: Transform
+      pos: -2.5,0.5
       parent: 1
-      type: Transform
 - proto: PowerCellRecharger
   entities:
   - uid: 114
     components:
-    - pos: 0.5,1.5
+    - type: Transform
+      pos: 0.5,1.5
       parent: 1
-      type: Transform
 - proto: PoweredlightEmpty
   entities:
   - uid: 340
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -0.5,4.5
       parent: 1
-      type: Transform
-    - containers:
+    - type: ContainerContainer
+      containers:
         light_bulb: !type:ContainerSlot
           showEnts: False
           occludes: True
           ent: 341
-      type: ContainerContainer
-    - powerLoad: 100
-      type: ApcPowerReceiver
+    - type: ApcPowerReceiver
+      powerLoad: 100
 - proto: PoweredlightLED
   entities:
   - uid: 155
     components:
-    - pos: -2.5,-1.5
+    - type: Transform
+      pos: -2.5,-1.5
       parent: 1
-      type: Transform
   - uid: 156
     components:
-    - pos: 3.5,-4.5
+    - type: Transform
+      pos: 3.5,-4.5
       parent: 1
-      type: Transform
   - uid: 194
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -1.5,-6.5
       parent: 1
-      type: Transform
-  - uid: 199
-    components:
-    - pos: 5.5,-1.5
-      parent: 1
-      type: Transform
   - uid: 221
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -2.5,0.5
       parent: 1
-      type: Transform
   - uid: 225
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 3.5,-2.5
       parent: 1
-      type: Transform
   - uid: 233
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 0.5,1.5
       parent: 1
-      type: Transform
 - proto: PoweredSmallLight
   entities:
   - uid: 117
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 5.5,1.5
       parent: 1
-      type: Transform
 - proto: Railing
   entities:
   - uid: 77
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -6.5,6.5
       parent: 1
-      type: Transform
   - uid: 80
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 8.5,6.5
       parent: 1
-      type: Transform
   - uid: 83
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 8.5,5.5
       parent: 1
-      type: Transform
   - uid: 159
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -6.5,5.5
       parent: 1
-      type: Transform
   - uid: 315
     components:
-    - pos: 7.5,4.5
+    - type: Transform
+      pos: 7.5,4.5
       parent: 1
-      type: Transform
   - uid: 316
     components:
-    - pos: -5.5,4.5
+    - type: Transform
+      pos: -5.5,4.5
       parent: 1
-      type: Transform
 - proto: RailingCorner
   entities:
   - uid: 110
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -6.5,4.5
       parent: 1
-      type: Transform
   - uid: 157
     components:
-    - pos: 8.5,4.5
+    - type: Transform
+      pos: 8.5,4.5
       parent: 1
-      type: Transform
 - proto: RailingCornerSmall
   entities:
   - uid: 78
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -6.5,7.5
       parent: 1
-      type: Transform
   - uid: 79
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 8.5,7.5
       parent: 1
-      type: Transform
   - uid: 82
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 6.5,4.5
       parent: 1
-      type: Transform
   - uid: 118
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -4.5,4.5
       parent: 1
-      type: Transform
 - proto: RandomPainting
   entities:
   - uid: 189
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -2.5,-0.5
       parent: 1
-      type: Transform
 - proto: RandomSpawner100
   entities:
   - uid: 97
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -2.5,-3.5
       parent: 1
-      type: Transform
   - uid: 120
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -2.5,5.5
       parent: 1
-      type: Transform
   - uid: 236
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -3.5,-2.5
       parent: 1
-      type: Transform
   - uid: 371
     components:
-    - pos: 1.5,1.5
+    - type: Transform
+      pos: 1.5,1.5
       parent: 1
-      type: Transform
   - uid: 374
     components:
-    - pos: 2.5,4.5
+    - type: Transform
+      pos: 2.5,4.5
       parent: 1
-      type: Transform
   - uid: 393
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 2.5,-1.5
       parent: 1
-      type: Transform
 - proto: ReinforcedWindow
   entities:
   - uid: 29
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -4.5,-2.5
       parent: 1
-      type: Transform
   - uid: 33
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -4.5,-3.5
       parent: 1
-      type: Transform
   - uid: 55
     components:
-    - pos: 3.5,-6.5
+    - type: Transform
+      pos: 3.5,-6.5
       parent: 1
-      type: Transform
   - uid: 63
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -3.5,3.5
       parent: 1
-      type: Transform
   - uid: 104
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -4.5,1.5
       parent: 1
-      type: Transform
   - uid: 112
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -4.5,-6.5
       parent: 1
-      type: Transform
   - uid: 137
     components:
-    - pos: 2.5,-3.5
+    - type: Transform
+      pos: 2.5,-3.5
       parent: 1
-      type: Transform
   - uid: 140
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 4.5,-5.5
       parent: 1
-      type: Transform
   - uid: 147
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 0.5,-6.5
       parent: 1
-      type: Transform
   - uid: 151
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -1.5,3.5
       parent: 1
-      type: Transform
   - uid: 152
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -2.5,3.5
       parent: 1
-      type: Transform
   - uid: 174
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -4.5,0.5
       parent: 1
-      type: Transform
   - uid: 197
     components:
-    - pos: 1.5,-3.5
+    - type: Transform
+      pos: 1.5,-3.5
       parent: 1
-      type: Transform
   - uid: 198
     components:
-    - pos: -0.5,0.5
+    - type: Transform
+      pos: -0.5,0.5
       parent: 1
-      type: Transform
   - uid: 201
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 1.5,-6.5
       parent: 1
-      type: Transform
   - uid: 202
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 2.5,-6.5
       parent: 1
-      type: Transform
   - uid: 218
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 4.5,-4.5
       parent: 1
-      type: Transform
   - uid: 227
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -4.5,2.5
       parent: 1
-      type: Transform
   - uid: 238
     components:
-    - pos: -2.5,-5.5
+    - type: Transform
+      pos: -2.5,-5.5
       parent: 1
-      type: Transform
   - uid: 280
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 3.5,3.5
       parent: 1
-      type: Transform
   - uid: 302
     components:
-    - pos: 5.5,-3.5
+    - type: Transform
+      pos: 5.5,-3.5
       parent: 1
-      type: Transform
   - uid: 345
     components:
-    - pos: 6.5,-2.5
+    - type: Transform
+      pos: 6.5,-2.5
       parent: 1
-      type: Transform
   - uid: 346
     components:
-    - pos: 6.5,-1.5
+    - type: Transform
+      pos: 6.5,-1.5
       parent: 1
-      type: Transform
 - proto: SheetUranium
   entities:
-  - uid: 329
+  - uid: 199
     components:
-    - pos: 2.5721993,-5.4875746
+    - type: Transform
+      pos: 2.6760316,-5.485401
       parent: 1
-      type: Transform
+- proto: ShipyardLiquidatorInfo
+  entities:
+  - uid: 143
+    components:
+    - type: Transform
+      pos: 2.2697816,-5.1477337
+      parent: 1
 - proto: ShuttersRadiationOpen
   entities:
   - uid: 100
     components:
-    - pos: 1.5,-6.5
+    - type: Transform
+      pos: 1.5,-6.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 109
-      type: DeviceLinkSink
   - uid: 134
     components:
-    - pos: 1.5,-3.5
+    - type: Transform
+      pos: 1.5,-3.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 109
-      type: DeviceLinkSink
   - uid: 179
     components:
-    - pos: 0.5,-6.5
+    - type: Transform
+      pos: 0.5,-6.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 109
-      type: DeviceLinkSink
   - uid: 193
     components:
-    - pos: 2.5,-3.5
+    - type: Transform
+      pos: 2.5,-3.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 109
-      type: DeviceLinkSink
   - uid: 250
     components:
-    - pos: 3.5,-6.5
+    - type: Transform
+      pos: 3.5,-6.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 109
-      type: DeviceLinkSink
   - uid: 360
     components:
-    - pos: 4.5,-4.5
+    - type: Transform
+      pos: 4.5,-4.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 109
-      type: DeviceLinkSink
   - uid: 372
     components:
-    - pos: 4.5,-5.5
+    - type: Transform
+      pos: 4.5,-5.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 109
-      type: DeviceLinkSink
   - uid: 387
     components:
-    - pos: -0.5,-4.5
+    - type: Transform
+      pos: -0.5,-4.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 109
-      type: DeviceLinkSink
   - uid: 388
     components:
-    - pos: 2.5,-6.5
+    - type: Transform
+      pos: 2.5,-6.5
       parent: 1
-      type: Transform
-    - links:
+    - type: DeviceLinkSink
+      links:
       - 109
-      type: DeviceLinkSink
 - proto: SignalButtonDirectional
   entities:
   - uid: 107
     components:
-    - name: door bolts switch
-      type: MetaData
-    - rot: 1.5707963267948966 rad
+    - type: MetaData
+      name: door bolts switch
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -4.5,-1.5
       parent: 1
-      type: Transform
-    - linkedPorts:
+    - type: DeviceLinkSource
+      linkedPorts:
         11:
         - Pressed: DoorBolt
         9:
         - Pressed: DoorBolt
-      type: DeviceLinkSource
   - uid: 109
     components:
-    - name: radiation shutters switch
-      type: MetaData
-    - rot: -1.5707963267948966 rad
+    - type: MetaData
+      name: radiation shutters switch
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -0.5326209,-3.2285466
       parent: 1
-      type: Transform
-    - linkedPorts:
+    - type: DeviceLinkSource
+      linkedPorts:
         134:
         - Pressed: Toggle
         193:
@@ -3045,475 +2736,463 @@ entities:
         - Pressed: Toggle
         387:
         - Pressed: Toggle
-      type: DeviceLinkSource
   - uid: 188
     components:
-    - desc: 'Reminder: keep... Uhh.. I forgot..'
+    - type: MetaData
+      desc: 'Reminder: keep... Uhh.. I forgot..'
       name: blast doors switch
-      type: MetaData
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -0.5,2.5
       parent: 1
-      type: Transform
-    - linkedPorts:
+    - type: DeviceLinkSource
+      linkedPorts:
         326:
         - Pressed: Toggle
         186:
         - Pressed: Toggle
-      type: DeviceLinkSource
 - proto: SignDirectionalJanitor
   entities:
   - uid: 86
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -1.5,-0.5
       parent: 1
-      type: Transform
 - proto: SignJanitor
   entities:
   - uid: 264
     components:
-    - pos: -4.5,-7.5
+    - type: Transform
+      pos: -4.5,-7.5
       parent: 1
-      type: Transform
   - uid: 265
     components:
-    - pos: -0.5,-7.5
+    - type: Transform
+      pos: -0.5,-7.5
       parent: 1
-      type: Transform
   - uid: 267
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -4.5,3.5
       parent: 1
-      type: Transform
   - uid: 268
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 6.5,3.5
       parent: 1
-      type: Transform
 - proto: SignRadiationMed
   entities:
   - uid: 397
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -0.5,-3.5
       parent: 1
-      type: Transform
 - proto: SinkWide
   entities:
   - uid: 356
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 0.5,-0.5
       parent: 1
-      type: Transform
 - proto: SMESBasic
   entities:
   - uid: 49
     components:
-    - pos: 1.5,-5.5
+    - type: Transform
+      pos: 1.5,-5.5
       parent: 1
-      type: Transform
-- proto: SpawnPointAtmos
-  entities:
-  - uid: 359
-    components:
-    - pos: 1.5,0.5
-      parent: 1
-      type: Transform
-- proto: SpawnPointChemist
-  entities:
-  - uid: 378
-    components:
-    - pos: 1.5,0.5
-      parent: 1
-      type: Transform
-- proto: SpawnPointJanitor
-  entities:
-  - uid: 322
-    components:
-    - pos: 1.5,0.5
-      parent: 1
-      type: Transform
 - proto: SpawnPointLatejoin
   entities:
-  - uid: 358
+  - uid: 223
     components:
-    - pos: 1.5,0.5
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-0.5
       parent: 1
-      type: Transform
-- proto: SpawnPointPilot
-  entities:
-  - uid: 461
-    components:
-    - pos: -2.5,1.5
-      parent: 1
-      type: Transform
 - proto: SpawnVehicleJanicart
   entities:
-  - uid: 398
+  - uid: 76
     components:
-    - pos: 3.5,-0.5
+    - type: Transform
+      pos: 5.5,0.5
       parent: 1
-      type: Transform
 - proto: SubstationBasic
   entities:
   - uid: 43
     components:
-    - pos: 0.5,-5.5
+    - type: Transform
+      pos: 0.5,-5.5
       parent: 1
-      type: Transform
 - proto: SuitStorageEVAAlternate
   entities:
   - uid: 53
     components:
-    - pos: -1.5,0.5
+    - type: Transform
+      pos: -1.5,0.5
       parent: 1
-      type: Transform
 - proto: Table
   entities:
   - uid: 3
     components:
-    - pos: 0.5,1.5
+    - type: Transform
+      pos: 0.5,1.5
       parent: 1
-      type: Transform
   - uid: 275
     components:
-    - pos: 0.5,0.5
+    - type: Transform
+      pos: 0.5,0.5
       parent: 1
-      type: Transform
 - proto: TableReinforcedGlass
   entities:
   - uid: 248
     components:
-    - pos: 5.5,-1.5
+    - type: Transform
+      pos: 5.5,-1.5
       parent: 1
-      type: Transform
 - proto: TableWood
   entities:
   - uid: 154
     components:
-    - pos: -1.5,2.5
+    - type: Transform
+      pos: -1.5,2.5
       parent: 1
-      type: Transform
   - uid: 175
     components:
-    - pos: -1.5,1.5
+    - type: Transform
+      pos: -1.5,1.5
       parent: 1
-      type: Transform
   - uid: 207
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -2.5,2.5
       parent: 1
-      type: Transform
   - uid: 404
     components:
-    - pos: -3.5,2.5
+    - type: Transform
+      pos: -3.5,2.5
       parent: 1
-      type: Transform
 - proto: Thruster
   entities:
   - uid: 81
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -5.5,3.5
       parent: 1
-      type: Transform
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 85
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 7.5,3.5
       parent: 1
-      type: Transform
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 106
     components:
-    - pos: 2.5,5.5
+    - type: Transform
+      pos: 2.5,5.5
       parent: 1
-      type: Transform
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 149
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 4.5,-7.5
       parent: 1
-      type: Transform
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 252
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 3.5,-7.5
       parent: 1
-      type: Transform
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 276
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 2.5,-7.5
       parent: 1
-      type: Transform
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 282
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 1.5,-7.5
       parent: 1
-      type: Transform
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 325
     components:
-    - pos: 3.5,5.5
+    - type: Transform
+      pos: 3.5,5.5
       parent: 1
-      type: Transform
+    - type: Thruster
+      originalPowerLoad: 1500
 - proto: TrashBag
   entities:
   - uid: 94
     components:
-    - pos: 0.97410214,-0.8047657
+    - type: Transform
+      pos: 0.97410214,-0.8047657
       parent: 1
-      type: Transform
 - proto: VehicleKeyJanicart
   entities:
   - uid: 331
     components:
-    - pos: -1.7792568,1.4143391
+    - type: Transform
+      pos: -1.7792568,1.4143391
       parent: 1
-      type: Transform
 - proto: VendingMachineChemicals
   entities:
   - uid: 347
     components:
-    - pos: 5.5,-2.5
+    - type: Transform
+      pos: 5.5,-2.5
       parent: 1
-      type: Transform
 - proto: VendingMachineJaniDrobe
   entities:
   - uid: 70
     components:
-    - pos: 3.5,2.5
+    - type: Transform
+      pos: 3.5,2.5
       parent: 1
-      type: Transform
 - proto: WallReinforced
   entities:
   - uid: 48
     components:
-    - pos: -4.5,-7.5
+    - type: Transform
+      pos: -4.5,-7.5
       parent: 1
-      type: Transform
   - uid: 51
     components:
-    - pos: -4.5,-4.5
+    - type: Transform
+      pos: -4.5,-4.5
       parent: 1
-      type: Transform
   - uid: 52
     components:
-    - pos: 4.5,-3.5
+    - type: Transform
+      pos: 4.5,-3.5
       parent: 1
-      type: Transform
   - uid: 93
     components:
-    - pos: 6.5,1.5
+    - type: Transform
+      pos: 6.5,1.5
       parent: 1
-      type: Transform
   - uid: 105
     components:
-    - pos: 6.5,3.5
+    - type: Transform
+      pos: 6.5,3.5
       parent: 1
-      type: Transform
   - uid: 121
     components:
-    - pos: -4.5,-0.5
+    - type: Transform
+      pos: -4.5,-0.5
       parent: 1
-      type: Transform
   - uid: 122
     components:
-    - pos: -0.5,-7.5
+    - type: Transform
+      pos: -0.5,-7.5
       parent: 1
-      type: Transform
   - uid: 123
     components:
-    - pos: -4.5,-5.5
+    - type: Transform
+      pos: -4.5,-5.5
       parent: 1
-      type: Transform
   - uid: 128
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 5.5,3.5
       parent: 1
-      type: Transform
   - uid: 135
     components:
-    - pos: -0.5,3.5
+    - type: Transform
+      pos: -0.5,3.5
       parent: 1
-      type: Transform
   - uid: 161
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 4.5,3.5
       parent: 1
-      type: Transform
   - uid: 165
     components:
-    - pos: 6.5,-0.5
+    - type: Transform
+      pos: 6.5,-0.5
       parent: 1
-      type: Transform
   - uid: 169
     components:
-    - pos: 6.5,0.5
+    - type: Transform
+      pos: 6.5,0.5
       parent: 1
-      type: Transform
   - uid: 172
     components:
-    - pos: 6.5,2.5
+    - type: Transform
+      pos: 6.5,2.5
       parent: 1
-      type: Transform
   - uid: 185
     components:
-    - pos: -4.5,-1.5
+    - type: Transform
+      pos: -4.5,-1.5
       parent: 1
-      type: Transform
   - uid: 209
     components:
-    - pos: 6.5,-3.5
+    - type: Transform
+      pos: 6.5,-3.5
       parent: 1
-      type: Transform
   - uid: 216
     components:
-    - pos: -0.5,-6.5
+    - type: Transform
+      pos: -0.5,-6.5
       parent: 1
-      type: Transform
   - uid: 217
     components:
-    - pos: -0.5,-5.5
+    - type: Transform
+      pos: -0.5,-5.5
       parent: 1
-      type: Transform
   - uid: 244
     components:
-    - pos: 4.5,-6.5
+    - type: Transform
+      pos: 4.5,-6.5
       parent: 1
-      type: Transform
   - uid: 283
     components:
-    - pos: -2.5,-7.5
+    - type: Transform
+      pos: -2.5,-7.5
       parent: 1
-      type: Transform
   - uid: 402
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 2.5,3.5
       parent: 1
-      type: Transform
 - proto: WallSolid
   entities:
   - uid: 24
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -2.5,-0.5
       parent: 1
-      type: Transform
   - uid: 28
     components:
-    - pos: 0.5,-3.5
+    - type: Transform
+      pos: 0.5,-3.5
       parent: 1
-      type: Transform
   - uid: 30
     components:
-    - pos: -0.5,1.5
+    - type: Transform
+      pos: -0.5,1.5
       parent: 1
-      type: Transform
   - uid: 67
     components:
-    - pos: -0.5,2.5
+    - type: Transform
+      pos: -0.5,2.5
       parent: 1
-      type: Transform
   - uid: 84
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -4.5,3.5
       parent: 1
-      type: Transform
   - uid: 219
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -1.5,-0.5
       parent: 1
-      type: Transform
   - uid: 231
     components:
-    - pos: 3.5,-3.5
+    - type: Transform
+      pos: 3.5,-3.5
       parent: 1
-      type: Transform
   - uid: 239
     components:
-    - pos: -0.5,-0.5
+    - type: Transform
+      pos: -0.5,-0.5
       parent: 1
-      type: Transform
   - uid: 342
     components:
-    - pos: -0.5,-3.5
+    - type: Transform
+      pos: -0.5,-3.5
       parent: 1
-      type: Transform
   - uid: 400
     components:
-    - pos: 4.5,-0.5
+    - type: Transform
+      pos: 4.5,-0.5
       parent: 1
-      type: Transform
   - uid: 401
     components:
-    - pos: 5.5,-0.5
+    - type: Transform
+      pos: 5.5,-0.5
       parent: 1
-      type: Transform
 - proto: WarpPointShip
   entities:
   - uid: 228
     components:
-    - rot: 3.141592653589793 rad
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 1.5,0.5
       parent: 1
-      type: Transform
 - proto: WaterTankHighCapacity
   entities:
   - uid: 286
     components:
-    - pos: -2.5,-1.5
+    - type: Transform
+      pos: -2.5,-1.5
       parent: 1
-      type: Transform
 - proto: WindoorSecure
   entities:
   - uid: 139
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 4.5,1.5
       parent: 1
-      type: Transform
-  - uid: 364
+  - uid: 235
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 4.5,-1.5
-      parent: 1
-      type: Transform
-  - uid: 373
-    components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 4.5,0.5
       parent: 1
-      type: Transform
+  - uid: 364
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-1.5
+      parent: 1
   - uid: 383
     components:
-    - rot: 1.5707963267948966 rad
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 4.5,2.5
       parent: 1
-      type: Transform
 - proto: WindowReinforcedDirectional
   entities:
   - uid: 363
     components:
-    - rot: -1.5707963267948966 rad
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 4.5,-2.5
       parent: 1
-      type: Transform
 - proto: Wrench
   entities:
   - uid: 408
     components:
-    - pos: 2.6283937,-5.1236
+    - type: Transform
+      pos: 2.6283937,-5.1236
       parent: 1
-      type: Transform
 ...

--- a/Resources/Maps/_NF/Shuttles/pioneer.yml
+++ b/Resources/Maps/_NF/Shuttles/pioneer.yml
@@ -22,15 +22,15 @@ entities:
       chunks:
         0,0:
           ind: 0,0
-          tiles: HgAAAAAAIwAAAAAAIwAAAAAAegAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAAAAIwAAAAAAIwAAAAAAegAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIwAAAAAAHgAAAAAAHgAAAAAAegAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIwAAAAAAegAAAAAAegAAAAAAegAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAegAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          tiles: HgAAAAAAIwAAAAAAegAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIwAAAAAAIwAAAAAAegAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIwAAAAAAegAAAAAAegAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAegAAAAAAeQAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
           version: 6
         -1,0:
           ind: -1,0
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAegAAAAAAHgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAegAAAAAAHgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAegAAAAAAHgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAegAAAAAAHgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAegAAAAAAegAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAegAAAAAAIwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAegAAAAAAIwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAegAAAAAAHgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAegAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
           version: 6
         0,-1:
           ind: 0,-1
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAegAAAAAAegAAAAAAegAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAAAAaQAAAAAAaQAAAAAAegAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAAAAHgAAAAAAHgAAAAAAegAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAAAAHgAAAAAAHgAAAAAAegAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAegAAAAAAegAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAAAAaQAAAAAAegAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAAAAHgAAAAAAegAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAAAAHgAAAAAAegAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
           version: 6
         -1,-1:
           ind: -1,-1
@@ -61,55 +61,59 @@ entities:
             color: '#FFFFFFFF'
             id: Arrows
           decals:
-            18: 2,-1
-            19: 2,-2
-        - node:
-            color: '#FFFFFFFF'
-            id: Bot
-          decals:
-            16: 2,1
+            32: 1,-1
+            33: 1,-2
         - node:
             angle: 1.5707963267948966 rad
             color: '#FFFFFFFF'
             id: Bot
           decals:
-            31: 1,1
+            11: 1,1
         - node:
             color: '#FFFFFFFF'
             id: BotGreyscale
           decals:
-            33: -1,1
+            12: -1,1
+            13: -1,0
         - node:
             color: '#FFFFFFFF'
             id: BoxGreyscale
           decals:
-            17: 0,2
+            9: 0,2
+            14: 0,1
+        - node:
+            color: '#96DAFFFF'
+            id: DeliveryGreyscale
+          decals:
+            19: -1,-1
         - node:
             color: '#FFFFFFFF'
-            id: BrickTileDarkLineW
+            id: DeliveryGreyscale
           decals:
-            4: 1,3
+            15: 1,-3
+            16: 2,-3
+            17: -1,-3
+            18: -1,-2
         - node:
             angle: 1.5707963267948966 rad
             color: '#FFFFFFFF'
             id: LoadingArea
           decals:
-            32: 1,0
+            34: 0,0
         - node:
             color: '#FFFFFFFF'
             id: StandClear
           decals:
-            13: 1,3
-            14: 2,3
-            15: 0,-4
+            8: 0,-4
+            22: 1,2
         - node:
-            angle: 1.5707963267948966 rad
+            angle: 4.71238898038469 rad
             color: '#FFFFFFFF'
             id: StandClear
           decals:
-            25: 3,-1
-            26: 3,-2
-            30: 3,0
+            29: 2,0
+            30: 2,-1
+            31: 2,-2
         - node:
             color: '#FFFFFFFF'
             id: WarnCornerSmallSE
@@ -124,49 +128,46 @@ entities:
             color: '#FFFFFFFF'
             id: WarnLineE
           decals:
-            5: 0,-3
-            23: 3,-1
-            24: 3,-2
-            29: 3,0
+            4: 0,-3
+            23: 2,-2
+            24: 2,-1
+            25: 2,0
         - node:
             color: '#FFFFFFFF'
             id: WarnLineN
           decals:
             0: 1,-2
-            7: 1,3
-            8: 2,3
-            12: 0,-4
-            20: 2,-2
-            27: -1,-1
+            7: 0,-4
+            10: -1,-1
+            20: 1,2
         - node:
             color: '#FFFFFFFF'
             id: WarnLineS
           decals:
             1: 0,-2
-            6: 0,-3
-            21: 3,-2
-            22: 3,-1
-            28: 3,0
+            5: 0,-3
+            26: 2,-2
+            27: 2,-1
+            28: 2,0
         - node:
             color: '#FFFFFFFF'
             id: WarnLineW
           decals:
-            9: 1,3
-            10: 2,3
-            11: 0,-4
+            6: 0,-4
+            21: 1,2
     - type: GridAtmosphere
       version: 2
       data:
         tiles:
           0,0:
-            0: 6007
+            0: 307
+            1: 24576
           0,-1:
-            0: 65392
-            1: 8
+            0: 30512
+            1: 4
           -1,0:
-            0: 34952
-          0,1:
-            1: 14
+            0: 2184
+            1: 16384
           -1,-1:
             0: 34944
             1: 4
@@ -212,19 +213,12 @@ entities:
       id: pioneer
 - proto: AirAlarm
   entities:
-  - uid: 111
+  - uid: 2
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 3.5,2.5
+      pos: 2.5,1.5
       parent: 1
-    - type: DeviceList
-      devices:
-      - 35
-      - 48
-    - type: AccessReader
-      enabled: False
-    - type: Emagged
 - proto: AirCanister
   entities:
   - uid: 27
@@ -237,72 +231,88 @@ entities:
       bodyType: Static
 - proto: AirlockGlassShuttle
   entities:
-  - uid: 121
+  - uid: 5
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 3.5,-0.5
+      pos: 2.5,-0.5
       parent: 1
-  - uid: 122
+  - uid: 10
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 3.5,-1.5
+      pos: 2.5,-1.5
       parent: 1
 - proto: APCBasic
   entities:
-  - uid: 21
+  - uid: 105
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -1.5,2.5
+      pos: -1.5,1.5
       parent: 1
 - proto: AtmosDeviceFanTiny
   entities:
-  - uid: 30
+  - uid: 8
     components:
     - type: Transform
-      pos: 1.5,3.5
+      rot: 3.141592653589793 rad
+      pos: 2.5,-0.5
       parent: 1
   - uid: 34
     components:
     - type: Transform
       pos: 0.5,-3.5
       parent: 1
-  - uid: 53
+  - uid: 49
     components:
     - type: Transform
-      pos: 2.5,3.5
+      rot: 3.141592653589793 rad
+      pos: 2.5,0.5
       parent: 1
-  - uid: 74
+  - uid: 67
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 3.5,-1.5
+      rot: 3.141592653589793 rad
+      pos: 2.5,-1.5
       parent: 1
-  - uid: 91
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 3.5,-0.5
-      parent: 1
-  - uid: 115
+  - uid: 72
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 3.5,0.5
+      pos: 1.5,2.5
       parent: 1
 - proto: AtmosFixBlockerMarker
   entities:
+  - uid: 30
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 1
   - uid: 37
     components:
     - type: Transform
       pos: 1.5,-4.5
       parent: 1
+  - uid: 39
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 1
   - uid: 63
     components:
     - type: Transform
       pos: -0.5,-4.5
+      parent: 1
+  - uid: 113
+    components:
+    - type: Transform
+      pos: 2.5,-3.5
+      parent: 1
+  - uid: 114
+    components:
+    - type: Transform
+      pos: -1.5,3.5
       parent: 1
   - uid: 128
     components:
@@ -314,59 +324,29 @@ entities:
     - type: Transform
       pos: -1.5,-3.5
       parent: 1
-  - uid: 131
-    components:
-    - type: Transform
-      pos: 2.5,4.5
-      parent: 1
-  - uid: 132
-    components:
-    - type: Transform
-      pos: 1.5,4.5
-      parent: 1
-  - uid: 136
-    components:
-    - type: Transform
-      pos: 3.5,4.5
-      parent: 1
-  - uid: 137
-    components:
-    - type: Transform
-      pos: 3.5,-3.5
-      parent: 1
 - proto: BoxFolderRed
   entities:
-  - uid: 56
+  - uid: 62
     components:
     - type: Transform
-      pos: -0.4789027,3.3607204
+      pos: -0.28687096,1.5974178
       parent: 1
 - proto: CableApcExtension
   entities:
-  - uid: 13
+  - uid: 4
     components:
     - type: Transform
-      pos: -1.5,2.5
-      parent: 1
-  - uid: 14
-    components:
-    - type: Transform
-      pos: 1.5,-1.5
+      pos: -0.5,1.5
       parent: 1
   - uid: 15
     components:
     - type: Transform
-      pos: 1.5,2.5
+      pos: 1.5,1.5
       parent: 1
   - uid: 17
     components:
     - type: Transform
       pos: 0.5,1.5
-      parent: 1
-  - uid: 19
-    components:
-    - type: Transform
-      pos: 0.5,2.5
       parent: 1
   - uid: 22
     components:
@@ -378,15 +358,10 @@ entities:
     - type: Transform
       pos: 0.5,-3.5
       parent: 1
-  - uid: 62
+  - uid: 29
     components:
     - type: Transform
-      pos: -0.5,2.5
-      parent: 1
-  - uid: 72
-    components:
-    - type: Transform
-      pos: 2.5,3.5
+      pos: -1.5,1.5
       parent: 1
   - uid: 76
     components:
@@ -403,16 +378,6 @@ entities:
     - type: Transform
       pos: 0.5,-0.5
       parent: 1
-  - uid: 84
-    components:
-    - type: Transform
-      pos: 2.5,-1.5
-      parent: 1
-  - uid: 88
-    components:
-    - type: Transform
-      pos: 2.5,2.5
-      parent: 1
 - proto: CableHV
   entities:
   - uid: 16
@@ -425,17 +390,22 @@ entities:
     - type: Transform
       pos: -0.5,-2.5
       parent: 1
-- proto: CableMV
-  entities:
-  - uid: 12
+  - uid: 84
     components:
     - type: Transform
-      pos: -1.5,2.5
+      pos: -1.5,-1.5
       parent: 1
+- proto: CableMV
+  entities:
   - uid: 18
     components:
     - type: Transform
       pos: -0.5,-1.5
+      parent: 1
+  - uid: 19
+    components:
+    - type: Transform
+      pos: -1.5,1.5
       parent: 1
   - uid: 71
     components:
@@ -447,29 +417,35 @@ entities:
     - type: Transform
       pos: -0.5,0.5
       parent: 1
-  - uid: 83
-    components:
-    - type: Transform
-      pos: -0.5,2.5
-      parent: 1
   - uid: 94
     components:
     - type: Transform
       pos: -0.5,1.5
       parent: 1
-- proto: Catwalk
-  entities:
-  - uid: 8
+  - uid: 98
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 2.5,4.5
+      pos: -1.5,-1.5
       parent: 1
+- proto: Catwalk
+  entities:
   - uid: 28
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-4.5
+      parent: 1
+  - uid: 31
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 47
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,3.5
       parent: 1
   - uid: 54
     components:
@@ -477,119 +453,107 @@ entities:
       rot: 3.141592653589793 rad
       pos: 1.5,-4.5
       parent: 1
-  - uid: 65
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 3.5,4.5
-      parent: 1
   - uid: 66
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-4.5
       parent: 1
-  - uid: 87
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,4.5
-      parent: 1
 - proto: ChairPilotSeat
   entities:
-  - uid: 89
+  - uid: 83
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 0.5,2.5
+      pos: 0.5,1.5
       parent: 1
 - proto: ComputerTabletopShuttle
   entities:
-  - uid: 46
+  - uid: 64
     components:
     - type: Transform
-      pos: 0.5,3.5
+      pos: 0.5,2.5
       parent: 1
 - proto: ComputerTabletopStationRecords
   entities:
-  - uid: 61
+  - uid: 56
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -0.5,2.5
+      pos: -0.5,1.5
       parent: 1
 - proto: ConveyorBelt
   entities:
-  - uid: 98
+  - uid: 14
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,0.5
+      rot: 1.5707963267948966 rad
+      pos: 1.5,0.5
       parent: 1
     - type: DeviceLinkSink
       links:
-      - 125
-  - uid: 127
+      - 40
+  - uid: 55
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
+      rot: 1.5707963267948966 rad
       pos: 2.5,0.5
       parent: 1
     - type: DeviceLinkSink
       links:
-      - 125
+      - 40
 - proto: DefibrillatorCabinetFilled
   entities:
-  - uid: 140
+  - uid: 26
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 3.5,1.5
+      pos: 2.5,-2.5
       parent: 1
 - proto: DrinkWaterJug
   entities:
-  - uid: 47
+  - uid: 65
     components:
     - type: Transform
-      pos: -0.6455693,3.214887
+      pos: -0.27645433,2.0661678
       parent: 1
 - proto: EmergencyLight
   entities:
-  - uid: 95
+  - uid: 43
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -0.5,0.5
+      pos: -0.5,1.5
       parent: 1
 - proto: ExteriorLightTube
   entities:
-  - uid: 135
+  - uid: 74
     components:
     - type: Transform
-      parent: 129
+      parent: 70
     - type: Physics
       canCollide: False
 - proto: ExtinguisherCabinetFilled
   entities:
-  - uid: 139
+  - uid: 112
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -1.5,-0.5
+      rot: 3.141592653589793 rad
+      pos: 1.5,-3.5
       parent: 1
 - proto: FaxMachineShip
   entities:
-  - uid: 45
+  - uid: 57
     components:
     - type: Transform
-      pos: -0.5,3.5
+      pos: -0.5,2.5
       parent: 1
 - proto: GasPassiveVent
   entities:
-  - uid: 96
+  - uid: 52
     components:
     - type: Transform
-      pos: 1.5,4.5
+      pos: 1.5,3.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -605,13 +569,6 @@ entities:
       color: '#990000FF'
 - proto: GasPipeStraight
   entities:
-  - uid: 10
-    components:
-    - type: Transform
-      pos: 1.5,3.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
   - uid: 44
     components:
     - type: Transform
@@ -628,11 +585,10 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 109
+  - uid: 102
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,1.5
+      pos: 1.5,2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -648,11 +604,11 @@ entities:
       color: '#0000CCFF'
 - proto: GasPressurePump
   entities:
-  - uid: 59
+  - uid: 68
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 1.5,2.5
+      pos: 1.5,1.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -667,8 +623,6 @@ entities:
     - type: DeviceNetwork
       configurators:
       - invalid
-      deviceLists:
-      - 111
     - type: AtmosPipeColor
       color: '#0000CCFF'
 - proto: GasVentScrubber
@@ -682,104 +636,63 @@ entities:
     - type: DeviceNetwork
       configurators:
       - invalid
-      deviceLists:
-      - 111
     - type: AtmosPipeColor
       color: '#990000FF'
 - proto: GravityGeneratorMini
   entities:
-  - uid: 92
+  - uid: 107
     components:
     - type: Transform
-      pos: 1.5,-2.5
+      pos: -0.5,-1.5
       parent: 1
 - proto: Grille
   entities:
-  - uid: 50
+  - uid: 3
     components:
     - type: Transform
-      pos: -0.5,4.5
+      rot: 1.5707963267948966 rad
+      pos: 0.5,3.5
       parent: 1
-  - uid: 52
+  - uid: 12
     components:
     - type: Transform
-      pos: 0.5,4.5
+      rot: 1.5707963267948966 rad
+      pos: -1.5,2.5
       parent: 1
-  - uid: 67
+  - uid: 109
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,3.5
+      parent: 1
+- proto: GrilleDiagonal
+  entities:
+  - uid: 111
     components:
     - type: Transform
       pos: -1.5,3.5
       parent: 1
-  - uid: 80
-    components:
-    - type: Transform
-      pos: -1.5,4.5
-      parent: 1
-- proto: GrilleBroken
-  entities:
-  - uid: 40
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,3.5
-      parent: 1
-  - uid: 43
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,4.5
-      parent: 1
-  - uid: 51
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 0.5,4.5
-      parent: 1
 - proto: LockerSalvageSpecialistFilled
   entities:
-  - uid: 102
+  - uid: 78
     components:
     - type: Transform
-      pos: -0.5,1.5
+      pos: -0.5,0.5
       parent: 1
-    - type: EntityStorage
-      air:
-        volume: 200
-        immutable: False
-        temperature: 293.14923
-        moles:
-        - 1.7459903
-        - 6.568249
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
 - proto: OreBox
   entities:
-  - uid: 110
+  - uid: 46
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,1.5
+      pos: 1.5,0.5
       parent: 1
-  - uid: 134
-    components:
-    - type: Transform
-      pos: 2.5,1.5
-      parent: 1
-- proto: PlasticFlapsAirtightClear
+- proto: PlasticFlapsClear
   entities:
-  - uid: 126
+  - uid: 50
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 3.5,0.5
+      pos: 2.5,0.5
       parent: 1
 - proto: PortableGeneratorPacmanShuttle
   entities:
@@ -792,67 +705,72 @@ entities:
       on: False
     - type: Physics
       bodyType: Static
+- proto: Poweredlight
+  entities:
+  - uid: 110
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-0.5
+      parent: 1
 - proto: PoweredlightEmpty
   entities:
-  - uid: 129
+  - uid: 70
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 3.5,4.5
+      pos: 2.5,3.5
       parent: 1
     - type: ContainerContainer
       containers:
         light_bulb: !type:ContainerSlot
           showEnts: False
           occludes: True
-          ent: 135
+          ent: 74
     - type: ApcPowerReceiver
       powerLoad: 100
-- proto: PoweredlightLED
+- proto: Railing
   entities:
-  - uid: 107
+  - uid: 33
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 2.5,1.5
-      parent: 1
-- proto: Railing
-  entities:
-  - uid: 39
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,4.5
+      pos: 2.5,3.5
       parent: 1
 - proto: RandomPosterAny
   entities:
-  - uid: 116
+  - uid: 92
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -1.5,1.5
+      pos: -1.5,-0.5
       parent: 1
 - proto: ReinforcedWindow
   entities:
-  - uid: 4
-    components:
-    - type: Transform
-      pos: -0.5,4.5
-      parent: 1
   - uid: 11
     components:
     - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,3.5
+      parent: 1
+  - uid: 51
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,3.5
+      parent: 1
+  - uid: 89
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,2.5
+      parent: 1
+- proto: ReinforcedWindowDiagonal
+  entities:
+  - uid: 95
+    components:
+    - type: Transform
       pos: -1.5,3.5
-      parent: 1
-  - uid: 26
-    components:
-    - type: Transform
-      pos: -1.5,4.5
-      parent: 1
-  - uid: 42
-    components:
-    - type: Transform
-      pos: 0.5,4.5
       parent: 1
 - proto: SheetPlasma
   entities:
@@ -874,22 +792,23 @@ entities:
       parent: 1
 - proto: ShuttersWindow
   entities:
-  - uid: 5
+  - uid: 13
     components:
     - type: Transform
-      pos: 1.5,3.5
+      rot: 1.5707963267948966 rad
+      pos: 2.5,0.5
       parent: 1
     - type: DeviceLinkSink
       links:
-      - 123
-  - uid: 29
+      - 91
+  - uid: 69
     components:
     - type: Transform
-      pos: 2.5,3.5
+      pos: 1.5,2.5
       parent: 1
     - type: DeviceLinkSink
       links:
-      - 123
+      - 88
   - uid: 97
     components:
     - type: Transform
@@ -898,17 +817,30 @@ entities:
     - type: DeviceLinkSink
       links:
       - 99
-  - uid: 120
+- proto: SignalButton
+  entities:
+  - uid: 88
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 3.5,0.5
+      rot: -1.5707963267948966 rad
+      pos: 2.5012543,1.7518108
       parent: 1
-    - type: DeviceLinkSink
-      links:
-      - 113
+    - type: DeviceLinkSource
+      linkedPorts:
+        69:
+        - Pressed: Toggle
 - proto: SignalButtonDirectional
   entities:
+  - uid: 91
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,1.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        13:
+        - Pressed: Toggle
   - uid: 99
     components:
     - type: MetaData
@@ -921,94 +853,71 @@ entities:
       linkedPorts:
         97:
         - Pressed: Toggle
-  - uid: 113
-    components:
-    - type: MetaData
-      name: starboard shutters switch
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5003784,2.2201123
-      parent: 1
-    - type: DeviceLinkSource
-      linkedPorts:
-        120:
-        - Pressed: Toggle
-  - uid: 123
-    components:
-    - type: MetaData
-      name: bow shutters switch
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,2.5
-      parent: 1
-    - type: DeviceLinkSource
-      linkedPorts:
-        5:
-        - Pressed: Toggle
-        29:
-        - Pressed: Toggle
 - proto: SignElectricalMed
   entities:
-  - uid: 118
+  - uid: 59
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -1.5,-1.5
-      parent: 1
-- proto: SignGravity
-  entities:
-  - uid: 117
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,-3.5
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-2.5
       parent: 1
 - proto: SignSpace
-  entities:
-  - uid: 119
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 3.5,3.5
-      parent: 1
-- proto: SmallGyroscope
-  entities:
-  - uid: 93
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,-2.5
-      parent: 1
-    - type: Thruster
-      originalPowerLoad: 200
-- proto: SpawnPointLatejoin
-  entities:
-  - uid: 57
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,0.5
-      parent: 1
-- proto: SpawnPointPilot
-  entities:
-  - uid: 85
-    components:
-    - type: Transform
-      pos: 0.5,0.5
-      parent: 1
-- proto: SpawnPointSalvageSpecialist
-  entities:
-  - uid: 112
-    components:
-    - type: Transform
-      pos: 1.5,0.5
-      parent: 1
-- proto: SubstationBasic
   entities:
   - uid: 86
     components:
     - type: Transform
-      pos: -0.5,-1.5
+      pos: 2.5,2.5
+      parent: 1
+- proto: SmallGyroscope
+  entities:
+  - uid: 61
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-2.5
+      parent: 1
+    - type: Thruster
+      originalPowerLoad: 200
+- proto: SmallThruster
+  entities:
+  - uid: 21
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 1
+    - type: Thruster
+      originalPowerLoad: 500
+  - uid: 90
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-4.5
+      parent: 1
+    - type: Thruster
+      originalPowerLoad: 500
+  - uid: 96
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-4.5
+      parent: 1
+    - type: Thruster
+      originalPowerLoad: 500
+- proto: SpawnPointLatejoin
+  entities:
+  - uid: 45
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,-0.5
+      parent: 1
+- proto: SubstationWallBasic
+  entities:
+  - uid: 93
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-1.5
       parent: 1
 - proto: SuitStorageWallmountSalv
   entities:
@@ -1027,16 +936,17 @@ entities:
     - type: Transform
       pos: -0.5,2.5
       parent: 1
-  - uid: 55
+  - uid: 42
     components:
     - type: Transform
-      pos: -0.5,3.5
+      rot: 3.141592653589793 rad
+      pos: 0.5,2.5
       parent: 1
   - uid: 60
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 0.5,3.5
+      rot: 3.141592653589793 rad
+      pos: -0.5,1.5
       parent: 1
 - proto: Thruster
   entities:
@@ -1048,54 +958,36 @@ entities:
       parent: 1
     - type: Thruster
       originalPowerLoad: 1500
-  - uid: 64
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -0.5,-4.5
-      parent: 1
-    - type: Thruster
-      originalPowerLoad: 1500
-  - uid: 78
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,-4.5
-      parent: 1
-    - type: Thruster
-      originalPowerLoad: 1500
-  - uid: 90
-    components:
-    - type: Transform
-      pos: 3.5,4.5
-      parent: 1
-    - type: Thruster
-      originalPowerLoad: 1500
 - proto: TwoWayLever
   entities:
-  - uid: 125
+  - uid: 40
     components:
-    - type: MetaData
-      name: conveyor belt lever
     - type: Transform
-      pos: 1.0009614,2.6627383
+      pos: 1.1267233,1.5855596
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        98:
+        14:
         - Left: Forward
         - Right: Reverse
         - Middle: Off
-        127:
+        55:
         - Left: Forward
         - Right: Reverse
         - Middle: Off
 - proto: WallSolid
   entities:
-  - uid: 2
+  - uid: 6
     components:
     - type: Transform
-      pos: -1.5,2.5
+      rot: 3.141592653589793 rad
+      pos: 2.5,2.5
+      parent: 1
+  - uid: 9
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,1.5
       parent: 1
   - uid: 23
     components:
@@ -1109,37 +1001,10 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 1.5,-3.5
       parent: 1
-  - uid: 33
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,-3.5
-      parent: 1
   - uid: 36
     components:
     - type: Transform
       pos: -1.5,-2.5
-      parent: 1
-  - uid: 49
-    components:
-    - type: Transform
-      pos: 3.5,-2.5
-      parent: 1
-  - uid: 68
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,3.5
-      parent: 1
-  - uid: 69
-    components:
-    - type: Transform
-      pos: 3.5,2.5
-      parent: 1
-  - uid: 70
-    components:
-    - type: Transform
-      pos: 3.5,1.5
       parent: 1
   - uid: 73
     components:
@@ -1150,6 +1015,12 @@ entities:
     components:
     - type: Transform
       pos: -1.5,1.5
+      parent: 1
+  - uid: 80
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-2.5
       parent: 1
   - uid: 81
     components:
@@ -1164,46 +1035,31 @@ entities:
       parent: 1
 - proto: WallSolidDiagonal
   entities:
-  - uid: 31
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 3.5,-3.5
-      parent: 1
   - uid: 32
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-3.5
       parent: 1
-- proto: WarpPointShip
-  entities:
-  - uid: 3
+  - uid: 87
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,0.5
+      rot: 3.141592653589793 rad
+      pos: 2.5,-3.5
+      parent: 1
+- proto: WarpPointShip
+  entities:
+  - uid: 85
+    components:
+    - type: Transform
+      pos: 0.5,0.5
       parent: 1
 - proto: WeaponGrapplingGun
   entities:
-  - uid: 105
+  - uid: 53
     components:
     - type: Transform
-      pos: -0.21848601,3.2044704
-      parent: 1
-- proto: WindowReinforcedDirectional
-  entities:
-  - uid: 6
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,3.5
-      parent: 1
-  - uid: 9
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,4.5
+      pos: 0.22354567,2.3995013
       parent: 1
 - proto: Wrench
   entities:

--- a/Resources/Maps/_NF/Shuttles/searchlight.yml
+++ b/Resources/Maps/_NF/Shuttles/searchlight.yml
@@ -249,46 +249,44 @@ entities:
       data:
         tiles:
           0,0:
-            0: 13175
+            0: 275
           0,-1:
-            0: 30719
-            1: 2048
-          -1,-1:
-            0: 52462
-            1: 1
+            0: 13079
+            2: 2048
           -1,0:
-            0: 35020
+            0: 8
           0,1:
-            0: 1
             1: 16
           1,0:
-            1: 13107
-          1,1:
-            1: 4371
-          -1,-3:
-            0: 65516
-            1: 2
-          -1,-2:
-            0: 65535
-          -1,-4:
-            0: 49152
-          0,-4:
-            0: 28672
-          0,-3:
-            0: 30711
-            2: 34816
-            1: 8
-          0,-2:
-            0: 65535
-          1,-3:
-            0: 8976
-            2: 4096
-            1: 16384
-          1,-2:
-            0: 30583
+            2: 13107
           1,-1:
-            0: 119
-            1: 14080
+            2: 14080
+            0: 3
+          1,1:
+            2: 4371
+          -1,-3:
+            0: 60552
+            2: 2
+          -1,-2:
+            0: 52974
+          -1,-1:
+            2: 1
+            0: 34828
+          -1,-4:
+            0: 32768
+          0,-3:
+            0: 29475
+            2: 8
+            3: 34816
+          0,-2:
+            0: 32755
+          0,-4:
+            0: 8192
+          1,-3:
+            3: 4096
+            2: 16384
+          1,-2:
+            0: 13104
         uniqueMixes:
         - volume: 2500
           temperature: 293.15
@@ -307,6 +305,21 @@ entities:
           - 0
         - volume: 2500
           temperature: 293.15
+          moles:
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          immutable: True
           moles:
           - 0
           - 0
@@ -358,8 +371,6 @@ entities:
       - 279
       - 272
       - 271
-    - type: AtmosDevice
-      joinedGrid: 1
     - type: AccessReader
       enabled: False
     - type: Emagged
@@ -374,8 +385,6 @@ entities:
       - 243
       - 245
       - 280
-    - type: AtmosDevice
-      joinedGrid: 1
     - type: AccessReader
       enabled: False
     - type: Emagged
@@ -389,8 +398,6 @@ entities:
       parent: 1
     - type: Physics
       bodyType: Static
-    - type: AtmosDevice
-      joinedGrid: 1
 - proto: AirlockCommandGlass
   entities:
   - uid: 113
@@ -1222,8 +1229,6 @@ entities:
     - type: Transform
       pos: 4.5,-1.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
     - type: AtmosPipeColor
       color: '#990000FF'
 - proto: GasPipeBend
@@ -1442,8 +1447,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -2.5,-5.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
     - type: AtmosPipeColor
       color: '#0000CCFF'
 - proto: GasPressurePump
@@ -1456,8 +1459,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -1.5,-5.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
     - type: AtmosPipeColor
       color: '#0000CCFF'
   - uid: 179
@@ -1468,8 +1469,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 4.5,-3.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
     - type: AtmosPipeColor
       color: '#990000FF'
 - proto: GasVentPump
@@ -1480,8 +1479,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -0.5,-0.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
     - type: AtmosPipeColor
       color: '#0000CCFF'
   - uid: 325
@@ -1490,8 +1487,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 0.5,-8.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
     - type: AtmosPipeColor
       color: '#0000CCFF'
 - proto: GasVentScrubber
@@ -1502,8 +1497,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 2.5,-3.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 219
@@ -1512,8 +1505,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 2.5,-4.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 236
@@ -1522,8 +1513,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 1.5,-8.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 243
@@ -1531,8 +1520,6 @@ entities:
     - type: Transform
       pos: 1.5,-0.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 261
@@ -1541,8 +1528,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 3.5,-8.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 319
@@ -1551,8 +1536,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -2.5,-6.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
     - type: AtmosPipeColor
       color: '#990000FF'
 - proto: GravityGeneratorMini
@@ -1696,6 +1679,8 @@ entities:
     - type: Transform
       pos: 1.5,-1.5
       parent: 1
+    - type: Thruster
+      originalPowerLoad: 1500
 - proto: HandheldHealthAnalyzer
   entities:
   - uid: 257
@@ -1736,101 +1721,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 3.5,-9.5
       parent: 1
-- proto: Paper
-  entities:
-  - uid: 181
-    components:
-    - type: Transform
-      pos: -2.2371995,-6.3594403
-      parent: 1
-    - type: Paper
-      stampState: paper_stamp-ce
-      stampedBy:
-      - stampedBorderless: False
-        stampedColor: '#C69B17FF'
-        stampedName: stamp-component-stamped-name-ce
-      - stampedBorderless: False
-        stampedColor: '#00BE00FF'
-        stampedName: stamp-component-stamped-name-approved
-      content: >-
-        [color=#1b67a5]█░░█░███[/color][color=#5b97bc]░███░█░█░█░██░░█░█░██░░██░░██░[/color]
-
-        [color=#1b67a5]██░█░░█░[/color][color=#5b97bc]██░░░█░█░█░█░█░█░█░█░█░█░█░█░█[/color]
-
-        [color=#1b67a5]█░██░░█░[/color][color=#5b97bc]░░██░███░█░██░░░█░░███░██░░█░█[/color]
-
-        [color=#1b67a5]█░░█░░█░[/color][color=#5b97bc]███░░█░█░█░█░░░░█░░█░█░█░█░██░[/color]
-
-
-        [head=1]=========================[/head]
-
-        [head=1]             Searchlight-class[/head]
-
-        [head=1]                  medical ship[/head]
-
-        [head=1] [/head]
-
-        [head=1]         PREFLIGHT CHECKLIST[/head]
-
-        [head=1]=========================[/head]
-
-
-        [head=2]1. Power supply.[/head]
-
-        [head=3]1.1. Battery units.[/head]
-
-        [bullet/][ ] Check if the SMES unit is anchored to the floor.
-
-        [bullet/][ ] Check if the APC unit's Main Breaker is toggled on.
-
-        [bullet/][ ] Check the APC unit's current Load[bold]*[/bold] (W).
-
-        [head=3]1.2. P.A.C.M.A.N. generator unit.[/head]
-
-        [bullet/][ ] Check if the P.A.C.M.A.N. generator unit is anchored to the floor.
-
-        [bullet/][ ] Check if the P.A.C.M.A.N. generator unit has fuel. For extended flights make sure that you have enough fuel stockpiled to sustain prolonged power generation.
-
-        [bullet/][ ] Check if the P.A.C.M.A.N. generator unit is set to HV output.
-
-        [bullet/][ ] Set Target Power for 15-16[bold]**[/bold] [bold]k[/bold]W.
-
-        [bullet/][ ] Start the P.A.C.M.A.N. generator unit.
-
-
-        [head=2]2. Atmospherics.[/head]
-
-        [head=3]2.1. Distribution Loop.[/head]
-
-        [bullet/][ ] Check if the air canister is anchored to connector port.
-
-        [bullet/][ ] Check if the distribution pump is set to normal pressure.
-
-        [bullet/][ ] Enable the distribution pump.
-
-        [head=3]2.2. Waste Loop.[/head]
-
-        [bullet/][ ] Enable the waste loop pump.
-
-        [bullet/][ ] Disable Auto Mode on the Air Alarm in the Engine Room.
-
-        [bullet/][ ] Set the Air Alarm in the Engine Room to Filtering (Wide).
-
-
-        [head=2]3. Other checks.[/head]
-
-        [bullet/][ ] Check if the gyroscope is anchored, powered, and enabled.
-
-        [bullet/][ ] Check if the mini gravity generator is anchored, powered, and enabled.
-
-        [bullet/][ ] Check if the bow blastdoors are closed.
-
-
-        __________________________________________________________________
-
-        [bold]*[/bold] - Searchlight-class medical ship are equipped with a single APC unit that can be used to appraise the ship's total power consumption (which for the unmodified ship is 14.7 kW). One can check the ship's total power consumption against the P.A.C.M.A.N. generator unit Target Power output: to keep substation and APC fully charged, P.A.C.M.A.N. generator unit Target Power output should exceed APC's Load. Remember to check APC Load and adjust the generator unit Target Power after connecting new power-consuming machines.
-
-        [bold]**[/bold] - Searchlight-class medical ship have average power demand meaning that standard P.A.C.M.A.N. generator unit's Target Power value can be put at 15 kW. Please note, that recommended Target Power value to avoid blackouts during Gravity Generator charging sequence is 16 kW.
 - proto: PortableGeneratorPacmanShuttle
   entities:
   - uid: 140
@@ -1903,6 +1793,12 @@ entities:
       parent: 1
 - proto: PoweredSmallLight
   entities:
+  - uid: 186
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-3.5
+      parent: 1
   - uid: 265
     components:
     - type: Transform
@@ -2103,6 +1999,13 @@ entities:
       count: 15
     - type: Item
       size: 15
+- proto: ShipyardSearchlightInfo
+  entities:
+  - uid: 54
+    components:
+    - type: Transform
+      pos: -2.2648783,-6.364795
+      parent: 1
 - proto: SignalButton
   entities:
   - uid: 191
@@ -2199,31 +2102,10 @@ entities:
       parent: 1
 - proto: SpawnPointLatejoin
   entities:
-  - uid: 258
+  - uid: 181
     components:
     - type: Transform
-      pos: 3.5,-8.5
-      parent: 1
-- proto: SpawnPointParamedic
-  entities:
-  - uid: 224
-    components:
-    - type: Transform
-      pos: 5.5,-6.5
-      parent: 1
-- proto: SpawnPointPilot
-  entities:
-  - uid: 186
-    components:
-    - type: Transform
-      pos: 0.5,-0.5
-      parent: 1
-- proto: SpawnPointStationEngineer
-  entities:
-  - uid: 54
-    components:
-    - type: Transform
-      pos: -0.5,-9.5
+      pos: 0.5,-6.5
       parent: 1
 - proto: StasisBed
   entities:
@@ -2288,34 +2170,46 @@ entities:
       rot: 3.141592653589793 rad
       pos: -2.5,-11.5
       parent: 1
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 51
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-11.5
       parent: 1
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 99
     components:
     - type: Transform
       pos: 3.5,-1.5
       parent: 1
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 100
     components:
     - type: Transform
       pos: 6.5,-1.5
       parent: 1
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 115
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,-8.5
       parent: 1
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 118
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-3.5
       parent: 1
+    - type: Thruster
+      originalPowerLoad: 1500
 - proto: TintedWindow
   entities:
   - uid: 200

--- a/Resources/Prototypes/_NF/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/Boxes/general.yml
@@ -120,3 +120,25 @@
     contents:
       - id: EncryptionKeyNfsd
         amount: 4
+
+- type: entity
+  name: exterior lighttube box
+  parent: BoxCardboard
+  id: BoxExteriorLightTube
+  description: This box is shaped on the inside so that only light tubes and bulbs fit.
+  components:
+  - type: StorageFill
+    contents:
+      - id: ExteriorLightTube
+        amount: 4
+  - type: Sprite
+    layers:
+      - state: box
+      - state: lighttube
+        color: "cyan"
+  - type: Storage
+    grid:
+    - 0,0,3,1
+    whitelist:
+      components:
+      - LightBulb

--- a/Resources/Prototypes/_NF/Catalog/Fills/Paper/Shipyard/manuals.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/Paper/Shipyard/manuals.yml
@@ -1,3 +1,159 @@
+
+- type: entity
+  parent: BaseItem
+  id: ShipyardBrigandInfo
+  name: brigand user manual
+  description: preflight checklist
+  components:
+  - type: Sprite
+    sprite: Objects/Misc/books.rsi
+    layers:
+    - state: paper
+    - state: cover_base
+      color: "#6c4718"
+    - state: decor_wingette
+      color: "#b5913c"
+    - state: icon_wrench
+    - state: icon_corner
+      color: gold
+  - type: GuideHelp
+    openOnActivation: true
+    guides:
+    - ShipyardBrigand
+
+- type: entity
+  parent: BaseItem
+  id: ShipyardGasbenderInfo
+  name: gasbender user manual
+  description: preflight checklist
+  components:
+  - type: Sprite
+    sprite: Objects/Misc/books.rsi
+    layers:
+    - state: paper
+    - state: cover_base
+      color: "#6c4718"
+    - state: decor_wingette
+      color: "#b5913c"
+    - state: icon_wrench
+    - state: icon_corner
+      color: gold
+  - type: GuideHelp
+    openOnActivation: true
+    guides:
+    - ShipyardGasbender
+
+- type: entity
+  parent: BaseItem
+  id: ShipyardHarbormasterInfo
+  name: harbormaster user manual
+  description: preflight checklist
+  components:
+  - type: Sprite
+    sprite: Objects/Misc/books.rsi
+    layers:
+    - state: paper
+    - state: cover_base
+      color: "#6c4718"
+    - state: decor_wingette
+      color: "#b5913c"
+    - state: icon_wrench
+    - state: icon_corner
+      color: gold
+  - type: GuideHelp
+    openOnActivation: true
+    guides:
+    - ShipyardHarbormaster
+
+- type: entity
+  parent: BaseItem
+  id: ShipyardKilderkinInfo
+  name: kilderkin user manual
+  description: preflight checklist
+  components:
+  - type: Sprite
+    sprite: Objects/Misc/books.rsi
+    layers:
+    - state: paper
+    - state: cover_base
+      color: "#6c4718"
+    - state: decor_wingette
+      color: "#b5913c"
+    - state: icon_wrench
+    - state: icon_corner
+      color: gold
+  - type: GuideHelp
+    openOnActivation: true
+    guides:
+    - ShipyardKilderkin
+
+- type: entity
+  parent: BaseItem
+  id: ShipyardLanternInfo
+  name: lantern user manual
+  description: preflight checklist
+  components:
+  - type: Sprite
+    sprite: Objects/Misc/books.rsi
+    layers:
+    - state: paper
+    - state: cover_strong
+      color: "#606060"
+    - state: icon_temple
+      color: gold
+    - state: decor_spine
+      color: gold
+    - sprite: Objects/Misc/bureaucracy.rsi
+      state: paper_stamp-chaplain
+  - type: GuideHelp
+    openOnActivation: true
+    guides:
+    - ShipyardLantern
+
+- type: entity
+  parent: BaseItem
+  id: ShipyardLegmanInfo
+  name: legman user manual
+  description: preflight checklist
+  components:
+  - type: Sprite
+    sprite: Objects/Misc/books.rsi
+    layers:
+    - state: paper
+    - state: cover_base
+      color: "#6c4718"
+    - state: decor_wingette
+      color: "#b5913c"
+    - state: icon_wrench
+    - state: icon_corner
+      color: gold
+  - type: GuideHelp
+    openOnActivation: true
+    guides:
+    - ShipyardLegman
+
+- type: entity
+  parent: BaseItem
+  id: ShipyardLiquidatorInfo
+  name: liquidator user manual
+  description: preflight checklist
+  components:
+  - type: Sprite
+    sprite: Objects/Misc/books.rsi
+    layers:
+    - state: paper
+    - state: cover_base
+      color: "#6c4718"
+    - state: decor_wingette
+      color: "#b5913c"
+    - state: icon_wrench
+    - state: icon_corner
+      color: gold
+  - type: GuideHelp
+    openOnActivation: true
+    guides:
+    - ShipyardLiquidator
+
 - type: entity
   parent: BaseItem
   id: ShipyardPioneerInfo
@@ -19,3 +175,25 @@
     openOnActivation: true
     guides:
     - ShipyardPioneer
+
+- type: entity
+  parent: BaseItem
+  id: ShipyardSearchlightInfo
+  name: searchlight user manual
+  description: preflight checklist
+  components:
+  - type: Sprite
+    sprite: Objects/Misc/books.rsi
+    layers:
+    - state: paper
+    - state: cover_base
+      color: "#6c4718"
+    - state: decor_wingette
+      color: "#b5913c"
+    - state: icon_wrench
+    - state: icon_corner
+      color: gold
+  - type: GuideHelp
+    openOnActivation: true
+    guides:
+    - ShipyardSearchlight

--- a/Resources/Prototypes/_NF/Entities/Structures/Power/chargers.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Power/chargers.yml
@@ -1,0 +1,10 @@
+
+- type: entity
+  parent: WallWeaponCapacitorRecharger
+  id: WallWeaponCapacitorRechargerOmnidirectional
+  name: wall recharger
+  suffix: Omnidirectional
+  components:
+  - type: WallMount
+    arc: 360
+  - type: Rotatable

--- a/Resources/Prototypes/_NF/Shipyard/Expedition/brigand.yml
+++ b/Resources/Prototypes/_NF/Shipyard/Expedition/brigand.yml
@@ -12,7 +12,7 @@
   id: Brigand
   name: NT Brigand
   description: Civilian conversion of an old military light frigate from the early days of humanity's expansion to the stars, predating FTL technology.
-  price: 53550 # 46550$ on mapinit + 7000$ from 15% markup
+  price: 55010 # ~47835$ on mapinit + ~7175$ from 15% markup
   category: Medium
   group: Expedition
   shuttlePath: /Maps/_NF/Shuttles/Expedition/brigand.yml
@@ -34,6 +34,6 @@
         - type: StationJobs
           overflowJobs: []
           availableJobs:
+            Contractor: [ 0, 0 ]
             Pilot: [ 0, 0 ]
             Mercenary: [ 0, 0 ]
-            SalvageSpecialist: [ 0, 0 ]

--- a/Resources/Prototypes/_NF/Shipyard/Expedition/gasbender.yml
+++ b/Resources/Prototypes/_NF/Shipyard/Expedition/gasbender.yml
@@ -12,19 +12,19 @@
   id: gasbender
   name: NT Gasbender
   description: The Gasbender is a medium-sized engineering vessel outfitted for deep space construction projects. Features atmospherics setup with mixing/ignition chamber. Designed to work in pair with smaller salvage ship.
-  price: 90500
+  price: 78400 # ~68140$ on mapinit + 10220$ from 15% markup
   category: Medium
-  group: Civilian
-  shuttlePath: /Maps/_NF/Shuttles/gasbender.yml
+  group: Expedition
+  shuttlePath: /Maps/_NF/Shuttles/Expedition/gasbender.yml
 
 - type: gameMap
   id: gasbender
   mapName: 'NT Gasbender'
-  mapPath: /Maps/_NF/Shuttles/gasbender.yml
+  mapPath: /Maps/_NF/Shuttles/Expedition/gasbender.yml
   minPlayers: 0
   stations:
     gasbender:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Gasbender {1}'
@@ -34,8 +34,6 @@
         - type: StationJobs
           overflowJobs: []
           availableJobs:
+            Contractor: [ 0, 0 ]
             Pilot: [ 0, 0 ]
-            ChiefEngineer: [ 0, 0 ]
-            AtmosphericTechnician: [ 0, 0 ]
-            StationEngineer: [ 0, 0 ]
-            Borg: [ 0, 0 ]
+            Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_NF/Shipyard/harbormaster.yml
+++ b/Resources/Prototypes/_NF/Shipyard/harbormaster.yml
@@ -8,12 +8,11 @@
 
 # Shuttle Notes:
 # 
-
 - type: vessel
   id: harbormaster
   name: NC Harbormaster
   description: A small tugboat.
-  price: 29500
+  price: 28300 # ~24600$ on mapinit + ~3690$ from 15% markup
   category: Small
   group: Civilian
   shuttlePath: /Maps/_NF/Shuttles/harbormaster.yml
@@ -35,4 +34,6 @@
         - type: StationJobs
           overflowJobs: []
           availableJobs:
+            Contractor: [ 0, 0 ]
             Pilot: [ 0, 0 ]
+            Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_NF/Shipyard/kilderkin.yml
+++ b/Resources/Prototypes/_NF/Shipyard/kilderkin.yml
@@ -8,12 +8,11 @@
 
 # Shuttle Notes:
 # 
-
 - type: vessel
   id: kilderkin
   name: NC Kilderkin
   description: "Spaceworthy bar/microbrewery with everything one needs to facilitate poor life choices: lots of booze, smokes, and lack of food."
-  price: 42900
+  price: 45900 # ~41730$ on mapinit + ~4170$ from 10% markup
   category: Medium
   group: Civilian
   shuttlePath: /Maps/_NF/Shuttles/kilderkin.yml
@@ -35,7 +34,6 @@
         - type: StationJobs
           overflowJobs: []
           availableJobs:
-            Bartender: [ 0, 0 ]
-            Botanist: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            Contractor: [ 0, 0 ]
             Pilot: [ 0, 0 ]
+            Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_NF/Shipyard/lantern.yml
+++ b/Resources/Prototypes/_NF/Shipyard/lantern.yml
@@ -12,7 +12,7 @@
   id: lantern
   name: NC Lantern
   description: The Lantern is a medium-sized chapel-vessel equipped with everything chaplain might need in their never ending battle for salvation of NT personnel souls.
-  price: 34500
+  price: 34125 # ~31020$ on mapinit + ~3100$ from 10% markup
   category: Medium
   group: Civilian
   shuttlePath: /Maps/_NF/Shuttles/lantern.yml
@@ -34,5 +34,6 @@
         - type: StationJobs
           overflowJobs: []
           availableJobs:
+            Contractor: [ 0, 0 ]
             Pilot: [ 0, 0 ]
-            Chaplain: [ 0, 0 ]
+            Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_NF/Shipyard/legman.yml
+++ b/Resources/Prototypes/_NF/Shipyard/legman.yml
@@ -12,7 +12,7 @@
   id: Legman
   name: NC Legman
   description: A small maneuverable shuttle with low operational costs for reporters who want to be first on a scene.
-  price: 11700
+  price: 10670 # 9700$ on mapinit + 970$ from 10% markup
   category: Small
   group: Civilian
   shuttlePath: /Maps/_NF/Shuttles/legman.yml
@@ -34,5 +34,6 @@
         - type: StationJobs
           overflowJobs: []
           availableJobs:
-            Reporter: [ 0, 0 ]
+            Contractor: [ 0, 0 ]
             Pilot: [ 0, 0 ]
+            Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_NF/Shipyard/liquidator.yml
+++ b/Resources/Prototypes/_NF/Shipyard/liquidator.yml
@@ -12,7 +12,7 @@
   id: Liquidator
   name: NT Liquidator
   description: A small vessel equipped with everything you need to make even the dirtiest ship squeaky clean (ducky slippers included).
-  price: 34000 # 27480+4120 from 15% markup
+  price: 35000 # ~30415$ on mapinit + 4565$ from 15% markup
   category: Small
   group: Civilian
   shuttlePath: /Maps/_NF/Shuttles/liquidator.yml
@@ -34,7 +34,6 @@
         - type: StationJobs
           overflowJobs: []
           availableJobs:
+            Contractor: [ 0, 0 ]
             Pilot: [ 0, 0 ]
-            Janitor: [ 0, 0 ]
-            AtmosphericTechnician: [ 0, 0 ]
-            Chemist: [ 0, 0 ]
+            Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_NF/Shipyard/pioneer.yml
+++ b/Resources/Prototypes/_NF/Shipyard/pioneer.yml
@@ -12,7 +12,7 @@
   id: Pioneer
   name: NC Pioneer
   description: A cargo container outfitted to be space-capable and equipped for salvaging and mining either on its own or as part of a fleet.
-  price: 14650
+  price: 12200 # ~10600$ on mapinit + ~1600$ from 15% markup
   category: Small
   group: Civilian
   shuttlePath: /Maps/_NF/Shuttles/pioneer.yml
@@ -34,5 +34,6 @@
         - type: StationJobs
           overflowJobs: []
           availableJobs:
+            Contractor: [ 0, 0 ]
             Pilot: [ 0, 0 ]
-            SalvageSpecialist: [ 0, 0 ]
+            Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_NF/Shipyard/searchlight.yml
+++ b/Resources/Prototypes/_NF/Shipyard/searchlight.yml
@@ -12,7 +12,7 @@
   id: Searchlight
   name: NM Searchlight
   description: A small vessel outfitted for the search and recovery of wounded NT personnel. Primarily for recovery. Search though? Well. You got that medical tracker implanted, right?
-  price: 29500
+  price: 29050 # ~26400$ on mapinit + ~2640$ from 10% markup
   category: Small
   group: Civilian
   shuttlePath: /Maps/_NF/Shuttles/searchlight.yml
@@ -34,6 +34,6 @@
         - type: StationJobs
           overflowJobs: []
           availableJobs:
-            Paramedic: [ 0, 0 ]
+            Contractor: [ 0, 0 ]
             Pilot: [ 0, 0 ]
-            StationEngineer: [ 0, 0 ]
+            Mercenary: [ 0, 0 ]

--- a/Resources/ServerInfo/_NF/Guidebook/Shipyard/Brigand.xml
+++ b/Resources/ServerInfo/_NF/Guidebook/Shipyard/Brigand.xml
@@ -16,7 +16,7 @@
 	
 	[color=#a4885c]IFF Console:[/color] None
 	
-	[color=#a4885c]Available Roles:[/color] Pilot, Mercenary, Salvage Specialist
+	[color=#a4885c]Available Roles:[/color] Contractor, Pilot, Mercenary
 	
   "Civilian conversion of an old military light frigate from the early days of humanity's expansion to the stars. The original light frigate design was made in pre-FTL era of technology."
   

--- a/Resources/ServerInfo/_NF/Guidebook/Shipyard/Gasbender.xml
+++ b/Resources/ServerInfo/_NF/Guidebook/Shipyard/Gasbender.xml
@@ -6,19 +6,25 @@
   <GuideEntityEmbed Entity="ShipyardRCD"/>
   <GuideEntityEmbed Entity="HolofanProjector"/>
   </Box>
+  <Box>
+  <GuideEntityEmbed Entity="GasPressurePump"/>
+  <GuideEntityEmbed Entity="GasFilterFlipped"/>
+  <GuideEntityEmbed Entity="GasVentScrubber"/>
+  <GuideEntityEmbed Entity="GasVentScrubber"/>
+  </Box>
     [color=#a4885c]Ship Size:[/color] Medium
 	
 	[color=#a4885c]Recommended Crew:[/color] 3-6
 	
 	[color=#a4885c]Power Gen Type:[/color] AME
 	
-	[color=#a4885c]Expeditions:[/color] None
+	[color=#a4885c]Expeditions:[/color] Yes
 	
 	[color=#a4885c]IFF Console:[/color] None
 	
-	[color=#a4885c]Available Roles:[/color] Pilot, Chief Engineer, Atmospheric Technician, Station Engineer, Borg
+	[color=#a4885c]Available Roles:[/color] Contractor, Pilot, Mercenary
 	
-  "The Gasbender is a medium-sized engineering vessel outfitted for deep space construction projects. Features atmospherics setup with mixing/ignition chamber. Designed to work in pair with smaller salvage ship."
+  "The Gasbender is a medium-sized engineering vessel outfitted for deep space construction projects and gas collection on planets. Features atmospherics setup with mixing/ignition chamber. Designed to work in pair with smaller salvage ship."
   
   # Piloting
   <Box>
@@ -37,6 +43,15 @@
   </Box>
   As a Captain of a Nanotrasen vessel, you have the authority to hire, fire, demote, or promote crew members at will. There are two ways you as a Captain can go about hiring crew: you can either use the [color=#a4885c]station records computer[/color] on your ship to open crew slots (jobs available vary from ship to ship) or invite through in-game communications other players to your crew.
   
+  # Salvage expeditions
+  <Box>
+  <GuideEntityEmbed Entity="ComputerSalvageExpedition"/>
+  <GuideEntityEmbed Entity="TelecomServerFilledShuttle"/>
+  </Box>
+  Expeditions are adventures that you can do with your fellow crewmates or on your own. You must pick a mission from the [color=#a4885c]salvage console[/color], each of which of varying difficulty and reward, the FTL transition to the location will initiate immediately if your shuttle is far enough away from celestial bodies (other shuttles, asteroids, POIs, etc.). Once you arrive, the chat will tell you in which direction the target dungeon of the expedition is.
+  
+  While planetside you will be unable to communicate via radio with the wider Frontier Sector, and unless you have [color=#a4885c]telecommunication server[/color] installed you won't be able to use radio to communicate with your crew in the expedition too.
+
   # PREFLIGHT CHECKLIST
   
   ## 1. Power supply
@@ -108,6 +123,6 @@
   
   ## Sidenotes
   
-  * - Gasbender-class service ships are equipped with a five APC units that can be used to appraise the ship's total power consumption. Unmodifued Gasbender-class ship requires 38 kW of power to remain operational.
+  * - Gasbender-class service ships are equipped with a five APC units that can be used to appraise the ship's total power consumption. Unmodifued Gasbender-class ship requires 40 kW of power to remain operational.
 
 </Document>

--- a/Resources/ServerInfo/_NF/Guidebook/Shipyard/Harbormaster.xml
+++ b/Resources/ServerInfo/_NF/Guidebook/Shipyard/Harbormaster.xml
@@ -18,7 +18,7 @@
 	
 	[color=#a4885c]IFF Console:[/color] None
 	
-	[color=#a4885c]Available Roles:[/color] Pilot
+	[color=#a4885c]Available Roles:[/color] Contractor, Pilot, Mercenary
 	
   "An affordable shuttle for towing derelict ships to and from Frontier Station."
   

--- a/Resources/ServerInfo/_NF/Guidebook/Shipyard/Kilderkin.xml
+++ b/Resources/ServerInfo/_NF/Guidebook/Shipyard/Kilderkin.xml
@@ -16,7 +16,7 @@
 	
 	[color=#a4885c]IFF Console:[/color] None
 	
-	[color=#a4885c]Available Roles:[/color] Pilot, Mercenary, Bartender, Botanist
+	[color=#a4885c]Available Roles:[/color] Contractor, Pilot, Mercenary
 	
   "A medium-sized space bar. In addition to the bar is equipped with hydroponics."
   

--- a/Resources/ServerInfo/_NF/Guidebook/Shipyard/Lantern.xml
+++ b/Resources/ServerInfo/_NF/Guidebook/Shipyard/Lantern.xml
@@ -23,7 +23,7 @@
 	
 	[color=#a4885c]IFF Console:[/color] None
 	
-	[color=#a4885c]Available Roles:[/color] Pilot, Chaplain
+	[color=#a4885c]Available Roles:[/color] Contractor, Pilot, Mercenary
 	
   "A medium-sized shuttle to promote your religion."
   

--- a/Resources/ServerInfo/_NF/Guidebook/Shipyard/Legman.xml
+++ b/Resources/ServerInfo/_NF/Guidebook/Shipyard/Legman.xml
@@ -15,7 +15,7 @@
 	
 	[color=#a4885c]IFF Console:[/color] None
 	
-	[color=#a4885c]Available Roles:[/color] Reporter
+	[color=#a4885c]Available Roles:[/color] Contractor, Pilot, Mercenary
 	
   "A small maneuverable shuttle with low operational costs for reporters who want to be first on a scene."
   
@@ -59,7 +59,7 @@
   - Check if the P.A.C.M.A.N. generator unit is anchored to the floor.
   - Check if the P.A.C.M.A.N. generator unit has fuel. For extended flights make sure that you have enough fuel stockpiled to sustain prolonged power generation during flight.
   - Check if the P.A.C.M.A.N. generator unit is set to HV output.
-  - Set Target Power to 9-10** [bold]k[/bold]W.
+  - Set Target Power to 5-6** [bold]k[/bold]W.
   - Start the P.A.C.M.A.N. generator unit.
   
   ## 2. Atmospherics
@@ -98,8 +98,8 @@
   
   ## Sidenotes
   
-  * - Legman-class service ships are equipped with a single APC unit that can be used to appraise the ship's total power consumption. One can check the ship's total power consumption against the P.A.C.M.A.N. generator unit Target Power output: to keep substation and APC fully charged, P.A.C.M.A.N. generator unit Target Power output should exceed APC's Load. Remember to check APC Load and adjust the generator unit Target Power after connecting new power-consuming machines.
+  * - Legman-class service ships are equipped with one APC units that can be used to appraise the ship's total power consumption. Unmodifued Legman-class ship requires 4.7 kW of power to remain operational.
   
-  ** - Legman-class service ships have low power demand meaning that standard P.A.C.M.A.N. generator unit's Target Power value can be lowered as low as 10 kW. Please note, that recommended Target Power value to avoid blackouts during Gravity Generator charging sequence is 11 kW.
+  ** - Legman-class service ships have low power demand meaning that standard P.A.C.M.A.N. generator unit's Target Power value can be lowered as low as 5 kW. Please note, that recommended Target Power value to avoid blackouts during Gravity Generator charging sequence is 6 kW.
 
 </Document>

--- a/Resources/ServerInfo/_NF/Guidebook/Shipyard/Liquidator.xml
+++ b/Resources/ServerInfo/_NF/Guidebook/Shipyard/Liquidator.xml
@@ -18,7 +18,7 @@
 	
 	[color=#a4885c]IFF Console:[/color] None
 	
-	[color=#a4885c]Available Roles:[/color] Pilot, Janitor
+	[color=#a4885c]Available Roles:[/color] Contractor, Pilot, Mercenary
 	
   "A small vessel equipped with everything you need to make even the dirtiest ship squeaky clean (ducky slippers included)."
   

--- a/Resources/ServerInfo/_NF/Guidebook/Shipyard/Pioneer.xml
+++ b/Resources/ServerInfo/_NF/Guidebook/Shipyard/Pioneer.xml
@@ -14,7 +14,7 @@
 	
 	[color=#a4885c]IFF Console:[/color] None
 	
-	[color=#a4885c]Available Roles:[/color] Salvage Specialist
+	[color=#a4885c]Available Roles:[/color] Contractor, Pilot, Mercenary
 	
   "A cargo container outfitted to be space-capable and equipped for salvaging and mining either on its own or as part of a fleet."
   
@@ -41,7 +41,7 @@
   
   ## 1.1. Battery units
   <Box>
-  <GuideEntityEmbed Entity="SubstationBasic"/>
+  <GuideEntityEmbed Entity="SubstationWallBasic"/>
   <GuideEntityEmbed Entity="APCBasic"/>
   </Box>
   
@@ -58,7 +58,7 @@
   - Check if the P.A.C.M.A.N. generator unit is anchored to the floor.
   - Check if the P.A.C.M.A.N. generator unit has fuel. For extended flights make sure that you have enough fuel stockpiled to sustain prolonged power generation during flight.
   - Check if the P.A.C.M.A.N. generator unit is set to HV output.
-  - Set Target Power to 10-11** [bold]k[/bold]W.
+  - Set Target Power to 5-6** [bold]k[/bold]W.
   - Start the P.A.C.M.A.N. generator unit.
   
   ## 2. Atmospherics
@@ -94,8 +94,8 @@
   
   ## Sidenotes
   
-  * - Pioneer-class salvage ships are equipped with a single APC unit that can be used to appraise the ship's total power consumption (8.6 kW). One can check the ship's total power consumption against the P.A.C.M.A.N. generator unit Target Power output: to keep substation and APC fully charged, P.A.C.M.A.N. generator unit Target Power output should exceed APC's Load. Remember to check APC Load and adjust the generator unit Target Power after connecting new power-consuming machines.
+  * - Pioneer-class salvage ships are equipped with a single APC unit that can be used to appraise the ship's total power consumption (4.6 kW). One can check the ship's total power consumption against the P.A.C.M.A.N. generator unit Target Power output: to keep substation and APC fully charged, P.A.C.M.A.N. generator unit Target Power output should exceed APC's Load. Remember to check APC Load and adjust the generator unit Target Power after connecting new power-consuming machines.
   
-  ** - Pioneer-class salvage ships have low power demand meaning that standard P.A.C.M.A.N. generator unit's Target Power value can be lowered as low as 10 kW. Please note, that recommended Target Power value to avoid blackouts during Gravity Generator charging sequence is 11 kW.
+  ** - Pioneer-class salvage ships have low power demand meaning that standard P.A.C.M.A.N. generator unit's Target Power value can be lowered as low as 5 kW. Please note, that recommended Target Power value to avoid blackouts during Gravity Generator charging sequence is 6 kW.
 
 </Document>

--- a/Resources/ServerInfo/_NF/Guidebook/Shipyard/Searchlight.xml
+++ b/Resources/ServerInfo/_NF/Guidebook/Shipyard/Searchlight.xml
@@ -17,7 +17,7 @@
 	
 	[color=#a4885c]IFF Console:[/color] None
 	
-	[color=#a4885c]Available Roles:[/color] Pilot, Paramedic, Engineer
+	[color=#a4885c]Available Roles:[/color] Contractor, Pilot, Mercenary
 	
   "A good small size shuttle to provide medical care throughout the sector."
   


### PR DESCRIPTION
## About the PR
Bulk update to my shuttles. Most of the changes are pretty minor, however changes made to Gasbender and arguably to Pioneer are substantial.

### Brigand
- Mapped user manual.
- Mapped filled salvage rig.
- Mapped omni directional wall chargers (created new prototype for that one).
- Removed job spawn points.
- Changed available from station records console roles to Contractor, Pilot and Mercenary.

### Gasbender
- Mapped user manual.
- The ship is now expedition capable (prep for upcoming gas collection expedition type).
- Mapped communication console (common).
- Remapped atmos lab.
- Removed job spawn points.
- Changed available from station records console roles to Contractor, Pilot and Mercenary.

### Harbormaster
- Mapped user manual.
- Changed generators to the ones that start running.
- Removed job spawn points.
- Changed available from station records console roles to Contractor, Pilot and Mercenary.

### Kilderkin
- Mapped user manual.
- Changed generators to the ones that start running.
- Added more firelocks.
- Added service techfab.
- Removed job spawn points.
- Changed available from station records console roles to Contractor, Pilot and Mercenary.

### Lantern
- Mapped user manual.
- Changed generator to the ones that start running.
- Removed job spawn points.
- Changed available from station records console roles to Contractor, Pilot and Mercenary.

### Legman
- Mapped user manual.
- Changed generator to the one that start running.
- Added double-staged airlock.
- Removed job spawn points.
- Changed available from station records console roles to Contractor, Pilot and Mercenary.

### Liquidator
- Mapped user manual.
- Changed generator to the one that start running.
- Mapped box with cleannages and exterior light tube (created new prototype for that one).
- Removed some loose items.
- Removed air canister.
- Removed job spawn points.
- Changed available from station records console roles to Contractor, Pilot and Mercenary.

### Pioneer
- Shrinked the shuttle from 57 tiles to 43.
- Removed job spawn points.
- Changed available from station records console roles to Contractor, Pilot and Mercenary.

### Searchlight
- Removed job spawn points.
- Changed available from station records console roles to Contractor, Pilot and Mercenary.

## Why / Balance
Maintenance.

## How to test
Buy shuttles, run them.

## Media
![2024-5-24_18 34 37](https://github.com/new-frontiers-14/frontier-station-14/assets/65374927/021a8023-16a7-44c6-92ae-91b464e72fa3)
![2024-5-24_19 09 59](https://github.com/new-frontiers-14/frontier-station-14/assets/65374927/d1631b66-170f-4b75-ac4f-989af20a25f5)
![2024-5-24_18 30 03](https://github.com/new-frontiers-14/frontier-station-14/assets/65374927/c0a09206-94ae-4bb5-afcf-3978df67a3b6)
![2024-5-24_19 14 05](https://github.com/new-frontiers-14/frontier-station-14/assets/65374927/345a979d-cbaf-4573-b916-ac7ed7c2c998)
![2024-5-24_18 31 00](https://github.com/new-frontiers-14/frontier-station-14/assets/65374927/e67d9e4d-966d-4122-87b0-04d4e7884c0f)
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None afaik

**Changelog**
:cl: erhardsteinhauer
- tweak: Maintenance pass on a number of shuttles with minor changes to: Brigand, Harbormaster, Kilderkin, Lantern, Legman, Liquidator and Searchlight; Major changes to Gasbender and Pioneer. Gasbender is now expedition capable. Pioneer is now smaller.