### PR TITLE
Fixed Slowdown Thresholds For Hostile NPCs

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_expeditions_aberrant_flesh.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_expeditions_aberrant_flesh.yml
@@ -151,6 +151,21 @@
   id: MobFleshClampExpeditions
   noSpawn: true
   components:
+  - type: CanMoveInAir
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeCircle
+          radius: 0.30 # Lowered the value, to allow them to fit through the airlocks
+        density: 100
+        mask:
+          - FlyingMobMask
+        layer:
+          - FlyingMobLayer
+  - type: FootstepModifier
+    footstepSoundCollection:
+      path: /Audio/_NF/Effects/silence.ogg
   - type: Sprite
     layers:
     - map: [ "enum.DamageStateVisualLayers.Base" ]

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_expeditions_aberrant_flesh.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_expeditions_aberrant_flesh.yml
@@ -2,6 +2,7 @@
 - type: entity
   parent:
   - MobNonHumanHostileBase
+  - MobHumanoidHostileAISimpleMelee
   id: BaseMobFleshExpeditions
   name: aberrant flesh
   description: A shambling mass of flesh, animated through anomalous energy.
@@ -10,24 +11,12 @@
   - type: NpcFactionMember
     factions:
     - AberrantFleshExpeditionNF
-  - type: HTN
-    rootTask:
-       task: SimpleHostileCompound
-    blackboard:
-      NavClimb: !type:Bool
-        true
-      NavInteract: !type:Bool
-        true
-      NavPry: !type:Bool
-        true
-      NavSmash: !type:Bool
-        true
   - type: Sprite
     drawdepth: Mobs
     sprite: _NF/Mobs/Aliens/flesh.rsi
   - type: MovementSpeedModifier
-    baseWalkSpeed: 1
-    baseSprintSpeed: 1.5
+    baseWalkSpeed: 3
+    baseSprintSpeed: 3.5
   - type: MobState
     allowedStates:
     - Alive
@@ -36,6 +25,10 @@
     thresholds:
       0: Alive
       70: Dead
+  - type: SlowOnDamage
+    speedModifierThresholds:
+      42: 0.7
+      56: 0.5
   - type: Stamina
     critThreshold: 50
   - type: Butcherable
@@ -108,6 +101,10 @@
     thresholds:
       0: Alive
       50: Dead
+  - type: SlowOnDamage
+    speedModifierThresholds:
+      30: 0.7
+      40: 0.5
 
 - type: entity
   parent: MobFleshGolemExpeditions
@@ -170,9 +167,13 @@
     thresholds:
       0: Alive
       40: Dead
+  - type: SlowOnDamage
+    speedModifierThresholds:
+      24: 0.7
+      32: 0.5
   - type: MovementSpeedModifier
-    baseWalkSpeed: 2
-    baseSprintSpeed: 2.5
+    baseWalkSpeed: 3
+    baseSprintSpeed: 3.5
   - type: RechargeBasicEntityAmmo
     rechargeCooldown: 6
     rechargeSound:
@@ -239,9 +240,13 @@
     thresholds:
       0: Alive
       30: Dead
+  - type: SlowOnDamage
+    speedModifierThresholds:
+      18: 0.7
+      24: 0.5
   - type: MovementSpeedModifier
-    baseWalkSpeed: 2
-    baseSprintSpeed: 2.5
+    baseWalkSpeed: 3
+    baseSprintSpeed: 3.5
 
 # EXPEDITION BOSS
 - type: entity
@@ -269,8 +274,12 @@
     thresholds:
       0: Alive
       200: Dead
+  - type: SlowOnDamage
+    speedModifierThresholds:
+      120: 0.7
+      160: 0.5
   - type: MovementSpeedModifier
-    baseWalkSpeed: 2.8
+    baseWalkSpeed: 3.8
     baseSprintSpeed: 3.8
   - type: MeleeWeapon
     soundHit:

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_expeditions_argocyte.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_expeditions_argocyte.yml
@@ -81,6 +81,10 @@
     thresholds:
       0: Alive
       30: Dead
+  - type: SlowOnDamage
+    speedModifierThresholds:
+      18: 0.7
+      24: 0.5
   - type: Fixtures
     fixtures:
       fix1:
@@ -120,6 +124,10 @@
     thresholds:
       0: Alive
       30: Dead
+  - type: SlowOnDamage
+    speedModifierThresholds:
+      18: 0.7
+      24: 0.5
   - type: Fixtures
     fixtures:
       fix1:
@@ -157,6 +165,10 @@
     thresholds:
       0: Alive
       30: Dead
+  - type: SlowOnDamage
+    speedModifierThresholds:
+      18: 0.7
+      24: 0.5
   - type: Fixtures
     fixtures:
       fix1:
@@ -194,6 +206,10 @@
     thresholds:
       0: Alive
       50: Dead
