### PR TITLE
Check outer clothing for footstep noise

### DIFF
--- a/Content.Shared/Movement/Systems/SharedMoverController.cs
+++ b/Content.Shared/Movement/Systems/SharedMoverController.cs
@@ -440,17 +440,10 @@ namespace Content.Shared.Movement.Systems
                 sound = moverModifier.FootstepSoundCollection;
                 return true;
             }
-            
-            // If got the component in yml and no shoes = no sound. Delta V
-            if (_entities.TryGetComponent(uid, out NoShoesSilentFootstepsComponent? _) &
-                !_inventory.TryGetSlotEntity(uid, "shoes", out var _))
-            {
-                return false;
-            }
-            // Delta V NoShoesSilentFootsteps till here.
 
             // Frontier: check outer clothes
             // If you have a hardsuit or power armor on that goes around your boots, it's the hardsuit that hits the floor.
+            // Check should happen before NoShoesSilentFootsteps check - loud power armor should count as wearing shoes.
             if (_inventory.TryGetSlotEntity(uid, "outerClothing", out var outerClothing) &&
                 TryComp<FootstepModifierComponent>(outerClothing, out var outerModifier))
             {
@@ -458,6 +451,14 @@ namespace Content.Shared.Movement.Systems
                 return true;
             }
             // End Frontier
+
+            // If got the component in yml and no shoes = no sound. Delta V
+            if (_entities.TryGetComponent(uid, out NoShoesSilentFootstepsComponent? _) &&
+                !_inventory.TryGetSlotEntity(uid, "shoes", out var _))
+            {
+                return false;
+            }
+            // Delta V NoShoesSilentFootsteps till here.
 
             if (_inventory.TryGetSlotEntity(uid, "shoes", out var shoes) &&
                 TryComp<FootstepModifierComponent>(shoes, out var modifier))

--- a/Content.Shared/Movement/Systems/SharedMoverController.cs
+++ b/Content.Shared/Movement/Systems/SharedMoverController.cs
@@ -449,6 +449,16 @@ namespace Content.Shared.Movement.Systems
             }
             // Delta V NoShoesSilentFootsteps till here.
 
+            // Frontier: check outer clothes
+            // If you have a hardsuit or power armor on that goes around your boots, it's the hardsuit that hits the floor.
+            if (_inventory.TryGetSlotEntity(uid, "outerClothing", out var outerClothing) &&
+                TryComp<FootstepModifierComponent>(outerClothing, out var outerModifier))
+            {
+                sound = outerModifier.FootstepSoundCollection;
+                return true;
+            }
+            // End Frontier
+
             if (_inventory.TryGetSlotEntity(uid, "shoes", out var shoes) &&
                 TryComp<FootstepModifierComponent>(shoes, out var modifier))
             {


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Outer clothing (hardsuits, etc.) that has a footstep modifier will apply its status to the player when they walk.  This takes precedence over the shoes (your shoes should be inside your armoured hardsuit).  Since outer clothing usually has sprites that cover the character's feet, this seems sensible to me.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Brought up in #1551.  No real balance, just fun - opens the possibility for more immersive, beefier hardsuits (could make the clown hardsuit squeak, for instance).  If this is desirable vs. pilotable mech suits, I do not know.

## How to test
<!-- Describe the way it can be tested -->

Check out [whatston3:maid-time](https://github.com/whatston3/frontier-station-14/tree/maid-time) - visually check that the commit history includes this PR's exact commits - all of them.  Run the following tests:

0. Walk around, you make barefoot/shoe noises.
1. Spawn a tactical maid hardsuit.
2. Walk around.  You make noise like a ripley.
3. Spawn in white cowboy boots, put them on.
4. Walk around.  You make noise like a ripley.
5. Take the hardsuit off.
6. Walk around.  You've got spurs that jingle jangle jingle.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** ***this PR does not require an ingame showcase***

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

None.

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
Changes aren't really externally facing, no changelog added.