### PR TITLE
Ceres (Update): Restock boxes + various tweaks

### DIFF
--- a/Resources/Locale/en-US/_NF/guidebook/guides.ftl
+++ b/Resources/Locale/en-US/_NF/guidebook/guides.ftl
@@ -3,6 +3,7 @@ guide-entry-bank = NT Galactic Bank
 guide-entry-shipyard = Shipyard
 guide-entry-shipyard-ambition = Ambition
 guide-entry-shipyard-brigand = Brigand
+guide-entry-shipyard-ceres = Ceres
 guide-entry-shipyard-gasbender = Gasbender
 guide-entry-shipyard-harbormaster = Harbormaster
 guide-entry-shipyard-kilderkin = Kilderkin

--- a/Resources/Maps/_NF/Shuttles/ceres.yml
+++ b/Resources/Maps/_NF/Shuttles/ceres.yml
@@ -43,19 +43,19 @@ entities:
           version: 6
         -1,-1:
           ind: -1,-1
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAXgAAAAAAXgAAAAACXgAAAAACXgAAAAAAXgAAAAAAfQAAAAAAPwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAXgAAAAAAXgAAAAACXgAAAAADXgAAAAADXgAAAAADPwAAAAAAPwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAXgAAAAADXgAAAAACXgAAAAAAXgAAAAABXgAAAAADfQAAAAAAPwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAXgAAAAAAXgAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALgAAAAACfQAAAAAAfQAAAAAAZwAAAAADfQAAAAAAawAAAAAAawAAAAAAawAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAeQAAAAADeQAAAAAAeQAAAAADfQAAAAAAawAAAAAAawAAAAAAawAAAAAAZgAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAeQAAAAABeQAAAAADeQAAAAADfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAeQAAAAAAeQAAAAADeQAAAAABfQAAAAAALgAAAAADAAAAAAAAfAAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAIgAAAAAAIgAAAAADfQAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALgAAAAADfQAAAAAAfQAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfQAAAAAAfQAAAAAAHgAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAfQAAAAAAIwAAAAADIgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAHgAAAAABIgAAAAABIgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAHgAAAAACIgAAAAADIgAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAHgAAAAAAIgAAAAABIgAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALgAAAAABfQAAAAAAIwAAAAADIgAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAfQAAAAAAHgAAAAAA
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAXgAAAAAAXgAAAAACXgAAAAACXgAAAAAAXgAAAAAAfQAAAAAAPwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAXgAAAAAAXgAAAAACXgAAAAADXgAAAAADXgAAAAADPwAAAAAAPwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAXgAAAAADXgAAAAACXgAAAAAAXgAAAAABXgAAAAADfQAAAAAAPwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAXgAAAAAAXgAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALgAAAAACfQAAAAAAfQAAAAAAZwAAAAADfQAAAAAAawAAAAAAawAAAAAAawAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAeQAAAAADeQAAAAAAeQAAAAADfQAAAAAAawAAAAAAawAAAAAAawAAAAAAZgAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAeQAAAAABeQAAAAADeQAAAAADfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAeQAAAAAAeQAAAAADeQAAAAABfQAAAAAALgAAAAADAAAAAAAAfAAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAIgAAAAAAIgAAAAADfQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALgAAAAADfQAAAAAAfQAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfQAAAAAAfQAAAAAAHgAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAfQAAAAAAIwAAAAADIgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAHgAAAAABIgAAAAABIgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAHgAAAAACIgAAAAADIgAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAHgAAAAAAIgAAAAABIgAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALgAAAAABfQAAAAAAIwAAAAADIgAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAfQAAAAAAHgAAAAAA
           version: 6
         0,-1:
           ind: 0,-1
-          tiles: PwAAAAAAfQAAAAAAcAAAAAACcAAAAAACcAAAAAACcAAAAAABcAAAAAADbwAAAAADfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPwAAAAAAdAAAAAACcAAAAAAAcAAAAAABcAAAAAAAcAAAAAACcAAAAAACbwAAAAACfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPwAAAAAAfQAAAAAAbwAAAAADbwAAAAADbwAAAAADbwAAAAADbwAAAAACbwAAAAACfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAfQAAAAAAdAAAAAADdAAAAAABfQAAAAAAdAAAAAADdAAAAAAAdAAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXAAAAAAAXAAAAAACXAAAAAADXAAAAAABfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAALgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXAAAAAAAXAAAAAAAXAAAAAACXAAAAAABIgAAAAAAHgAAAAADHgAAAAABIwAAAAACIwAAAAABfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXAAAAAADfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAHgAAAAABLgAAAAABLgAAAAACIwAAAAADfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXAAAAAACfQAAAAAAfAAAAAAAAAAAAAAALgAAAAABfQAAAAAAHgAAAAADHgAAAAADHgAAAAADfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIgAAAAAAfQAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAfQAAAAAAHgAAAAACHgAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAAADHgAAAAABfQAAAAAAfQAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfQAAAAAAfQAAAAAALgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIgAAAAADIgAAAAABIwAAAAAAfQAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIgAAAAAAIgAAAAABIgAAAAACHgAAAAADfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMwAAAAAAIgAAAAABIgAAAAACHgAAAAADfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIgAAAAAAIgAAAAACIgAAAAABHgAAAAADfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIgAAAAAAIgAAAAABIwAAAAAAfQAAAAAALgAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAAAAHgAAAAACfQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          tiles: PwAAAAAAfQAAAAAAcAAAAAACcAAAAAACcAAAAAACcAAAAAABcAAAAAADbwAAAAADfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPwAAAAAAdAAAAAACcAAAAAAAcAAAAAABcAAAAAAAcAAAAAACcAAAAAACbwAAAAACfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPwAAAAAAfQAAAAAAbwAAAAADbwAAAAADbwAAAAADbwAAAAADbwAAAAACbwAAAAACfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAfQAAAAAAdAAAAAADdAAAAAABfQAAAAAAdAAAAAADdAAAAAAAdAAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXAAAAAAAXAAAAAACXAAAAAADXAAAAAABfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAALgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXAAAAAAAXAAAAAAAXAAAAAACXAAAAAABIgAAAAAAHgAAAAADHgAAAAABIwAAAAACIwAAAAABfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXAAAAAADfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAHgAAAAABLgAAAAABLgAAAAACIwAAAAADfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXAAAAAACfQAAAAAAfAAAAAAAAAAAAAAALgAAAAABfQAAAAAAHgAAAAADHgAAAAADHgAAAAADfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIgAAAAAAfQAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAfQAAAAAAHgAAAAACHgAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAAADHgAAAAABfQAAAAAAfQAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfQAAAAAAfQAAAAAALgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIgAAAAADIgAAAAABIwAAAAAAfQAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIgAAAAAAIgAAAAABIgAAAAACHgAAAAADfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMwAAAAAAIgAAAAABIgAAAAACHgAAAAADfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIgAAAAAAIgAAAAACIgAAAAABHgAAAAADfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIgAAAAAAIgAAAAABIwAAAAAAfQAAAAAALgAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAAAAHgAAAAACfQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
           version: 6
         -1,-2:
           ind: -1,-2
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALgAAAAADfQAAAAAAfQAAAAAAfQAAAAAALgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALgAAAAADfQAAAAAAIwAAAAAAIwAAAAABIwAAAAADfQAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAIwAAAAADHgAAAAABHgAAAAADHgAAAAACfQAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAIwAAAAABHgAAAAABfQAAAAAAZwAAAAABfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAIwAAAAAAHgAAAAACZwAAAAABXgAAAAADXgAAAAABXgAAAAACXgAAAAACXgAAAAADXgAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALgAAAAACfQAAAAAAfQAAAAAAXgAAAAACXgAAAAAAXgAAAAADXgAAAAABXgAAAAAAXgAAAAABXgAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAfQAAAAAAXgAAAAADXgAAAAADXgAAAAACXgAAAAACXgAAAAADXgAAAAACXgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAXgAAAAABXgAAAAACXgAAAAAAXgAAAAAAXgAAAAACXgAAAAABXgAAAAAC
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALgAAAAADfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAALgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALgAAAAADfQAAAAAAIwAAAAAAIwAAAAABIwAAAAADIgAAAAAAfQAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAIwAAAAADHgAAAAABHgAAAAADHgAAAAACIgAAAAAAfQAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAIwAAAAABHgAAAAABfQAAAAAAZwAAAAABfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAIwAAAAAAHgAAAAACZwAAAAABXgAAAAADXgAAAAABXgAAAAACXgAAAAACXgAAAAADXgAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALgAAAAACfQAAAAAAfQAAAAAAXgAAAAACXgAAAAAAXgAAAAADXgAAAAABXgAAAAAAXgAAAAABXgAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAfQAAAAAAXgAAAAADXgAAAAADXgAAAAACXgAAAAACXgAAAAADXgAAAAACXgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAXgAAAAABXgAAAAACXgAAAAAAXgAAAAAAXgAAAAACXgAAAAABXgAAAAAC
           version: 6
         0,-2:
           ind: 0,-2
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALgAAAAAAfQAAAAAAfQAAAAAAfQAAAAAALgAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAfQAAAAAALQAAAAAALQAAAAAALQAAAAAAfQAAAAAALgAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfQAAAAAALQAAAAAALQAAAAAALQAAAAAALQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAALQAAAAAALQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXgAAAAACZwAAAAADbwAAAAACbwAAAAACbwAAAAADbwAAAAAAbwAAAAACdAAAAAAALQAAAAAALQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXgAAAAACfQAAAAAAbwAAAAADbwAAAAADbwAAAAAAbwAAAAACbwAAAAABfQAAAAAAfQAAAAAAfQAAAAAALgAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXgAAAAACbwAAAAABcAAAAAABcAAAAAAAcAAAAAABcAAAAAAAcAAAAAABbwAAAAADfQAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXgAAAAABbwAAAAABcAAAAAACcAAAAAAAcAAAAAADcAAAAAABcAAAAAADbwAAAAABfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALgAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAALgAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAfQAAAAAALQAAAAAALQAAAAAALQAAAAAALQAAAAAAfQAAAAAALgAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfQAAAAAALQAAAAAALQAAAAAALQAAAAAALQAAAAAALQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAALQAAAAAALQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXgAAAAACZwAAAAADbwAAAAACbwAAAAACbwAAAAADbwAAAAAAbwAAAAACdAAAAAAALQAAAAAALQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXgAAAAACfQAAAAAAbwAAAAADbwAAAAADbwAAAAAAbwAAAAACbwAAAAABfQAAAAAAfQAAAAAAfQAAAAAALgAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXgAAAAACbwAAAAABcAAAAAABcAAAAAAAcAAAAAABcAAAAAAAcAAAAAABbwAAAAADfQAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXgAAAAABbwAAAAABcAAAAAACcAAAAAAAcAAAAAADcAAAAAABcAAAAAADbwAAAAABfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
           version: 6
     - type: Broadphase
     - type: Physics
