### PR TITLE
Loadouts: fix empty SR messenger bag

### DIFF
--- a/Resources/Prototypes/_NF/Catalog/Fills/Backpacks/StarterGear/messenger.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/Backpacks/StarterGear/messenger.yml
@@ -136,7 +136,7 @@
 
 - type: entity
   noSpawn: true
-  parent: [ClothingBackpackMessenger, ClothingBackpackSrFilled]
+  parent: [ClothingBackpackMessengerSr, ClothingBackpackSrFilled]
   id: ClothingBackpackMessengerSrFilled
 
 - type: entity

--- a/Resources/Prototypes/_NF/Loadouts/Jobs/StationRep/bags.yml
+++ b/Resources/Prototypes/_NF/Loadouts/Jobs/StationRep/bags.yml
@@ -29,14 +29,14 @@
     back: ClothingBackpackSatchelSrFilled
 
 - type: loadout
-  id: StationRepClothingBackpackMessengerSr
-  equipment: StationRepClothingBackpackMessengerSr
+  id: StationRepClothingBackpackMessengerSrFilled
+  equipment: StationRepClothingBackpackMessengerSrFilled
   price: 0
 
 - type: startingGear
-  id: StationRepClothingBackpackMessengerSr
+  id: StationRepClothingBackpackMessengerSrFilled
   equipment:
-    back: ClothingBackpackMessengerSr
+    back: ClothingBackpackMessengerSrFilled
 
 - type: loadout
   id: StationRepClothingBackpackIanFilled

--- a/Resources/Prototypes/_NF/Loadouts/stationrep_loadout_groups.yml
+++ b/Resources/Prototypes/_NF/Loadouts/stationrep_loadout_groups.yml
@@ -13,7 +13,7 @@
   - StationRepClothingBackpackSrFilled
   - StationRepClothingBackpackDuffelSrFilled
   - StationRepClothingBackpackSatchelSrFilled
-  - StationRepClothingBackpackMessengerSr
+  - StationRepClothingBackpackMessengerSrFilled
   - StationRepClothingBackpackIanFilled #We put the ian bag here so its not default, we also let SR pick a bag out of drip concerns.
   
 - type: loadoutGroup


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Changes the station rep's messenger bag in loadouts.  Uses a filled version, and uses the green and tan version that @ErhardSteinhauer created.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Not giving the SR a filled bag was an oversight.
Giving the SR a green bag makes sense, since we have a role-specific version.

## How to test
<!-- Describe the way it can be tested -->

Build and run local server.
1. Open loadout, check SR backpack options.  Green messenger bag should appear.
2. Select messenger bag, spawn in-game.  Check backpack contents, should include a flash, stamp, access configurator and red phone.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

![image](https://github.com/new-frontiers-14/frontier-station-14/assets/166147148/85921d2e-6faf-458b-87af-89442b7465fb)

![sr-messengerbag](https://github.com/new-frontiers-14/frontier-station-14/assets/166147148/ec048b1c-b560-4fd2-8488-48fdbeb9564e)

- [X] ***I have added screenshots/videos to this PR showcasing its changes ingame***, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
- fix: The station representative's messenger bag loadout option is now correctly filled.