### PR TITLE
Reclaimer update

### DIFF
--- a/Content.Server/Materials/MaterialReclaimerSystem.cs
+++ b/Content.Server/Materials/MaterialReclaimerSystem.cs
@@ -85,7 +85,8 @@ public sealed class MaterialReclaimerSystem : SharedMaterialReclaimerSystem
             return;
 
         // if we're trying to get a solution out of the reclaimer, don't destroy it
-        if (_solutionContainer.TryGetSolution(entity.Owner, entity.Comp.SolutionContainerId, out _, out var outputSolution) && outputSolution.Contents.Any())
+        // if (_solutionContainer.TryGetSolution(entity.Owner, entity.Comp.SolutionContainerId, out _, out var outputSolution) && outputSolution.Contents.Any()) // Frontier: previous implementation
+        if (_solutionContainer.TryGetSolution(entity.Owner, entity.Comp.SolutionContainerId, out _, out var outputSolution)) // Frontier: do not trash solution containers if the reclaimer is empty
         {
             if (TryComp<SolutionContainerManagerComponent>(args.Used, out var managerComponent) &&
                 _solutionContainer.EnumerateSolutions((args.Used, managerComponent)).Any(s => s.Solution.Comp.Solution.AvailableVolume > 0))

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -144,6 +144,9 @@
   - type: Produce
     seedId: towercap
   - type: Log
+  - type: PhysicalComposition # Frontier
+    materialComposition:
+      Wood: 100
 
 - type: entity
   name: steel-cap log
@@ -163,6 +166,9 @@
   - type: Log
     spawnedPrototype: SheetSteel1
     spawnCount: 1
+  - type: PhysicalComposition # Frontier
+    materialComposition:
+      Steel: 100
 
 - type: entity
   name: nettle

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -146,7 +146,7 @@
   - type: Log
   - type: PhysicalComposition # Frontier
     materialComposition:
-      Wood: 100
+      Wood: 200
 
 - type: entity
   name: steel-cap log

--- a/Resources/Prototypes/Entities/Objects/Specific/chemical-containers.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemical-containers.yml
@@ -83,6 +83,8 @@
     - type: Tag
       tags:
       - ChemDispensable
+    - type: TrashOnSolutionEmpty # Frontier
+      solution: beaker # Frontier
 
 - type: entity
   parent: Jug

--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
@@ -92,6 +92,8 @@
         Blunt: 5
   - type: StaticPrice
     price: 30
+  - type: TrashOnSolutionEmpty # Frontier
+    solution: beaker # Frontier
 
 - type: entity
   parent: BaseItem
@@ -153,6 +155,8 @@
     damageModifierSet: Glass
   - type: StaticPrice
     price: 30
+  - type: TrashOnSolutionEmpty # Frontier
+    solution: beaker # Frontier
 
 - type: entity
   name: beaker
@@ -215,9 +219,9 @@
     fillBaseName: beakerlarge
     inHandsMaxFillLevels: 4
     inHandsFillBaseName: -fill-
-  - type: PhysicalComposition
-    materialComposition:
-      Glass: 100
+  # - type: PhysicalComposition # Frontier
+    # materialComposition: # Frontier
+      # Glass: 100 # Frontier
   - type: StaticPrice
     price: 20
 

--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
@@ -164,9 +164,9 @@
     solution: beaker
   - type: StaticPrice
     price: 10
-  - type: PhysicalComposition
-    materialComposition:
-      Glass: 50
+  # - type: PhysicalComposition # Frontier
+    # materialComposition:
+      # Glass: 50
   - type: SolutionContainerVisuals
     maxFillLevels: 6
     fillBaseName: beaker

--- a/Resources/Prototypes/Entities/Objects/Tools/bucket.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/bucket.yml
@@ -62,6 +62,6 @@
   - type: Tag
     tags:
       - Bucket
-  - type: PhysicalComposition
-    materialComposition:
-      Plastic: 50
+  # - type: PhysicalComposition # Frontier
+    # materialComposition:
+      # Plastic: 50

--- a/Resources/Prototypes/Entities/Objects/Tools/bucket.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/bucket.yml
@@ -65,3 +65,5 @@
   # - type: PhysicalComposition # Frontier
     # materialComposition:
       # Plastic: 50
+  - type: TrashOnSolutionEmpty # Frontier
+    solution: bucket # Frontier

--- a/Resources/Prototypes/Entities/Structures/Machines/material_reclaimer.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/material_reclaimer.yml
@@ -66,7 +66,7 @@
       components:
       - PhysicalComposition
       - SpaceGarbage
-      - Logs # Frontier
+      - Log # Frontier
       tags:
       - Trash
       - Recyclable

--- a/Resources/Prototypes/Entities/Structures/Machines/material_reclaimer.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/material_reclaimer.yml
@@ -66,6 +66,7 @@
       components:
       - PhysicalComposition
       - SpaceGarbage
+      - Logs # Frontier
       tags:
       - Trash
       - Recyclable
@@ -77,6 +78,8 @@
       - Brain
       tags:
       - HighRiskItem
+      - Bucket # Frontier
+      - GlassBeaker # Frontier
     soundCooldown: 0
     sound:
       path: /Audio/Ambience/Objects/crushing.ogg
@@ -94,7 +97,7 @@
   - type: SolutionContainerManager
     solutions:
       output:
-        maxVol: 100
+        maxVol: 1000 # Frontier 100<1000
   - type: DrainableSolution
     solution: output
   - type: ExaminableSolution

--- a/Resources/Prototypes/Entities/Structures/Machines/material_reclaimer.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/material_reclaimer.yml
@@ -78,8 +78,6 @@
       - Brain
       tags:
       - HighRiskItem
-      - Bucket # Frontier
-      - GlassBeaker # Frontier
     soundCooldown: 0
     sound:
       path: /Audio/Ambience/Objects/crushing.ogg


### PR DESCRIPTION
## About the PR
Allow reclaimer to convert logs.
Increase storage to 1000 from 100
Remove beakers and buckets from recycle

## Why / Balance
Improvements

## How to test
Use the reclaimer

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
N/A

**Changelog**
:cl:
- tweak: Reclaimers can now process logs and empty beakers, jugs, and buckets.
- tweak: Reclaimers liquid storage increased to 1000u.