@@ -83,15 +83,15 @@ entities:
             color: '#FFFFFFFF'
             id: Bot
           decals:
-            162: 8,-10
-            163: 8,-11
+            152: 8,-10
+            153: 8,-11
         - node:
             color: '#FFFFFFFF'
             id: Box
           decals:
-            159: 7,-11
-            168: -3,-12
-            169: -2,-12
+            151: 7,-11
+            154: -3,-12
+            155: -2,-12
         - node:
             color: '#FFFFFFFF'
             id: BrickTileDarkCornerNe
@@ -120,12 +120,12 @@ entities:
             color: '#FFFFFFFF'
             id: BrickTileDarkEndE
           decals:
-            112: 7,-10
+            110: 7,-10
         - node:
             color: '#FFFFFFFF'
             id: BrickTileDarkEndW
           decals:
-            113: 6,-10
+            111: 6,-10
         - node:
             color: '#FFFFFFFF'
             id: BrickTileDarkInnerNe
@@ -198,37 +198,37 @@ entities:
             color: '#334E6DC8'
             id: BrickTileWhiteInnerNe
           decals:
-            115: 3,-12
+            113: 3,-12
         - node:
             color: '#EFB34196'
             id: BrickTileWhiteInnerNw
           decals:
-            121: 0,-12
+            119: 0,-12
         - node:
             color: '#80C71FFF'
             id: BrickTileWhiteInnerSe
           decals:
-            133: -1,-7
+            126: -1,-7
         - node:
             color: '#334E6DC8'
             id: BrickTileWhiteInnerSw
           decals:
-            117: 5,-10
+            115: 5,-10
         - node:
             color: '#80C71FFF'
             id: BrickTileWhiteInnerSw
           decals:
-            134: 1,-7
+            127: 1,-7
         - node:
             color: '#EFB34196'
             id: BrickTileWhiteInnerSw
           decals:
-            130: 0,-10
+            123: 0,-10
         - node:
             color: '#334E6DC8'
             id: BrickTileWhiteLineE
           decals:
-            114: 3,-11
+            112: 3,-11
         - node:
             color: '#FFFFFFFF'
             id: BrickTileWhiteLineE
@@ -239,7 +239,7 @@ entities:
             color: '#80C71FFF'
             id: BrickTileWhiteLineN
           decals:
-            135: 0,-9
+            128: 0,-9
         - node:
             color: '#FFFFFFFF'
             id: BrickTileWhiteLineN
@@ -251,7 +251,7 @@ entities:
             color: '#80C71FFF'
             id: BrickTileWhiteLineS
           decals:
-            132: 0,-7
+            125: 0,-7
         - node:
             color: '#FFFFFFFF'
             id: BrickTileWhiteLineS
@@ -263,12 +263,12 @@ entities:
             color: '#334E6DC8'
             id: BrickTileWhiteLineW
           decals:
-            116: 5,-11
+            114: 5,-11
         - node:
             color: '#EFB34196'
             id: BrickTileWhiteLineW
           decals:
-            120: 0,-11
+            118: 0,-11
         - node:
             color: '#FFFFFFFF'
             id: BrickTileWhiteLineW
@@ -328,72 +328,72 @@ entities:
             color: '#474F52D3'
             id: Dirt
           decals:
-            142: -7,-23
-            143: -9,-21
+            135: -7,-23
+            136: -9,-21
         - node:
             cleanable: True
             color: '#474F52B7'
             id: DirtHeavyMonotile
           decals:
-            144: -9,-22
+            137: -9,-22
         - node:
             cleanable: True
             color: '#474F52DF'
             id: DirtHeavyMonotile
           decals:
-            140: -8,-23
-            141: -9,-20
+            133: -8,-23
+            134: -9,-20
         - node:
             cleanable: True
             color: '#474F52F2'
             id: DirtHeavyMonotile
           decals:
-            145: -6,-23
+            138: -6,-23
         - node:
             cleanable: True
             color: '#474F527F'
             id: DirtLight
           decals:
-            150: -8,-21
+            143: -8,-21
         - node:
             cleanable: True
             color: '#474F5295'
             id: DirtLight
           decals:
-            146: -8,-22
-            149: -7,-22
+            139: -8,-22
+            142: -7,-22
         - node:
             cleanable: True
             color: '#FFFFFFFF'
             id: DirtLight
           decals:
-            137: 1,-12
-            138: 0,-10
-            139: 2,-11
-            151: -6,-20
+            130: 1,-12
+            131: 0,-10
+            132: 2,-11
+            144: -6,-20
         - node:
             cleanable: True
             color: '#474F529E'
             id: DirtMedium
           decals:
-            147: -8,-20
+            140: -8,-20
         - node:
             cleanable: True
             color: '#474F52D6'
             id: DirtMedium
           decals:
-            148: -6,-22
+            141: -6,-22
         - node:
             cleanable: True
             color: '#FFFFFFFF'
             id: DirtMedium
           decals:
-            136: 0,-12
+            129: 0,-12
         - node:
             color: '#334E6DC8'
             id: MiniTileCheckerAOverlay
           decals:
-            118: 4,-11
+            116: 4,-11
         - node:
             color: '#80C71FFF'
             id: MiniTileCheckerAOverlay
@@ -418,45 +418,45 @@ entities:
             17: -2,-4
             18: -2,-3
             19: -1,-4
-            131: 0,-8
+            124: 0,-8
         - node:
             color: '#EFB34196'
             id: MiniTileCheckerBOverlay
           decals:
-            119: -1,-11
+            117: -1,-11
         - node:
             color: '#791500FF'
             id: MiniTileWhiteInnerNe
           decals:
-            157: -3,-17
+            150: -3,-17
         - node:
             color: '#791500FF'
             id: MiniTileWhiteLineE
           decals:
-            124: -3,-14
-            152: -3,-15
-            153: -3,-16
+            122: -3,-14
+            145: -3,-15
+            146: -3,-16
         - node:
             color: '#791500FF'
             id: MiniTileWhiteLineN
           decals:
-            154: -2,-17
-            155: -1,-17
-            156: 0,-17
+            147: -2,-17
+            148: -1,-17
+            149: 0,-17
         - node:
             color: '#FFFFFFFF'
             id: WarnLineN
           decals:
             54: 2,-13
             55: 3,-13
-            122: -6,-12
+            120: -6,-12
         - node:
             color: '#FFFFFFFF'
             id: WarnLineW
           decals:
             52: 2,-13
             53: 3,-13
-            123: -6,-12
+            121: -6,-12
         - node:
             color: '#FFFFFFFF'
             id: WoodTrimThinCornerNe
@@ -501,107 +501,92 @@ entities:
       version: 2
       data:
         tiles:
+          0,-1:
+            0: 14335
           0,0:
-            0: 3
             1: 4
           -1,0:
             1: 4
-            0: 8
-          -1,-2:
-            1: 276
-            0: 65256
           -1,-1:
-            0: 61183
-            1: 256
-          0,-2:
-            0: 65523
-            1: 4
-          0,-1:
-            0: 65535
-          1,-2:
-            1: 2418
-            0: 4236
-          1,-1:
-            0: 17
+            0: 36078
             1: 256
           -3,-3:
             1: 8
-            0: 34944
-          -3,-2:
-            0: 8
-            1: 128
-          -2,-4:
-            0: 65535
           -2,-3:
-            0: 65535
+            0: 30580
+          -3,-2:
+            1: 128
           -2,-2:
-            0: 55
-            1: 968
-          -1,-4:
-            0: 65535
-          -1,-3:
-            0: 36863
-            1: 20480
-          0,-4:
-            0: 65535
-          0,-3:
-            0: 16383
-            1: 16384
-          1,-4:
-            0: 65535
-          1,-3:
-            0: 61439
-            1: 4096
-          2,-4:
-            0: 4369
-          2,-3:
-            0: 13105
-            1: 2
-          2,-2:
-            0: 19
-            1: 288
+            0: 3
+            2: 968
+          -2,-4:
+            0: 28398
           -2,-5:
-            0: 65535
-          -2,-6:
-            0: 65527
-            1: 8
-          -1,-6:
-            0: 61671
-            1: 3856
+            0: 61167
+          -1,-4:
+            0: 3067
+          -1,-3:
+            0: 247
+            1: 4096
+            2: 16384
+          -1,-2:
+            2: 276
+            0: 60544
           -1,-5:
             0: 65535
-          0,-6:
-            0: 61692
-            1: 3840
+          0,-4:
+            0: 52733
+          0,-3:
+            0: 4607
+            2: 16384
+          0,-2:
+            0: 63281
+            2: 4
           0,-5:
-            0: 65535
-          1,-6:
-            0: 65261
-            1: 274
+            0: 65503
+          1,-4:
+            0: 61439
+          1,-3:
+            0: 52976
+            1: 4096
+          1,-2:
+            2: 2418
+            0: 8
+          1,-1:
+            1: 256
           1,-5:
-            0: 65535
-          2,-5:
-            0: 4407
-            1: 576
-          -2,-7:
-            0: 65024
-          -1,-7:
-            0: 29440
-          0,-7:
-            0: 51200
-          1,-7:
-            0: 65280
-          2,-7:
-            0: 4096
-          2,-6:
-            0: 30513
-            1: 66
+            0: 65407
+          2,-3:
+            0: 4368
+            1: 2
+          2,-2:
+            0: 1
+            2: 256
+            1: 32
           -3,-6:
             1: 72
