### PR TITLE
Mini Auth

### DIFF
--- a/Content.Client/RCD/RCDMenu.xaml.cs
+++ b/Content.Client/RCD/RCDMenu.xaml.cs
@@ -68,7 +68,7 @@ public sealed partial class RCDMenu : RadialMenu
                 tooltip = Loc.GetString(entProto.Name);
             }
 
-            tooltip = char.ToUpper(tooltip[0]) + tooltip.Remove(0, 1);
+            tooltip = OopsConcat(char.ToUpper(tooltip[0]).ToString(), tooltip.Remove(0, 1));
 
             var button = new RCDMenuButton()
             {
@@ -117,6 +117,12 @@ public sealed partial class RCDMenu : RadialMenu
         OnChildAdded += AddRCDMenuButtonOnClickActions;
 
         SendRCDSystemMessageAction += bui.SendRCDSystemMessage;
+    }
+
+    private static string OopsConcat(string a, string b)
+    {
+        // This exists to prevent Roslyn being clever and compiling something that fails sandbox checks.
+        return a + b;
     }
 
     private void AddRCDMenuButtonOnClickActions(Control control)

--- a/Content.Server.Database/Model.cs
+++ b/Content.Server.Database/Model.cs
@@ -881,6 +881,7 @@ namespace Content.Server.Database
         Whitelist = 1,
         Full = 2,
         Panic = 3,
+        Connected = 4,
     }
 
     public class ServerBanHit

--- a/Content.Server/Administration/ServerApi.cs
+++ b/Content.Server/Administration/ServerApi.cs
@@ -666,7 +666,7 @@ public sealed partial class ServerApi : IPostInjectInit
     /// <summary>
     /// Record used to send the response for the info endpoint.
     /// </summary>
