### PR TITLE
Buffing Data Carrier Duration

### DIFF
--- a/Resources/Prototypes/_NF/Events/events_bluespace.yml
+++ b/Resources/Prototypes/_NF/Events/events_bluespace.yml
@@ -142,8 +142,8 @@
     minimumPlayers: 35
     weight: 2
     startDelay: 10
-    duration: 900
-    maxDuration: 1200
+    duration: 2100
+    maxDuration: 2400
     maxOccurrences: 1 # Only once per shift possible
   - type: BluespaceErrorRule
     gridPaths:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
It increses its duration from 15-20 minutes to 35-40 minutes to give players more time to loot it.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
15-20 minutes is defently not enough to kill all enemies and loot it, even with the sheer of 20-30 creates. I mostly see NFSD starting to loot it and then just disappearing when they directly responded to it.

## How to test
<!-- Describe the way it can be tested -->
Run fork
add the game rule BluespaceDataCarrier via addgamerule
go and wait the timer out and see it disappear

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: The Data Carrier is now lasting longer before it disappears.