### PR TITLE
Add new pumps that start with map

### DIFF
--- a/Content.Server/Atmos/Piping/Binary/Components/GasPressurePumpComponent.cs
+++ b/Content.Server/Atmos/Piping/Binary/Components/GasPressurePumpComponent.cs
@@ -27,5 +27,11 @@ namespace Content.Server.Atmos.Piping.Binary.Components
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("maxTargetPressure")]
         public float MaxTargetPressure = Atmospherics.MaxOutputPressure;
+
+        /// <summary>
+        /// Frontier - Start the pump with the map.
+        /// </summary>
+        [DataField]
+        public bool StartOnMapInit { get; set; } = false;
     }
 }

--- a/Content.Server/Atmos/Piping/Binary/Components/GasVolumePumpComponent.cs
+++ b/Content.Server/Atmos/Piping/Binary/Components/GasVolumePumpComponent.cs
@@ -46,5 +46,11 @@ namespace Content.Server.Atmos.Piping.Binary.Components
 
         [DataField("lastMolesTransferred")]
         public float LastMolesTransferred;
+
+        /// <summary>
+        /// Frontier - Start the pump with the map.
+        /// </summary>
+        [DataField]
+        public bool StartOnMapInit { get; set; } = false;
     }
 }

--- a/Content.Server/Atmos/Piping/Binary/EntitySystems/GasPressurePumpSystem.cs
+++ b/Content.Server/Atmos/Piping/Binary/EntitySystems/GasPressurePumpSystem.cs
@@ -42,6 +42,8 @@ namespace Content.Server.Atmos.Piping.Binary.EntitySystems
             // Bound UI subscriptions
             SubscribeLocalEvent<GasPressurePumpComponent, GasPressurePumpChangeOutputPressureMessage>(OnOutputPressureChangeMessage);
             SubscribeLocalEvent<GasPressurePumpComponent, GasPressurePumpToggleStatusMessage>(OnToggleStatusMessage);
+
+            SubscribeLocalEvent<GasPressurePumpComponent, MapInitEvent>(OnMapInit); // Frontier
         }
 
         private void OnInit(EntityUid uid, GasPressurePumpComponent pump, ComponentInit args)
@@ -152,6 +154,18 @@ namespace Content.Server.Atmos.Piping.Binary.EntitySystems
                 return;
 
             _appearance.SetData(uid, PumpVisuals.Enabled, pump.Enabled, appearance);
+        }
+
+        private void OnMapInit(EntityUid uid, GasPressurePumpComponent pump, MapInitEvent args) // Frontier - Init on map
+        {
+            if (pump.StartOnMapInit)
+            {
+                pump.Enabled = true;
+                UpdateAppearance(uid, pump);
+
+                DirtyUI(uid, pump);
+                _userInterfaceSystem.CloseUi(uid, GasPressurePumpUiKey.Key);
+            }
         }
     }
 }

--- a/Content.Server/Atmos/Piping/Binary/EntitySystems/GasVolumePumpSystem.cs
+++ b/Content.Server/Atmos/Piping/Binary/EntitySystems/GasVolumePumpSystem.cs
@@ -50,6 +50,8 @@ namespace Content.Server.Atmos.Piping.Binary.EntitySystems
             SubscribeLocalEvent<GasVolumePumpComponent, GasVolumePumpToggleStatusMessage>(OnToggleStatusMessage);
 
             SubscribeLocalEvent<GasVolumePumpComponent, DeviceNetworkPacketEvent>(OnPacketRecv);
+
+            SubscribeLocalEvent<GasVolumePumpComponent, MapInitEvent>(OnMapInit); // Frontier
         }
 
         private void OnInit(EntityUid uid, GasVolumePumpComponent pump, ComponentInit args)
@@ -204,6 +206,18 @@ namespace Content.Server.Atmos.Piping.Binary.EntitySystems
 
                     _deviceNetwork.QueuePacket(uid, args.SenderAddress, payload, device: netConn);
                     return;
+            }
+        }
+
+        private void OnMapInit(EntityUid uid, GasVolumePumpComponent pump, MapInitEvent args) // Frontier - Init on map
+        {
+            if (pump.StartOnMapInit)
+            {
+                pump.Enabled = true;
+                UpdateAppearance(uid, pump);
+
+                DirtyUI(uid, pump);
+                _userInterfaceSystem.CloseUi(uid, GasVolumePumpUiKey.Key);
             }
         }
     }

