### PR TITLE
Disable client replays

### DIFF
--- a/Resources/clientCommandPerms.yml
+++ b/Resources/clientCommandPerms.yml
@@ -27,6 +27,9 @@
     - gc_mode
     - cvar
     - midipanic
+#    - replay_recording_start # Frontier
+#    - replay_recording_stop # Frontier
+#    - replay_recording_stats # Frontier
     - replay_play
     - replay_pause
     - replay_toggle

--- a/Resources/clientCommandPerms.yml
+++ b/Resources/clientCommandPerms.yml
@@ -27,9 +27,6 @@
     - gc_mode
     - cvar
     - midipanic
-    - replay_recording_start
-    - replay_recording_stop
-    - replay_recording_stats
     - replay_play
     - replay_pause
     - replay_toggle


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Removes the ability for clients to record replays, most people already use stuff like OBS or better options to record their game.

## Why / Balance

Lead to abuse and exploits.

No need for CL