### PR TITLE
Pen signing fix

### DIFF
--- a/Content.Server/Paper/PaperSystem.cs
+++ b/Content.Server/Paper/PaperSystem.cs
@@ -154,10 +154,6 @@ namespace Content.Server.Paper
             if (TryComp<StampComponent>(args.Used, out var stampComp) &&
                 TryStamp(uid, GetStampInfo(stampComp), stampComp.StampState, paperComp))
             {
-                if (stampComp.StampedPersonal) // Frontier
-                    stampComp.StampedName =
-                        Loc.GetString("stamp-component-signee-name", ("user", args.User)); // Frontier
-
                 // successfully stamped, play popup
                 var stampPaperOtherMessage = Loc.GetString("paper-component-action-stamp-paper-other",
                     ("user", args.User), ("target", args.Target), ("stamp", args.Used));

--- a/Content.Shared/Paper/StampComponent.cs
+++ b/Content.Shared/Paper/StampComponent.cs
@@ -61,19 +61,4 @@ public sealed partial class StampComponent : Component
     [DataField("sound")]
     public SoundSpecifier? Sound = null;
 
-    /// <summary>
-    /// Frontier - The stamp using the person name on it
-    /// </summary>
-    [DataField("stampedPersonal")]
-    public bool StampedPersonal = false;
-
-    [DataField("stampedBorderless")]
-    public bool StampedBorderless = false;
-
-    [ViewVariables]
-    public EntityUid? StampedIdUser = null;
-
-    [ViewVariables(VVAccess.ReadWrite)]
-    [DataField("nameSetUser")]
-    public bool NameSetUser { get; set; }
 }

--- a/Resources/Prototypes/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/paper.yml
@@ -307,16 +307,6 @@
   - type: PhysicalComposition
     materialComposition:
       Steel: 25
-  - type: Stamp
-    stampedColor: "#000001"
-    stampState: "paper_stamp-generic"
-    stampedPersonal: true
-    stampedBorderless: true
-    sound:
-      path: /Audio/_NF/Items/Pen/pen_sign.ogg
-      params:
-        volume: -2
-        maxDistance: 5
 
 - type: entity
   parent: Pen


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Fixes a bug where the server would erroneously let people think they are, and I quote, `A very important person`. This was caused by pens still having the stamp component from the old signing system, component has now been removed and signing works as normal.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Fixing bugs.

## How to test
<!-- Describe the way it can be tested -->

Spawn paper.
Spawn any stamp.
Stamp paper.
Click paper without alt, observe. You are not `A very important person`.

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl:
- fix: Left clicking a signed/stamped paper won't add a bogus signature onto it anymore.
