### PR TITLE
Loadouts: add overrides for name, description, and preview entity

### DIFF
--- a/Content.Client/Preferences/UI/LoadoutContainer.xaml.cs
+++ b/Content.Client/Preferences/UI/LoadoutContainer.xaml.cs
@@ -40,7 +40,7 @@ public sealed partial class LoadoutContainer : BoxContainer
             Price.Text = "$" + loadProto.Price;
 
             bool hasDescription = !string.IsNullOrEmpty(loadProto.Description);
-            bool hasEntity = !string.IsNullOrEmpty(loadProto.PreviewEntity.Id);
+            bool hasEntity = !string.IsNullOrEmpty(loadProto.PreviewEntity?.Id);
 
             EntProtoId? ent = null;
             if (!hasEntity || !hasDescription) {

--- a/Content.Client/Preferences/UI/LoadoutContainer.xaml.cs
+++ b/Content.Client/Preferences/UI/LoadoutContainer.xaml.cs
@@ -36,17 +36,28 @@ public sealed partial class LoadoutContainer : BoxContainer
 
         if (_protoManager.TryIndex(proto, out var loadProto))
         {
-            var ent = _entManager.System<LoadoutSystem>().GetFirstOrNull(loadProto);
+            // Frontier: overrideable prototype fields (description, name, icon [via entity])
             Price.Text = "$" + loadProto.Price;
-            if (ent != null)
+
+            bool hasDescription = !string.IsNullOrEmpty(loadProto.Description);
+            bool hasEntity = !string.IsNullOrEmpty(loadProto.PreviewEntity.Id);
+
+            EntProtoId? ent = null;
+            if (!hasEntity || !hasDescription) {
+                ent = _entManager.System<LoadoutSystem>().GetFirstOrNull(loadProto);
+            }
+            var finalEnt = hasEntity ? loadProto.PreviewEntity : ent;
+            if (finalEnt != null)
             {
-                _entity = _entManager.SpawnEntity(ent, MapCoordinates.Nullspace);
+                _entity = _entManager.SpawnEntity(finalEnt, MapCoordinates.Nullspace);
                 Sprite.SetEntity(_entity);
 
                 var spriteTooltip = new Tooltip();
-                spriteTooltip.SetMessage(FormattedMessage.FromUnformatted(_entManager.GetComponent<MetaDataComponent>(_entity.Value).EntityDescription));
+                var description = hasDescription ? loadProto.Description : _entManager.GetComponent<MetaDataComponent>(_entity.Value).EntityDescription; 
+                spriteTooltip.SetMessage(FormattedMessage.FromUnformatted(description));
                 Sprite.TooltipSupplier = _ => spriteTooltip;
             }
+            // End Frontier
         }
     }
 

--- a/Content.Client/Preferences/UI/LoadoutGroupContainer.xaml.cs
+++ b/Content.Client/Preferences/UI/LoadoutGroupContainer.xaml.cs
@@ -77,7 +77,7 @@ public sealed partial class LoadoutGroupContainer : BoxContainer
             var enabled = loadout.IsValid(session, loadoutProto, collection, out var reason);
             var loadoutContainer = new LoadoutContainer(loadoutProto, !enabled, reason);
             loadoutContainer.Select.Pressed = pressed;
-            loadoutContainer.Text = loadoutSystem.GetName(loadProto);
+            loadoutContainer.Text = string.IsNullOrEmpty(loadProto.Name) ? loadoutSystem.GetName(loadProto) : loadProto.Name; // Frontier: allow overriding loadout names
 
             loadoutContainer.Select.OnPressed += args =>
             {

--- a/Content.Shared/Preferences/Loadouts/LoadoutPrototype.cs
+++ b/Content.Shared/Preferences/Loadouts/LoadoutPrototype.cs
@@ -50,5 +50,5 @@ public sealed partial class LoadoutPrototype : IPrototype
     /// Currently, if not defaulted, this will be the fallback entity used to get the description if an override is not provided here.
     /// </remarks>
     [DataField]
-    public EntProtoId PreviewEntity = default!;
+    public EntProtoId? PreviewEntity = default!;
 }

