### PR TITLE
Removes the Helix

### DIFF
--- a/Resources/Prototypes/_NF/Shipyard/helix.yml
+++ b/Resources/Prototypes/_NF/Shipyard/helix.yml
@@ -1,39 +1,39 @@
-# Author Info
-# GitHub: ???
-# Discord: ???
+# # Author Info
+# # GitHub: ???
+# # Discord: ???
 
-# Maintainer Info
-# GitHub: ???
-# Discord: ???
+# # Maintainer Info
+# # GitHub: ???
+# # Discord: ???
 
-# Shuttle Notes:
-#
-- #type: vessel
-  #id: Helix
-  #name: NM Helix
-  #description: A medium, modular hospital. Standard issue equipped with chem lab, cloning, and treatment ward
-  #price: 44600 # +5800 from 15% markup
-  #category: Medium
-  #group: Civilian
-  #shuttlePath: /Maps/_NF/Shuttles/helix.yml
+# # Shuttle Notes:
+# #
+# - type: vessel
+  # id: Helix
+  # name: NM Helix
+  # description: A medium, modular hospital. Standard issue equipped with chem lab, cloning, and treatment ward
+  # price: 44600 # +5800 from 15% markup
+  # category: Medium
+  # group: Civilian
+  # shuttlePath: /Maps/_NF/Shuttles/helix.yml
 
-- #type: gameMap
-  #id: Helix
-  #mapName: 'NM Helix'
-  #mapPath: /Maps/_NF/Shuttles/helix.yml
-  #minPlayers: 0
-  #stations:
-  #  Helix:
-  #    stationProto: StandardFrontierVessel
-  #    components:
-  #      - type: StationNameSetup
-  #        mapNameTemplate: 'Helix {1}'
-  #        nameGenerator:
-  #          !type:NanotrasenNameGenerator
-  #          prefixCreator: '14'
-  #      - type: StationJobs
-  #        overflowJobs: []
-  #        availableJobs:
-  #          Contractor: [ 0, 0 ]
-  #          Pilot: [ 0, 0 ]
-  #          Mercenary: [ 0, 0 ]
+# - type: gameMap
+  # id: Helix
+  # mapName: 'NM Helix'
+  # mapPath: /Maps/_NF/Shuttles/helix.yml
+  # minPlayers: 0
+  # stations:
+    # Helix:
+      # stationProto: StandardFrontierVessel
+      # components:
+        # - type: StationNameSetup
+          # mapNameTemplate: 'Helix {1}'
+          # nameGenerator:
+            # !type:NanotrasenNameGenerator
+            # prefixCreator: '14'
+        # - type: StationJobs
+          # overflowJobs: []
+          # availableJobs:
+            # Contractor: [ 0, 0 ]
+            # Pilot: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_NF/Shipyard/helix.yml
+++ b/Resources/Prototypes/_NF/Shipyard/helix.yml
@@ -8,32 +8,32 @@
 
 # Shuttle Notes:
 #
-- type: vessel
-  id: Helix
-  name: NM Helix
-  description: A medium, modular hospital. Standard issue equipped with chem lab, cloning, and treatment ward
-  price: 44600 # +5800 from 15% markup
-  category: Medium
-  group: Civilian
-  shuttlePath: /Maps/_NF/Shuttles/helix.yml
+- #type: vessel
+  #id: Helix
+  #name: NM Helix
+  #description: A medium, modular hospital. Standard issue equipped with chem lab, cloning, and treatment ward
+  #price: 44600 # +5800 from 15% markup
+  #category: Medium
+  #group: Civilian
+  #shuttlePath: /Maps/_NF/Shuttles/helix.yml
 
-- type: gameMap
-  id: Helix
-  mapName: 'NM Helix'
-  mapPath: /Maps/_NF/Shuttles/helix.yml
-  minPlayers: 0
-  stations:
-    Helix:
-      stationProto: StandardFrontierVessel
-      components:
-        - type: StationNameSetup
-          mapNameTemplate: 'Helix {1}'
-          nameGenerator:
-            !type:NanotrasenNameGenerator
-            prefixCreator: '14'
-        - type: StationJobs
-          overflowJobs: []
-          availableJobs:
-            Contractor: [ 0, 0 ]
-            Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+- #type: gameMap
+  #id: Helix
+  #mapName: 'NM Helix'
+  #mapPath: /Maps/_NF/Shuttles/helix.yml
+  #minPlayers: 0
+  #stations:
+  #  Helix:
+  #    stationProto: StandardFrontierVessel
+  #    components:
+  #      - type: StationNameSetup
+  #        mapNameTemplate: 'Helix {1}'
+  #        nameGenerator:
+  #          !type:NanotrasenNameGenerator
+  #          prefixCreator: '14'
+  #      - type: StationJobs
+  #        overflowJobs: []
+  #        availableJobs:
+  #          Contractor: [ 0, 0 ]
+  #          Pilot: [ 0, 0 ]
+  #          Mercenary: [ 0, 0 ]


### PR DESCRIPTION

## About the PR
Removes the Helix from the Shipyard

## Why / Balance
With the influx of new Medical oriented vessels, the Helix has grown to show its wrinkles. Paling in comparison to other medical vessels and leaving it in an awkward position lacking modern chemistry amenities and structural artifacts reflecting the time it was designed. Also Cloning Bad 

## How to test
Spawn in
Check that shipyard is missing the Helix

**Changelog**
:cl:
- remove: NT has decided to rescind its License for the Helix Blueprint from the Frontier.
