### PR TITLE
NFSD Bike for NFSD Fun Category

### DIFF
--- a/Resources/Prototypes/_NF/Loadouts/Jobs/Contractor/fun.yml
+++ b/Resources/Prototypes/_NF/Loadouts/Jobs/Contractor/fun.yml
@@ -226,6 +226,19 @@
     - HoverbikeFlatpack
 
 - type: loadout
+  id: NFSDHoverbikeFlatpack
+  equipment: NFSDHoverbikeFlatpack
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: ContractorT3
+  price: 25000
+
+- type: startingGear
+  id: NFSDHoverbikeFlatpack
+  inhand:
+    - HoverbikeNfsdFlatpack
+
+- type: loadout
   id: ContractorEmotionalPetCarrier
   equipment: ContractorEmotionalPetCarrier
   name: emotional support pet

--- a/Resources/Prototypes/_NF/Loadouts/contractor_loadout_groups.yml
+++ b/Resources/Prototypes/_NF/Loadouts/contractor_loadout_groups.yml
@@ -642,6 +642,30 @@
   - ContractorEmotionalPetCarrier
 
 - type: loadoutGroup
+  id: NFSDFun # Left Hand - 1 only, variant with the NFSD HoverBike.
+  name: loadout-group-contractor-fun
+  minLimit: 0
+  loadouts:
+  - ContractorBriefcaseBrownFilled
+  - ContractorToolboxEmergency
+  - ContractorToolboxMechanical
+  - ContractorPlushieSharkGrey
+  - ContractorPlushieSharkBlue
+  - ContractorPlushieSharkPink
+  - ContractorHarmonicaInstrument
+  - ContractorSaxophoneInstrument
+  - ContractorAcousticGuitarInstrument
+  - ContractorCane
+  - ContractorLGBTQHandyFlag
+  - ContractorNTHandyFlag
+  - ContractorBalloonNT
+  - ContractorPonderingOrb
+  - ContractorPlushieRGBee
+  - ContractorDawInstrumentFlatpack
+  - NFSDHoverbikeFlatpack
+  - ContractorEmotionalPetCarrier
+
+- type: loadoutGroup
   id: ContractorFace
   name: loadout-group-contractor-face
   minLimit: 0

--- a/Resources/Prototypes/_NF/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_NF/Loadouts/role_loadouts.yml
@@ -172,7 +172,7 @@
   - NfsdBoxSurvival
   - ContractorImplanter
   - ContractorEncryptionKey
-  - ContractorFun
+  - NFSDFun
   - ContractorTrinkets
 
 - type: roleLoadout
@@ -191,7 +191,7 @@
   - NfsdBoxSurvival
   - ContractorImplanter
   - ContractorEncryptionKey
-  - ContractorFun
+  - NFSDFun
   - ContractorTrinkets
   
 - type: roleLoadout
@@ -211,7 +211,7 @@
   - NfsdBoxSurvival
   - ContractorImplanter
   - ContractorEncryptionKey
-  - ContractorFun
+  - NFSDFun
   - ContractorTrinkets
 
 - type: roleLoadout
@@ -230,7 +230,7 @@
   - NfsdBoxSurvival
   - ContractorImplanter
   - ContractorEncryptionKey
-  - ContractorFun
+  - NFSDFun
   - ContractorTrinkets
 
 # - type: roleLoadout # Fix when this is actully used
@@ -263,7 +263,7 @@
   - NfsdBoxSurvival
   - ContractorImplanter
   - ContractorEncryptionKey
-  - ContractorFun
+  - NFSDFun
   - ContractorTrinkets
 
 - type: roleLoadout
@@ -282,7 +282,7 @@
   - NfsdBoxSurvival
   - ContractorImplanter
   - ContractorEncryptionKey
-  - ContractorFun
+  - NFSDFun
   - ContractorTrinkets
 
 - type: roleLoadout
@@ -301,7 +301,7 @@
   - NfsdBelt
   - NfsdBoxSurvival
   - ContractorImplanter
-  - ContractorFun
+  - NFSDFun
   - ContractorTrinkets
 
 # Pirate


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Swaps the Civillian hoverbike in the fun part of the loadout tab for the NFSD Variant if playing an NFSD role, costs 25k.
<!-- What did you change in this PR? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Why / Balance
Its an NFSD hoverbike, I feel like if you buy a bike roundstart as NFSD you should get it. And the 10k discount is because theres enough expenses on NFSD already anyway.
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

## How to test
Run the build in a release config and check the loadouts tab of any NFSD role if you have atleast 50 hours of playtime, it should show the NFSD bike under the fun tab instead of the civ one.
<!-- Describe the way it can be tested -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase.

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- tweak: The Hoverbike under the fun tab of the loadouts menu has been replaced with the NFSD variant for NFSD personell, keeping the 50 hours playtime requirement.
<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
-->
