### PR TITLE
Cryogenics: restrict cryo pods to cryo meds, restore limited metabolism

### DIFF
--- a/Content.Server/Body/Components/MetabolizerComponent.cs
+++ b/Content.Server/Body/Components/MetabolizerComponent.cs
@@ -59,18 +59,11 @@ namespace Content.Server.Body.Components
         ///     Used to nerf 'stacked poisons' where having 5+ different poisons in a syringe, even at low
         ///     quantity, would be muuuuch better than just one poison acting.
         /// </summary>
+        /// <remarks>
+        ///     Frontier: only poisons count towards MaxReagentsProcessable.
+        /// </remarks>
         [DataField("maxReagents")]
         public int MaxReagentsProcessable = 3;
-
-        /// <summary>
-        ///     Frontier
-        ///  
-        ///     How many poisons can this metabolizer process at once?
-        ///     Used to nerf 'stacked poisons' where having 5+ different poisons in a syringe, even at low
-        ///     quantity, would be muuuuch better than just one poison acting.
-        /// </summary>
-        [DataField("maxPoisons")]
-        public int MaxPoisonsProcessable = 3;
 
         /// <summary>
         ///     A list of metabolism groups that this metabolizer will act on, in order of precedence.

--- a/Content.Server/Body/Components/MetabolizerComponent.cs
+++ b/Content.Server/Body/Components/MetabolizerComponent.cs
@@ -59,9 +59,6 @@ namespace Content.Server.Body.Components
         ///     Used to nerf 'stacked poisons' where having 5+ different poisons in a syringe, even at low
         ///     quantity, would be muuuuch better than just one poison acting.
         /// </summary>
-        /// <remarks>
-        ///     Frontier: only poisons count towards MaxReagentsProcessable.
-        /// </remarks>
         [DataField("maxReagents")]
         public int MaxReagentsProcessable = 3;
 

--- a/Content.Server/Body/Systems/MetabolizerSystem.cs
+++ b/Content.Server/Body/Systems/MetabolizerSystem.cs
@@ -159,8 +159,8 @@ namespace Content.Server.Body.Systems
                     continue;
                 }
 
-                // Frontier: process all reagents, but limit poisons.  If we've processed all the poisons we should, skip to the next reagent.
-                if (reagents >= ent.Comp1.MaxReagentsProcessable && proto.Metabolisms.ContainsKey("Poison"))
+                // Frontier: process all cryogenic reagents.
+                if (reagents >= ent.Comp1.MaxReagentsProcessable && !proto.Metabolisms.ContainsKey("Cryogenic"))
                     continue;
                 // End Frontier
 
@@ -221,7 +221,7 @@ namespace Content.Server.Body.Systems
                 {
                     solution.RemoveReagent(reagent, mostToRemove);
                     // Frontier: We have processed a poison, so count it towards the cap
-                    if (proto.Metabolisms.ContainsKey("Poison"))
+                    if (!proto.Metabolisms.ContainsKey("Cryogenic"))
                         reagents++;
                     // End Frontier
                 }

--- a/Content.Server/Body/Systems/MetabolizerSystem.cs
+++ b/Content.Server/Body/Systems/MetabolizerSystem.cs
@@ -159,7 +159,7 @@ namespace Content.Server.Body.Systems
                     continue;
                 }
 
-                // Frontier: process all cryogenic reagents.
+                // Frontier: all cryogenic reagents in the solution should be processed, others should be limited (buff cryo meds)
                 if (reagents >= ent.Comp1.MaxReagentsProcessable && !proto.Metabolisms.ContainsKey("Cryogenic"))
                     continue;
                 // End Frontier
