### PR TITLE
Dungeon Weapon Spawner Rebalance

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/dungeon_items_mercenary.yml
+++ b/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/dungeon_items_mercenary.yml
@@ -99,7 +99,7 @@
     - SpawnDungeonLootGunT1
     - SpawnDungeonLootGunT1
     - SpawnDungeonLootMeleeT1
-    chance: 0.6
+    chance: 0.5
     offset: 0.0
     rarePrototypes:
     - WeaponCaseShort
@@ -158,7 +158,7 @@
     prototypes:
     - SpawnDungeonLootMeleeT1
     - SpawnDungeonLootMeleeT2
-    chance: 0.95
+    chance: 0.9
     offset: 0.0
     rarePrototypes:
     - SpawnDungeonLootMeleeT3
@@ -184,7 +184,7 @@
     - SpawnDungeonLootGunT3
     - SpawnDungeonLootGunT3
     - SpawnDungeonLootMeleeT3
-    chance: 0.8
+    chance: 0.9
     offset: 0.0
     rarePrototypes:
     - WeaponCaseShort

--- a/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/dungeon_items_mercenary.yml
+++ b/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/dungeon_items_mercenary.yml
@@ -96,12 +96,10 @@
         color: red
   - type: RandomSpawner
     prototypes:
-    - WeaponCaseShort
-    - WeaponCaseLong
     - SpawnDungeonLootGunT1
     - SpawnDungeonLootGunT1
     - SpawnDungeonLootMeleeT1
-    chance: 0.8
+    chance: 0.6
     offset: 0.0
     rarePrototypes:
     - WeaponCaseShort
@@ -128,12 +126,10 @@
         color: red
   - type: RandomSpawner
     prototypes:
-    - WeaponCaseShort
-    - WeaponCaseLong
     - SpawnDungeonLootGunT2
     - SpawnDungeonLootGunT2
     - SpawnDungeonLootMeleeT2
-    chance: 0.8
+    chance: 0.7
     offset: 0.0
     rarePrototypes:
     - WeaponCaseShort
@@ -185,12 +181,10 @@
         color: red
   - type: RandomSpawner
     prototypes:
-    - WeaponCaseShort
-    - WeaponCaseLong
     - SpawnDungeonLootGunT3
     - SpawnDungeonLootGunT3
     - SpawnDungeonLootMeleeT3
-    chance: 0.95
+    chance: 0.8
     offset: 0.0
     rarePrototypes:
     - WeaponCaseShort

--- a/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/dungeon_items_weapons.yml
+++ b/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/dungeon_items_weapons.yml
@@ -62,7 +62,7 @@
     - WhiteCane
     - CombatKnife
     - SurvivalKnife
-    chance: 0.95
+    chance: 1.0
     offset: 0.0
     rarePrototypes:
     - SpawnDungeonLootMeleeT2
@@ -93,7 +93,7 @@
     - WeaponCaseLongShotgunDoubleBarreledExpedition
     - WeaponCaseShortSawnExpedition
     - WeaponCaseLongMosinExpedition
-    chance: 0.95
+    chance: 1.0
     offset: 0.0
     rarePrototypes:
     - SpawnDungeonLootGunT2
@@ -118,7 +118,7 @@
   - type: RandomSpawner
     prototypes:
     - WeaponCaseShortFireBomb
-    chance: 0.95
+    chance: 0.3
     offset: 0.0
     rarePrototypes:
     - SpawnDungeonLootExplosivesT2
@@ -150,7 +150,7 @@
     - KukriKnife
     - Stunbaton
     - ThrowingKnife
-    chance: 0.95
+    chance: 1.0
     offset: 0.0
     rarePrototypes:
     - SpawnDungeonLootMeleeT3
@@ -181,7 +181,7 @@
     - WeaponCaseLongKammererExpedition
     - WeaponCaseLongEnergyGunExpedition
     - WeaponCaseLongRepeaterExpedition
-    chance: 0.95
+    chance: 1.0
     offset: 0.0
     rarePrototypes:
     - SpawnDungeonLootGunT3
@@ -206,7 +206,7 @@
   - type: RandomSpawner
     prototypes:
     - WeaponCaseShortPipeBomb
-    chance: 0.95
+    chance: 0.4
     offset: 0.0
     rarePrototypes:
     - SpawnDungeonLootExplosivesT3
@@ -236,7 +236,7 @@
     - Claymore
     - Truncheon
     - WeaponCaseShortEnergyDaggerExpedition
-    chance: 0.95
+    chance: 1.0
     offset: 0.0
     rarePrototypes:
     - SpawnDungeonLootMeleeT4
@@ -265,7 +265,7 @@
     - WeaponCaseLongLecterExpedition
     - WeaponCaseLongLaserCarbineExpedition
     - WeaponCaseLongHristovExpedition
-    chance: 0.95
+    chance: 1.0
     offset: 0.0
     rarePrototypes:
     - SpawnDungeonLootGunT4
@@ -290,7 +290,7 @@
   - type: RandomSpawner
     prototypes:
     - WeaponCaseShortSeismicCharge
-    chance: 0.95
+    chance: 0.5
     offset: 0.0
     rarePrototypes:
     - SpawnDungeonLootExplosivesT4
@@ -320,7 +320,7 @@
     - SecBreachingHammer
     - WeaponCaseShortEnergySwordExpedition
     - WeaponCaseShortEnergyCutlassExpedition
-    chance: 0.95
+    chance: 1.0
     offset: 0.0
     rarePrototypes:
     - SpawnDungeonLootMeleeT5
@@ -350,7 +350,7 @@
     - WeaponCaseLongAkExpedition
     - WeaponCaseShortSvalinnExpedition
     - WeaponCaseShortAdvancedLaserExpedition
-    chance: 0.95
+    chance: 1.0
     offset: 0.0
     rarePrototypes:
     - SpawnDungeonLootGunT5
@@ -375,7 +375,7 @@
   - type: RandomSpawner
     prototypes:
     - WeaponCaseShortExGrenade
-    chance: 0.95
+    chance: 0.4
     offset: 0.0
     rarePrototypes:
     - SpawnDungeonLootExplosivesT5
@@ -401,7 +401,7 @@
   - type: RandomSpawner
     prototypes:
     - WeaponCaseShortEnergySwordDoubleExpedition
-    chance: 0.95
+    chance: 1.0
     offset: 0.0
 
 - type: entity
@@ -427,7 +427,7 @@
     - WeaponCaseLongLauncherRocketExpedition
     - WeaponCaseLongLauncherChinaLake
     - WeaponCaseLongLightMachineGunL6
-    chance: 0.95
+    chance: 1.0
     offset: 0.0
 
 - type: entity
@@ -449,5 +449,5 @@
   - type: RandomSpawner
     prototypes:
     - WeaponCaseShortC4
-    chance: 0.95
+    chance: 0.3
     offset: 0.0


### PR DESCRIPTION
## About the PR
- Lowered the chance for spawning explosives: 30% for tier 1 (fire bombs), 40% for tier 2 (pipe bombs), 50% for tier 3 (seismic charges), 40% for tier 4 (hiex grenades) and 30% for tier 5 (C4).
- Removed empty weapon cases from weapon spawners.
- Lowered the chance for spawning weapon cases overall: "loose" weapon cases - 50%, vault - 70% for unprotected and 90% for protected.

## Why / Balance
Cutting down explosives spam, changing somewhat frustrating for players mechanics with empty cases.

## How to test
Use `random weapon [Dungeon, ...]` spawners, observe the results.

## Media
- [x] This PR does not require an ingame showcase

## Breaking changes
none

**Changelog**
not needed I think