--- a/Content.Shared/Preferences/Loadouts/LoadoutPrototype.cs
+++ b/Content.Shared/Preferences/Loadouts/LoadoutPrototype.cs
@@ -1,6 +1,7 @@
 using Content.Shared.Preferences.Loadouts.Effects;
 using Content.Shared.Roles;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Utility;
 
 namespace Content.Shared.Preferences.Loadouts;
 
@@ -29,4 +30,25 @@ public sealed partial class LoadoutPrototype : IPrototype
     /// </summary>
     [DataField]
     public int Price = 0;
+
+    /// <summary>
+    /// Frontier - optional name of the loadout as it appears in the menu
+    /// </summary>
+    [DataField]
+    public string Name = "";
+
+    /// <summary>
+    /// Frontier - optional description of the loadout as it appears in the menu
+    /// </summary>
+    [DataField]
+    public string Description = "";
+
+    /// <summary>
+    /// Frontier - optional entity to use for its sprite in the loadout as it appears in the menu
+    /// </summary>
+    /// <remarks>
+    /// Currently, if not defaulted, this will be the fallback entity used to get the description if an override is not provided here.
+    /// </remarks>
+    [DataField]
+    public EntProtoId PreviewEntity = default!;
 }

--- a/Resources/Prototypes/_NF/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/Boxes/emergency.yml
@@ -1,8 +1,7 @@
 - type: entity
-  name: oxygen survival box
-  parent: BoxCardboard
+  parent: BoxSurvival
   id: BoxSurvivalNFOxygen
-  description: It's a box with basic oxygen internals inside.
+  suffix: Oxygen
   components:
   - type: StorageFill
     contents:
@@ -18,10 +17,9 @@
       - state: emergencytank
 
 - type: entity
-  name: nitrogen survival box
-  parent: BoxCardboard
+  parent: BoxSurvival
   id: BoxSurvivalNFNitrogen
-  description: It's a box with basic nitrogen internals inside.
+  suffix: Nitrogen
   components:
   - type: StorageFill
     contents:
@@ -37,10 +35,9 @@
       - state: emergencytank
 
 - type: entity
-  name: extended-oxygen survival box
-  parent: BoxCardboard
+  parent: BoxSurvivalEngineering
   id: BoxSurvivalNFOxygenExtended
-  description: It's a box with extended internals inside.
+  suffix: Oxygen
   components:
   - type: StorageFill
     contents:
@@ -56,10 +53,9 @@
       - state: extendedtank
 
 - type: entity
-  name: extended-nitrogen survival box
-  parent: BoxCardboard
+  parent: BoxSurvivalEngineering
   id: BoxSurvivalNFNitrogenExtended
-  description: It's a box with extended nitrogen internals inside.
+  suffix: Nitrogen
   components:
   - type: StorageFill
     contents:
@@ -69,27 +65,6 @@
       - id: FoodPSB
       - id: DrinkWaterBottleFull
       - id: CrowbarRed
-  - type: Sprite
-    layers:
-      - state: internals
-      - state: extendedtank
-
-- type: entity
-  name: survival box
-  parent: BoxSurvivalSecurity
-  id: BoxSurvivalNfsd
-  description: It's a box with basic internals inside. This one is labelled to contain an double extended-capacity tank.
-  suffix: NFSD
-  components:
-  - type: StorageFill
-    contents:
-      - id: ClothingMaskGasNfsd
-      - id: DoubleEmergencyAirTankFilled
-      - id: SpaceMedipen
-      - id: EmergencyMedipen
-      - id: FoodPSB
-      - id: DrinkWaterBottleFull
-      - id: EncryptionKeyTraffic
   - type: Sprite
     layers:
       - state: internals

--- a/Resources/Prototypes/_NF/Catalog/Fills/Crates/npc.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/Crates/npc.yml
@@ -72,5 +72,4 @@
 
 - type: entity
   id: PetCarrierNPCEmotionalSupportSafe
-  parent: [FillNPCEmotionalSupportSafe, PetCarrier]
-  name: emotional support pet in a pet carrier
+  parent: [PetCarrier, FillNPCEmotionalSupportSafe]