+  - type: SlowOnDamage
+    speedModifierThresholds:
+      30: 0.7
+      40: 0.5
   - type: MovementSpeedModifier
     baseSprintSpeed : 5
 
@@ -216,6 +232,10 @@
     thresholds:
       0: Alive
       70: Dead
+  - type: SlowOnDamage
+    speedModifierThresholds:
+      42: 0.7
+      56: 0.5
   - type: MovementSpeedModifier
     baseSprintSpeed : 4
     baseWalkSpeed : 3.5
@@ -239,6 +259,10 @@
     thresholds:
       0: Alive
       70: Dead
+  - type: SlowOnDamage
+    speedModifierThresholds:
+      42: 0.7
+      56: 0.5
   - type: MeleeWeapon
     damage:
       types:
@@ -264,6 +288,10 @@
     thresholds:
       0: Alive
       70: Dead
+  - type: SlowOnDamage
+    speedModifierThresholds:
+      42: 0.7
+      56: 0.5
   - type: MeleeWeapon
     damage:
       types:
@@ -320,6 +348,10 @@
     thresholds:
       0: Alive
       60: Dead
+  - type: SlowOnDamage
+    speedModifierThresholds:
+      36: 0.7
+      48: 0.5
   - type: MeleeWeapon
     damage:
       types:
@@ -349,6 +381,10 @@
     thresholds:
       0: Alive
       120: Dead
+  - type: SlowOnDamage
+    speedModifierThresholds:
+      72: 0.7
+      96: 0.5
   - type: MeleeWeapon
     damage:
       types:
@@ -379,6 +415,10 @@
     thresholds:
       0: Alive
       250: Dead
+  - type: SlowOnDamage
+    speedModifierThresholds:
+      150: 0.7
+      200: 0.5
   - type: MeleeWeapon
     damage:
       types:
@@ -408,6 +448,10 @@
     thresholds:
       0: Alive
       500: Dead
+  - type: SlowOnDamage
+    speedModifierThresholds:
+      300: 0.7
+      400: 0.5
   - type: MeleeWeapon
     damage:
       types:

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_expeditions_carp.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_expeditions_carp.yml
@@ -37,6 +37,10 @@
     thresholds:
       0: Alive
       50: Dead
+  - type: SlowOnDamage
+    speedModifierThresholds:
+      30: 0.7
+      40: 0.5
   - type: Stamina
     critThreshold: 100
   - type: DamageStateVisuals
@@ -159,6 +163,10 @@
     thresholds:
       0: Alive
       80: Dead
+  - type: SlowOnDamage
+    speedModifierThresholds:
+      48: 0.7
+      64: 0.5
   - type: Stamina
     critThreshold: 150
   - type: Body

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_expeditions_dinosaurs.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_expeditions_dinosaurs.yml
@@ -79,6 +79,10 @@
     thresholds:
       0: Alive
       50: Dead
+  - type: SlowOnDamage
+    speedModifierThresholds:
+      30: 0.7
+      40: 0.5
   - type: DamageStateVisuals
     states:
       Alive:
@@ -116,6 +120,10 @@
     thresholds:
       0: Alive
       50: Dead
+  - type: SlowOnDamage
+    speedModifierThresholds:
+      30: 0.7
+      40: 0.5
   - type: DamageStateVisuals
     states:
       Alive:
@@ -154,6 +162,10 @@
     thresholds:
       0: Alive
       80: Dead
+  - type: SlowOnDamage
+    speedModifierThresholds:
+      48: 0.7
+      64: 0.5
   - type: DamageStateVisuals
     states:
       Alive:
@@ -228,6 +240,10 @@
     thresholds:
       0: Alive
       150: Dead
+  - type: SlowOnDamage
+    speedModifierThresholds:
+      90: 0.7
+      120: 0.5
   - type: DamageStateVisuals
     states:
       Alive:
@@ -265,6 +281,10 @@
     thresholds:
       0: Alive
       200: Dead
+  - type: SlowOnDamage
+    speedModifierThresholds:
+      120: 0.7
+      160: 0.5
   - type: DamageStateVisuals
     states:
       Alive:
@@ -302,6 +322,10 @@
     thresholds:
       0: Alive
       250: Dead
+  - type: SlowOnDamage
+    speedModifierThresholds:
+      150: 0.7
+      200: 0.5
   - type: DamageStateVisuals
     states:
       Alive:
@@ -339,6 +363,10 @@
     thresholds:
       0: Alive
       350: Dead
+  - type: SlowOnDamage
+    speedModifierThresholds:
+      210: 0.7
+      280: 0.5
   - type: DamageStateVisuals
     states:
       Alive:
@@ -376,6 +404,10 @@
     thresholds:
       0: Alive
       350: Dead
+  - type: SlowOnDamage
+    speedModifierThresholds:
+      210: 0.7
+      280: 0.5
   - type: DamageStateVisuals
     states:
       Alive:
@@ -415,6 +447,10 @@
     thresholds:
       0: Alive
       450: Dead
