### PR TITLE
Fix: Clear news articles on round restart

### DIFF
--- a/Content.Server/MassMedia/Systems/NewsSystem.cs
+++ b/Content.Server/MassMedia/Systems/NewsSystem.cs
@@ -11,7 +11,6 @@ using Content.Shared.Access.Systems;
 using Content.Shared.CartridgeLoader;
 using Content.Shared.CartridgeLoader.Cartridges;
 using Content.Shared.Database;
-using Content.Shared.GameTicking;
 using Content.Shared.MassMedia.Components;
 using Content.Shared.MassMedia.Systems;
 using Robust.Server.GameObjects;
@@ -21,6 +20,7 @@ using Content.Server.Station.Systems;
 using Content.Shared.Popups;
 using Content.Shared.StationRecords;
 using Robust.Shared.Audio.Systems;
+using Content.Shared.GameTicking; // Frontier
 
 namespace Content.Server.MassMedia.Systems;
 

--- a/Content.Server/MassMedia/Systems/NewsSystem.cs
+++ b/Content.Server/MassMedia/Systems/NewsSystem.cs
@@ -11,6 +11,7 @@ using Content.Shared.Access.Systems;
 using Content.Shared.CartridgeLoader;
 using Content.Shared.CartridgeLoader.Cartridges;
 using Content.Shared.Database;
+using Content.Shared.GameTicking;
 using Content.Shared.MassMedia.Components;
 using Content.Shared.MassMedia.Systems;
 using Robust.Server.GameObjects;
@@ -43,6 +44,8 @@ public sealed class NewsSystem : SharedNewsSystem
         // News writer
         // Frontier: News is shared across the sector.  No need to create shuttle-local news caches.
         // SubscribeLocalEvent<NewsWriterComponent, MapInitEvent>(OnMapInit);
+
+        SubscribeLocalEvent<RoundRestartCleanupEvent>(OnRoundRestart);
         // End Frontier
 
         // New writer bui messages
@@ -59,6 +62,14 @@ public sealed class NewsSystem : SharedNewsSystem
         SubscribeLocalEvent<NewsReaderCartridgeComponent, CartridgeMessageEvent>(OnReaderUiMessage);
         SubscribeLocalEvent<NewsReaderCartridgeComponent, CartridgeUiReadyEvent>(OnReaderUiReady);
     }
+ 
+    // Frontier: article lifecycle management
+    private void OnRoundRestart(RoundRestartCleanupEvent ev)
+    {
+        // A new round is starting, clear any articles from the previous round.
+        SectorNewsComponent.Articles.Clear();
+    }
+    // End Frontier
 
     public override void Update(float frameTime)
     {


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

This PR adds an event handler for round restart cleanup in NewsSystem.  This handler cleans up the current article set.  This is a return to behaviour that existed before the March upstream pull (compare vs [6ac021f4](https://github.com/new-frontiers-14/frontier-station-14/blob/6ac021f43cb6c6b39e8edf053062500b96954285/Content.Server/MassMedia/Systems/NewsSystem.cs#L58)).

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Articles published in previous rounds showed up in later ones.  The article set is static, and has no lifecycle separate from the program's.  It must be cleared at some point, but that wasn't being done.  I should have included this in the initial feature.

## How to test
<!-- Describe the way it can be tested -->

1. Start a round.
2. Spawn a MassMediaConsole.
3. Publish an article.
4. Run `/golobby`.
5. Start a new round.
6. Spawn a MassMediaConsole.
7. Open it, the article published in step 3 should not be listed.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

Videos showing both the failure and success case are available [on imgur](https://imgur.com/a/kJv29X8).

- [X] ***I have added screenshots/videos to this PR showcasing its changes ingame***, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl:
- fix: News articles published in prior rounds no longer show up in later rounds.