### PR TITLE
Mail Buff

### DIFF
--- a/Content.Server/Nyanotrasen/Mail/Components/MailComponent.cs
+++ b/Content.Server/Nyanotrasen/Mail/Components/MailComponent.cs
@@ -75,7 +75,7 @@ namespace Content.Server.Mail.Components
         /// The amount that cargo will be awarded for delivering this mail.
         /// </summary>
         [DataField("bounty")]
-        public int Bounty = 750; // Frontier 750<7500
+        public int Bounty = 7500; // Frontier 750<7500
 
         /// <summary>
         /// Penalty if the mail is destroyed.

--- a/Content.Server/Nyanotrasen/Mail/Components/MailComponent.cs
+++ b/Content.Server/Nyanotrasen/Mail/Components/MailComponent.cs
@@ -75,7 +75,7 @@ namespace Content.Server.Mail.Components
         /// The amount that cargo will be awarded for delivering this mail.
         /// </summary>
         [DataField("bounty")]
-        public int Bounty = 750;
+        public int Bounty = 750; // Frontier 750<7500
 
         /// <summary>
         /// Penalty if the mail is destroyed.

--- a/Content.Server/Nyanotrasen/Mail/Components/MailTeleporterComponent.cs
+++ b/Content.Server/Nyanotrasen/Mail/Components/MailTeleporterComponent.cs
@@ -12,7 +12,7 @@ namespace Content.Server.Mail.Components
 
         // Not starting accumulator at 0 so mail carriers have some deliveries to make shortly after roundstart.
         [DataField("accumulator")]
-        public float Accumulator = 285f;
+        public float Accumulator = 1995f; // Frontier 285*7=1995
 
         [DataField("teleportInterval")]
         public TimeSpan TeleportInterval = TimeSpan.FromMinutes(5);
@@ -72,7 +72,7 @@ namespace Content.Server.Mail.Components
         /// What's the bonus for delivering a fragile package intact?
         /// </summary>
         [DataField("fragileBonus")]
-        public int FragileBonus = 200;
+        public int FragileBonus = 2000; // Frontier 200<2000
 
         /// <summary>
         /// What's the malus for failing to deliver a fragile package?
@@ -91,13 +91,13 @@ namespace Content.Server.Mail.Components
         /// if not delivered?
         /// </summary>
         [DataField("priorityDuration")]
-        public TimeSpan priorityDuration = TimeSpan.FromMinutes(15);
+        public TimeSpan priorityDuration = TimeSpan.FromMinutes(45); // Frontier 15<45
 
         /// <summary>
         /// What's the bonus for delivering a priority package on time?
         /// </summary>
         [DataField("priorityBonus")]
-        public int PriorityBonus = 500;
+        public int PriorityBonus = 5000; // Frontier 500<5000
 
         /// <summary>
         /// What's the malus for failing to deliver a priority package?

--- a/Content.Server/Nyanotrasen/Mail/Components/MailTeleporterComponent.cs
+++ b/Content.Server/Nyanotrasen/Mail/Components/MailTeleporterComponent.cs
@@ -15,7 +15,7 @@ namespace Content.Server.Mail.Components
         public float Accumulator = 1995f; // Frontier 285*7=1995
 
         [DataField("teleportInterval")]
-        public TimeSpan TeleportInterval = TimeSpan.FromMinutes(5);
+        public TimeSpan TeleportInterval = TimeSpan.FromMinutes(35);
 
         /// <summary>
         /// The sound that's played when new mail arrives.

--- a/Content.Server/Nyanotrasen/Mail/MailSystem.cs
+++ b/Content.Server/Nyanotrasen/Mail/MailSystem.cs
@@ -230,8 +230,8 @@ namespace Content.Server.Mail
                 return;
             }
 
-            //_popupSystem.PopupEntity(Loc.GetString("mail-unlocked-reward", ("bounty", component.Bounty)), uid, args.User);
-            _popupSystem.PopupEntity(Loc.GetString("mail-unlocked-reward"), uid, args.User); // Frontier - Remove the mention of station income
+            _popupSystem.PopupEntity(Loc.GetString("mail-unlocked-reward", ("bounty", component.Bounty)), uid, args.User);
+            //_popupSystem.PopupEntity(Loc.GetString("mail-unlocked-reward"), uid, args.User); // Frontier - Remove the mention of station income
 
             component.IsProfitable = false;
 

--- a/Resources/Locale/en-US/nyanotrasen/mail.ftl
+++ b/Resources/Locale/en-US/nyanotrasen/mail.ftl
@@ -9,7 +9,7 @@ mail-desc-priority = The anti-tamper lock's [color=yellow]yellow priority tape[/
 mail-desc-priority-inactive = The anti-tamper lock's [color=#886600]yellow priority tape[/color] is inactive.
 mail-unlocked = Anti-tamper system unlocked.
 mail-unlocked-by-emag = Anti-tamper system *BZZT*.
