### PR TITLE
CE Suit rads fixup

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -330,7 +330,7 @@
         Slash: 0.8
         Piercing: 0.8
         Heat: 0.4
-        Radiation: 0.0
+        Radiation: 0.05
         Caustic: 0.7
   - type: ClothingSpeedModifier
     walkModifier: 0.75

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -330,7 +330,7 @@
         Slash: 0.8
         Piercing: 0.8
         Heat: 0.4
-        Radiation: 0.05
+        Radiation: 0.05 # Frontier - 0<0.05
         Caustic: 0.7
   - type: ClothingSpeedModifier
     walkModifier: 0.75


### PR DESCRIPTION
This was changed by mistake when restoring the old names of suits.
Should be 95% radiation protection.

![image](https://github.com/new-frontiers-14/frontier-station-14/assets/39403717/87997fe4-8cbf-44c9-be2b-11d9bdbba410)

https://github.com/new-frontiers-14/frontier-station-14/pull/996