### PR TITLE
Proof of Concept: Junk food reagent

### DIFF
--- a/Resources/Locale/en-US/_NF/flavors/flavor-profiles.ftl
+++ b/Resources/Locale/en-US/_NF/flavors/flavor-profiles.ftl
@@ -1,0 +1,1 @@
+flavor-complex-unhealthy = unhealthy

--- a/Resources/Locale/en-US/_NF/reagents/meta/consumable/food/food.ftl
+++ b/Resources/Locale/en-US/_NF/reagents/meta/consumable/food/food.ftl
@@ -1,2 +1,5 @@
 reagent-name-flavorol = flavorol
 reagent-desc-flavorol = All the vitamins, minerals, and carbohydrates the body needs in pure form.
+
+reagent-name-noxiose = noxiose
+reagent-desc-noxiose = The junk in junk food that makes you feel slow and bloated.

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/snacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/snacks.yml
@@ -18,7 +18,9 @@
         maxVol: 30 # Room for extra condiments
         reagents:
         - ReagentId: Nutriment
-          Quantity: 10
+          Quantity: 8 # Frontier
+        - ReagentId: Noxiose # Frontier
+          Quantity: 2
   - type: Item
     sprite: Objects/Consumable/Food/snacks.rsi
     heldPrefix: packet
@@ -296,8 +298,10 @@
         maxVol: 30 # Room for extra condiments
         reagents:
         - ReagentId: Nutriment
-          Quantity: 10
+          Quantity: 8 # Frontier
         - ReagentId: Soysauce
+          Quantity: 2
+        - ReagentId: Noxiose # Frontier
           Quantity: 2
   - type: Food
     trash: FoodPacketChowMeinTrash
@@ -322,10 +326,12 @@
         maxVol: 30 # Room for extra condiments
         reagents:
         - ReagentId: Nutriment
-          Quantity: 10
+          Quantity: 8 # Frontier
         - ReagentId: CapsaicinOil
           Quantity: 2
         - ReagentId: Soysauce
+          Quantity: 2
+        - ReagentId: Noxiose # Frontier
           Quantity: 2
   - type: Food
     trash: FoodPacketDanDanTrash

--- a/Resources/Prototypes/_NF/Flavors/flavors.yml
+++ b/Resources/Prototypes/_NF/Flavors/flavors.yml
@@ -1,0 +1,4 @@
+- type: flavor
+  id: unhealthy
+  flavorType: Base
+  description: flavor-complex-unhealthy

--- a/Resources/Prototypes/_NF/Reagents/Consumables/food.yml
+++ b/Resources/Prototypes/_NF/Reagents/Consumables/food.yml
@@ -31,3 +31,34 @@
   - !type:PlantAdjustHealth
     amount: 0.5
   pricePerUnit: 10
+
+- type: reagent
+  id: Noxiose # The bad stuff in junk food that makes you feel slow and bloated and discourages you from eating too much unhealthy stuff.
+  name: reagent-name-noxiose
+  group: Foods
+  desc: reagent-desc-noxiose
+  physicalDesc: reagent-physical-desc-clumpy
+  flavor: unhealthy # new
+  color: "#CCCCCC" # TODO
+  metabolisms:
+    Food:
+      metabolismRate: 0.2 # Stays in your system for a while
+      effects:
+      # Slow down a bit if you eat some
+      - !type:MovespeedModifier
+        walkSpeedModifier: 0.95
+        sprintSpeedModifier: 0.9
+        conditions:
+        - !type:ReagentThreshold
+          max: 10
+      # Slow down lots if you eat lots
+      - !type:MovespeedModifier
+        walkSpeedModifier: 0.85
+        sprintSpeedModifier: 0.8
+        conditions:
+        - !type:ReagentThreshold
+          min: 10
+      # Makes you *very slightly* hungrier, to offset the nutrition in the food. Not enough to nullify the food.
+      - !type:SatiateHunger
+        factor: -0.2
+  pricePerUnit: 0 # literally worthless


### PR DESCRIPTION
## About the PR
This PR introduces a new reagent, placeholder name _Noxiose_ (_noxi-_ from "noxious", _-ose_ signifying a sugar). It effectively implements the junk in junk food: it's the unhealthy _stuff_ that makes you feel bloated and slow after eating bad food.

* New reagent: Noxiose
* New flavour: "unhealthy"
* Update basic snack foods to contain noxiose, removing some nutritional value

This PR is a proof of concept. This reagent may not be desirable, and all values must be tweaked and balanced. Since it took all of 20 minutes to make this work, I figured I'd put it on GitHub for people to try out.

TODO: Decide on a good colour for the reagent. I set it to a neutral grey (#CCCCCC) for the time being.

## Why / Balance
The basic idea is to encourage people to seek out food ships. In addition to flavorol, which provides active benefits for many cooked foods, the idea behind this new reagent is to provide active _debuffs_ for snack foods, so you can't just load up on sus jerky and get on with your shift. Powergamers will find ways around it, but the casual player might take it as incentive to roleplay with some service people for a change.

At time of writing, the following effects are in place:

* Up to 10u: 5% walk slowdown, 10% sprint slowdown.
* Above 10u: 15% walk slowdown, 20% sprint slowdown.
* Makes you *very slightly* hungrier, to offset the nutritional value of snack foods. In essence, it makes snack foods less nutritious. Since snack foods have also had their nutriment content reduced as part of this PR, this effect may be unnecessary.

I've added 2u noxiose to `FoodSnackBase`, removing 2u of nutriment in the process. This prototype is used by almost all foods you get out of a vending machine. Chow mein and dan dan noodles were also updated separately. I'm sure there are more foods that could contain it.

The unique flavour profile is intended to give players a hint as to which foods they ought to avoid. Otherwise it's hard to understand why you're suddenly slowing down when all you've done is eat.

Several cooked foods could be described as unhealthy, such as cakes and sweet pies, but these deliberately do _not_ contain noxiose. Those have to be made by players, usually on food ships, which is exactly what I want to encourage. Hence, no reason to discourage people from eating delicious cakes. :cake:

## How to test
Spawn any of the snack foods that come from GetMore Chocolate Corp, Discount Dan's or Mr Chang's. Eat. After a while, you should slow down – a little or a lot, depending on how much you ate. The food should taste distinctly _unhealthy_.

## Media
![image](https://github.com/new-frontiers-14/frontier-station-14/assets/30327355/1e76962c-731b-4e52-be8c-1c879de081a5)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- add: Most snack foods as found in vending machines will now slow you down for a while. Find a restaurant to eat at instead!