### PR TITLE
Make rubber rounds printable in NFSD Techfab

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -802,10 +802,10 @@
       - MagazineBoxPistolUranium
       - MagazineBoxRifleIncendiary
       - MagazineBoxRifleUranium
-#      - MagazineBoxLightRifleRubber # Frontier - Restore This Later
-#      - MagazineBoxMagnumRubber # Frontier - Restore This Later
-#      - MagazineBoxPistolRubber # Frontier - Restore This Later
-#      - MagazineBoxRifleRubber # Frontier - Restore This Later
+      - MagazineBoxLightRifleRubber # Frontier
+      - MagazineBoxMagnumRubber # Frontier
+      - MagazineBoxPistolRubber # Frontier
+      - MagazineBoxRifleRubber # Frontier
       - MagazineGrenadeEmpty
       - MagazineLightRifleIncendiary
       - MagazineLightRifleUranium

--- a/Resources/Prototypes/Research/arsenal.yml
+++ b/Resources/Prototypes/Research/arsenal.yml
@@ -66,6 +66,10 @@
   - ShellTranquilizer
   - BoxBeanbag
   - WeaponDisabler
+  - MagazineBoxLightRifleRubber # Frontier
+  - MagazineBoxMagnumRubber # Frontier
+  - MagazineBoxPistolRubber # Frontier
+  - MagazineBoxRifleRubber # Frontier
 
 - type: technology
   id: UraniumMunitions

--- a/Resources/Prototypes/_NF/Recipes/Lathes/security.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/security.yml
@@ -40,3 +40,39 @@
   materials:
     Steel: 50
     Plastic: 150
+
+- type: latheRecipe
+  id: MagazineBoxLightRifleRubber
+  result: MagazineBoxLightRifleRubber
+  category: Ammo
+  completetime: 5
+  materials:
+    Steel: 300
+    Plastic: 600
+
+- type: latheRecipe
+  id: MagazineBoxMagnumRubber
+  result: MagazineBoxMagnumRubber
+  category: Ammo
+  completetime: 5
+  materials:
+    Steel: 80
+    Plastic: 160
+
+- type: latheRecipe
+  id: MagazineBoxPistolRubber
+  result: MagazineBoxPistolRubber
+  category: Ammo
+  completetime: 5
+  materials:
+    Steel: 200
+    Plastic: 400
+
+- type: latheRecipe
+  id: MagazineBoxRifleRubber
+  result: MagazineBoxRifleRubber
+  category: Ammo
+  completetime: 5
+  materials:
+    Steel: 250
+    Plastic: 500


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Restores rubber ammunition recipes to NFSD techfab.  Adds recipes to non-lethal ammunition tech.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Rubber rounds were brought back, but were left commented out of the NFSD techfab.

For the lathe recipe amounts, from [previous amounts here](https://github.com/new-frontiers-14/frontier-station-14/blob/3f1c55ea8554317085a4b05f168e8a4bd0525598/Resources/Prototypes/Recipes/Lathes/security.yml), there were ratios of 1:1 and 2:1 plastic:steel, I settled on 2:1 and applied that onto the total materials required for lethal rounds of each type.  Since plastic is considerably more expensive/difficult to obtain than steel, I think this might disincentivize its use.

## How to test
<!-- Describe the way it can be tested -->

1. Spawn research server, R&D computer, NFSD techfab, and research point disks
2. Research non-lethal rounds on the R&D computer (should list the printable rubber ammunition types in the tech)
3. Make sure the techfab is connected to the R&D computer.
4. Print a few boxes of non-lethal rounds.
5. Disconnect the fab from the server, the recipes should disappear.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

![rubber-nfsd-fab](https://github.com/new-frontiers-14/frontier-station-14/assets/166147148/c4b2f247-cef3-4b28-a927-9529a7f42251)

- [X] ***I have added screenshots/videos to this PR showcasing its changes ingame***, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

None.

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: Rubber bullets can be printed in the NFSD techfab with Nonlethal Ammunition researched.