-            0: 52352
+            0: 35840
           -3,-5:
-            0: 140
-            1: 2112
+            0: 12
+            1: 64
+            2: 2048
+          -2,-6:
+            0: 24565
+          -1,-6:
+            1: 1
+            2: 3616
+          0,-6:
+            2: 3968
+          1,-6:
+            1: 1
+            0: 3808
+          2,-6:
+            0: 13072
+            1: 66
+          2,-5:
+            0: 3
+            2: 512
+            1: 64
         uniqueMixes:
         - volume: 2500
           temperature: 293.15
@@ -620,6 +605,21 @@ entities:
           - 0
         - volume: 2500
           temperature: 293.15
+          moles:
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          immutable: True
           moles:
           - 0
           - 0
@@ -652,7 +652,7 @@ entities:
       - 775
       - 419
       - 382
-      - 677
+      - 685
       - 566
       - 417
       - 418
@@ -666,8 +666,6 @@ entities:
       - 590
       - 299
       - 774
-    - type: AtmosDevice
-      joinedGrid: 2
   - uid: 494
     components:
     - type: Transform
@@ -677,9 +675,7 @@ entities:
       devices:
       - 241
       - 301
-      - 458
-    - type: AtmosDevice
-      joinedGrid: 2
+      - 459
   - uid: 495
     components:
     - type: Transform
@@ -691,8 +687,6 @@ entities:
       - 646
       - 698
       - 771
-    - type: AtmosDevice
-      joinedGrid: 2
   - uid: 585
     components:
     - type: Transform
@@ -700,12 +694,10 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 283
+      - 284
       - 265
       - 299
       - 769
-    - type: AtmosDevice
-      joinedGrid: 2
   - uid: 588
     components:
     - type: Transform
@@ -715,7 +707,7 @@ entities:
       devices:
       - 180
       - 382
-      - 422
+      - 423
       - 416
       - 415
       - 419
@@ -726,18 +718,17 @@ entities:
       - 529
       - 496
       - 396
-      - 677
-    - type: AtmosDevice
-      joinedGrid: 2
+      - 685
 - proto: AirCanister
   entities:
-  - uid: 802
+  - uid: 803
     components:
     - type: Transform
+      anchored: True
       pos: 7.5,-10.5
       parent: 2
-    - type: AtmosDevice
-      joinedGrid: 2
+    - type: Physics
+      bodyType: Static
 - proto: AirlockCommand
   entities:
   - uid: 130
@@ -778,12 +769,12 @@ entities:
     - type: Transform
       pos: 0.5,-7.5
       parent: 2
-  - uid: 546
+  - uid: 547
     components:
     - type: Transform
       pos: 1.5,-19.5
       parent: 2
-  - uid: 671
+  - uid: 677
     components:
     - type: Transform
       pos: 1.5,-14.5
@@ -858,6 +849,22 @@ entities:
     components:
     - type: Transform
       pos: 8.5,-21.5
+      parent: 2
+- proto: AlwaysPoweredlightGreen
+  entities:
+  - uid: 106
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-6.5
+      parent: 2
+- proto: AlwaysPoweredlightRed
+  entities:
+  - uid: 94
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-6.5
       parent: 2
 - proto: APCBasic
   entities:
@@ -956,35 +963,25 @@ entities:
     - type: Transform
       pos: 2.5,-21.5
       parent: 2
-  - uid: 531
-    components:
-    - type: Transform
-      pos: 4.5,-22.5
-      parent: 2
   - uid: 533
     components:
     - type: Transform
       pos: -0.5,-21.5
       parent: 2
-  - uid: 573
+  - uid: 572
     components:
     - type: Transform
-      pos: -3.5,-21.5
+      pos: -3.5,-23.5
       parent: 2
-  - uid: 580
+  - uid: 575
     components:
     - type: Transform
-      pos: 4.5,-21.5
+      pos: 4.5,-23.5
       parent: 2
   - uid: 581
     components:
     - type: Transform
       pos: 5.5,-23.5
-      parent: 2
-  - uid: 582
-    components:
-    - type: Transform
-      pos: -4.5,-23.5
       parent: 2
   - uid: 583
     components:
@@ -1014,7 +1011,7 @@ entities:
   - uid: 696
     components:
     - type: Transform
-      pos: -3.5,-22.5
+      pos: 3.5,-22.5
       parent: 2
   - uid: 703
     components:
@@ -1040,6 +1037,11 @@ entities:
     components:
     - type: Transform
       pos: 9.5,-23.5
+      parent: 2
+  - uid: 729
+    components:
+    - type: Transform
+      pos: -2.5,-22.5
       parent: 2
   - uid: 747
     components:
@@ -1141,9 +1143,29 @@ entities:
     - type: Transform
       pos: -3.5,-1.5
       parent: 2
+- proto: BenchSofaLeft
+  entities:
+  - uid: 739
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-22.5
+      parent: 2
+    - type: Physics
+      bodyType: Static
+- proto: BenchSofaRight
+  entities:
+  - uid: 286
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-21.5
+      parent: 2
+    - type: Physics
+      bodyType: Static
 - proto: BoozeDispenser
   entities:
-  - uid: 228
+  - uid: 229
     components:
     - type: Transform
       pos: -0.5,-13.5
@@ -1154,6 +1176,50 @@ entities:
     components:
     - type: Transform
       pos: -0.73503387,-5.6378756
+      parent: 2
+- proto: ButtonFrameCaution
+  entities:
+  - uid: 578
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-6.5
+      parent: 2
+  - uid: 580
+    components:
+    - type: Transform
+      pos: 1.5,-13.5
+      parent: 2
+  - uid: 582
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-18.5
+      parent: 2
+  - uid: 654
+    components:
+    - type: Transform
+      pos: 6.5,-7.5
+      parent: 2
+  - uid: 813
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,-20.5
+      parent: 2
+- proto: ButtonFrameGrey
+  entities:
+  - uid: 640
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-20.5
+      parent: 2
+  - uid: 649
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-8.5
       parent: 2
 - proto: CableApcExtension
   entities:
@@ -1182,20 +1248,15 @@ entities:
     - type: Transform
       pos: -7.5,-19.5
       parent: 2
-  - uid: 127
+  - uid: 128
     components:
     - type: Transform
       pos: -2.5,-14.5
       parent: 2
-  - uid: 128
-    components:
-    - type: Transform
-      pos: -3.5,-14.5
-      parent: 2
   - uid: 129
     components:
     - type: Transform
-      pos: -5.5,-14.5
+      pos: -3.5,-14.5
       parent: 2
   - uid: 148
     components:
@@ -1205,14 +1266,19 @@ entities:
   - uid: 149
     components:
     - type: Transform
-      pos: -1.5,-14.5
+      pos: -5.5,-14.5
       parent: 2
   - uid: 158
     components:
     - type: Transform
-      pos: -0.5,-14.5
+      pos: -1.5,-14.5
       parent: 2
   - uid: 167
+    components:
+    - type: Transform
+      pos: -0.5,-14.5
+      parent: 2
+  - uid: 168
     components:
     - type: Transform
       pos: -0.5,-15.5
@@ -1644,12 +1710,12 @@ entities:
       parent: 2
 - proto: CableHV
   entities:
-  - uid: 119
+  - uid: 127
     components:
     - type: Transform
       pos: -3.5,-11.5
       parent: 2
-  - uid: 229
+  - uid: 234
     components:
     - type: Transform
       pos: -1.5,-11.5
@@ -1659,19 +1725,19 @@ entities:
     - type: Transform
       pos: -1.5,-11.5
       parent: 2
-  - uid: 539
+  - uid: 545
     components:
     - type: Transform
       pos: -3.5,-10.5
       parent: 2
-  - uid: 709
+  - uid: 770
     components:
     - type: Transform
       pos: -2.5,-11.5
       parent: 2
 - proto: CableMV
   entities:
-  - uid: 168
+  - uid: 176
     components:
     - type: Transform
       pos: -2.5,-10.5
@@ -1686,7 +1752,7 @@ entities:
     - type: Transform
       pos: 2.5,-10.5
       parent: 2
-  - uid: 238
+  - uid: 240
     components:
     - type: Transform
       pos: -3.5,-10.5
@@ -1761,39 +1827,39 @@ entities:
     - type: Transform
       pos: 1.5,-12.5
       parent: 2
-  - uid: 570
+  - uid: 571
     components:
     - type: Transform
       pos: 2.5,-16.5
       parent: 2
-  - uid: 794
+  - uid: 795
     components:
     - type: Transform
       pos: 0.5,-16.5
       parent: 2
-  - uid: 795
+  - uid: 796
     components:
     - type: Transform
       pos: -0.5,-16.5
       parent: 2
-  - uid: 796
+  - uid: 797
     components:
     - type: Transform
       pos: -1.5,-16.5
       parent: 2
-  - uid: 797
+  - uid: 798
     components:
     - type: Transform
       pos: -2.5,-16.5
       parent: 2
-  - uid: 798
+  - uid: 799
     components:
     - type: Transform
       pos: -3.5,-16.5
       parent: 2
 - proto: CableTerminal
   entities:
-  - uid: 179
+  - uid: 182
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1886,7 +1952,7 @@ entities:
       parent: 2
 - proto: ChairFolding
   entities:
-  - uid: 460
+  - uid: 464
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2006,14 +2072,14 @@ entities:
       parent: 2
 - proto: ClosetChefFilled
   entities:
-  - uid: 799
+  - uid: 800
     components:
     - type: Transform
       pos: 4.5,-18.5
       parent: 2
 - proto: ComputerShuttle
   entities:
-  - uid: 437
+  - uid: 458
     components:
     - type: Transform
       pos: 7.5,-7.5
@@ -2028,7 +2094,7 @@ entities:
       parent: 2
 - proto: ComputerWallmountWithdrawBankATM
   entities:
-  - uid: 338
+  - uid: 339
     components:
     - type: Transform
       pos: 1.5,-15.5