+  - type: SlowOnDamage
+    speedModifierThresholds:
+      270: 0.7
+      360: 0.5
   - type: DamageStateVisuals
     states:
       Alive:

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_expeditions_explorers.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_expeditions_explorers.yml
@@ -345,6 +345,10 @@
       200: Dead
   - type: Stamina
     critThreshold: 600
+  - type: SlowOnDamage
+    speedModifierThresholds:
+      120: 0.7
+      160: 0.5
   - type: MovementSpeedModifier
     baseWalkSpeed: 2.75
     baseSprintSpeed: 4

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_expeditions_xeno.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_expeditions_xeno.yml
@@ -40,6 +40,10 @@
     thresholds:
       0: Alive
       50: Dead
+  - type: SlowOnDamage
+    speedModifierThresholds:
+      30: 0.7
+      40: 0.5
   - type: Stamina
     critThreshold: 200
   - type: Bloodstream
@@ -110,6 +114,10 @@
     thresholds:
       0: Alive
       75: Dead
+  - type: SlowOnDamage
+    speedModifierThresholds:
+      45: 0.7
+      60: 0.5
   - type: Stamina
     critThreshold: 300
 
@@ -129,6 +137,10 @@
     thresholds:
       0: Alive
       80: Dead
+  - type: SlowOnDamage
+    speedModifierThresholds:
+      48: 0.7
+      64: 0.5
   - type: MeleeWeapon
     damage:
       groups:
@@ -153,6 +165,10 @@
     thresholds:
       0: Alive
       150: Dead
+  - type: SlowOnDamage
+    speedModifierThresholds:
+      90: 0.7
+      120: 0.5
   - type: Stamina
     critThreshold: 550
   - type: MovementSpeedModifier
@@ -201,6 +217,10 @@
     thresholds:
       0: Alive
       75: Dead
+  - type: SlowOnDamage
+    speedModifierThresholds:
+      45: 0.7
+      60: 0.5
   - type: HTN
     rootTask:
       task: SimpleRangedHostileCompound
@@ -239,6 +259,10 @@
     thresholds:
       0: Alive
       250: Dead
+  - type: SlowOnDamage
+    speedModifierThresholds:
+      150: 0.7
+      200: 0.5
   - type: MovementSpeedModifier
     baseWalkSpeed: 2.8
     baseSprintSpeed: 3.8

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_rogue_ai.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_rogue_ai.yml
@@ -76,6 +76,10 @@
       Dead: BorgDead
     showOverlays: false
     allowRevives: true
+  - type: SlowOnDamage
+    speedModifierThresholds:
+      48: 0.7
+      64: 0.5
   - type: HealthExaminable
     examinableTypes:
       - Blunt
@@ -173,6 +177,10 @@
       0: Alive
       60: Critical
       120: Dead
+  - type: SlowOnDamage
+    speedModifierThresholds:
+      36: 0.7
+      48: 0.5
   - type: Stamina
     critThreshold: 600
 
@@ -224,6 +232,10 @@
       0: Alive
       30: Critical
       90: Dead
+  - type: SlowOnDamage
+    speedModifierThresholds:
+      18: 0.7
+      24: 0.5
   - type: Stamina
     critThreshold: 600
   - type: Gun
@@ -818,6 +830,10 @@
       0: Alive
       110: Critical
       160: Dead
+  - type: SlowOnDamage
+    speedModifierThresholds:
+      66: 0.7
+      88: 0.5
   - type: Stamina
     critThreshold: 600
   - type: ProjectileBatteryAmmoProvider
@@ -886,7 +902,11 @@
     thresholds:
       0: Alive
       150: Critical
-      400: Dead
+      200: Dead
+  - type: SlowOnDamage
+    speedModifierThresholds:
+      90: 0.7
+      120: 0.5
   - type: Stamina
     critThreshold: 600
   - type: HitscanBatteryAmmoProvider
@@ -934,8 +954,12 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      200: Critical
-      600: Dead
+      300: Critical
+      400: Dead
+  - type: SlowOnDamage
+    speedModifierThresholds:
+      200: 0.7
+      240: 0.5
   - type: Stamina
     critThreshold: 600
   - type: BasicEntityAmmoProvider


### PR DESCRIPTION
## About the PR
- Corrected `speedModifierThresholds` for `SlowOnDamage` for expedition mobs.
- Fixed ranged aberrant flesh enemies.
- Buffed movement speed for aberrant flesh enemies.

## Why / Balance
Fixes

## How to test
1. Spawn expedition specific mobs
2. Attack them
3. When mob's HP goes down to around 40% from max, mob should slowdown
4. When mob's HP goes down to around 20%, mob should slowdown even more

## Media
- [x] This PR does not require an ingame showcase

## Breaking changes
None afaik

**Changelog**
:cl: erhardsteinhauer
- fix: Fixed SlowOnDamage mechanic thresholds for expedition mobs.
