### PR TITLE
Increase cryo delete time

### DIFF
--- a/Content.Shared/_NF/CCVars/CCVars.cs
+++ b/Content.Shared/_NF/CCVars/CCVars.cs
@@ -27,7 +27,7 @@ public sealed class NF14CVars
     /// The time in seconds after which a cryosleeping body is considered expired and can be deleted from the storage map.
     /// </summary>
     public static readonly CVarDef<float> CryoExpirationTime =
-        CVarDef.Create("nf14.uncryo.maxtime", 60 * 60f, CVar.SERVER | CVar.REPLICATED);
+        CVarDef.Create("nf14.uncryo.maxtime", 180 * 60f, CVar.SERVER | CVar.REPLICATED);
 
     /*
      *  Public Transit


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Makes cryobed delete people after 3 hours instead of 1.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Most people come back to the server after 1 or 2 hours when they SSD cryo, this will make sure they dont need to ask or wait for respawn as often.

No need for CL