### PR TITLE
Fix mech codes to stop AI abuse

### DIFF
--- a/Content.Server/Mech/Systems/MechSystem.cs
+++ b/Content.Server/Mech/Systems/MechSystem.cs
@@ -38,7 +38,6 @@ public sealed partial class MechSystem : SharedMechSystem
     [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly UserInterfaceSystem _ui = default!;
-    [Dependency] private readonly AppearanceSystem _appearance = default!; // Frontier
 
     /// <inheritdoc/>
     public override void Initialize()

--- a/Content.Server/Mech/Systems/MechSystem.cs
+++ b/Content.Server/Mech/Systems/MechSystem.cs
@@ -232,7 +232,7 @@ public sealed partial class MechSystem : SharedMechSystem
         }
 
         // Frontier - Make AI Attack mechs based on user.
-        if (TryComp<MobStateComponent>(args.User, out var state))
+        if (TryComp<MobStateComponent>(args.User, out var _))
             EnsureComp<MobStateComponent>(uid);
         if (TryComp<NpcFactionMemberComponent>(args.User, out var faction))
         {

--- a/Content.Shared/Mech/EntitySystems/SharedMechSystem.cs
+++ b/Content.Shared/Mech/EntitySystems/SharedMechSystem.cs
@@ -392,9 +392,9 @@ public abstract class SharedMechSystem : EntitySystem
         UpdateAppearance(uid, component);
 
         // Frontier - Make NPC AI attack Mechs
-        if (TryComp<MobStateComponent>(uid, out var state))
+        if (TryComp<MobStateComponent>(uid, out var _))
             RemComp<MobStateComponent>(uid);
-        if (TryComp<NpcFactionMemberComponent>(uid, out var faction))
+        if (TryComp<NpcFactionMemberComponent>(uid, out var _))
             RemComp<NpcFactionMemberComponent>(uid);
         // Frontier
 

--- a/Content.Shared/Mech/EntitySystems/SharedMechSystem.cs
+++ b/Content.Shared/Mech/EntitySystems/SharedMechSystem.cs
@@ -19,6 +19,8 @@ using Robust.Shared.Containers;
 using Robust.Shared.Network;
 using Robust.Shared.Serialization;
 using Robust.Shared.Timing;
+using Content.Shared.Mobs.Components; // Frontier
+using Content.Shared.NPC.Components; // Frontier
 
 namespace Content.Shared.Mech.EntitySystems;
 
@@ -388,6 +390,14 @@ public abstract class SharedMechSystem : EntitySystem
         RemoveUser(uid, pilot);
         _container.RemoveEntity(uid, pilot);
         UpdateAppearance(uid, component);
+
+        // Frontier - Make NPC AI attack Mechs
+        if (TryComp<MobStateComponent>(uid, out var state))
+            RemComp<MobStateComponent>(uid);
+        if (TryComp<NpcFactionMemberComponent>(uid, out var faction))
+            RemComp<NpcFactionMemberComponent>(uid);
+        // Frontier
+
         return true;
     }
 

--- a/Content.Shared/NPC/Components/NpcFactionMemberComponent.cs
+++ b/Content.Shared/NPC/Components/NpcFactionMemberComponent.cs
@@ -2,10 +2,11 @@ using Content.Shared.NPC.Prototypes;
 using Content.Shared.NPC.Systems;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
+using Content.Shared.Mech.EntitySystems; // Frontier
 
 namespace Content.Shared.NPC.Components;
 
-[RegisterComponent, NetworkedComponent, Access(typeof(NpcFactionSystem))]
+[RegisterComponent, NetworkedComponent, Access(typeof(NpcFactionSystem), typeof(SharedMechSystem))] // Frontier - Added MechSystem
 public sealed partial class NpcFactionMemberComponent : Component
 {
     /// <summary>

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/turrets.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/turrets.yml
@@ -29,6 +29,7 @@
                 SheetSteel1:
                   min: 2
                   max: 4
+    - type: MobState # Frontier (otherwise NPCs won't attack the entity)
 
 - type: entity
   parent: BaseStructure


### PR DESCRIPTION
## About the PR
Mechs now copy the user mob state and factions when you enter them, making AI no longer ignore mechs
Remove the faction and mob state when you exit the mech so AI ignore it ones again.
Fixed it so mechs now eject dead users.

## Why / Balance
Abuse in mech code allow it to be used to ignore AI and attack it without ever getting hit back.

## How to test
Spawn in,
Spawn a mech
Enter the mech
Spawn any hostile AI
Die.

## Media
N/A

## Breaking changes
N/A

**Changelog**
N/A