@@ -220,7 +220,7 @@ namespace Content.Server.Body.Systems
                 if (mostToRemove > FixedPoint2.Zero)
                 {
                     solution.RemoveReagent(reagent, mostToRemove);
-                    // Frontier: We have processed a poison, so count it towards the cap
+                    // Frontier: do not count cryogenics chems against the reagent limit (to buff cryo meds)
                     if (!proto.Metabolisms.ContainsKey("Cryogenic"))
                         reagents++;
                     // End Frontier

--- a/Content.Server/Body/Systems/MetabolizerSystem.cs
+++ b/Content.Server/Body/Systems/MetabolizerSystem.cs
@@ -142,7 +142,7 @@ namespace Content.Server.Body.Systems
             var list = solution.Contents.ToArray();
             _random.Shuffle(list);
 
-            int poisons = 0; // frontier modified
+            int reagents = 0;
             foreach (var (reagent, quantity) in list)
             {
                 if (!_prototypeManager.TryIndex<ReagentPrototype>(reagent.Prototype, out var proto))
@@ -158,10 +158,11 @@ namespace Content.Server.Body.Systems
 
                     continue;
                 }
-                // frontier modified
-                // Already processed all poisons, skip to the next reagent.
-                if (poisons >= ent.Comp1.MaxPoisonsProcessable && proto.Metabolisms.ContainsKey("Poison"))
+
+                // Frontier: process all reagents, but limit poisons.  If we've processed all the poisons we should, skip to the next reagent.
+                if (reagents >= ent.Comp1.MaxReagentsProcessable && proto.Metabolisms.ContainsKey("Poison"))
                     continue;
+                // End Frontier
 
 
                 // loop over all our groups and see which ones apply
@@ -219,10 +220,10 @@ namespace Content.Server.Body.Systems
                 if (mostToRemove > FixedPoint2.Zero)
                 {
                     solution.RemoveReagent(reagent, mostToRemove);
-                    // frontier modified
-                    // We have processed a poison, so count it towards the cap
+                    // Frontier: We have processed a poison, so count it towards the cap
                     if (proto.Metabolisms.ContainsKey("Poison"))
-                        poisons++;
+                        reagents++;
+                    // End Frontier
                 }
             }
 

--- a/Content.Server/Medical/CryoPodSystem.cs
+++ b/Content.Server/Medical/CryoPodSystem.cs
@@ -115,13 +115,14 @@ public sealed partial class CryoPodSystem : SharedCryoPodSystem
                     continue;
                 }
 
-                // frontier
+
+                // Frontier
 
                 // Filter out a fixed amount of each reagent from the cryo pod's beaker
                 var solutionToInject = _solutionContainerSystem.SplitSolutionReagentsEvenly(containerSolution.Value, cryoPod.BeakerTransferAmount);
-                //  for every .25 units used, .5 units per second are added to the body, making cryo-pod more efficient than injections
-                solutionToInject.ScaleSolution(cryoPod.PotencyMultiplier);
 
+                // For every .25 units used, .5 units per second are added to the body, making cryo-pod more efficient than injections.
+                solutionToInject.ScaleSolution(cryoPod.PotencyMultiplier);
                 // End frontier
 
                 _bloodstreamSystem.TryAddToChemicals(patient.Value, solutionToInject, bloodstream);

--- a/Content.Server/Medical/CryoPodSystem.cs
+++ b/Content.Server/Medical/CryoPodSystem.cs
@@ -55,6 +55,9 @@ public sealed partial class CryoPodSystem : SharedCryoPodSystem
     [Dependency] private readonly IAdminLogManager _adminLogger = default!;
     [Dependency] private readonly NodeContainerSystem _nodeContainer = default!;
 
+    // Frontier: keep a list of cryogenics reagents. The pod will only filter these out from the provided solution.
+    private static readonly string[] CryogenicsReagents = ["Cryoxadone", "Aloxadone", "Doxarubixadone", "Opporozidone", "Necrosol", "Traumoxadone", "Stelloxadone"];
+
     public override void Initialize()
     {
         base.Initialize();
@@ -117,13 +120,12 @@ public sealed partial class CryoPodSystem : SharedCryoPodSystem
 
 
                 // Frontier
-
                 // Filter out a fixed amount of each reagent from the cryo pod's beaker
-                var solutionToInject = _solutionContainerSystem.SplitSolutionReagentsEvenly(containerSolution.Value, cryoPod.BeakerTransferAmount);
+                var solutionToInject = _solutionContainerSystem.SplitSolutionPerReagentWithOnly(containerSolution.Value, cryoPod.BeakerTransferAmount, CryogenicsReagents);
 
                 // For every .25 units used, .5 units per second are added to the body, making cryo-pod more efficient than injections.
                 solutionToInject.ScaleSolution(cryoPod.PotencyMultiplier);
-                // End frontier
+                // End Frontier
 
                 _bloodstreamSystem.TryAddToChemicals(patient.Value, solutionToInject, bloodstream);
                 _reactiveSystem.DoEntityReaction(patient.Value, solutionToInject, ReactionMethod.Injection);

--- a/Content.Shared/Chemistry/Components/Solution.cs
+++ b/Content.Shared/Chemistry/Components/Solution.cs
@@ -717,6 +717,52 @@ namespace Content.Shared.Chemistry.Components
 
             return newSolution;
         }