-mail-unlocked-reward = Anti-tamper system unlocked.
+mail-unlocked-reward = Anti-tamper system unlocked. {$bounty} spesos have been added to Frontier account.
 mail-penalty-lock = ANTI-TAMPER LOCK BROKEN. STATION BANK ACCOUNT PENALIZED BY {$credits} SPESOS.
 mail-penalty-fragile = INTEGRITY COMPROMISED. STATION BANK ACCOUNT PENALIZED BY {$credits} SPESOS.
 mail-penalty-expired = DELIVERY PAST DUE. STATION BANK ACCOUNT PENALIZED BY {$credits} SPESOS.

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Specific/Mail/base_mail.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Specific/Mail/base_mail.yml
@@ -21,7 +21,7 @@
       visible: false
     - map: ["enum.MailVisualLayers.JobStamp"]
       scale: 0.8, 0.8 # Frontier 0.5<0.8
-      offset: 0.275, 0.2
+      offset: 0.225, 0.165 # Frontier (0.275, 0.2)<(0.225, 0.165)
     - state: locked
       map: ["enum.MailVisualLayers.Lock"]
     - state: priority

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Specific/Mail/base_mail.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Specific/Mail/base_mail.yml
@@ -4,8 +4,8 @@
   id: BaseMail
   name: mail-item-name-unaddressed
   components:
-  - type: Item
-    size: Normal
+#  - type: Item # Frontier
+#    size: Normal # Frontier
   - type: Mail
   - type: AccessReader
   - type: Sprite
@@ -19,7 +19,7 @@
       map: ["enum.MailVisualLayers.FragileStamp"]
       visible: false
     - map: ["enum.MailVisualLayers.JobStamp"]
-      scale: 0.5, 0.5
+      scale: 0.7, 0.7 # Frontier 0.5<0.7
       offset: 0.275, 0.2
     - state: locked
       map: ["enum.MailVisualLayers.Lock"]
@@ -92,7 +92,8 @@
     damage:
       types:
         Blunt: 10
-  - type: CargoSellBlacklist
+  - type: CargoSellBlacklist # Frontier
+
   - type: Food # Frontier - Moth food
     requiresSpecialDigestion: true
   - type: SolutionContainerManager

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Specific/Mail/base_mail.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Specific/Mail/base_mail.yml
@@ -94,7 +94,6 @@
       types:
         Blunt: 10
   - type: CargoSellBlacklist # Frontier
-
   - type: Food # Frontier - Moth food
     requiresSpecialDigestion: true
   - type: SolutionContainerManager

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Specific/Mail/base_mail.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Specific/Mail/base_mail.yml
@@ -4,8 +4,9 @@
   id: BaseMail
   name: mail-item-name-unaddressed
   components:
-#  - type: Item # Frontier
+  - type: Item # Frontier
 #    size: Normal # Frontier
+    storedRotation: -90
   - type: Mail
   - type: AccessReader
   - type: Sprite
@@ -19,7 +20,7 @@
       map: ["enum.MailVisualLayers.FragileStamp"]
       visible: false
     - map: ["enum.MailVisualLayers.JobStamp"]
-      scale: 0.7, 0.7 # Frontier 0.5<0.7
+      scale: 0.75, 0.75 # Frontier 0.5<0.75
       offset: 0.275, 0.2
     - state: locked
       map: ["enum.MailVisualLayers.Lock"]

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Specific/Mail/base_mail.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Specific/Mail/base_mail.yml
@@ -20,7 +20,7 @@
       map: ["enum.MailVisualLayers.FragileStamp"]
       visible: false
     - map: ["enum.MailVisualLayers.JobStamp"]
-      scale: 0.75, 0.75 # Frontier 0.5<0.75
+      scale: 0.8, 0.8 # Frontier 0.5<0.8
       offset: 0.275, 0.2
     - state: locked
       map: ["enum.MailVisualLayers.Lock"]

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Specific/Mail/base_mail.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Specific/Mail/base_mail.yml
@@ -4,7 +4,7 @@
   id: BaseMail
   name: mail-item-name-unaddressed
   components:
-  - type: Item # Frontier
+  - type: Item
 #    size: Normal # Frontier
     storedRotation: -90
   - type: Mail


### PR DESCRIPTION
## About the PR
Mail Spawn 7 times less, worth 10 times more.
Mail now take 2 storage and not 4, and is now a small item size.
Icon of job is a bit bigger on mail.
Added back the mention of station income when you open mail.

## Why / Balance
Buff mail income. lower entity spam.

## How to test
Spawn in.
Use command Mailnow
Turn on the mail teleporter 
Open / pickup mail

## Media
N/A

## Breaking changes
N/A

**Changelog**
:cl: dvir01
- tweak: Frontier has increased mail related profits, but lowered the amount of existing mail, expect the mail to find you soon. 
