### PR TITLE
Remove Shield Mob Abuse

### DIFF
--- a/Content.Shared/Blocking/BlockingSystem.cs
+++ b/Content.Shared/Blocking/BlockingSystem.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using Content.Shared.Actions;
 using Content.Shared.Damage;
 using Content.Shared.Examine;
@@ -209,7 +209,7 @@ public sealed partial class BlockingSystem : EntitySystem
             _fixtureSystem.TryCreateFixture(user,
                 component.Shape,
                 BlockingComponent.BlockFixtureID,
-                hard: true,
+                hard: false, // Frontier - True to false, mobs AI abuse.
                 collisionLayer: (int) CollisionGroup.WallLayer,
                 body: physicsComponent);
         }


### PR DESCRIPTION
## About the PR
Stop the ability to make mobs never attack you on using a shield.

## Why / Balance
It used to turn you into a wall, now mobs will attack you normally.

## How to test
<!-- Describe the way it can be tested -->

## Media
N/A

## Breaking changes
N/A

**Changelog**
N/A