+
+        /// <summary>
+        /// Splits a solution, taking the specified amount of each reagent specified in reagents from the solution.
+        /// If any reagent in the solution has less volume than specified, it will all be transferred into the new solution.
+        /// </summary>
+        /// <param name="toTakePer">How much of each reagent to take.</param>
+        /// <returns>A new solution containing the reagents taken from the original solution.</returns>
+        public Solution SplitSolutionPerReagentWithOnly(FixedPoint2 toTakePer, params string[] reagents)
+        {
+            if (toTakePer <= FixedPoint2.Zero)
+                return new Solution();
+
+            var origVol = Volume;
+            Solution newSolution = new Solution(Contents.Count) { Temperature = Temperature };
+
+            for (var i = Contents.Count - 1; i >= 0; i--) // iterate backwards because of remove swap.
+            {
+                var (reagent, quantity) = Contents[i];
+
+                // Must be in 
+                if (!reagents.Contains(reagent.Prototype))
+                    continue;
+
+                if (quantity > toTakePer)
+                {
+                    Contents[i] = new ReagentQuantity(reagent, quantity - toTakePer);
+                    newSolution.Contents.Add(new ReagentQuantity(reagent, toTakePer));
+                    Volume -= toTakePer;
+                }
+                else
+                {
+                    Contents.RemoveSwap(i);
+                    newSolution.Contents.Add(new ReagentQuantity(reagent, quantity));
+                    Volume -= quantity;
+                }
+            }
+
+            newSolution.Volume = origVol - Volume;
+            _heatCapacityDirty = true;
+            newSolution._heatCapacityDirty = true;
+
+            ValidateSolution();
+            newSolution.ValidateSolution();
+
+            return newSolution;
+        }
         // End Frontier
 
         /// <summary>

--- a/Content.Shared/Chemistry/Components/Solution.cs
+++ b/Content.Shared/Chemistry/Components/Solution.cs
@@ -675,7 +675,7 @@ namespace Content.Shared.Chemistry.Components
             return newSolution;
         }
 
-        // Frontier: cryogenics per-reagent filter function (#1443)
+        // Frontier: cryogenics per-reagent filter function (#1443, #1533)
         /// <summary>
         /// Splits a solution, taking the specified amount of each reagent from the solution.
         /// If any reagent in the solution has less volume than specified, it will all be transferred into the new solution.
@@ -704,13 +704,26 @@ namespace Content.Shared.Chemistry.Components
                 else
                 {
                     Contents.RemoveSwap(i);
-                    newSolution.Contents.Add(new ReagentQuantity(reagent, quantity));
-                    Volume -= quantity;
+                    //Only add positive quantities to our new solution.
+                    if (quantity > 0)
+                    {
+                        newSolution.Contents.Add(new ReagentQuantity(reagent, quantity));
+                        Volume -= quantity;
+                    }
                 }
             }
 
-            newSolution.Volume = origVol - Volume;
-            _heatCapacityDirty = true;
+            // If old solution is empty, invalidate old solution and transfer all volume to new.
+            if (Volume <= 0)
+            {
+                RemoveAllSolution();
+                newSolution.Volume = origVol;
+            }
+            else
+            {
+                newSolution.Volume = origVol - Volume;
+                _heatCapacityDirty = true;
+            }
             newSolution._heatCapacityDirty = true;
 
             ValidateSolution();
@@ -751,13 +764,26 @@ namespace Content.Shared.Chemistry.Components
                 else
                 {
                     Contents.RemoveSwap(i);
-                    newSolution.Contents.Add(new ReagentQuantity(reagent, quantity));
-                    Volume -= quantity;
+                    //Only add positive quantities to our new solution.
+                    if (quantity > 0)
+                    {
+                        newSolution.Contents.Add(new ReagentQuantity(reagent, quantity));
+                        Volume -= quantity;
+                    }
                 }
             }
 
-            newSolution.Volume = origVol - Volume;
-            _heatCapacityDirty = true;
+            // If old solution is empty, invalidate old solution and transfer all volume to new.
+            if (Volume <= 0)
+            {
+                RemoveAllSolution();
+                newSolution.Volume = origVol;
+            }
+            else
+            {
+                newSolution.Volume = origVol - Volume;
+                _heatCapacityDirty = true;
+            }
             newSolution._heatCapacityDirty = true;
 
             ValidateSolution();