@@ -2146,11 +2212,15 @@ entities:
   entities:
   - uid: 621
     components:
+    - type: MetaData
+      name: transport to botany
     - type: Transform
       pos: 4.5,-13.5
       parent: 2
   - uid: 622
     components:
+    - type: MetaData
+      name: transport to kitchen
     - type: Transform
       pos: 1.5,-6.5
       parent: 2
@@ -2163,7 +2233,7 @@ entities:
       parent: 2
 - proto: Dropper
   entities:
-  - uid: 472
+  - uid: 474
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2171,7 +2241,7 @@ entities:
       parent: 2
 - proto: EmergencyLight
   entities:
-  - uid: 1
+  - uid: 3
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2343,7 +2413,7 @@ entities:
     - type: Transform
       pos: 1.5,-14.5
       parent: 2
-  - uid: 677
+  - uid: 685
     components:
     - type: Transform
       pos: 1.5,-17.5
@@ -2370,19 +2440,19 @@ entities:
       fixtures: {}
 - proto: FoodCartCold
   entities:
-  - uid: 656
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 8.5,-22.5
-      parent: 2
-- proto: FoodCartHot
-  entities:
-  - uid: 640
+  - uid: 414
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-22.5
+      parent: 2
+- proto: FoodCartHot
+  entities:
+  - uid: 684
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-22.5
       parent: 2
 - proto: FoodContainerEgg
   entities:
@@ -2422,8 +2492,6 @@ entities:
     - type: Transform
       pos: -1.5,-8.5
       parent: 2
-    - type: AtmosDevice
-      joinedGrid: 2
     - type: AtmosPipeColor
       color: '#990000FF'
 - proto: GasPipeBend
@@ -2451,7 +2519,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 284
+  - uid: 287
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2459,7 +2527,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 297
+  - uid: 298
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2475,14 +2543,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 394
+  - uid: 397
     components:
     - type: Transform
       pos: -3.5,-15.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 411
+  - uid: 412
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2515,7 +2583,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 547
+  - uid: 570
     components:
     - type: Transform
       pos: 2.5,-16.5
@@ -2524,14 +2592,6 @@ entities:
       color: '#990000FF'
 - proto: GasPipeStraight
   entities:
-  - uid: 3
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -5.5,-13.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 73
     components:
     - type: Transform
@@ -2540,6 +2600,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
+  - uid: 74
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-13.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 131
     components:
     - type: Transform
@@ -2719,7 +2787,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 282
+  - uid: 283
     components:
     - type: Transform
       pos: 2.5,-18.5
@@ -2747,7 +2815,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 292
+  - uid: 297
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2755,7 +2823,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 303
+  - uid: 304
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2763,14 +2831,6 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 304
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,-16.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
   - uid: 308
     components:
     - type: Transform
@@ -2805,8 +2865,8 @@ entities:
   - uid: 316
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 3.5,-19.5
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-16.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -2845,7 +2905,15 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 340
+  - uid: 338
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-19.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 341
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2853,14 +2921,6 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 341
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 0.5,-16.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
   - uid: 342
     components:
     - type: Transform
@@ -2873,15 +2933,15 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 1.5,-14.5
+      pos: 0.5,-16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0055CCFF'
+      color: '#990000FF'
   - uid: 347
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -4.5,-14.5
+      pos: 1.5,-14.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
@@ -2889,11 +2949,19 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
+      pos: -4.5,-14.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 350
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -1.5,-16.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 350
+  - uid: 351
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2901,7 +2969,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 351
+  - uid: 352
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2909,7 +2977,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 352
+  - uid: 353
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2917,7 +2985,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 353
+  - uid: 355
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2925,7 +2993,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 358
+  - uid: 383
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2933,14 +3001,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 383
+  - uid: 394
     components:
     - type: Transform
       pos: 3.5,-13.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 402
+  - uid: 403
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2948,7 +3016,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 403
+  - uid: 411
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3126,7 +3194,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 273
+  - uid: 274
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3134,7 +3202,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 287
+  - uid: 292
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3142,7 +3210,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 339
+  - uid: 340
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3150,7 +3218,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 355
+  - uid: 358
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3166,7 +3234,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 513
+  - uid: 539
     components:
     - type: Transform
       pos: -0.5,-16.5
@@ -3183,29 +3251,25 @@ entities:
       color: '#0055CCFF'
 - proto: GasPort
   entities:
-  - uid: 412
+  - uid: 422
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,-10.5
       parent: 2
-    - type: AtmosDevice
-      joinedGrid: 2
 - proto: GasPressurePump
   entities:
-  - uid: 267
+  - uid: 273
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,-10.5
       parent: 2
-    - type: AtmosDevice
-      joinedGrid: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
 - proto: GasVentPump
   entities:
-  - uid: 283
+  - uid: 284
     components:
     - type: Transform
       pos: 5.5,-9.5
@@ -3213,8 +3277,6 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 585
-    - type: AtmosDevice
-      joinedGrid: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 323
@@ -3222,8 +3284,6 @@ entities:
     - type: Transform
       pos: -5.5,-9.5
       parent: 2
-    - type: AtmosDevice
-      joinedGrid: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 426
@@ -3232,11 +3292,9 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -4.5,-16.5
       parent: 2
-    - type: AtmosDevice
-      joinedGrid: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 458
+  - uid: 459
     components:
     - type: Transform
       pos: -1.5,-10.5
@@ -3244,8 +3302,6 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 494
-    - type: AtmosDevice
-      joinedGrid: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 496
@@ -3254,8 +3310,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: -5.5,-21.5
       parent: 2
-    - type: AtmosDevice
-      joinedGrid: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 590
@@ -3263,8 +3317,6 @@ entities:
     - type: Transform
       pos: 3.5,-10.5
       parent: 2
-    - type: AtmosDevice
-      joinedGrid: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 633
@@ -3273,8 +3325,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 5.5,-15.5
       parent: 2
-    - type: AtmosDevice
-      joinedGrid: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 646
@@ -3282,8 +3332,6 @@ entities:
     - type: Transform
       pos: 1.5,-3.5
       parent: 2
-    - type: AtmosDevice
-      joinedGrid: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 727
@@ -3292,8 +3340,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 7.5,-21.5
       parent: 2
-    - type: AtmosDevice
-      joinedGrid: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
 - proto: GasVentScrubber
@@ -3304,8 +3350,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -2.5,-10.5
       parent: 2
-    - type: AtmosDevice
-      joinedGrid: 2
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 265
@@ -3314,8 +3358,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 5.5,-10.5
       parent: 2
-    - type: AtmosDevice
-      joinedGrid: 2
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 300
@@ -3324,8 +3366,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 8.5,-19.5
       parent: 2
-    - type: AtmosDevice
-      joinedGrid: 2
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 322
@@ -3333,8 +3373,6 @@ entities:
     - type: Transform
       pos: -6.5,-9.5
       parent: 2
-    - type: AtmosDevice
-      joinedGrid: 2
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 344
@@ -3343,11 +3381,9 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 3.5,-16.5
       parent: 2
-    - type: AtmosDevice
-      joinedGrid: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 422
+  - uid: 423
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3356,8 +3392,6 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 588
-    - type: AtmosDevice
-      joinedGrid: 2
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 529
@@ -3366,8 +3400,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -7.5,-19.5
       parent: 2
-    - type: AtmosDevice
-      joinedGrid: 2
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 591
@@ -3376,8 +3408,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 1.5,-11.5
       parent: 2
-    - type: AtmosDevice
-      joinedGrid: 2
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 698
@@ -3385,8 +3415,6 @@ entities:
     - type: Transform
       pos: -0.5,-3.5
       parent: 2
-    - type: AtmosDevice
-      joinedGrid: 2
     - type: AtmosPipeColor
       color: '#990000FF'
 - proto: GravityGeneratorMini
@@ -3548,15 +3576,15 @@ entities:
     - type: Transform
       pos: 8.5,-15.5
       parent: 2
-  - uid: 274
-    components:
-    - type: Transform
-      pos: -1.5,-15.5
-      parent: 2
   - uid: 276
     components:
     - type: Transform
       pos: 8.5,-23.5
+      parent: 2
+  - uid: 282
+    components:
+    - type: Transform
+      pos: -1.5,-15.5
       parent: 2
   - uid: 302
     components:
@@ -3598,11 +3626,6 @@ entities:
     - type: Transform
       pos: 10.5,-20.5
       parent: 2
-  - uid: 655
-    components:
-    - type: Transform
-      pos: -2.5,-20.5
-      parent: 2
   - uid: 669
     components:
     - type: Transform
@@ -3613,23 +3636,25 @@ entities:
     - type: Transform
       pos: -0.5,-20.5
       parent: 2
-  - uid: 741
-    components:
-    - type: Transform
-      pos: -4.5,-22.5
-      parent: 2
   - uid: 751
     components:
     - type: Transform
       pos: -9.5,-20.5
       parent: 2
+  - uid: 761
+    components:
+    - type: Transform
+      pos: -3.5,-22.5
+      parent: 2
 - proto: Gyroscope
   entities:
-  - uid: 266
+  - uid: 267
     components:
     - type: Transform
       pos: 8.5,-9.5
       parent: 2
+    - type: Thruster
+      originalPowerLoad: 1500
 - proto: HospitalCurtainsOpen
   entities:
   - uid: 490
@@ -3802,6 +3827,63 @@ entities:
     - type: Transform
       pos: 2.6987016,-18.387365
       parent: 2
