### PR TITLE
Detective Gameplay, Gloves are made in Space China

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Hands/base_clothinghands.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/base_clothinghands.yml
@@ -43,4 +43,4 @@
   components:
   - type: Fiber
     fiberMaterial: fibers-synthetic
-  - type: FingerprintMask
+#  - type: FingerprintMask # Frontier

--- a/Resources/Prototypes/Entities/Clothing/Hands/colored.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/colored.yml
@@ -300,7 +300,7 @@
   name: insulated gloves
   description: These gloves will protect the wearer from electric shocks.
   components:
-  - type: FingerprintMask
+#  - type: FingerprintMask # Frontier
   - type: Sprite
     sprite: Clothing/Hands/Gloves/Color/yellow.rsi
   - type: Clothing

--- a/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
@@ -24,7 +24,7 @@
   - type: Fiber
     fiberMaterial: fibers-leather
     fiberColor: fibers-red
-  - type: FingerprintMask
+#  - type: FingerprintMask # Frontier
   - type: Tag
     tags:
     - Kangaroo
@@ -44,7 +44,7 @@
   - type: Fiber
     fiberMaterial: fibers-leather
     fiberColor: fibers-blue
-  - type: FingerprintMask
+#  - type: FingerprintMask # Frontier
 
 - type: entity
   parent: ClothingHandsGlovesBoxingRed
@@ -60,7 +60,7 @@
   - type: Fiber
     fiberMaterial: fibers-leather
     fiberColor: fibers-green
-  - type: FingerprintMask
+#  - type: FingerprintMask # Frontier
 
 - type: entity
   parent: ClothingHandsGlovesBoxingRed
@@ -76,7 +76,7 @@
   - type: Fiber
     fiberMaterial: fibers-leather
     fiberColor: fibers-yellow
-  - type: FingerprintMask
+#  - type: FingerprintMask # Frontier
 
 - type: entity
   parent: ClothingHandsGlovesBoxingBlue
@@ -109,7 +109,7 @@
   - type: Fiber
     fiberMaterial: fibers-durathread
     fiberColor: fibers-regal-blue
-  - type: FingerprintMask
+#  - type: FingerprintMask # Frontier
 
 - type: entity
   parent: ClothingHandsBase
@@ -128,7 +128,7 @@
     modifiers:
       coefficients:
         Slash: 0.95
-  - type: FingerprintMask
+#  - type: FingerprintMask # Frontier
 
 #### Medical
 - type: entity
@@ -143,7 +143,7 @@
     sprite: Clothing/Hands/Gloves/latex.rsi
   - type: Fiber
     fiberMaterial: fibers-latex
-  - type: FingerprintMask
+#  - type: FingerprintMask # Frontier
 
 - type: entity
   parent: ClothingHandsButcherable
@@ -157,7 +157,7 @@
     sprite: Clothing/Hands/Gloves/nitrile.rsi
   - type: Fiber
     fiberMaterial: fibers-nitrile
-  - type: FingerprintMask
+#  - type: FingerprintMask # Frontier
 ####
 - type: entity
   parent: ClothingHandsButcherable
@@ -174,7 +174,7 @@
   - type: Fiber
     fiberMaterial: fibers-leather
     fiberColor: fibers-brown
-  - type: FingerprintMask
+#  - type: FingerprintMask # Frontier
 
 - type: entity
   parent: ClothingHandsBase
@@ -188,7 +188,7 @@
     sprite: Clothing/Hands/Gloves/powerglove.rsi
   - type: Fiber
     fiberMaterial: fibers-nanomachines
-  - type: FingerprintMask
+#  - type: FingerprintMask # Frontier
 
 - type: entity
   parent: ClothingHandsButcherable
@@ -203,7 +203,7 @@
   - type: Fiber
     fiberMaterial: fibers-leather
     fiberColor: fibers-black
-  - type: FingerprintMask
+#  - type: FingerprintMask # Frontier
 
 - type: entity
   parent: ClothingHandsBase
@@ -335,7 +335,8 @@
   - type: Thieving
     stripTimeReduction: 1.5
     stealthy: true
-  - type: Contraband #frontier
+  - type: FingerprintMask # Frontier
+  - type: Contraband # Frontier
 
 - type: entity
   parent: ClothingHandsGlovesColorWhite
@@ -412,4 +413,4 @@
   - type: Fiber
     fiberMaterial: fibers-rubber
     fiberColor: fibers-yellow
-  - type: FingerprintMask
+#  - type: FingerprintMask # Frontier


### PR DESCRIPTION
## About the PR
None antag gloves and forensic can still hide your fingerprints, but all other gloves wont anymore.

## Why / Balance
Give detectives some power in this world.

Also you can still hide your DNA with soap / using antag gloves if you find any.

## How to test
Get insulated gloves
Grab something
Scan it, get your DNA back

## Media
N/A

## Breaking changes
N/A

**Changelog**
:cl: dvir01
- tweak: NT Found there is too much fiber and plastic in all employees blood, making gloves use less fiber, but now they also allow your fingerprints to mark stuff you interact with, some illegal gloves possibly kept the old fibers quality.