--- a/Resources/Prototypes/_NF/Loadouts/Jobs/Contractor/belt.yml
+++ b/Resources/Prototypes/_NF/Loadouts/Jobs/Contractor/belt.yml
@@ -11,6 +11,7 @@
 - type: loadout
   id: ContractorClothingBeltPlantFilled
   equipment: ContractorClothingBeltPlantFilled
+  name: botanical belt (filled)
   price: 1500
 
 - type: startingGear
@@ -31,6 +32,7 @@
 - type: loadout
   id: ContractorClothingBeltChefFilled
   equipment: ContractorClothingBeltChefFilled
+  name: chef belt (filled)
   price: 1500
 
 - type: startingGear
@@ -61,6 +63,7 @@
 - type: loadout
   id: ContractorClothingBeltMedicalFilled
   equipment: ContractorClothingBeltMedicalFilled
+  name: medical belt (filled)
   price: 2000
 
 - type: startingGear
@@ -81,6 +84,7 @@
 - type: loadout
   id: ContractorClothingBeltMedicalEMTFilled
   equipment: ContractorClothingBeltMedicalEMTFilled
+  name: EMT belt (filled)
   price: 2000
 
 - type: startingGear
@@ -101,6 +105,7 @@
 - type: loadout
   id: ContractorClothingBeltUtilityFilled
   equipment: ContractorClothingBeltUtilityFilled
+  name: utility belt (filled)
   price: 1500
 
 - type: startingGear
@@ -121,6 +126,7 @@
 - type: loadout
   id: ContractorClothingBeltSalvageWebbingFilledNF
   equipment: ContractorClothingBeltSalvageWebbingFilledNF
+  name: salvage rig (filled)
   price: 1500
 
 - type: startingGear
@@ -158,6 +164,7 @@
 - type: loadout
   id: ContractorClothingBeltPilotFilled
   equipment: ContractorClothingBeltPilotFilled
+  name: pilot webbing (filled)
   effects:
   - !type:GroupLoadoutEffect
     proto: ContractorT1
@@ -210,6 +217,7 @@
 - type: loadout
   id: ContractorClothingBeltChaplainSashFilled
   equipment: ContractorClothingBeltChaplainSashFilled
+  name: chaplain sash (filled)
   effects:
   - !type:GroupLoadoutEffect
     proto: ContractorT1

--- a/Resources/Prototypes/_NF/Loadouts/Jobs/Contractor/fun.yml
+++ b/Resources/Prototypes/_NF/Loadouts/Jobs/Contractor/fun.yml
@@ -2,6 +2,7 @@
 - type: loadout
   id: ContractorBriefcaseBrownFilled
   equipment: ContractorBriefcaseBrownFilled
+  name: brown briefcase (empty)
   effects:
   - !type:GroupLoadoutEffect
     proto: ContractorT1
@@ -15,6 +16,7 @@
 - type: loadout
   id: ContractorToolboxEmergency
   equipment: ContractorToolboxEmergency
+  name: emergency toolbox (empty)
   effects:
   - !type:GroupLoadoutEffect
     proto: ContractorT1
@@ -28,6 +30,7 @@
 - type: loadout
   id: ContractorToolboxMechanical
   equipment: ContractorToolboxMechanical
+  name: mechanical toolbox (empty)
   effects:
   - !type:GroupLoadoutEffect
     proto: ContractorT1
@@ -225,6 +228,7 @@
 - type: loadout
   id: ContractorEmotionalPetCarrier
   equipment: ContractorEmotionalPetCarrier
+  name: emotional support pet
   effects:
   - !type:GroupLoadoutEffect
     proto: ContractorT3

--- a/Resources/Prototypes/_NF/Loadouts/Jobs/Contractor/survival.yml
+++ b/Resources/Prototypes/_NF/Loadouts/Jobs/Contractor/survival.yml
@@ -2,6 +2,7 @@
 - type: loadout
   id: ContractorBoxSurvivalNFOxygen
   equipment: ContractorBoxSurvivalNFOxygen
+  name: oxygen survival box
 
 - type: startingGear
   id: ContractorBoxSurvivalNFOxygen
@@ -12,6 +13,7 @@
 - type: loadout
   id: ContractorBoxSurvivalNFNitrogen
   equipment: ContractorBoxSurvivalNFNitrogen