--- a/Content.Shared/Chemistry/Components/Solution.cs
+++ b/Content.Shared/Chemistry/Components/Solution.cs
@@ -682,7 +682,7 @@ namespace Content.Shared.Chemistry.Components
         /// </summary>
         /// <param name="toTakePer">How much of each reagent to take.</param>
         /// <returns>A new solution containing the reagents taken from the original solution.</returns>
-        public Solution SplitSolutionReagentsEvenly(FixedPoint2 toTakePer)
+        public Solution SplitSolutionPerReagent(FixedPoint2 toTakePer)
         {
             if (toTakePer <= FixedPoint2.Zero)
                 return new Solution();
@@ -694,6 +694,7 @@ namespace Content.Shared.Chemistry.Components
             {
                 var (reagent, quantity) = Contents[i];
 
+                // If the reagent has more than enough volume to remove, no need to remove it from the list.
                 if (quantity > toTakePer)
                 {
                     Contents[i] = new ReagentQuantity(reagent, quantity - toTakePer);
@@ -736,10 +737,11 @@ namespace Content.Shared.Chemistry.Components
             {
                 var (reagent, quantity) = Contents[i];
 
-                // Must be in 
+                // Each reagent to split must be in the set given.
                 if (!reagents.Contains(reagent.Prototype))
                     continue;
 
+                // If the reagent has more than enough volume to remove, no need to remove it from the list.
                 if (quantity > toTakePer)
                 {
                     Contents[i] = new ReagentQuantity(reagent, quantity - toTakePer);

--- a/Content.Shared/Chemistry/EntitySystems/SharedSolutionContainerSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/SharedSolutionContainerSystem.cs
@@ -333,7 +333,7 @@ public abstract partial class SharedSolutionContainerSystem : EntitySystem
     /// <param name="soln">The container to split the solution from.</param>
     /// <param name="quantity">The amount of each reagent to split.</param>
     /// <param name="reagents">The list of reagents to split a fixed amount of, if present.</param>
-    /// <returns></returns>
+    /// <returns>The solution that was removed.</returns>
     public Solution SplitSolutionPerReagentWithOnly(Entity<SolutionComponent> soln, FixedPoint2 quantity, params string[] reagents)
     {
         var (uid, comp) = soln;

--- a/Content.Shared/Chemistry/EntitySystems/SharedSolutionContainerSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/SharedSolutionContainerSystem.cs
@@ -316,13 +316,30 @@ public abstract partial class SharedSolutionContainerSystem : EntitySystem
     /// </summary>
     /// <param name="soln">The container to split the solution from.</param>
     /// <param name="quantity">The amount of each reagent to split.</param>
-    /// <returns></returns>
-    public Solution SplitSolutionReagentsEvenly(Entity<SolutionComponent> soln, FixedPoint2 quantity)
+    /// <returns>The solution that was removed.</returns>
+    public Solution SplitSolutionPerReagent(Entity<SolutionComponent> soln, FixedPoint2 quantity)
     {
         var (uid, comp) = soln;
         var solution = comp.Solution;
 
         var splitSol = solution.SplitSolutionReagentsEvenly(quantity);
+        UpdateChemicals(soln);
+        return splitSol;
+    }
+
+    /// <summary>
+    /// Splits a solution removing a specified amount of each reagent, if available.
+    /// </summary>
+    /// <param name="soln">The container to split the solution from.</param>
+    /// <param name="quantity">The amount of each reagent to split.</param>
+    /// <param name="reagents">The list of reagents to split a fixed amount of, if present.</param>
+    /// <returns></returns>
+    public Solution SplitSolutionPerReagentWithOnly(Entity<SolutionComponent> soln, FixedPoint2 quantity, params string[] reagents)
+    {
+        var (uid, comp) = soln;
+        var solution = comp.Solution;
+
+        var splitSol = solution.SplitSolutionPerReagentWithOnly(quantity, reagents);
         UpdateChemicals(soln);
         return splitSol;
     }

--- a/Content.Shared/Chemistry/EntitySystems/SharedSolutionContainerSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/SharedSolutionContainerSystem.cs
@@ -310,8 +310,8 @@ public abstract partial class SharedSolutionContainerSystem : EntitySystem
         return splitSol;
     }
 
+    // Frontier: cryogenics filtering functions (#1443)
     /// <summary>
-    /// Frontier
     /// Splits a solution removing a specified amount of each reagent, if available.
     /// </summary>
     /// <param name="soln">The container to split the solution from.</param>
@@ -326,6 +326,7 @@ public abstract partial class SharedSolutionContainerSystem : EntitySystem
         UpdateChemicals(soln);
         return splitSol;
     }
+    // End Frontier
 
     public Solution SplitStackSolution(Entity<SolutionComponent> soln, FixedPoint2 quantity, int stackCount)
     {

--- a/Content.Shared/Chemistry/EntitySystems/SharedSolutionContainerSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/SharedSolutionContainerSystem.cs
@@ -322,7 +322,7 @@ public abstract partial class SharedSolutionContainerSystem : EntitySystem
         var (uid, comp) = soln;
         var solution = comp.Solution;
 
-        var splitSol = solution.SplitSolutionReagentsEvenly(quantity);
+        var splitSol = solution.SplitSolutionPerReagent(quantity);
         UpdateChemicals(soln);
         return splitSol;
     }

--- a/Content.Shared/Medical/Cryogenics/CryoPodComponent.cs
+++ b/Content.Shared/Medical/Cryogenics/CryoPodComponent.cs
@@ -38,15 +38,16 @@ public sealed partial class CryoPodComponent : Component
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
     [DataField("beakerTransferAmount")]
-    public float BeakerTransferAmount = .25f;// Frontier: 1<0.25
+    public float BeakerTransferAmount = .25f; // Frontier: 1<0.25 (applied per reagent)
 
+    // Frontier: more efficient cryogenics (#1443)
     /// <summary>
-    /// Frontier 
     /// How potent (multiplier) the reagents are when transferred from the beaker to the mob.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
     [DataField("PotencyAmount")]
     public float PotencyMultiplier = 2f;
+    // End Frontier
 
     /// <summary>
     ///     Delay applied when inserting a mob in the pod.

--- a/Resources/Locale/en-US/_NF/metabolism/metabolism-groups.ftl
+++ b/Resources/Locale/en-US/_NF/metabolism/metabolism-groups.ftl
@@ -1,0 +1,1 @@
+metabolism-group-cryogenic = Cryogenic

--- a/Resources/Locale/en-US/reagents/meta/medicine.ftl
+++ b/Resources/Locale/en-US/reagents/meta/medicine.ftl
@@ -14,13 +14,11 @@ reagent-name-bicaridine = bicaridine
 reagent-desc-bicaridine = An analgesic which is highly effective at treating brute damage. It's useful for stabilizing people who have been severely beaten, as well as treating less life-threatening injuries.
 
 # Frontier: consistent cryogenics descriptors
-
 reagent-name-cryoxadone = cryoxadone
-reagent-desc-cryoxadone = Required for the proper function of cryogenics. Useful in treating asphyxiation and bloodloss, but only works in temperatures under 213K. It can treat and rejuvenate plants when applied in small doses. Works regardless of the patient being alive or dead.
+reagent-desc-cryoxadone = A cryogenics chemical. Useful in treating asphyxiation and bloodloss, but only works in temperatures under 213K. It can treat and rejuvenate plants when applied in small doses. Works regardless of the patient being alive or dead.
 
 reagent-name-doxarubixadone = doxarubixadone
 reagent-desc-doxarubixadone = A cryogenics chemical. Heals certain types of cellular damage done by Slimes and improper use of other chemicals. Works regardless of the patient being alive or dead.
-
 # End Frontier
 
 reagent-name-dermaline = dermaline
@@ -134,8 +132,10 @@ reagent-desc-insuzine = Rapidly repairs dead tissue caused by electrocution, but
 reagent-name-opporozidone = opporozidone
 reagent-desc-opporozidone= A difficult to synthesize cryogenic drug used to regenerate rotting tissue and brain matter.
 
+# Frontier: consistent cryogenics descriptors
 reagent-name-necrosol = necrosol
-reagent-desc-necrosol = A necrotic substance that seems to be able to heal frozen corpses. It can treat and rejuvenate plants when applied in small doses.
+reagent-desc-necrosol = A cryogenics chemical. Heals most organic damage, a true panacea. It can treat and rejuvenate plants when applied in small doses.  Works regardless of the patient being alive or dead.
+# End Frontier
 
 reagent-name-aloxadone = aloxadone
 reagent-desc-aloxadone = A cryogenics chemical. Used to treat severe third degree burns via regeneration of the burnt tissue. Works regardless of the patient being alive or dead.

--- a/Resources/Prototypes/Body/Organs/Animal/animal.yml
+++ b/Resources/Prototypes/Body/Organs/Animal/animal.yml
@@ -129,6 +129,7 @@
     metabolizerTypes: [ Animal ]
     groups:
     - id: Medicine
+    - id: Cryogenic # Frontier
     - id: Poison
     - id: Narcotic
 

--- a/Resources/Prototypes/Body/Organs/Animal/slimes.yml
+++ b/Resources/Prototypes/Body/Organs/Animal/slimes.yml
@@ -16,6 +16,7 @@
         - id: Food
         - id: Drink
         - id: Medicine
+        - id: Cryogenic # Frontier
         - id: Poison
         - id: Narcotic
         - id: Alcohol

--- a/Resources/Prototypes/Body/Organs/arachnid.yml
+++ b/Resources/Prototypes/Body/Organs/arachnid.yml
@@ -104,6 +104,7 @@
     metabolizerTypes: [Arachnid]
     groups:
     - id: Medicine
+    - id: Cryogenic # Frontier
     - id: Poison
     - id: Narcotic
 

--- a/Resources/Prototypes/Body/Organs/diona.yml
+++ b/Resources/Prototypes/Body/Organs/diona.yml
@@ -86,6 +86,7 @@
       - id: Food
       - id: Drink
       - id: Medicine
+      - id: Cryogenic # Frontier
       - id: Poison
       - id: Narcotic
       - id: Alcohol

--- a/Resources/Prototypes/Body/Organs/human.yml
+++ b/Resources/Prototypes/Body/Organs/human.yml
@@ -159,6 +159,7 @@
     metabolizerTypes: [Human]
     groups:
     - id: Medicine
+    - id: Cryogenic # Frontier
     - id: Poison
     - id: Narcotic
 

--- a/Resources/Prototypes/Body/Organs/moth.yml
+++ b/Resources/Prototypes/Body/Organs/moth.yml
@@ -27,6 +27,7 @@
       - id: Food
       - id: Drink
       - id: Medicine
+      - id: Cryogenic # Frontier
       - id: Poison
       - id: Narcotic
       - id: Alcohol

--- a/Resources/Prototypes/Body/Organs/slime.yml
+++ b/Resources/Prototypes/Body/Organs/slime.yml
@@ -16,6 +16,7 @@
         - id: Food
         - id: Drink
         - id: Medicine
+        - id: Cryogenic # Frontier
         - id: Poison
         - id: Narcotic
         - id: Alcohol

--- a/Resources/Prototypes/Entities/Mobs/NPCs/behonker.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/behonker.yml
@@ -88,6 +88,7 @@
       metabolizerTypes: [ Dragon ]
       groups:
         - id: Medicine
+        - id: Cryogenic # Frontier
         - id: Poison
     - type: Butcherable
       spawned:

--- a/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
@@ -101,6 +101,7 @@
     metabolizerTypes: [ Dragon ]
     groups:
     - id: Medicine
+    - id: Cryogenic # Frontier
     - id: Poison
   - type: Butcherable
     spawned:

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -176,7 +176,7 @@
     amount: 5
   - !type:PlantCryoxadone {}
   metabolisms:
-    Medicine:
+    Cryogenic: # Frontier: Medicine<Cryogenic
       effects:
         - !type:HealthChange
           conditions:
@@ -203,7 +203,7 @@
   color: "#32cd32"
   worksOnTheDead: true # Frontier
   metabolisms:
-    Medicine:
+    Cryogenic: # Frontier: Medicine<Cryogenic
       effects:
         - !type:HealthChange
           conditions:
@@ -1165,7 +1165,7 @@
   color: "#b5e36d"
   worksOnTheDead: true
   metabolisms:
-    Medicine:
+    Cryogenic: # Frontier: Medicine<Cryogenic
       effects:
         - !type:ReduceRotting
           seconds: 20
@@ -1192,7 +1192,7 @@
     amount: 5
   - !type:PlantCryoxadone {}
   metabolisms:
-    Medicine:
+    Cryogenic: # Frontier: Medicine<Cryogenic
       effects:
         - !type:HealthChange
           conditions:
@@ -1215,7 +1215,7 @@
   color: "#89f77f"
   worksOnTheDead: true
   metabolisms:
-    Medicine:
+    Cryogenic: # Frontier: Medicine<Cryogenic
       effects:
       - !type:HealthChange
         conditions:

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -168,7 +168,7 @@
   physicalDesc: reagent-physical-desc-fizzy
   flavor: medicine
   color: "#0091ff"
-  worksOnTheDead: true # Frontier 
+  worksOnTheDead: true # Frontier
   plantMetabolism:
   - !type:PlantAdjustToxins
     amount: -5
@@ -1225,7 +1225,7 @@
           types:
             Heat: -3.0
             Shock: -3.0
-            Cold: -3.0 # Frontier 
+            Cold: -3.0 # Frontier
             Caustic: -1.0
 
 - type: reagent

--- a/Resources/Prototypes/_NF/Body/Organs/goblin_organs.yml
+++ b/Resources/Prototypes/_NF/Body/Organs/goblin_organs.yml
@@ -142,6 +142,7 @@
     - id: Food
     - id: Drink
     - id: Medicine
+    - id: Cryogenic
     - id: Poison
     - id: Narcotic
     - id: Alcohol

--- a/Resources/Prototypes/_NF/Body/Organs/synthetic_organs.yml
+++ b/Resources/Prototypes/_NF/Body/Organs/synthetic_organs.yml
@@ -12,6 +12,7 @@
     metabolizerTypes: [Human]
     groups:
     - id: Medicine
+    - id: Cryogenic # Frontier
 #    - id: Poison
 #    - id: Narcotic
 #    - id: Toxins

--- a/Resources/Prototypes/_NF/Chemistry/metabolism_groups.yml
+++ b/Resources/Prototypes/_NF/Chemistry/metabolism_groups.yml
@@ -1,0 +1,4 @@
+# Separate cryogenics from regular medicine (to buff cryo)
+- type: metabolismGroup
+  id: Cryogenic
+  name: metabolism-group-cryogenic

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/baby_dragon.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/baby_dragon.yml
@@ -117,6 +117,7 @@
     metabolizerTypes: [ Dragon ]
     groups:
     - id: Medicine
+    - id: Cryogenic
     - id: Poison
   - type: Butcherable
     spawned:

--- a/Resources/Prototypes/_NF/Entities/Mobs/Player/jerma.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/Player/jerma.yml
@@ -71,6 +71,7 @@
     metabolizerTypes: [ Dragon ]
     groups:
     - id: Medicine
+    - id: Cryogenic
     - id: Poison
   - type: Butcherable
     spawned:

--- a/Resources/Prototypes/_NF/Reagents/medicine.yml
+++ b/Resources/Prototypes/_NF/Reagents/medicine.yml
@@ -8,7 +8,7 @@
   color: "#880077"
   worksOnTheDead: true
   metabolisms:
-    Medicine:
+    Cryogenic:
       effects:
       - !type:HealthChange
         conditions:
@@ -21,7 +21,7 @@
             Slash: -2
 
 - type: reagent
-  id : Stelloxadone
+  id: Stelloxadone
   name: reagent-name-stelloxadone
   group: Medicine
   desc: reagent-desc-stelloxadone
@@ -30,7 +30,7 @@
   color: "#FFA861"
   worksOnTheDead: true
   metabolisms:
-    Medicine:
+    Cryogenic:
       effects:
       - !type:HealthChange
         conditions:

--- a/Resources/ServerInfo/Guidebook/Medical/Cryogenics.xml
+++ b/Resources/ServerInfo/Guidebook/Medical/Cryogenics.xml
@@ -43,7 +43,7 @@ Once things have been set up, you're going to require cryogenic medications (all
 
 The standard pressure for a gas pump is 100.325 kpa. Cryogenics medicines work at under 213K (150K for Opporozidone), but it is standard practice to set the freezer to 100K for faster freezing.
 
-Cryo pods separate out each reagent from the beaker in the pod, injecting a small, steady amount of each into the patient.  This allows for medicine to be administered twice as efficiently than with injection or oral administration.
+Cryo pods separate out each reagent from the beaker in the pod, injecting a small, steady amount of each into the patient. This allows for medicine to be administered twice as efficiently as through injection or oral administration.
 
 <GuideReagentEmbed Reagent="Cryoxadone"/>
 <GuideReagentEmbed Reagent="Doxarubixadone"/>

--- a/Resources/ServerInfo/Guidebook/Medical/Cryogenics.xml
+++ b/Resources/ServerInfo/Guidebook/Medical/Cryogenics.xml
@@ -43,7 +43,7 @@ Once things have been set up, you're going to require cryogenic medications (all
 
 The standard pressure for a gas pump is 100.325 kpa. Cryogenics medicines work at under 213K (150K for Opporozidone), but it is standard practice to set the freezer to 100K for faster freezing.
 
-Cryo pods separate out each reagent from the beaker in the pod, injecting a small, steady amount of each into the patient. This allows for medicine to be administered twice as efficiently as through injection or oral administration.
+Cryo pods filter out each cryogenic medicine from the beaker in the pod, injecting a small, steady amount of each into the patient. This allows for medicine to be administered twice as efficiently than with injection or oral administration.
 
 <GuideReagentEmbed Reagent="Cryoxadone"/>
 <GuideReagentEmbed Reagent="Doxarubixadone"/>


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

This PR addresses side effects of the Cryo Overhaul PR, and reverts most changes in behaviour to metabolism.
1. Metabolism is once again limited (see point 4) to a fixed number of reagents per metabolizer (hereafter, organ).
2. A new metabolism group was added, "Cryogenic", that contains all current cryogenic medicine.
3. All existing organs that could metabolize Medicine have had Cryogenics metabolism added.
4. Any organ that can metabolize cryogenic medicine can metabolize an unlimited number of them at once without counting against the number of processed reagents.
5. Cryo pods now only administer cryogenics medicines, but maintain all efficiency and injection rate changes (2x as efficient, 0.25u/s draw per reagent in solution)

I have added versions of per-reagent SplitSolution functions (one with whitelist, one without) that are more consistent with other methods in the class.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

The change in behaviour from metabolizing a fixed number of things to an unlimited number of things affects the metabolism of food, of medicine, and of poisons.  It removed most differences between species apart from arachnids metabolizing less frequently.

The goal is to keep cryo strong, but appropriately strong, and to avoid overreliance or abuse of cryo pods for non-cryo meds.  I believe injections, pills, topical meds and bedrest should ideally all have a place in medical gameplay.

## How to test
<!-- Describe the way it can be tested -->

1. Buy a Caduceus.  Make sure it's fueled and prepare the atmos for cryo.
2. Spawn a Urist McHands (human), place them on the stasis bed inside.
3. Edit Solutions on the Urist.  Add 20u of Inaprovaline, DexalinPlus, Kelotane, Cryoxadone, Aloxadone, Necrosol, Stelloxadone, Traumoxadone, Doxarubixadone, Opporozidone.
4. Watch the solutions metabolize.  Two of the first three should randomly drop 0.5u each metabolism update, but all of the cryogenic reagents should all metabolize at 0.5u per update.
5. Spawn a bluespace beaker.  Add 100u of Cryoxadone, Aloxadone, Necrosol, Stelloxadone, Traumoxadone, Doxarubixadone, Opporozidone, Ketchup, CarpoToxin, and DexalinPlus.
6. Put the Urist McHands in the cryo pod.
7. Examine the solution in the bluespace beaker and Urist McHands, insert it into the cryo pod.
8. Only the cryogenic meds should be inserted (0.25u per second).  Ketchup, CarpoToxin, and DexalinPlus should remain.
9. Urist should receive 0.5u per second of all cryogenic meds being removed from the beaker.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

Testing metabolism: non-cryo meds are randomly metabolized if too many in solution, vs. consistently metabolized cryo meds
![human_solution](https://github.com/new-frontiers-14/frontier-station-14/assets/166147148/52955427-e263-4df8-8c4d-1e9214edc17f)

Testing cryo pod extraction: only cryo meds are extracted, non-cryo reagents are left in the beaker
![cryo_beaker](https://github.com/new-frontiers-14/frontier-station-14/assets/166147148/2507055e-2d71-4080-acda-7db379fb76d2)

- [X] ***I have added screenshots/videos to this PR showcasing its changes ingame***, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

`Content.Shared.Chemistry.Components.Solution`:
* `SplitSolutionEvenly` has been renamed to `SplitSolutionPerReagent`, its parameters have not changed.
* Added a public method, `SplitSolutionPerReagentWithOnly`.

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: 
- tweak: Organs once again metabolize a limited number of reagents at once.
- tweak: Cryo pods now only extract cryogenic medicines from beakers.