--- a/Content.Server/Atmos/Piping/Trinary/Components/GasMixerComponent.cs
+++ b/Content.Server/Atmos/Piping/Trinary/Components/GasMixerComponent.cs
@@ -38,5 +38,11 @@ namespace Content.Server.Atmos.Piping.Trinary.Components
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("inletTwoConcentration")]
         public float InletTwoConcentration = 0.5f;
+
+        /// <summary>
+        /// Frontier - Start the pump with the map.
+        /// </summary>
+        [DataField]
+        public bool StartOnMapInit { get; set; } = false;
     }
 }

--- a/Content.Server/Atmos/Piping/Trinary/EntitySystems/GasMixerSystem.cs
+++ b/Content.Server/Atmos/Piping/Trinary/EntitySystems/GasMixerSystem.cs
@@ -43,6 +43,8 @@ namespace Content.Server.Atmos.Piping.Trinary.EntitySystems
             SubscribeLocalEvent<GasMixerComponent, GasMixerToggleStatusMessage>(OnToggleStatusMessage);
 
             SubscribeLocalEvent<GasMixerComponent, AtmosDeviceDisabledEvent>(OnMixerLeaveAtmosphere);
+
+            SubscribeLocalEvent<GasMixerComponent, MapInitEvent>(OnMapInit); // Frontier
         }
 
         private void OnInit(EntityUid uid, GasMixerComponent mixer, ComponentInit args)
@@ -231,6 +233,18 @@ namespace Content.Server.Atmos.Piping.Trinary.EntitySystems
             }
 
             args.DeviceFlipped = inletOne != null && inletTwo != null && inletOne.CurrentPipeDirection.ToDirection() == inletTwo.CurrentPipeDirection.ToDirection().GetClockwise90Degrees();
+        }
+
+        private void OnMapInit(EntityUid uid, GasMixerComponent mixer, MapInitEvent args) // Frontier - Init on map
+        {
+            if (mixer.StartOnMapInit)
+            {
+                mixer.Enabled = true;
+                DirtyUI(uid, mixer);
+
+                UpdateAppearance(uid, mixer);
+                _userInterfaceSystem.CloseUi(uid, GasFilterUiKey.Key);
+            }
         }
     }
 }

--- a/Resources/Prototypes/_NF/Entities/Structures/Piping/Atmospherics/binary.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Piping/Atmospherics/binary.yml
@@ -1,0 +1,29 @@
+﻿- type: entity
+  parent: GasPressurePump
+  id: GasPressurePumpOn
+  suffix: On
+  placement:
+    mode: SnapgridCenter
+  components:
+  - type: GasPressurePump
+    startOnMapInit: true
+
+- type: entity
+  parent: GasPressurePumpOn
+  id: GasPressurePumpOnMax
+  suffix: On, Max
+  placement:
+    mode: SnapgridCenter
+  components:
+  - type: GasPressurePump
+    targetPressure: 4500
+
+- type: entity
+  parent: GasVolumePump
+  id: GasVolumePumpOn
+  suffix: On
+  placement:
+    mode: SnapgridCenter
+  components:
+  - type: GasVolumePump
+    startOnMapInit: true

--- a/Resources/Prototypes/_NF/Entities/Structures/Piping/Atmospherics/trinary.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Piping/Atmospherics/trinary.yml
@@ -1,0 +1,16 @@
+- type: entity
+  parent: GasMixer
+  id: GasMixerOn
+  suffix: On
+  placement:
+    mode: SnapgridCenter
+  components:
+    - type: GasMixer
+
+
+- type: entity
+  parent: [GasMixerFlipped, GasMixerOn]
+  id: GasMixerOnFlipped
+  suffix: On, Flipped
+  placement:
+    mode: SnapgridCenter

--- a/Resources/Prototypes/_NF/Entities/Structures/Piping/Atmospherics/trinary.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Piping/Atmospherics/trinary.yml
@@ -6,7 +6,7 @@
     mode: SnapgridCenter
   components:
     - type: GasMixer
-
+      startOnMapInit: true
 
 - type: entity
   parent: [GasMixerFlipped, GasMixerOn]


### PR DESCRIPTION
## About the PR
Allow fixing POI and ships pumps and mixers to start with the map

## Why / Balance
QOL, and removing the need to manage POI air setups.

## How to test
Spawn them in
They run, that is all

## Media
- [X] this PR does not require an ingame showcase

## Breaking changes
N/A

**Changelog**
:cl: dvir01
- add: Added new pumps that start on when places, to be used in mapping.