+  name: nitrogen survival box
 
 - type: startingGear
   id: ContractorBoxSurvivalNFNitrogen
@@ -23,6 +25,7 @@
 - type: loadout
   id: ContractorBoxSurvivalNFOxygenExtended
   equipment: ContractorBoxSurvivalNFOxygenExtended
+  name: extended-oxygen survival box
   effects:
   - !type:GroupLoadoutEffect
     proto: ContractorT1
@@ -37,6 +40,7 @@
 - type: loadout
   id: ContractorBoxSurvivalNFNitrogenExtended
   equipment: ContractorBoxSurvivalNFNitrogenExtended
+  name: extended-nitrogen survival box
   effects:
   - !type:GroupLoadoutEffect
     proto: ContractorT1

--- a/Resources/Prototypes/_NF/Loadouts/Jobs/Nfsd/belt.yml
+++ b/Resources/Prototypes/_NF/Loadouts/Jobs/Nfsd/belt.yml
@@ -1,6 +1,7 @@
 - type: loadout
   id: NfsdWebbing
   equipment: NfsdWebbing
+  name: nfsd webbing (filled)
 
 - type: startingGear
   id: NfsdWebbing
@@ -10,6 +11,7 @@
 - type: loadout
   id: NfsdBelt
   equipment: NfsdBelt
+  name: nfsd belt (filled)
 
 - type: startingGear
   id: NfsdBelt
@@ -20,6 +22,7 @@
 - type: loadout
   id: BrigmedicClothingBeltBrigmedicWebbing
   equipment: BrigmedicClothingBeltBrigmedicWebbing
+  name: nfsd webbing (filled)
 
 - type: startingGear
   id: BrigmedicClothingBeltBrigmedicWebbing

--- a/Resources/Prototypes/_NF/Loadouts/Jobs/Nfsd/survival.yml
+++ b/Resources/Prototypes/_NF/Loadouts/Jobs/Nfsd/survival.yml
@@ -2,6 +2,7 @@
 - type: loadout
   id: NfsdBoxSurvivalNfsdOxygen
   equipment: NfsdBoxSurvivalNfsdOxygen
+  name: extended-oxygen survival box
 
 - type: startingGear
   id: NfsdBoxSurvivalNfsdOxygen
@@ -12,6 +13,7 @@
 - type: loadout
   id: NfsdBoxSurvivalNfsdNitrogen
   equipment: NfsdBoxSurvivalNfsdNitrogen
+  name: extended-nitrogen survival box
 
 - type: startingGear
   id: NfsdBoxSurvivalNfsdNitrogen


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Adds override fields for the name, description, and the entity used to get the preview sprite, to loadouts.

The loadout window under Character Setup uses these fields now to populate loadout entries.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Being stuck with the name and description of an item led to some redundancy (particularly in filled vs. unfilled belts).  Any loadout entry with more than one item shows up without a sprite, name, or description - this allows a way to get a normal-looking entry.  More control is better.

## How to test
<!-- Describe the way it can be tested -->

**Note:** the steps below do not test all fields (Description, PreviewEntity) on the branch under PR.  To test these, use [whatston3/branch 2024-06-07_bibleuser-implanter-tools-loadout](https://github.com/whatston3/frontier-station-14/tree/2024-06-07_bibleuser-implanter-tools-loadout), which adds a new multi-item loadout.

Build and run local server.
1. Go to the Character Select screen.
2. Open the loadout for Pilot, Mercenary, or Contractor.
3. Overall, the window should look and behave as it did previously.
4. Go to the belts screen.
5. Filled belts should be labelled as being filled.
6. If not using `2024-06-07_bibleuser-implanter-tools-loadout`, the test is complete.
7. Go to the tools section, scroll to the bottom.
8. Check that the name, image, and description of the last entry matches the picture below.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

Belts vs. filled belts: 
![image](https://github.com/new-frontiers-14/frontier-station-14/assets/166147148/c42a5439-f612-469f-a66f-e03e0c74854e)

Bible and Faith implanter test:
![bible_test](https://github.com/new-frontiers-14/frontier-station-14/assets/166147148/1c0c59ca-4e59-473c-b1e2-7d5008421c52)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Filled belts are now labelled as such in the Loadout window.