+- proto: Paper
+  entities:
+  - uid: 817
+    components:
+    - type: MetaData
+      name: pre-flight checklist
+    - type: Transform
+      pos: -2.0040264,-10.642405
+      parent: 2
+    - type: Paper
+      stampState: paper_stamp-ce
+      stampedBy:
+      - stampedBorderless: False
+        stampedColor: '#C69B17FF'
+        stampedName: stamp-component-stamped-name-ce
+      content: >2-
+
+        [color=#1B8CD6][head=1]=BB=[/head]
+
+        [head=2]BlueBird Starship Design & Construction[/head][/color]
+
+
+        [head=2][bold][color=#9413ED]Ceres[/color][/bold][/head]
+
+        Dear Captain,
+
+        Thank you for your purchase of the BB Ceres!
+
+        We hope this ship will serve you well, and allow you to serve your customers the highest quality dining experience.
+
+
+        [head=3][color=#1B8CD6]Pre-Flight Checklist[/head][/color]
+
+        1. Check all machines, generators and canisters are [bold]anchored[/bold].
+
+        2. Top off generator fuel.
+
+        3. Set [bold]generator output to 12 kW[/bold]. [italic]If you are not planning to use the grill, you can go as low as 11 kW.[/italic]
+
+        4. Start generators if not already running.
+
+        5. Check distro pump settings, then turn on. [italic]Note: The distro pump is on the bridge.[/italic]
+
+        6. Check gyro is turned on.
+
+        7. Check all APCs are functioning and charged.
+
+
+        [head=3][color=#1B8CD6]Getting the Most out of the Ceres[/head][/color]
+
+        1. The Ceres is designed for multi-person crews. Consider having a dedicated botanist to grow quality produce.
+
+        2. Though unorthodox, the disposal units are designed to safely and efficiently transport produce from botany to kitchen. Make use of them!
+
+        3. Don't be afraid to adjust the table and seating layout to suit your needs.
+
+        4. For serving food to a larger party, the food carts in the freezer may simplify transportation.
 - proto: PaperBin10
   entities:
   - uid: 404
@@ -3811,7 +3893,7 @@ entities:
       parent: 2
 - proto: PortableGeneratorPacmanShuttle
   entities:
-  - uid: 176
+  - uid: 179
     components:
     - type: Transform
       pos: -2.5,-11.5
@@ -3820,7 +3902,7 @@ entities:
       on: False
     - type: Physics
       bodyType: Static
-  - uid: 234
+  - uid: 235
     components:
     - type: Transform
       pos: -1.5,-11.5
@@ -3841,7 +3923,7 @@ entities:
     - type: Transform
       pos: -8.5,-20.5
       parent: 2
-  - uid: 226
+  - uid: 228
     components:
     - type: Transform
       pos: 0.5,-18.5
@@ -3858,12 +3940,6 @@ entities:
       parent: 2
 - proto: Poweredlight
   entities:
-  - uid: 106
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -3.5,-6.5
-      parent: 2
   - uid: 201
     components:
     - type: Transform
@@ -3874,12 +3950,6 @@ entities:
     components:
     - type: Transform
       pos: 0.5,-21.5
-      parent: 2
-  - uid: 389
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 4.5,-6.5
       parent: 2
   - uid: 390
     components:
@@ -3926,12 +3996,12 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -5.5,-12.5
       parent: 2
-  - uid: 578
+  - uid: 573
     components:
     - type: Transform
       pos: 9.5,-19.5
       parent: 2
-  - uid: 662
+  - uid: 671
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3954,6 +4024,18 @@ entities:
     components:
     - type: Transform
       pos: -6.5,-21.5
+      parent: 2
+  - uid: 661
+    components:
+    - type: Transform
+      pos: 6.5,-21.5
+      parent: 2
+- proto: Rack
+  entities:
+  - uid: 307
+    components:
+    - type: Transform
+      pos: 8.5,-22.5
       parent: 2
 - proto: Railing
   entities:
@@ -4007,7 +4089,7 @@ entities:
       parent: 2
 - proto: RandomPainting
   entities:
-  - uid: 236
+  - uid: 238
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4052,7 +4134,7 @@ entities:
       parent: 2
 - proto: SheetPlasma
   entities:
-  - uid: 697
+  - uid: 709
     components:
     - type: Transform
       pos: -2,-10.5
@@ -4067,7 +4149,7 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       links:
-      - 239
+      - 814
   - uid: 294
     components:
     - type: Transform
@@ -4076,7 +4158,7 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       links:
-      - 239
+      - 814
   - uid: 295
     components:
     - type: Transform
@@ -4085,7 +4167,7 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       links:
-      - 239
+      - 814
   - uid: 296
     components:
     - type: Transform
@@ -4093,7 +4175,7 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       links:
-      - 239
+      - 814
   - uid: 311
     components:
     - type: Transform
@@ -4102,7 +4184,7 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       links:
-      - 239
+      - 814
   - uid: 312
     components:
     - type: Transform
@@ -4111,7 +4193,7 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       links:
-      - 239
+      - 814
   - uid: 360
     components:
     - type: Transform
@@ -4119,7 +4201,7 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       links:
-      - 239
+      - 814
   - uid: 361
     components:
     - type: Transform
@@ -4127,7 +4209,7 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       links:
-      - 239
+      - 814
   - uid: 413
     components:
     - type: Transform
@@ -4136,7 +4218,7 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       links:
-      - 239
+      - 814
   - uid: 540
     components:
     - type: Transform
@@ -4144,7 +4226,7 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       links:
-      - 414
+      - 812
   - uid: 639
     components:
     - type: Transform
@@ -4152,7 +4234,7 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       links:
-      - 414
+      - 812
   - uid: 652
     components:
     - type: Transform
@@ -4160,7 +4242,7 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       links:
-      - 670
+      - 816
   - uid: 653
     components:
     - type: Transform
@@ -4168,7 +4250,7 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       links:
-      - 414
+      - 812
   - uid: 659
     components:
     - type: Transform
@@ -4176,7 +4258,7 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       links:
-      - 670
+      - 816
   - uid: 663
     components:
     - type: Transform
@@ -4184,7 +4266,7 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       links:
-      - 670
+      - 816
   - uid: 690
     components:
     - type: Transform
@@ -4193,7 +4275,7 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       links:
-      - 414
+      - 812
   - uid: 720
     components:
     - type: Transform
@@ -4202,7 +4284,7 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       links:
-      - 729
+      - 811
   - uid: 721
     components:
     - type: Transform
@@ -4211,7 +4293,7 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       links:
-      - 729
+      - 811
   - uid: 722
     components:
     - type: Transform
@@ -4220,7 +4302,7 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       links:
-      - 729
+      - 811
   - uid: 723
     components:
     - type: Transform
@@ -4228,7 +4310,7 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       links:
-      - 729
+      - 811
   - uid: 724
     components:
     - type: Transform
@@ -4236,7 +4318,7 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       links:
-      - 729
+      - 811
   - uid: 731
     components:
     - type: Transform
@@ -4244,7 +4326,7 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       links:
-      - 730
+      - 815
   - uid: 732
     components:
     - type: Transform
@@ -4252,7 +4334,7 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       links:
-      - 730
+      - 815
   - uid: 733
     components:
     - type: Transform
@@ -4261,7 +4343,7 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       links:
-      - 730
+      - 815
   - uid: 734
     components:
     - type: Transform
@@ -4270,7 +4352,7 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       links:
-      - 730
+      - 815
   - uid: 735
     components:
     - type: Transform
@@ -4279,7 +4361,7 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       links:
-      - 730
+      - 815
   - uid: 737
     components:
     - type: Transform
@@ -4288,7 +4370,7 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       links:
-      - 414
+      - 812
   - uid: 753
     components:
     - type: Transform
@@ -4296,7 +4378,7 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       links:
-      - 670
+      - 816
   - uid: 758
     components:
     - type: Transform
@@ -4304,7 +4386,7 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       links:
-      - 670
+      - 816
   - uid: 759
     components:
     - type: Transform
@@ -4312,7 +4394,7 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       links:
-      - 670
+      - 816
   - uid: 760
     components:
     - type: Transform
@@ -4320,15 +4402,15 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       links:
-      - 670
+      - 816
   - uid: 762
     components:
     - type: Transform
-      pos: -4.5,-22.5
+      pos: -3.5,-22.5
       parent: 2
     - type: DeviceLinkSink
       links:
-      - 670
+      - 816
 - proto: ShuttersWindowOpen
   entities:
   - uid: 313
@@ -4339,7 +4421,7 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       links:
-      - 744
+      - 655
   - uid: 385
     components:
     - type: Transform
@@ -4347,7 +4429,7 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       links:
-      - 387
+      - 810
   - uid: 386
     components:
     - type: Transform
@@ -4355,8 +4437,8 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       links:
-      - 387
-  - uid: 466
+      - 810
+  - uid: 472
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4364,7 +4446,7 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       links:
-      - 744
+      - 655
 - proto: ShuttleWindow
   entities:
   - uid: 85
@@ -4517,7 +4599,7 @@ entities:
     - type: Transform
       pos: 8.5,-16.5
       parent: 2
-  - uid: 401
+  - uid: 402
     components:
     - type: Transform
       pos: -1.5,-15.5
@@ -4567,11 +4649,6 @@ entities:
     - type: Transform
       pos: 6.5,-23.5
       parent: 2
-  - uid: 684
-    components:
-    - type: Transform
-      pos: -2.5,-20.5
-      parent: 2
   - uid: 688
     components:
     - type: Transform
@@ -4582,20 +4659,91 @@ entities:
     - type: Transform
       pos: 10.5,-21.5
       parent: 2
+  - uid: 730
+    components:
+    - type: Transform
+      pos: -3.5,-22.5
+      parent: 2
   - uid: 752
     components:
     - type: Transform
       pos: -9.5,-20.5
       parent: 2
-  - uid: 761
+- proto: SignalButton
+  entities:
+  - uid: 810
     components:
+    - type: MetaData
+      name: bar shutter button
     - type: Transform
-      pos: -4.5,-22.5
+      pos: 1.5,-13.5
       parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        386:
+        - Pressed: Toggle
+        385:
+        - Pressed: Toggle
 - proto: SignalButtonDirectional
   entities:
-  - uid: 239
+  - uid: 655
     components:
+    - type: MetaData
+      name: kitchen shutter button
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-18.5
+      parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        472:
+        - Pressed: Toggle
+        313:
+        - Pressed: Toggle
+  - uid: 811
+    components:
+    - type: MetaData
+      name: shutter button
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-8.5
+      parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        724:
+        - Pressed: Toggle
+        723:
+        - Pressed: Toggle
+        720:
+        - Pressed: Toggle
+        721:
+        - Pressed: Toggle
+        722:
+        - Pressed: Toggle
+  - uid: 812
+    components:
+    - type: MetaData
+      name: shutter button
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,-20.5
+      parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        690:
+        - Pressed: Toggle
+        737:
+        - Pressed: Toggle
+        653:
+        - Pressed: Toggle
+        540:
+        - Pressed: Toggle
+        639:
+        - Pressed: Toggle
+  - uid: 814
+    components:
+    - type: MetaData
+      name: shutter button
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-6.5
@@ -4620,37 +4768,29 @@ entities:
         - Pressed: Toggle
         295:
         - Pressed: Toggle
-  - uid: 387
+  - uid: 815
     components:
+    - type: MetaData
+      name: shutter button
     - type: Transform
-      pos: 0.5,-12.5
+      pos: 6.5,-7.5
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        386:
+        731:
         - Pressed: Toggle
-        385:
+        732:
         - Pressed: Toggle
-  - uid: 414
+        733:
+        - Pressed: Toggle
+        734:
+        - Pressed: Toggle
+        735:
+        - Pressed: Toggle
+  - uid: 816
     components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 7.5,-20.5
-      parent: 2
-    - type: DeviceLinkSource
-      linkedPorts:
-        690:
-        - Pressed: Toggle
-        737:
-        - Pressed: Toggle
-        653:
-        - Pressed: Toggle
-        540:
-        - Pressed: Toggle
-        639:
-        - Pressed: Toggle
-  - uid: 670
-    components:
+    - type: MetaData
+      name: dock shutter button
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-20.5
@@ -4673,66 +4813,19 @@ entities:
         - Pressed: Toggle
         762:
         - Pressed: Toggle
-  - uid: 729
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -4.5,-8.5
-      parent: 2
-    - type: DeviceLinkSource
-      linkedPorts:
-        722:
-        - Pressed: Toggle
-        721:
-        - Pressed: Toggle
-        720:
-        - Pressed: Toggle
-        723:
-        - Pressed: Toggle
-        724:
-        - Pressed: Toggle
-  - uid: 730
-    components:
-    - type: Transform
-      pos: 6.5,-7.5
-      parent: 2
-    - type: DeviceLinkSource
-      linkedPorts:
-        731:
-        - Pressed: Toggle
-        732:
-        - Pressed: Toggle
-        733:
-        - Pressed: Toggle
-        734:
-        - Pressed: Toggle
-        735:
-        - Pressed: Toggle
-  - uid: 744
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 1.5,-18.5
-      parent: 2
-    - type: DeviceLinkSource
-      linkedPorts:
-        313:
-        - Pressed: Toggle
-        466:
-        - Pressed: Toggle
 - proto: SignBar
   entities:
-  - uid: 545
+  - uid: 387
+    components:
+    - type: Transform
+      pos: -3.5,-21.5
+      parent: 2
+  - uid: 546
     components:
     - type: Transform
       pos: -1.5,-13.5
       parent: 2
-  - uid: 800
-    components:
-    - type: Transform
-      pos: -4.5,-21.5
-      parent: 2
-  - uid: 803
+  - uid: 804
     components:
     - type: Transform
       pos: -7.5,-18.5
@@ -4754,7 +4847,7 @@ entities:
       parent: 2
 - proto: SignElectricalMed
   entities:
-  - uid: 801
+  - uid: 802
     components:
     - type: Transform
       pos: -0.5,-11.5
@@ -4769,14 +4862,14 @@ entities:
       parent: 2
 - proto: SMESBasic
   entities:
-  - uid: 459
+  - uid: 460
     components:
     - type: Transform
       pos: -3.5,-11.5
       parent: 2
 - proto: soda_dispenser
   entities:
-  - uid: 235
+  - uid: 236
     components:
     - type: Transform
       pos: 0.5,-13.5
@@ -4795,40 +4888,12 @@ entities:
     - type: Transform
       pos: 0.5,-3.5
       parent: 2
-- proto: SpawnPointBotanist
-  entities:
-  - uid: 575
-    components:
-    - type: Transform
-      pos: 0.5,-1.5
-      parent: 2
-- proto: SpawnPointChef
-  entities:
-  - uid: 572
-    components:
-    - type: Transform
-      pos: 4.5,-14.5
-      parent: 2
 - proto: SpawnPointLatejoin
   entities:
   - uid: 650
     components:
     - type: Transform
       pos: 1.5,-10.5
-      parent: 2
-- proto: SpawnPointPilot
-  entities:
-  - uid: 661
-    components:
-    - type: Transform
-      pos: 7.5,-9.5
-      parent: 2
-- proto: SpawnPointServiceWorker
-  entities:
-  - uid: 626
-    components:
-    - type: Transform
-      pos: 0.5,-14.5
       parent: 2
 - proto: SprayBottleSpaceCleaner
   entities:
@@ -4839,7 +4904,7 @@ entities:
       parent: 2
 - proto: SubstationBasic
   entities:
-  - uid: 510
+  - uid: 513
     components:
     - type: Transform
       pos: -3.5,-10.5
@@ -4865,12 +4930,12 @@ entities:
     - type: Transform
       pos: 8.5,-8.5
       parent: 2
-  - uid: 182
+  - uid: 226
     components:
     - type: Transform
       pos: 2.5,-18.5
       parent: 2
-  - uid: 240
+  - uid: 266
     components:
     - type: Transform
       pos: 3.5,-18.5
@@ -4928,19 +4993,19 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 1.5,-16.5
       parent: 2
-  - uid: 464
+  - uid: 466
     components:
     - type: Transform
       pos: 1.5,-17.5
       parent: 2
 - proto: TableCounterWood
   entities:
-  - uid: 770
+  - uid: 793
     components:
     - type: Transform
       pos: 0.5,-15.5
       parent: 2
-  - uid: 793
+  - uid: 794
     components:
     - type: Transform
       pos: -0.5,-15.5
@@ -4964,7 +5029,7 @@ entities:
     - type: Transform
       pos: -6.5,-9.5
       parent: 2
-  - uid: 397
+  - uid: 401
     components:
     - type: Transform
       pos: 0.5,-13.5
@@ -5004,7 +5069,7 @@ entities:
     - type: Transform
       pos: -3.5,-14.5
       parent: 2
-  - uid: 509
+  - uid: 510
     components:
     - type: Transform
       pos: -0.5,-13.5
@@ -5017,46 +5082,62 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 9.5,-17.5
       parent: 2
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 224
     components:
     - type: Transform
       pos: -6.5,-5.5
       parent: 2
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 225
     components:
     - type: Transform
       pos: 7.5,-5.5
       parent: 2
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 259
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,-17.5
       parent: 2
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 486
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,-5.5
       parent: 2
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 544
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,-5.5
       parent: 2
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 756
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -2.5,-21.5
+      pos: -1.5,-21.5
       parent: 2
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 757
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 3.5,-21.5
+      pos: 2.5,-21.5
       parent: 2
+    - type: Thruster
+      originalPowerLoad: 1500
 - proto: VariantCubeBox
   entities:
   - uid: 233
@@ -5073,10 +5154,10 @@ entities:
       parent: 2
 - proto: VendingMachineChefDrobe
   entities:
-  - uid: 689
+  - uid: 714
     components:
     - type: Transform
-      pos: 6.5,-21.5
+      pos: 5.5,-21.5
       parent: 2
 - proto: VendingMachineChefvend
   entities:
@@ -5087,7 +5168,7 @@ entities:
       parent: 2
 - proto: VendingMachineCondiments
   entities:
-  - uid: 571
+  - uid: 626
     components:
     - type: Transform
       pos: -0.5,-15.5
@@ -5101,10 +5182,10 @@ entities:
       parent: 2
 - proto: VendingMachineHydrobe
   entities:
-  - uid: 739
+  - uid: 159
     components:
     - type: Transform
-      pos: 6.5,-22.5
+      pos: 5.5,-22.5
       parent: 2
 - proto: VendingMachineNutri
   entities:
@@ -5112,6 +5193,34 @@ entities:
     components:
     - type: Transform
       pos: -1.5,-5.5
+      parent: 2
+- proto: VendingMachineRestockBooze
+  entities:
+  - uid: 239
+    components:
+    - type: Transform
+      pos: 8.2885895,-22.483995
+      parent: 2
+- proto: VendingMachineRestockChefvend
+  entities:
+  - uid: 689
+    components:
+    - type: Transform
+      pos: 8.642728,-22.360958
+      parent: 2
+- proto: VendingMachineRestockCondimentStation
+  entities:
+  - uid: 809
+    components:
+    - type: Transform
+      pos: 8.6115055,-22.640354
+      parent: 2
+- proto: VendingMachineRestockDinnerware
+  entities:
+  - uid: 230
+    components:
+    - type: Transform
+      pos: 8.382312,-22.267143
       parent: 2
 - proto: VendingMachineSeedsUnlocked
   entities:
@@ -5122,6 +5231,11 @@ entities:
       parent: 2
 - proto: WallShuttle
   entities:
+  - uid: 1
+    components:
+    - type: Transform
+      pos: -4.5,-7.5
+      parent: 2
   - uid: 4
     components:
     - type: Transform
@@ -5297,11 +5411,6 @@ entities:
     - type: Transform
       pos: 0.5,-12.5
       parent: 2
-  - uid: 74
-    components:
-    - type: Transform
-      pos: 1.5,-18.5
-      parent: 2
   - uid: 75
     components:
     - type: Transform
@@ -5337,6 +5446,11 @@ entities:
     - type: Transform
       pos: 8.5,-12.5
       parent: 2
+  - uid: 88
+    components:
+    - type: Transform
+      pos: 5.5,-7.5
+      parent: 2
   - uid: 89
     components:
     - type: Transform
@@ -5351,6 +5465,11 @@ entities:
     components:
     - type: Transform
       pos: 2.5,-20.5
+      parent: 2
+  - uid: 119
+    components:
+    - type: Transform
+      pos: 1.5,-18.5
       parent: 2
   - uid: 121
     components:
@@ -5367,11 +5486,6 @@ entities:
     - type: Transform
       pos: 4.5,-20.5
       parent: 2
-  - uid: 159
-    components:
-    - type: Transform
-      pos: 0.5,-20.5
-      parent: 2
   - uid: 166
     components:
     - type: Transform
@@ -5382,20 +5496,10 @@ entities:
     - type: Transform
       pos: 1.5,-12.5
       parent: 2
-  - uid: 286
-    components:
-    - type: Transform
-      pos: 5.5,-21.5
-      parent: 2
-  - uid: 298
+  - uid: 303
     components:
     - type: Transform
       pos: 1.5,-13.5
-      parent: 2
-  - uid: 307
-    components:
-    - type: Transform
-      pos: 5.5,-22.5
       parent: 2
   - uid: 356
     components:
@@ -5417,11 +5521,6 @@ entities:
     - type: Transform
       pos: -4.5,-20.5
       parent: 2
-  - uid: 474
-    components:
-    - type: Transform
-      pos: 1.5,-15.5
-      parent: 2
   - uid: 489
     components:
     - type: Transform
@@ -5431,6 +5530,16 @@ entities:
     components:
     - type: Transform
       pos: 3.5,-9.5
+      parent: 2
+  - uid: 509
+    components:
+    - type: Transform
+      pos: 1.5,-15.5
+      parent: 2
+  - uid: 531
+    components:
+    - type: Transform
+      pos: 0.5,-20.5
       parent: 2
   - uid: 541
     components:
@@ -5457,6 +5566,11 @@ entities:
     - type: Transform
       pos: -6.5,-20.5
       parent: 2
+  - uid: 656
+    components:
+    - type: Transform
+      pos: -4.5,-23.5
+      parent: 2
   - uid: 658
     components:
     - type: Transform
@@ -5472,20 +5586,40 @@ entities:
     - type: Transform
       pos: 10.5,-19.5
       parent: 2
-  - uid: 685
-    components:
-    - type: Transform
-      pos: -1.5,-13.5
-      parent: 2
   - uid: 693
     components:
     - type: Transform
-      pos: -4.5,-21.5
+      pos: -2.5,-20.5
+      parent: 2
+  - uid: 697
+    components:
+    - type: Transform
+      pos: -1.5,-13.5
       parent: 2
   - uid: 725
     components:
     - type: Transform
       pos: 8.5,-18.5
+      parent: 2
+  - uid: 741
+    components:
+    - type: Transform
+      pos: -3.5,-21.5
+      parent: 2
+  - uid: 744
+    components:
+    - type: Transform
+      pos: 5.5,-23.5
+      parent: 2
+  - uid: 807
+    components:
+    - type: Transform
+      pos: 4.5,-21.5
+      parent: 2
+  - uid: 808
+    components:
+    - type: Transform
+      pos: 4.5,-22.5
       parent: 2
 - proto: WallShuttleDiagonal
   entities:
@@ -5547,12 +5681,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -5.5,-6.5
       parent: 2
-  - uid: 88
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -4.5,-7.5
-      parent: 2
   - uid: 90
     components:
     - type: Transform
@@ -5569,11 +5697,6 @@ entities:
     components:
     - type: Transform
       pos: 6.5,-6.5
-      parent: 2
-  - uid: 94
-    components:
-    - type: Transform
-      pos: 5.5,-7.5
       parent: 2
   - uid: 95
     components:
@@ -5597,12 +5720,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -8.5,-23.5
       parent: 2
-  - uid: 230
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -3.5,-21.5
-      parent: 2
   - uid: 343
     components:
     - type: Transform
@@ -5621,29 +5738,23 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -6.5,-18.5
       parent: 2
-  - uid: 649
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -4.5,-23.5
-      parent: 2
-  - uid: 654
+  - uid: 662
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 4.5,-21.5
+      pos: 3.5,-21.5
+      parent: 2
+  - uid: 670
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-21.5
       parent: 2
   - uid: 674
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 10.5,-22.5
-      parent: 2
-  - uid: 714
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 5.5,-23.5
       parent: 2
   - uid: 743
     components:
@@ -5655,6 +5766,18 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -9.5,-22.5
+      parent: 2
+  - uid: 801
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-23.5
+      parent: 2
+  - uid: 806
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-23.5
       parent: 2
 - proto: WarpPointShip
   entities:
@@ -5672,7 +5795,7 @@ entities:
       parent: 2
 - proto: WindoorSecure
   entities:
-  - uid: 423
+  - uid: 437
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -5680,7 +5803,7 @@ entities:
       parent: 2
 - proto: Wrench
   entities:
-  - uid: 804
+  - uid: 805
     components:
     - type: Transform
       pos: 7.5,-10.5

--- a/Resources/Maps/_NF/Shuttles/ceres.yml
+++ b/Resources/Maps/_NF/Shuttles/ceres.yml
@@ -852,7 +852,7 @@ entities:
       parent: 2
 - proto: AlwaysPoweredlightGreen
   entities:
-  - uid: 106
+  - uid: 818
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -860,7 +860,7 @@ entities:
       parent: 2
 - proto: AlwaysPoweredlightRed
   entities:
-  - uid: 94
+  - uid: 389
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3827,63 +3827,6 @@ entities:
     - type: Transform
       pos: 2.6987016,-18.387365
       parent: 2
-- proto: Paper
-  entities:
-  - uid: 817
-    components:
-    - type: MetaData
-      name: pre-flight checklist
-    - type: Transform
-      pos: -2.0040264,-10.642405
-      parent: 2
-    - type: Paper
-      stampState: paper_stamp-ce
-      stampedBy:
-      - stampedBorderless: False
-        stampedColor: '#C69B17FF'
-        stampedName: stamp-component-stamped-name-ce
-      content: >2-
-
-        [color=#1B8CD6][head=1]=BB=[/head]
-
-        [head=2]BlueBird Starship Design & Construction[/head][/color]
-
-
-        [head=2][bold][color=#9413ED]Ceres[/color][/bold][/head]
-
-        Dear Captain,
-
-        Thank you for your purchase of the BB Ceres!
-
-        We hope this ship will serve you well, and allow you to serve your customers the highest quality dining experience.
-
-
-        [head=3][color=#1B8CD6]Pre-Flight Checklist[/head][/color]
-
-        1. Check all machines, generators and canisters are [bold]anchored[/bold].
-
-        2. Top off generator fuel.
-
-        3. Set [bold]generator output to 12 kW[/bold]. [italic]If you are not planning to use the grill, you can go as low as 11 kW.[/italic]
-
-        4. Start generators if not already running.
-
-        5. Check distro pump settings, then turn on. [italic]Note: The distro pump is on the bridge.[/italic]
-
-        6. Check gyro is turned on.
-
-        7. Check all APCs are functioning and charged.
-
-
-        [head=3][color=#1B8CD6]Getting the Most out of the Ceres[/head][/color]
-
-        1. The Ceres is designed for multi-person crews. Consider having a dedicated botanist to grow quality produce.
-
-        2. Though unorthodox, the disposal units are designed to safely and efficiently transport produce from botany to kitchen. Make use of them!
-
-        3. Don't be afraid to adjust the table and seating layout to suit your needs.
-
-        4. For serving food to a larger party, the food carts in the freezer may simplify transportation.
 - proto: PaperBin10
   entities:
   - uid: 404
@@ -4132,12 +4075,40 @@ entities:
     - type: Transform
       pos: -1.5,-1.5
       parent: 2
+- proto: ServiceTechFab
+  entities:
+  - uid: 106
+    components:
+    - type: Transform
+      pos: 7.5,-12.5
+      parent: 2
+- proto: SheetGlass
+  entities:
+  - uid: 820
+    components:
+    - type: Transform
+      pos: 7.63264,-13.474377
+      parent: 2
 - proto: SheetPlasma
   entities:
   - uid: 709
     components:
     - type: Transform
       pos: -2,-10.5
+      parent: 2
+- proto: SheetPlastic
+  entities:
+  - uid: 817
+    components:
+    - type: Transform
+      pos: 7.3556504,-13.585793
+      parent: 2
+- proto: SheetSteel
+  entities:
+  - uid: 819
+    components:
+    - type: Transform
+      pos: 7.38264,-13.422256
       parent: 2
 - proto: ShuttersNormalOpen
   entities:
@@ -4832,6 +4803,18 @@ entities:
       parent: 2
 - proto: SignDirectionalFood
   entities:
+  - uid: 88
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,-22.5
+      parent: 2
+  - uid: 94
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-23.5
+      parent: 2
   - uid: 607
     components:
     - type: Transform
@@ -5173,13 +5156,6 @@ entities:
     - type: Transform
       pos: -0.5,-15.5
       parent: 2
-- proto: VendingMachineDinnerware
-  entities:
-  - uid: 388
-    components:
-    - type: Transform
-      pos: 7.5,-12.5
-      parent: 2
 - proto: VendingMachineHydrobe
   entities:
   - uid: 159
@@ -5215,13 +5191,6 @@ entities:
     - type: Transform
       pos: 8.6115055,-22.640354
       parent: 2
-- proto: VendingMachineRestockDinnerware
-  entities:
-  - uid: 230
-    components:
-    - type: Transform
-      pos: 8.382312,-22.267143
-      parent: 2
 - proto: VendingMachineSeedsUnlocked
   entities:
   - uid: 145
@@ -5231,11 +5200,6 @@ entities:
       parent: 2
 - proto: WallShuttle
   entities:
-  - uid: 1
-    components:
-    - type: Transform
-      pos: -4.5,-7.5
-      parent: 2
   - uid: 4
     components:
     - type: Transform
@@ -5446,11 +5410,6 @@ entities:
     - type: Transform
       pos: 8.5,-12.5
       parent: 2
-  - uid: 88
-    components:
-    - type: Transform
-      pos: 5.5,-7.5
-      parent: 2
   - uid: 89
     components:
     - type: Transform
@@ -5491,6 +5450,11 @@ entities:
     - type: Transform
       pos: -3.5,-20.5
       parent: 2
+  - uid: 230
+    components:
+    - type: Transform
+      pos: -4.5,-7.5
+      parent: 2
   - uid: 285
     components:
     - type: Transform
@@ -5520,6 +5484,11 @@ entities:
     components:
     - type: Transform
       pos: -4.5,-20.5
+      parent: 2
+  - uid: 388
+    components:
+    - type: Transform
+      pos: 5.5,-7.5
       parent: 2
   - uid: 489
     components:

--- a/Resources/Prototypes/Nyanotrasen/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Structures/Machines/lathe.yml
@@ -120,6 +120,8 @@
       - ServiceFoodPlateSmall
       - ServiceFoodPlateTin
       - ServiceFoodKebabSkewer
+      - Beaker
+      - LargeBeaker
       - ClothingOuterSuitEmergency
       - ClothingHeadHelmetEVA
       - ClothingOuterHardsuitEVA

--- a/Resources/Prototypes/_NF/Guidebook/shipyard.yml
+++ b/Resources/Prototypes/_NF/Guidebook/shipyard.yml
@@ -5,6 +5,7 @@
   children:
   - ShipyardAmbition
   - ShipyardBrigand
+  - ShipyardCeres
   - ShipyardGasbender
   - ShipyardHarbormaster
   - ShipyardKilderkin
@@ -23,6 +24,11 @@
   id: ShipyardBrigand
   name: guide-entry-shipyard-brigand
   text: "/ServerInfo/_NF/Guidebook/Shipyard/Brigand.xml"
+
+- type: guideEntry
+  id: ShipyardCeres
+  name: guide-entry-shipyard-ceres
+  text: "/ServerInfo/_NF/Guidebook/Shipyard/Ceres.xml"
 
 - type: guideEntry
   id: ShipyardGasbender

--- a/Resources/Prototypes/_NF/Shipyard/ceres.yml
+++ b/Resources/Prototypes/_NF/Shipyard/ceres.yml
@@ -1,6 +1,6 @@
 - type: vessel
   id: Ceres
-  name: NC Ceres
+  name: SBB Ceres
   description: A medium-size, high-class restaurant ship with ample seating, integrated botany and a dining room for VIP guests
   price: 49500
   category: Medium
@@ -9,7 +9,7 @@
 
 - type: gameMap
   id: Ceres
-  mapName: 'NC Ceres'
+  mapName: 'SBB Ceres'
   mapPath: /Maps/_NF/Shuttles/ceres.yml
   minPlayers: 0
   stations:

--- a/Resources/ServerInfo/_NF/Guidebook/Shipyard/Ceres.xml
+++ b/Resources/ServerInfo/_NF/Guidebook/Shipyard/Ceres.xml
@@ -1,0 +1,107 @@
+<Document>
+  # CERES-CLASS SERVICE SHUTTLE
+  <Box>
+  <GuideEntityEmbed Entity="KitchenKnife"/>
+  <GuideEntityEmbed Entity="KitchenMicrowave"/>
+  <GuideEntityEmbed Entity="KitchenElectricGrill"/>
+  </Box>
+  [color=#a4885c]Ship Size:[/color] Medium
+
+  [color=#a4885c]Recommended Crew:[/color] 2-4
+
+  [color=#a4885c]Power Gen Type:[/color] Plasma
+
+  [color=#a4885c]Expeditions:[/color] None
+
+  [color=#a4885c]IFF Console:[/color] None
+
+  [color=#a4885c]Available Roles:[/color] Contractor, Pilot, Mercenary
+
+  "A medium-size, high-class restaurant ship with ample seating, integrated botany and a dining room for VIP guests."
+
+  [italic]Brought to you by BlueBird Starship Design & Construction.[/italic]
+
+  # Piloting
+  <Box>
+    <GuideEntityEmbed Entity="ComputerShuttle"/>
+  </Box>
+  After clicking the shuttle console, you should see a radar view of the shuttle. Here are the steps for piloting the shuttle back and forth:
+
+  - First, disconnect any airlocks that are connected to the dock.
+  - Then, you actually get to pilot the shuttle. The controls are fairly simple, with [color=#028ed9]"W"[/color] and [color=#028ed9]"S"[/color] being forward and backward, [color=#028ed9]"A"[/color] and [color=#028ed9]"D"[/color] being left and right, and [color=#028ed9]"Q"[/color] and [color=#028ed9]"E"[/color] being rotating left and right; and [color=#028ed9]"spacebar"[/color] being the brake and moving precicely by holding the [color=#028ed9]"spacebar"[/color] while doing other inputs.
+
+  # Hiring crew
+  <Box>
+    <GuideEntityEmbed Entity="ComputerStationRecords"/>
+    <GuideEntityEmbed Entity="ClothingHeadsetGrey"/>
+    <GuideEntityEmbed Entity="IntercomCommon"/>
+  </Box>
+  As a Captain of a Nanotrasen vessel, you have the authority to hire, fire, demote, or promote crew members at will. There are two ways you as a Captain can go about hiring crew: you can either use the [color=#a4885c]station records computer[/color] on your ship to open crew slots (jobs available vary from ship to ship) or invite through in-game communications other players to your crew.
+
+  # PREFLIGHT CHECKLIST
+
+  ## 1. Power supply
+
+  ## 1.1. Battery units
+  <Box>
+  <GuideEntityEmbed Entity="SMESBasic"/>
+  <GuideEntityEmbed Entity="SubstationBasic"/>
+  <GuideEntityEmbed Entity="APCBasic"/>
+  </Box>
+
+  - Check that the SMES unit is anchored to the floor.
+  - Check that the substation unit is anchored to the floor.
+  - Check that the APC unit's Main Breaker is toggled on.
+  - Check the APC unit's current Load (W).
+
+  ## 1.2. P.A.C.M.A.N. generator unit
+  <Box>
+  <GuideEntityEmbed Entity="PortableGeneratorPacmanShuttle"/>
+  <GuideEntityEmbed Entity="SheetPlasma"/>
+  </Box>
+
+  - Check that P.A.C.M.A.N. generator units are anchored to the floor.
+  - Check that P.A.C.M.A.N. generator units are fueled. For extended flights make sure that you have enough fuel stockpiled to sustain prolonged power generation.
+  - Check that P.A.C.M.A.N. generator units are set to HV output.
+  - Set Target Power to [bold]12 kW[/bold] on each  generator unit.
+  - Start P.A.C.M.A.N. generator units.
+
+  ## 2. Atmospherics
+
+  ## 2.1. Distribution Loop
+  <Box>
+  <GuideEntityEmbed Entity="AirCanister"/>
+  <GuideEntityEmbed Entity="GasPort"/>
+  <GuideEntityEmbed Entity="GasPressurePump"/>
+  </Box>
+
+  - Check that the air canister is anchored to connector port.
+  - Check that the distribution pump is set to normal pressure.
+  - Enable the distribution pump.
+
+  ## 2.2. Waste Loop
+  <Box>
+  <GuideEntityEmbed Entity="GasPressurePump"/>
+  <GuideEntityEmbed Entity="AirAlarm"/>
+  </Box>
+
+  - Enable waste loop pump.
+  - Disable Auto Mode on the Air Alarm in the Engine Room.
+  - Set the Air Alarm in the Engine Room to Filtering (Wide).
+
+  ## 3. Other checks
+  <Box>
+  <GuideEntityEmbed Entity="Gyroscope"/>
+  <GuideEntityEmbed Entity="GravityGeneratorMini"/>
+  </Box>
+
+  - Check that the gyroscope is anchored, powered, and enabled.
+  - Check that the mini gravity generator is anchored, powered, and enabled.
+
+  # GETTING THE MOST OUT OF THE CERES
+
+  - The Ceres is designed for multi-person crews. Consider having a dedicated botanist to grow quality produce.
+  - Though unorthodox, the disposal units are designed to safely and efficiently transport produce from botany to kitchen. Make use of them!
+  - Don't be afraid to adjust the table and seating layout to suit your needs.
+  - For serving food to a larger party, the food carts in the freezer may simplify transportation.
+</Document>


### PR DESCRIPTION
## About the PR
Main changes:
* Expanded the freezer by one tile so I could fit a rack with restock boxes for the ChefVend, Plasteel Chef, Booze-O-Mat and condiment station.
* Also expanded the dock/entry area for symmetry. Put down a sofa in the absence of any better ideas.
* Rebranded the ship from NC Ceres to SBB Ceres. It's now made by Shipyard BlueBird, alongside the Lyrae and the Bookworm.
* Added a pre-flight checklist as is standard on all BlueBird ships. :)

Tweaks:
* Add frames around all buttons, for better visibility. Also moved the bar shutter button for increased reachability.
* Renamed a few things to make their purpose clearer.
* Correct lateral lights, in accordance with BlueBird safety requirements. :)

## Why / Balance
Restock boxes were requested by @dvir001 as these are no longer available from cargo and it kinda sucks to run out of the items in these vending machines. Other changes were aimed at enhancing the experience.

These tweaks have no appreciable effect on the ship's appraisal price after purchase, so it remains at $49,500.

## How to test
Buy yourself a Ceres!

## Media
Preinit:
![image_2024-06-03_14-15-49](https://github.com/new-frontiers-14/frontier-station-14/assets/30327355/e7095227-7d72-472c-bb83-b0faf2b43de0)

Postinit:
![image_2024-06-03_14-19-27](https://github.com/new-frontiers-14/frontier-station-14/assets/30327355/4d6c47a5-4120-4d86-8cb7-067c30da0c48)

Freezer with restock boxes (one of each):
![image_2024-06-03_14-16-44](https://github.com/new-frontiers-14/frontier-station-14/assets/30327355/c028b5b6-cc80-44ff-8f92-56f2282d04d9)

New dock area:
![image_2024-06-03_14-16-26](https://github.com/new-frontiers-14/frontier-station-14/assets/30327355/284f055d-dadf-484c-b8fa-10bf79f66ab2)

Service techfab and materials:
![image_2024-06-03_14-17-01](https://github.com/new-frontiers-14/frontier-station-14/assets/30327355/c5538583-f949-4f27-9a51-be97f9822167)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
none

**Changelog**
:cl:
- tweak: The Ceres is no longer under NanoTrasen branding: look for SBB Ceres instead.