### PR TITLE
Fix Oni accuracy with wielded weapons, and apply Oni accuracy to handguns.

### DIFF
--- a/Content.Server/Nyanotrasen/Abilities/Oni/HeldByOniComponent.cs
+++ b/Content.Server/Nyanotrasen/Abilities/Oni/HeldByOniComponent.cs
@@ -4,5 +4,11 @@ namespace Content.Server.Abilities.Oni
     public sealed partial class HeldByOniComponent : Component
     {
         public EntityUid Holder = default!;
+
+        // Frontier: wield accuracy fix
+        public double minAngleAdded = 0.0;
+        public double maxAngleAdded = 0.0;
+        public double angleIncreaseAdded = 0.0;
+        // End Frontier
     }
 }

--- a/Content.Server/Nyanotrasen/Abilities/Oni/OniSystem.cs
+++ b/Content.Server/Nyanotrasen/Abilities/Oni/OniSystem.cs
@@ -12,6 +12,8 @@ namespace Content.Server.Abilities.Oni
     {
         [Dependency] private readonly ToolSystem _toolSystem = default!;
 
+        private const double GunInaccuracyFactor = 17.0; // Frontier (20x<18x -> 10% buff)
+
         public override void Initialize()
         {
             base.Initialize();
@@ -33,15 +35,15 @@ namespace Content.Server.Abilities.Oni
                 if (TryComp<GunWieldBonusComponent>(args.Entity, out var bonus))
                 {
                     //GunWieldBonus values are stored as negative.
-                    heldComp.minAngleAdded = (gun.MinAngle + bonus.MinAngle) * 19.0;
-                    heldComp.angleIncreaseAdded = (gun.AngleIncrease + bonus.AngleIncrease) * 19.0;
-                    heldComp.maxAngleAdded = (gun.MaxAngle + bonus.MaxAngle) * 19.0;
+                    heldComp.minAngleAdded = (gun.MinAngle + bonus.MinAngle) * GunInaccuracyFactor;
+                    heldComp.angleIncreaseAdded = (gun.AngleIncrease + bonus.AngleIncrease) * GunInaccuracyFactor;
+                    heldComp.maxAngleAdded = (gun.MaxAngle + bonus.MaxAngle) * GunInaccuracyFactor;
                 }
                 else
                 {
-                    heldComp.minAngleAdded = gun.MinAngle * 19.0;
-                    heldComp.angleIncreaseAdded = gun.AngleIncrease * 19.0;
-                    heldComp.maxAngleAdded = gun.MaxAngle * 19.0;
+                    heldComp.minAngleAdded = gun.MinAngle * GunInaccuracyFactor;
+                    heldComp.angleIncreaseAdded = gun.AngleIncrease * GunInaccuracyFactor;
+                    heldComp.maxAngleAdded = gun.MaxAngle * GunInaccuracyFactor;
                 }
                 gun.MinAngle += heldComp.minAngleAdded;
                 gun.AngleIncrease += heldComp.angleIncreaseAdded;
@@ -52,7 +54,7 @@ namespace Content.Server.Abilities.Oni
 
         private void OnEntRemoved(EntityUid uid, OniComponent component, EntRemovedFromContainerMessage args)
         {
-            // Frontier: store angle manipulation in HeldByOniComponent
+            // Frontier: angle manipulation stored in HeldByOniComponent
             if (TryComp<GunComponent>(args.Entity, out var gun) &&
                 TryComp<HeldByOniComponent>(args.Entity, out var heldByOni))
             {

--- a/Content.Server/Nyanotrasen/Abilities/Oni/OniSystem.cs
+++ b/Content.Server/Nyanotrasen/Abilities/Oni/OniSystem.cs
@@ -47,9 +47,6 @@ namespace Content.Server.Abilities.Oni
                     heldComp.maxAngleAdded = gun.MaxAngle * GunInaccuracyFactor;
                 }
 
-                // TODO: Max out the min/maxAngle at 90 (no shooting behind - L6 SAW)
-                // TODO: Make sure previous step didn't result in a negative minAngleAdded/maxAngleAdded
-
                 gun.MinAngle += heldComp.minAngleAdded;
                 gun.AngleIncrease += heldComp.angleIncreaseAdded;
                 gun.MaxAngle += heldComp.maxAngleAdded;


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Wielded weapons will now generally* fire in front of you as an Oni.  You are not accurate, you are an Oni.
One-handed weapons will now generally* fire about as well as wielded weapons in front of you as an Oni.

OniSystem now tracks if a weapon has a wielded malus before increasing its spread, and stores how much penalty was added in HeldByOniComponent.  It should also now prevent consistency issues with race conditions from picking up/dropping entities.

This also reduces overall spread for Oni weapons by 10% (20x normal spread to 18x normal spread).

\*See Balance.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Previous behaviour had all wielded weapons shooting in all possible directions (see media for previous behaviour) when they should be marginally accurate.  Previous behaviour also had Oni shooting pistols as reliably as any other species, which is also unintended, and broke with the wield change.

The previous implementation did not dirty the components altered, and could result in strange values when guns were rapidly picked up and dropped.

This implementation is still fragile to further changes to gun accuracy mechanics.

### Balance

This makes most guns behave reasonably.  The Atreides and L6 are particularly noteworthy exceptions - they have very high MaxAngle values, and can result in bullets going in all directions.  Changes to spread could be capped, or have some scaling applied at larger angles, but as-is, this keeps the behaviour at "multiply spread by some number".

## How to test
<!-- Describe the way it can be tested -->

1. Spawn in as an Oni.
2. Spawn a Lecter.
3. Wield it, mag dump.
4. You should get a roughly 60 degree cone of fire.
5. Spawn a Viper.
6. Mag dump.
7. You should get a roughly 60 degree cone of fire.
8. Spawn an Atreides.
9. Mag dump.
10. Bullets go flying in all directions.
11. Spawn an L6.
12. Wield it, mag dump.
13. Bullets go flying in all directions.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

Modified behaviour (wielded guns, pistol accuracy, Atreides and L6 inaccuracy)
https://github.com/new-frontiers-14/frontier-station-14/assets/166147148/2552afd4-ebcd-4053-801d-4330bb5df15b

Prior behaviour with wielded guns, pistol accuracy.
https://github.com/new-frontiers-14/frontier-station-14/assets/166147148/543d0828-7b0e-4676-ad8e-92c1d520a25b
(Thank you to 00FF00 for providing the video)
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** ***this PR does not require an ingame showcase***

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Oni accuracy penalty is now reduced from 20x normal spread to 18x normal spread.
- fix: Oni accuracy penalty is now properly applied to handguns, and does not compound on wielded penalty.