-    public sealed class InfoResponse //frontier - public to maybe reuse
+    private sealed class InfoResponse
     {
         public required int RoundId { get; init; }
         public required List<Player> Players { get; init; }

--- a/Content.Server/Administration/ServerApi.cs
+++ b/Content.Server/Administration/ServerApi.cs
@@ -67,7 +67,7 @@ public sealed partial class ServerApi : IPostInjectInit
         _sawmill = _logManager.GetSawmill("serverApi");
 
         // Get
-        RegisterActorHandler(HttpMethod.Get, "/admin/info", InfoHandler);
+        RegisterHandler(HttpMethod.Get, "/admin/info", InfoHandler); //frontier - not sure why this action needs an actor
         RegisterHandler(HttpMethod.Get, "/admin/game_rules", GetGameRules);
         RegisterHandler(HttpMethod.Get, "/admin/presets", GetPresets);
 
@@ -452,7 +452,7 @@ public sealed partial class ServerApi : IPostInjectInit
     /// <summary>
     ///     Handles fetching information.
     /// </summary>
-    private async Task InfoHandler(IStatusHandlerContext context, Actor actor)
+    private async Task InfoHandler(IStatusHandlerContext context)
     {
         /*
         Information to display

--- a/Content.Server/Administration/ServerApi.cs
+++ b/Content.Server/Administration/ServerApi.cs
@@ -666,7 +666,7 @@ public sealed partial class ServerApi : IPostInjectInit
     /// <summary>
     /// Record used to send the response for the info endpoint.
     /// </summary>
-    private sealed class InfoResponse
+    public sealed class InfoResponse //frontier - changed to public because we are also handling this information for auth
     {
         public required int RoundId { get; init; }
         public required List<Player> Players { get; init; }

--- a/Content.Server/Administration/ServerApi.cs
+++ b/Content.Server/Administration/ServerApi.cs
@@ -666,7 +666,7 @@ public sealed partial class ServerApi : IPostInjectInit
     /// <summary>
     /// Record used to send the response for the info endpoint.
     /// </summary>
-    public sealed class InfoResponse //frontier - changed to public because we are also handling this information for auth
+    private sealed class InfoResponse
     {
         public required int RoundId { get; init; }
         public required List<Player> Players { get; init; }

--- a/Content.Server/Administration/ServerApi.cs
+++ b/Content.Server/Administration/ServerApi.cs
@@ -666,7 +666,7 @@ public sealed partial class ServerApi : IPostInjectInit
     /// <summary>
     /// Record used to send the response for the info endpoint.
     /// </summary>
-    private sealed class InfoResponse
+    public sealed class InfoResponse //frontier - public to maybe reuse
     {
         public required int RoundId { get; init; }
         public required List<Player> Players { get; init; }

--- a/Content.Server/Administration/ServerApi.cs
+++ b/Content.Server/Administration/ServerApi.cs
@@ -452,7 +452,7 @@ public sealed partial class ServerApi : IPostInjectInit
     /// <summary>
     ///     Handles fetching information.
     /// </summary>
-    private async Task InfoHandler(IStatusHandlerContext context)
+    private async Task InfoHandler(IStatusHandlerContext context) //frontier - we had an actor here and never used it so we drop it for now until im compelled to re-add it
     {
         /*
         Information to display

--- a/Content.Server/Connection/ConnectionManager.cs
+++ b/Content.Server/Connection/ConnectionManager.cs
@@ -237,7 +237,7 @@ namespace Content.Server.Connection
             if (!_cfg.GetCVar(CCVars.AllowMultiConnect) && !adminBypass)
             {
                 var serverListString = _cfg.GetCVar(CCVars.ServerAuthList);
-                var serverList = serverListString.Split(",");
+                var serverList = serverListString.Split(", ").ToImmutableList();
                 foreach (var server in serverList)
                 {
                     if (await _authManager.IsPlayerConnected(server, userId))

--- a/Content.Server/Connection/ConnectionManager.cs
+++ b/Content.Server/Connection/ConnectionManager.cs
@@ -234,6 +234,9 @@ namespace Content.Server.Connection
             }
 
             //Frontier
+            //This is our little chunk that serves as a dAuth. It takes in a comma seperated list of IP:PORT, and chekcs
+            //the requesting player against the list of players logged in to other servers. It is intended to be failsafe.
+            //In the case of Admins, it shares the same bypass setting as the soft_max_player_limit
             if (!_cfg.GetCVar(CCVars.AllowMultiConnect) && !adminBypass)
             {
                 var serverListString = _cfg.GetCVar(CCVars.ServerAuthList);

--- a/Content.Server/Connection/ConnectionManager.cs
+++ b/Content.Server/Connection/ConnectionManager.cs
@@ -244,7 +244,7 @@ namespace Content.Server.Connection
                 foreach (var server in serverList)
                 {
                     if (await _authManager.IsPlayerConnected(server, userId))
-                        return (ConnectionDenyReason.Connected, "Account Already Connected to Official Servers", null);
+                        return (ConnectionDenyReason.Connected, Loc.GetString("multiauth-already-connected"), null);
                 }
             }
             // end Frontier

--- a/Content.Server/Connection/ConnectionManager.cs
+++ b/Content.Server/Connection/ConnectionManager.cs
@@ -237,7 +237,7 @@ namespace Content.Server.Connection
             if (!_cfg.GetCVar(CCVars.AllowMultiConnect) && !adminBypass)
             {
                 var serverListString = _cfg.GetCVar(CCVars.ServerAuthList);
-                var serverList = serverListString.Split(", ").ToImmutableList();
+                var serverList = serverListString.Split(",");
                 foreach (var server in serverList)
                 {
                     if (await _authManager.IsPlayerConnected(server, userId))

--- a/Content.Server/Connection/ConnectionManager.cs
+++ b/Content.Server/Connection/ConnectionManager.cs
@@ -236,7 +236,8 @@ namespace Content.Server.Connection
             //Frontier
             if (!_cfg.GetCVar(CCVars.AllowMultiConnect) && !adminBypass)
             {
-                var serverList = _cfg.GetCVar(CCVars.ServerAuthList);
+                var serverListString = _cfg.GetCVar(CCVars.ServerAuthList);
+                var serverList = serverListString.Split(',');
                 foreach (var server in serverList)
                 {
                     if (await _authManager.IsPlayerConnected(server, userId))

--- a/Content.Server/Connection/ConnectionManager.cs
+++ b/Content.Server/Connection/ConnectionManager.cs
@@ -237,7 +237,7 @@ namespace Content.Server.Connection
             if (!_cfg.GetCVar(CCVars.AllowMultiConnect) && !adminBypass)
             {
                 var serverListString = _cfg.GetCVar(CCVars.ServerAuthList);
-                var serverList = serverListString.Split(',');
+                var serverList = serverListString.Split(",");
                 foreach (var server in serverList)
                 {
                     if (await _authManager.IsPlayerConnected(server, userId))

--- a/Content.Server/Entry/EntryPoint.cs
+++ b/Content.Server/Entry/EntryPoint.cs
@@ -1,3 +1,4 @@
+using Content.Server._NF.Auth;
 using Content.Server.Acz;
 using Content.Server.Administration;
 using Content.Server.Administration.Logs;
@@ -103,6 +104,7 @@ namespace Content.Server.Entry
                 IoCManager.Resolve<GhostKickManager>().Initialize();
                 IoCManager.Resolve<ServerInfoManager>().Initialize();
                 IoCManager.Resolve<ServerApi>().Initialize();
+                IoCManager.Resolve<MiniAuthManager>();
 
                 _voteManager.Initialize();
                 _updateManager.Initialize();

--- a/Content.Server/IoC/ServerContentIoC.cs
+++ b/Content.Server/IoC/ServerContentIoC.cs
@@ -1,3 +1,4 @@
+using Content.Server._NF.Auth;
 using Content.Server.Administration;
 using Content.Server.Administration.Logs;
 using Content.Server.Administration.Managers;
@@ -61,6 +62,8 @@ namespace Content.Server.IoC
             IoCManager.Register<ServerDbEntryManager>();
             IoCManager.Register<ISharedPlaytimeManager, PlayTimeTrackingManager>();
             IoCManager.Register<ServerApi>();
+            IoCManager.Register<MiniAuthManager>(); //Frontier
+
         }
     }
 }

--- a/Content.Server/_NF/Auth/Auth.cs
+++ b/Content.Server/_NF/Auth/Auth.cs
@@ -6,6 +6,7 @@ using System.Net.Http;
 using System.Net.Http.Json;
 //using System.IO;
 using System.Net.Http.Headers;
+using System.Text.Json;
 using Content.Shared.CCVar;
 using JetBrains.Annotations;
 using Robust.Shared.Configuration;
@@ -27,8 +28,13 @@ public sealed class MiniAuthManager
 
         var linkedToken = CancellationTokenSource.CreateLinkedTokenSource(cancel);
         linkedToken.CancelAfter(TimeSpan.FromSeconds(10));
-
+        var actor = new Actor()
+        {
+            Guid = player,
+            Name = player.ToString()
+        };
         _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("SS14Token", _cfg.GetCVar(CCVars.AdminApiToken));
+        _http.DefaultRequestHeaders.Add("Actor", JsonSerializer.Serialize(actor));
         using var response = await _http.GetAsync(statusAddress, linkedToken.Token);
 
         if (response.StatusCode == HttpStatusCode.NotFound)
@@ -78,4 +84,11 @@ public sealed class MiniAuthManager
             public required string Name { get; init; }
         }
     }
+
+    private sealed class Actor
+    {
+        public required Guid Guid { get; init; }
+        public required string Name { get; init; }
+    }
+
 }

--- a/Content.Server/_NF/Auth/Auth.cs
+++ b/Content.Server/_NF/Auth/Auth.cs
@@ -36,7 +36,6 @@ public sealed class MiniAuthManager
 
         if (response.IsSuccessStatusCode)
         {
-            response.StatusCode.ToString();
             var status = await response.Content.ReadFromJsonAsync<InfoResponse>(linkedToken.Token);
             foreach (var connectedPlayer in status!.Players)
             {

--- a/Content.Server/_NF/Auth/Auth.cs
+++ b/Content.Server/_NF/Auth/Auth.cs
@@ -34,7 +34,6 @@ public sealed class MiniAuthManager
             Name = player.ToString()
         };
         _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("SS14Token", _cfg.GetCVar(CCVars.AdminApiToken));
-        _http.DefaultRequestHeaders.Add("Actor", JsonSerializer.Serialize(actor));
         using var response = await _http.GetAsync(statusAddress, linkedToken.Token);
 
         if (response.StatusCode == HttpStatusCode.NotFound)

--- a/Content.Server/_NF/Auth/Auth.cs
+++ b/Content.Server/_NF/Auth/Auth.cs
@@ -15,6 +15,11 @@ public sealed class MiniAuthManager
 {
     [Dependency] private readonly IConfigurationManager _cfg = default!;
 
+    public void Initialize()
+    {
+
+    }
+
     private readonly HttpClient _http = new();
 
     public async Task<bool> IsPlayerConnected(string address, Guid player)

--- a/Content.Server/_NF/Auth/Auth.cs
+++ b/Content.Server/_NF/Auth/Auth.cs
@@ -18,7 +18,7 @@ public sealed class MiniAuthManager
     public async Task<bool> IsPlayerConnected(string address, Guid player)
     {
         var connected = false;
-        var statusAddress = "http://" + address.Split("//")[1] + "/admin/info";
+        var statusAddress = "http://" + address + "/admin/info";
 
         var cancel = new CancellationToken();
 

--- a/Content.Server/_NF/Auth/Auth.cs
+++ b/Content.Server/_NF/Auth/Auth.cs
@@ -4,7 +4,6 @@ using System.Net.Http;
 using System.Net.Http.Json;
 //using System.IO;
 using System.Net.Http.Headers;
-using Content.Server.Administration;
 using Content.Shared.CCVar;
 using Robust.Shared.Configuration;
 
@@ -28,7 +27,7 @@ public sealed class MiniAuthManager
             {
                 linkedToken.CancelAfter(TimeSpan.FromSeconds(10));
                 _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("SS14Token", _cfg.GetCVar(CCVars.AdminApiToken));
-                var status = await _http.GetFromJsonAsync<ServerApi.InfoResponse>(statusAddress, linkedToken.Token)
+                var status = await _http.GetFromJsonAsync<InfoResponse>(statusAddress, linkedToken.Token)
                             ?? throw new NotImplementedException();
                 foreach (var connectedPlayer in status.Players)
                 {
@@ -45,5 +44,33 @@ public sealed class MiniAuthManager
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Record used to recieve the response for the info endpoint.
+    /// </summary>
+    private sealed class InfoResponse
+    {
+        public required int RoundId { get; init; }
+        public required List<Player> Players { get; init; }
+        public required List<string> GameRules { get; init; }
+        public required string? GamePreset { get; init; }
+        public required MapInfo? Map { get; init; }
+        public required string? MOTD { get; init; }
+        public required Dictionary<string, object> PanicBunker { get; init; }
+
+        public sealed class Player
+        {
+            public required Guid UserId { get; init; }
+            public required string Name { get; init; }
+            public required bool IsAdmin { get; init; }
+            public required bool IsDeadminned { get; init; }
+        }
+
+        public sealed class MapInfo
+        {
+            public required string Id { get; init; }
+            public required string Name { get; init; }
+        }
     }
 }

--- a/Content.Server/_NF/Auth/Auth.cs
+++ b/Content.Server/_NF/Auth/Auth.cs
@@ -27,8 +27,10 @@ public sealed class MiniAuthManager
         linkedToken.CancelAfter(TimeSpan.FromSeconds(10));
 
         _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("SS14Token", _cfg.GetCVar(CCVars.AdminApiToken));
-
-        var status = await _http.GetFromJsonAsync<ServerApi.InfoResponse>(statusAddress, linkedToken.Token);
+        using var response = await _http.GetAsync(statusAddress, linkedToken.Token);
+        Logger.Debug(response.StatusCode.ToString());
+        var status = await response.Content.ReadFromJsonAsync<ServerApi.InfoResponse>(linkedToken.Token);
+        //var status = await _http.GetFromJsonAsync<ServerApi.InfoResponse>(statusAddress, linkedToken.Token);
         if (status == null)
             return connected;
 

--- a/Content.Server/_NF/Auth/Auth.cs
+++ b/Content.Server/_NF/Auth/Auth.cs
@@ -39,8 +39,8 @@ public sealed class MiniAuthManager
             _sawmill.Error("Auth server returned bad response {StatusCode}!", response.StatusCode);
             return connected;
         }
-
-        var status = await response.Content.ReadFromJsonAsync<ServerApi.InfoResponse>(linkedToken.Token);
+        _sawmill.Info(response.StatusCode.ToString());
+        using var status = await response.Content.ReadFromJsonAsync<ServerApi.InfoResponse>(linkedToken.Token);
         //var status = await _http.GetFromJsonAsync<ServerApi.InfoResponse>(statusAddress, linkedToken.Token);
         if (status == null)
             return connected;

--- a/Content.Server/_NF/Auth/Auth.cs
+++ b/Content.Server/_NF/Auth/Auth.cs
@@ -43,7 +43,7 @@ public sealed class MiniAuthManager
     /// <summary>
     /// Record used to recieve the response for the info endpoint.
     /// </summary>
-    private sealed record InfoResponse
+    private sealed class InfoResponse
     {
         public required int RoundId { get; init; }
         public required List<Player> Players { get; init; }

--- a/Content.Server/_NF/Auth/Auth.cs
+++ b/Content.Server/_NF/Auth/Auth.cs
@@ -2,9 +2,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Net.Http;
 using System.Net.Http.Json;
-using System.IO;
+//using System.IO;
 using System.Net.Http.Headers;
-using System.Text.Json;
 using Content.Server.Administration;
 using Content.Shared.CCVar;
 using Robust.Shared.Configuration;
@@ -14,11 +13,6 @@ namespace Content.Server._NF.Auth;
 public sealed class MiniAuthManager
 {
     [Dependency] private readonly IConfigurationManager _cfg = default!;
-
-    public void Initialize()
-    {
-
-    }
 
     private readonly HttpClient _http = new();
 
@@ -35,7 +29,7 @@ public sealed class MiniAuthManager
                 linkedToken.CancelAfter(TimeSpan.FromSeconds(10));
                 _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("SS14Token", _cfg.GetCVar(CCVars.AdminApiToken));
                 var status = await _http.GetFromJsonAsync<ServerApi.InfoResponse>(statusAddress, linkedToken.Token)
-                            ?? throw new InvalidDataException();
+                            ?? throw new NotImplementedException();
                 foreach (var connectedPlayer in status.Players)
                 {
                     if (connectedPlayer.UserId == player)

--- a/Content.Server/_NF/Auth/Auth.cs
+++ b/Content.Server/_NF/Auth/Auth.cs
@@ -34,23 +34,21 @@ public sealed class MiniAuthManager
         if (response.StatusCode == HttpStatusCode.NotFound)
             return connected;
 
-        if (!response.IsSuccessStatusCode)
+        if (response.IsSuccessStatusCode)
+        {
+            response.StatusCode.ToString();
+            var status = await response.Content.ReadFromJsonAsync<InfoResponse>(linkedToken.Token);
+            foreach (var connectedPlayer in status!.Players)
+            {
+                if (connectedPlayer.UserId == player)
+                    connected = true;
+            }
+        }
+        else
         {
             _sawmill.Error("Auth server returned bad response {StatusCode}!", response.StatusCode);
-            return connected;
         }
-        _sawmill.Info(response.StatusCode.ToString());
-        var status = await response.Content.ReadFromJsonAsync<InfoResponse>(linkedToken.Token);
         //var status = await _http.GetFromJsonAsync<ServerApi.InfoResponse>(statusAddress, linkedToken.Token);
-        if (status == null)
-            return connected;
-
-        foreach (var connectedPlayer in status.Players)
-        {
-            if (connectedPlayer.UserId == player)
-                connected = true;
-        }
-
         return connected;
     }
     /// <summary>

--- a/Content.Server/_NF/Auth/Auth.cs
+++ b/Content.Server/_NF/Auth/Auth.cs
@@ -12,8 +12,7 @@ namespace Content.Server._NF.Auth;
 public sealed class MiniAuthManager
 {
     [Dependency] private readonly IConfigurationManager _cfg = default!;
-
-    private readonly HttpClient _http = new();
+    [Dependency] private readonly HttpClient _http = new();
 
     public async Task<bool> IsPlayerConnected(string address, Guid player)
     {

--- a/Content.Server/_NF/Auth/Auth.cs
+++ b/Content.Server/_NF/Auth/Auth.cs
@@ -15,7 +15,6 @@ public sealed class MiniAuthManager
     [Dependency] private readonly IConfigurationManager _cfg = default!;
 
     private readonly HttpClient _http = new();
-    private readonly ISawmill _sawmill = default!;
 
     /// <summary>
     /// Frontier function to ping a server and check to see if the given player is currently connected to the given server.
@@ -53,7 +52,6 @@ public sealed class MiniAuthManager
         }
         catch (Exception e)
         {
-            _sawmill.Error("Bad data received from auth server:" + e.Message);
         }
         return connected;
     }

--- a/Content.Server/_NF/Auth/Auth.cs
+++ b/Content.Server/_NF/Auth/Auth.cs
@@ -40,15 +40,7 @@ public sealed class MiniAuthManager
         //people can still connect.
         try
         {
-            using var response = await _http.GetAsync(statusAddress, linkedToken.Token);
-
-            if (response.StatusCode == HttpStatusCode.NotFound || !response.IsSuccessStatusCode)
-            {
-                _sawmill.Error("Auth server returned bad response {StatusCode}!", response.StatusCode);
-                return connected;
-            }
-
-            var status = await response.Content.ReadFromJsonAsync<InfoResponse>(linkedToken.Token);
+            var status = await _http.GetFromJsonAsync<InfoResponse>(statusAddress, linkedToken.Token);
 
             foreach (var connectedPlayer in status!.Players)
             {
@@ -59,9 +51,9 @@ public sealed class MiniAuthManager
                 }
             }
         }
-        catch (Exception)
+        catch (Exception e)
         {
-            _sawmill.Error("Bad data received from auth server");
+            _sawmill.Error("Bad data received from auth server:" + e.Message);
         }
         return connected;
     }

--- a/Content.Server/_NF/Auth/Auth.cs
+++ b/Content.Server/_NF/Auth/Auth.cs
@@ -5,6 +5,7 @@ using System.Net.Http;
 using System.Net.Http.Json;
 //using System.IO;
 using System.Net.Http.Headers;
+using Content.Server.Administration;
 using Content.Shared.CCVar;
 using Robust.Shared.Configuration;
 
@@ -27,7 +28,7 @@ public sealed class MiniAuthManager
 
         _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("SS14Token", _cfg.GetCVar(CCVars.AdminApiToken));
 
-        var status = await _http.GetFromJsonAsync<InfoResponse>(statusAddress, linkedToken.Token);
+        var status = await _http.GetFromJsonAsync<ServerApi.InfoResponse>(statusAddress, linkedToken.Token);
         if (status == null)
             return connected;
 
@@ -38,33 +39,5 @@ public sealed class MiniAuthManager
         }
 
         return connected;
-    }
-
-    /// <summary>
-    /// Record used to recieve the response for the info endpoint.
-    /// </summary>
-    private sealed class InfoResponse
-    {
-        public required int RoundId { get; init; }
-        public required List<Player> Players { get; init; }
-        public required List<string> GameRules { get; init; }
-        public required string? GamePreset { get; init; }
-        public required MapInfo? Map { get; init; }
-        public required string? MOTD { get; init; }
-        public required Dictionary<string, object> PanicBunker { get; init; }
-
-        public sealed class Player
-        {
-            public required Guid UserId { get; init; }
-            public required string Name { get; init; }
-            public required bool IsAdmin { get; init; }
-            public required bool IsDeadminned { get; init; }
-        }
-
-        public sealed class MapInfo
-        {
-            public required string Id { get; init; }
-            public required string Name { get; init; }
-        }
     }
 }

--- a/Content.Server/_NF/Auth/Auth.cs
+++ b/Content.Server/_NF/Auth/Auth.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Net.Http;
@@ -16,6 +17,7 @@ public sealed class MiniAuthManager
 
     public async Task<bool> IsPlayerConnected(string address, Guid player)
     {
+        var connected = false;
         var statusAddress = "http://" + address.Split("//")[1] + "/admin/info";
 
         var cancel = new CancellationToken();
@@ -27,15 +29,15 @@ public sealed class MiniAuthManager
 
         var status = await _http.GetFromJsonAsync<InfoResponse>(statusAddress, linkedToken.Token);
         if (status == null)
-            return false;
+            return connected;
 
         foreach (var connectedPlayer in status.Players)
         {
             if (connectedPlayer.UserId == player)
-                return true;
+                connected = true;
         }
 
-        return false;
+        return connected;
     }
 
     /// <summary>

--- a/Content.Server/_NF/Auth/Auth.cs
+++ b/Content.Server/_NF/Auth/Auth.cs
@@ -40,7 +40,7 @@ public sealed class MiniAuthManager
             return connected;
         }
         _sawmill.Info(response.StatusCode.ToString());
-        using var status = await response.Content.ReadFromJsonAsync<ServerApi.InfoResponse>(linkedToken.Token);
+        var status = await response.Content.ReadFromJsonAsync<ServerApi.InfoResponse>(linkedToken.Token);
         //var status = await _http.GetFromJsonAsync<ServerApi.InfoResponse>(statusAddress, linkedToken.Token);
         if (status == null)
             return connected;

--- a/Content.Server/_NF/Auth/Auth.cs
+++ b/Content.Server/_NF/Auth/Auth.cs
@@ -1,0 +1,50 @@
+using System.Threading;
+using System.Threading.Tasks;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.IO;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using Content.Server.Administration;
+using Content.Shared.CCVar;
+using Robust.Shared.Configuration;
+
+namespace Content.Server._NF.Auth;
+
+public sealed class MiniAuthManager
+{
+    [Dependency] private readonly IConfigurationManager _cfg = default!;
+
+    private readonly HttpClient _http = new();
+
+    public async Task<bool> IsPlayerConnected(string address, Guid player)
+    {
+        var statusAddress = "http://" + address.Split("//")[1] + "/admin/info";
+
+        var cancel = new CancellationToken();
+
+        try
+        {
+            using (var linkedToken = CancellationTokenSource.CreateLinkedTokenSource(cancel))
+            {
+                linkedToken.CancelAfter(TimeSpan.FromSeconds(10));
+                _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("SS14Token", _cfg.GetCVar(CCVars.AdminApiToken));
+                var status = await _http.GetFromJsonAsync<ServerApi.InfoResponse>(statusAddress, linkedToken.Token)
+                            ?? throw new InvalidDataException();
+                foreach (var connectedPlayer in status.Players)
+                {
+                    if (connectedPlayer.UserId == player)
+                        return true;
+                }
+            }
+
+            cancel.ThrowIfCancellationRequested();
+        }
+        catch
+        {
+            return false;
+        }
+
+        return false;
+    }
+}

--- a/Content.Server/_NF/Auth/Auth.cs
+++ b/Content.Server/_NF/Auth/Auth.cs
@@ -12,7 +12,7 @@ namespace Content.Server._NF.Auth;
 public sealed class MiniAuthManager
 {
     [Dependency] private readonly IConfigurationManager _cfg = default!;
-    [Dependency] private readonly HttpClient _http = new();
+    private readonly HttpClient _http = new();
 
     public async Task<bool> IsPlayerConnected(string address, Guid player)
     {

--- a/Content.Server/_NF/Auth/Auth.cs
+++ b/Content.Server/_NF/Auth/Auth.cs
@@ -6,8 +6,8 @@ using System.Net.Http;
 using System.Net.Http.Json;
 //using System.IO;
 using System.Net.Http.Headers;
-using Content.Server.Administration;
 using Content.Shared.CCVar;
+using JetBrains.Annotations;
 using Robust.Shared.Configuration;
 
 namespace Content.Server._NF.Auth;
@@ -40,7 +40,7 @@ public sealed class MiniAuthManager
             return connected;
         }
         _sawmill.Info(response.StatusCode.ToString());
-        var status = await response.Content.ReadFromJsonAsync<ServerApi.InfoResponse>(linkedToken.Token);
+        var status = await response.Content.ReadFromJsonAsync<InfoResponse>(linkedToken.Token);
         //var status = await _http.GetFromJsonAsync<ServerApi.InfoResponse>(statusAddress, linkedToken.Token);
         if (status == null)
             return connected;
@@ -52,5 +52,33 @@ public sealed class MiniAuthManager
         }
 
         return connected;
+    }
+    /// <summary>
+    /// Record used to send the response for the info endpoint.
+    /// </summary>
+    [UsedImplicitly]
+    private sealed record InfoResponse //frontier - public to maybe reuse
+    {
+        public required int RoundId { get; init; }
+        public required List<Player> Players { get; init; }
+        public required List<string> GameRules { get; init; }
+        public required string? GamePreset { get; init; }
+        public required MapInfo? Map { get; init; }
+        public required string? MOTD { get; init; }
+        public required Dictionary<string, object> PanicBunker { get; init; }
+
+        public sealed class Player
+        {
+            public required Guid UserId { get; init; }
+            public required string Name { get; init; }
+            public required bool IsAdmin { get; init; }
+            public required bool IsDeadminned { get; init; }
+        }
+
+        public sealed class MapInfo
+        {
+            public required string Id { get; init; }
+            public required string Name { get; init; }
+        }
     }
 }

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -2045,6 +2045,11 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<string> TippyEntity =
             CVarDef.Create("tippy.entity", "TippyClippy", CVar.SERVER | CVar.REPLICATED); // Frontier - Tippy<TippyClippy
 
+        public static readonly CVarDef<List<string>> ServerAuthList =
+            CVarDef.Create("frontier.auth_servers", new List<string>(), CVar.CONFIDENTIAL | CVar.SERVERONLY);
+
+        public static readonly CVarDef<bool> AllowMultiConnect =
+            CVarDef.Create("frontier.allow_multi_connect", true, CVar.CONFIDENTIAL | CVar.SERVERONLY);
         /*
          * DEBUG
          */

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -2045,8 +2045,8 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<string> TippyEntity =
             CVarDef.Create("tippy.entity", "TippyClippy", CVar.SERVER | CVar.REPLICATED); // Frontier - Tippy<TippyClippy
 
-        public static readonly CVarDef<List<string>> ServerAuthList =
-            CVarDef.Create("frontier.auth_servers", new List<string>(), CVar.CONFIDENTIAL | CVar.SERVERONLY);
+        public static readonly CVarDef<string> ServerAuthList =
+            CVarDef.Create("frontier.auth_servers", "", CVar.CONFIDENTIAL | CVar.SERVERONLY);
 
         public static readonly CVarDef<bool> AllowMultiConnect =
             CVarDef.Create("frontier.allow_multi_connect", true, CVar.CONFIDENTIAL | CVar.SERVERONLY);

--- a/Content.Shared/Chat/SharedChatSystem.cs
+++ b/Content.Shared/Chat/SharedChatSystem.cs
@@ -152,8 +152,14 @@ public abstract class SharedChatSystem : EntitySystem
         if (string.IsNullOrEmpty(message))
             return message;
         // Capitalize first letter
-        message = char.ToUpper(message[0]) + message.Remove(0, 1);
+        message = OopsConcat(char.ToUpper(message[0]).ToString(), message.Remove(0, 1));
         return message;
+    }
+
+    private static string OopsConcat(string a, string b)
+    {
+        // This exists to prevent Roslyn being clever and compiling something that fails sandbox checks.
+        return a + b;
     }
 
     public string SanitizeMessageCapitalizeTheWordI(string message, string theWordI = "i")

--- a/Resources/Locale/en-US/_NF/adventure/adventure.ftl
+++ b/Resources/Locale/en-US/_NF/adventure/adventure.ftl
@@ -21,6 +21,7 @@ shipyard-rules-default2 =
 shuttle-ftl-proximity = Nearby objects too massive for FTL!
 
 changelog-tab-title-Upstream = Upstream Changelog
+multiauth-already-connected = Already connected to Frontier Official servers.
 
 public-transit-departure = Now departing for {$destination}. Estimated travel time: {$flytime} seconds.
 public-transit-arrival = Thank you for choosing NT Public Transit. Next transfer to {$destination} departs in {$waittime} seconds.


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Adds a server to server auth system for checking to see if a player is already logged into a server. Uses the existing soft player cap admin bypass setting, to allow admins to bypass the restriction if they can also bypass pop limit restrictions in general.
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
We dont really want to allow players to power game/level the same database account/character or even multiple characters, or attempt to bypass our time gated rewards by cheesing the playtime system or other means.
## How to test
<!-- Describe the way it can be tested -->
While this PR is in review, I have 4 servers setup in a simulated 'official network' of servers that would communicate among themselves to enforce the multiconnection restriction. They are all configured differently to demonstrate the behavior of the distributed auth behavior.

All of their `server_config.toml ` contain the following at the bottom:
```
[frontier]

#do we allow players to connect to multiple servers?
#and if so, which servers do we ping? Requires servers to have matching api_token as listed above
allow_multi_connect = false
auth_servers = "168.119.1.233:1213,168.119.1.233:1212,168.119.1.233:1215"
```
168.119.1.233:1212 `This server allows admins to bypass the restrictions, to log in to *this server* only`
168.119.1.233:1213 `This server is now disabled to simulate a server that is 'down'`
168.119.1.233:1214 `This server does not allow admins to bypass the restriction, to log in to *this server* only`
168.119.1.233:1215 `This server has a mismatched API key, and so is not giving/recieving authorized responses`
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
also contains 2 fixes to sandbox from char concats or something
**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
