### PR TITLE
STC Role Time Requirement

### DIFF
--- a/Resources/Prototypes/_NF/Roles/Jobs/Command/stc.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Command/stc.yml
@@ -8,9 +8,9 @@
   requirements:
     - !type:OverallPlaytimeRequirement
       time: 72000 # 20 hrs
-    - !type:DepartmentTimeRequirement
-      department: Security
-      time: 10800 # 3 hrs as sec
+    - !type:RoleTimeRequirement
+      role: JobSecurityGuard
+      time: 10800 # 3 hrs as security guard
   canBeAntag: false
   icon: "JobIconStc" 
   supervisors: job-supervisors-sr


### PR DESCRIPTION
## About the PR
Update the STC requirements to use Security Guard playtime.

## Why / Balance
Since the security guard is no longer NFSD

## How to test
Run and look at play times

## Media
N/A

## Breaking changes
N/A

**Changelog**
N/A