### PR TITLE
Unhardcode a bunch of shipyard console stuff

### DIFF
--- a/Content.Server/Shipyard/Systems/ShipyardSystem.Consoles.cs
+++ b/Content.Server/Shipyard/Systems/ShipyardSystem.Consoles.cs
@@ -231,10 +231,7 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
         if (TryComp<ShuttleDeedComponent>(targetId, out var deed))
             sellValue = (int) _pricing.AppraiseGrid((EntityUid) (deed?.ShuttleUid!));
 
-        if (CalculateSalesTax(component, sellValue, out var tax))
-        {
-            sellValue -= tax;
-        }
+        sellValue -= CalculateSalesTax(component, sellValue);
 
         SendPurchaseMessage(uid, player, name, component.ShipyardChannel, secret: false);
         if (component.SecretShipyardChannel is { } secretChannel)
@@ -319,7 +316,8 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
 
         RemComp<ShuttleDeedComponent>(targetId);
 
-        if (CalculateSalesTax(component, bill, out var tax))
+        var tax = CalculateSalesTax(component, bill);
+        if (tax != 0)
         {
             var query = EntityQueryEnumerator<StationBankAccountComponent>();
 
@@ -373,10 +371,7 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
         if (deed?.ShuttleUid != null)
             sellValue = (int) _pricing.AppraiseGrid((EntityUid) (deed?.ShuttleUid!));
 
-        if (CalculateSalesTax(component, sellValue, out var tax))
-        {
-            sellValue -= tax;
-        }
+        sellValue -= CalculateSalesTax(component, sellValue);
 
         var fullName = deed != null ? GetFullName(deed) : null;
         RefreshState(uid, bank.Balance, true, fullName, sellValue, targetId.HasValue, (ShipyardConsoleUiKey) args.UiKey);
@@ -460,10 +455,7 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
             if (deed?.ShuttleUid != null)
                 sellValue = (int) _pricing.AppraiseGrid((EntityUid) (deed?.ShuttleUid!));
 
-            if (CalculateSalesTax(component, sellValue, out var tax))
-            {
-                sellValue -= tax;
-            }
+            sellValue -= CalculateSalesTax(component, sellValue);
 
             var fullName = deed != null ? GetFullName(deed) : null;
             RefreshState(uid, bank.Balance, true, fullName, sellValue, targetId.HasValue,
@@ -556,15 +548,13 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
         deed.ShuttleOwner = shuttleOwner;
     }
 
-    private bool CalculateSalesTax(ShipyardConsoleComponent component, int sellValue, out int tax)
+    private int CalculateSalesTax(ShipyardConsoleComponent component, int sellValue)
     {
         if (float.IsFinite(component.SalesTax) && component.SalesTax != 0f)
         {
-            tax = (int) (sellValue * component.SalesTax);
-            return true;
+            return (int) (sellValue * component.SalesTax);
         }
-        tax = 0;
-        return false;
+        return 0;
     }
 
     private void OnInitDeedSpawner(EntityUid uid, StationDeedSpawnerComponent component, MapInitEvent args)

--- a/Content.Server/Shipyard/Systems/ShipyardSystem.Consoles.cs
+++ b/Content.Server/Shipyard/Systems/ShipyardSystem.Consoles.cs
@@ -67,10 +67,10 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
 
     private void OnPurchaseMessage(EntityUid uid, ShipyardConsoleComponent component, ShipyardConsolePurchaseMessage args)
     {
-        if (args.Actor is not { Valid : true } player)
+        if (args.Actor is not { Valid: true } player)
             return;
 
-        if (component.TargetIdSlot.ContainerSlot?.ContainedEntity is not { Valid : true } targetId)
+        if (component.TargetIdSlot.ContainerSlot?.ContainedEntity is not { Valid: true } targetId)
         {
             ConsolePopup(args.Actor, Loc.GetString("shipyard-console-no-idcard"));
             PlayDenySound(uid, component);
@@ -116,7 +116,7 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
         if (vessel.Price <= 0)
             return;
 
-        if (_station.GetOwningStation(uid) is not { Valid : true } station)
+        if (_station.GetOwningStation(uid) is not { Valid: true } station)
         {
             ConsolePopup(args.Actor, Loc.GetString("shipyard-console-invalid-station"));
             PlayDenySound(uid, component);
@@ -173,14 +173,7 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
         if (TryComp<AccessComponent>(targetId, out var newCap))
         {
             var newAccess = newCap.Tags.ToList();
-            newAccess.Add($"Captain");
-
-            if (ShipyardConsoleUiKey.Security == (ShipyardConsoleUiKey) args.UiKey)
-            {
-                newAccess.Add($"Security");
-                newAccess.Add($"Brig");
-            }
-
+            newAccess.AddRange(component.NewAccessLevels);
             _accessSystem.TrySetTags(targetId, newAccess, newCap);
         }
 
@@ -190,12 +183,8 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
         var deedShuttle = EnsureComp<ShuttleDeedComponent>(shuttle.Owner);
         AssignShuttleDeedProperties(deedShuttle, shuttle.Owner, name, player);
 
-        var channel = component.ShipyardChannel;
-
-        if (ShipyardConsoleUiKey.Security != (ShipyardConsoleUiKey) args.UiKey)
-            _idSystem.TryChangeJobTitle(targetId, $"Captain", idCard, player);
-        else
-            channel = component.SecurityShipyardChannel;
+        if (!string.IsNullOrEmpty(component.NewJobTitle))
+            _idSystem.TryChangeJobTitle(targetId, component.NewJobTitle, idCard, player);
 
         // The following block of code is entirely to do with trying to sanely handle moving records from station to station.
         // it is ass.
@@ -241,16 +230,15 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
         if (TryComp<ShuttleDeedComponent>(targetId, out var deed))
             sellValue = (int) _pricing.AppraiseGrid((EntityUid) (deed?.ShuttleUid!));
 
-        if (ShipyardConsoleUiKey.BlackMarket == (ShipyardConsoleUiKey) args.UiKey || ShipyardConsoleUiKey.Syndicate == (ShipyardConsoleUiKey) args.UiKey) // Unhardcode this please
+        if (component.SalesTax != 0f)
         {
-            var tax = (int) (sellValue * 0.30f);
+            var tax = (int) (sellValue * component.SalesTax);
             sellValue -= tax;
-            channel = component.ShipyardChannel;
-
-            SendPurchaseMessage(uid, player, name, component.SecurityShipyardChannel, true);
         }
 
-        SendPurchaseMessage(uid, player, name, channel, false);
+        SendPurchaseMessage(uid, player, name, component.ShipyardChannel, secret: false);
+        if (component.SecretShipyardChannel is { } secretChannel)
+            SendPurchaseMessage(uid, player, name, secretChannel, secret: true);
 
         PlayConfirmSound(uid, component);
         _adminLogger.Add(LogType.ShipYardUsage, LogImpact.Low, $"{ToPrettyString(player):actor} purchased shuttle {ToPrettyString(shuttle.Owner)} for {vessel.Price} credits via {ToPrettyString(component.Owner)}");
@@ -288,7 +276,7 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
             return;
         }
 
-        if (!TryComp<ShuttleDeedComponent>(targetId, out var deed) || deed.ShuttleUid is not { Valid : true } shuttleUid)
+        if (!TryComp<ShuttleDeedComponent>(targetId, out var deed) || deed.ShuttleUid is not { Valid: true } shuttleUid)
         {
             ConsolePopup(args.Actor, Loc.GetString("shipyard-console-no-deed"));
             PlayDenySound(uid, component);
@@ -302,14 +290,14 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
             return;
         }
 
-        if (_station.GetOwningStation(uid) is not { Valid : true } stationUid)
+        if (_station.GetOwningStation(uid) is not { Valid: true } stationUid)
         {
             ConsolePopup(args.Actor, Loc.GetString("shipyard-console-invalid-station"));
             PlayDenySound(uid, component);
             return;
         }
 
-        if (_station.GetOwningStation(shuttleUid) is { Valid : true } shuttleStation
+        if (_station.GetOwningStation(shuttleUid) is { Valid: true } shuttleStation
             && TryComp<StationRecordKeyStorageComponent>(targetId, out var keyStorage)
             && keyStorage.Key != null
             && keyStorage.Key.Value.OriginStation == shuttleStation
@@ -322,8 +310,6 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
 
         var shuttleName = ToPrettyString(shuttleUid); // Grab the name before it gets 1984'd
 
-        var channel = component.ShipyardChannel;
-
         if (!TrySellShuttle(stationUid, shuttleUid, out var bill))
         {
             ConsolePopup(args.Actor, Loc.GetString("shipyard-console-sale-reqs"));
@@ -333,12 +319,9 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
 
         RemComp<ShuttleDeedComponent>(targetId);
 
-        if (ShipyardConsoleUiKey.Security == (ShipyardConsoleUiKey) args.UiKey)
-            channel = component.SecurityShipyardChannel;
-
-        if (ShipyardConsoleUiKey.BlackMarket == (ShipyardConsoleUiKey) args.UiKey || ShipyardConsoleUiKey.Syndicate == (ShipyardConsoleUiKey) args.UiKey) // Unhardcode this please
+        if (component.SalesTax != 0f)
         {
-            var tax = (int) (bill * 0.30f);
+            var tax = (int) (bill * component.SalesTax);
             var query = EntityQueryEnumerator<StationBankAccountComponent>();
 
             while (query.MoveNext(out _, out var comp))
@@ -347,15 +330,15 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
             }
 
             bill -= tax;
-            channel = component.ShipyardChannel;
-
-            SendSellMessage(uid, deed.ShuttleOwner!, GetFullName(deed), component.SecurityShipyardChannel, player, true);
         }
 
         _bank.TryBankDeposit(player, bill);
         PlayConfirmSound(uid, component);
 
-        SendSellMessage(uid, deed.ShuttleOwner!, GetFullName(deed), channel, player, false);
+        var name = GetFullName(deed);
+        SendSellMessage(uid, deed.ShuttleOwner!, name, component.ShipyardChannel, player, secret: false);
+        if (component.SecretShipyardChannel is { } secretChannel)
+            SendSellMessage(uid, deed.ShuttleOwner!, name, secretChannel, player, secret: true);
 
         _adminLogger.Add(LogType.ShipYardUsage, LogImpact.Low, $"{ToPrettyString(player):actor} sold {shuttleName} for {bill} credits via {ToPrettyString(component.Owner)}");
         RefreshState(uid, bank.Balance, true, null, 0, true, (ShipyardConsoleUiKey) args.UiKey);
@@ -391,9 +374,9 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
         if (deed?.ShuttleUid != null)
             sellValue = (int) _pricing.AppraiseGrid((EntityUid) (deed?.ShuttleUid!));
 
-        if (ShipyardConsoleUiKey.BlackMarket == (ShipyardConsoleUiKey) args.UiKey || ShipyardConsoleUiKey.Syndicate == (ShipyardConsoleUiKey) args.UiKey) // Unhardcode this please
+        if (component.SalesTax != 0f)
         {
-            var tax = (int) (sellValue * 0.30f);
+            var tax = (int) (sellValue * component.SalesTax);
             sellValue -= tax;
         }
 
@@ -403,7 +386,7 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
 
     private void ConsolePopup(EntityUid uid, string text)
     {
-            _popup.PopupEntity(text, uid);
+        _popup.PopupEntity(text, uid);
     }
 
     private void SendPurchaseMessage(EntityUid uid, EntityUid player, string name, string shipyardChannel, bool secret)
@@ -479,10 +462,9 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
             if (deed?.ShuttleUid != null)
                 sellValue = (int) _pricing.AppraiseGrid((EntityUid) (deed?.ShuttleUid!));
 
-            if (ShipyardConsoleUiKey.BlackMarket == (ShipyardConsoleUiKey) uiComp.Key ||
-                ShipyardConsoleUiKey.Syndicate == (ShipyardConsoleUiKey) uiComp.Key) // Unhardcode this please
+            if (component.SalesTax != 0f)
             {
-                var tax = (int) (sellValue * 0.30f);
+                var tax = (int) (sellValue * component.SalesTax);
                 sellValue -= tax;
             }
 

--- a/Content.Shared/Shipyard/Components/SharedShipyardConsoleComponent.cs
+++ b/Content.Shared/Shipyard/Components/SharedShipyardConsoleComponent.cs
@@ -46,7 +46,7 @@ public sealed partial class ShipyardConsoleComponent : Component
     /// <summary>
     /// Access levels to be added to the owner's ID card.
     /// </summary>
-    [DataField(required: true)]
+    [DataField]
     public List<ProtoId<AccessLevelPrototype>> NewAccessLevels = new();
 
     /// <summary>

--- a/Content.Shared/Shipyard/Components/SharedShipyardConsoleComponent.cs
+++ b/Content.Shared/Shipyard/Components/SharedShipyardConsoleComponent.cs
@@ -1,7 +1,9 @@
 using Robust.Shared.GameStates;
 using Robust.Shared.Audio;
-using Content.Shared.Shipyard;
 using Content.Shared.Containers.ItemSlots;
+using Robust.Shared.Prototypes;
+using Content.Shared.Radio;
+using Content.Shared.Access;
 
 namespace Content.Shared.Shipyard.Components;
 
@@ -21,9 +23,37 @@ public sealed partial class ShipyardConsoleComponent : Component
     public SoundSpecifier ConfirmSound =
         new SoundPathSpecifier("/Audio/Effects/Cargo/ping.ogg");
 
+    /// <summary>
+    /// The comms channel that announces the ship purchase. The purchase is *always* announced
+    /// on this channel.
+    /// </summary>
     [DataField("shipyardChannel")]
-    public string ShipyardChannel = "Traffic";
+    public ProtoId<RadioChannelPrototype> ShipyardChannel = "Traffic";
 
-    [DataField("securityShipyardChannel")]
-    public string SecurityShipyardChannel = "Nfsd";
+    /// <summary>
+    /// A second comms channel that announces the ship purchase, with some information redacted.
+    /// Currently used for black market and syndicate shipyards to alert the NFSD.
+    /// </summary>
+    [DataField("secretShipyardChannel")]
+    public ProtoId<RadioChannelPrototype>? SecretShipyardChannel = null;
+
+    /// <summary>
+    /// If non-empty, specifies the new job title that should be given to the owner of the ship.
+    /// </summary>
+    [DataField]
+    public string? NewJobTitle = null;
+
+    /// <summary>
+    /// Access levels to be added to the owner's ID card.
+    /// </summary>
+    [DataField(required: true)]
+    public List<ProtoId<AccessLevelPrototype>> NewAccessLevels = new();
+
+    /// <summary>
+    /// A tax rate that is imposed on the owner when a shuttle is sold. The tax is credited to
+    /// the station's bank account.
+    /// Expressed as a percentage: 0.3 means the owner loses 30% of the shuttle's value.
+    /// </summary>
+    [DataField]
+    public float SalesTax = 0;
 }

--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers_shipyard.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers_shipyard.yml
@@ -1,10 +1,11 @@
 - type: entity
   name: shipyard console
   parent: [BaseStructureDisableToolUse, BaseStructureIndestructible, BaseStructureComputer]
-  id: ComputerShipyard
+  id: ComputerShipyardBase
   description: Used to purchase and sell shuttles
   placement:
     mode: SnapgridCenter
+  abstract: true
   components:
   - type: MeleeSound
     soundGroups:
@@ -61,6 +62,7 @@
       whitelist:
         components:
         - IdCard
+    newAccessLevels: [Captain]
   - type: ActivatableUI
     singleUser: true
     key: enum.ShipyardConsoleUiKey.Shipyard
@@ -75,8 +77,16 @@
 
 # Hardcoded consoles
 - type: entity
+  name: shipyard console
+  parent: ComputerShipyardBase
+  id: ComputerShipyard
+  components:
+  - type: ShipyardConsole
+    newJobTitle: Captain
+
+- type: entity
   id: ComputerShipyardSecurity
-  parent: [BaseStructureDisableToolUse, BaseStructureIndestructible, ComputerShipyard]
+  parent: [BaseStructureDisableToolUse, BaseStructureIndestructible, ComputerShipyardBase]
   name: security shipyard console
   description: Used to enlist into Nanotrasen Security Forces
   components:
@@ -97,10 +107,13 @@
     interfaces:
       enum.ShipyardConsoleUiKey.Security:
         type: ShipyardConsoleBoundUserInterface
+  - type: ShipyardConsole
+    shipyardChannel: Nfsd
+    newAccessLevels: [Captain, Security, Brig]
 
 - type: entity
   id: ComputerShipyardNfsd
-  parent: [BaseStructureDisableToolUse, BaseStructureIndestructible, ComputerShipyard]
+  parent: [BaseStructureDisableToolUse, BaseStructureIndestructible, ComputerShipyardBase]
   name: nfsd shipyard console
   description: Used to buy nfsd patrol vessels
   components:
@@ -121,6 +134,9 @@
     interfaces:
       enum.ShipyardConsoleUiKey.Security:
         type: ShipyardConsoleBoundUserInterface
+  - type: ShipyardConsole
+    shipyardChannel: Nfsd
+    newAccessLevels: [Captain, Security, Brig]
 
 - type: entity
   id: ComputerShipyardSyndicate
@@ -147,6 +163,8 @@
       state: blackmarket_key
   - type: ShipyardConsole
     shipyardChannel: Syndicate
+    secretShipyardChannel: Nfsd
+    salesTax: 0.3
 
 - type: entity
   id: ComputerShipyardBlackMarket
@@ -173,6 +191,8 @@
       state: blackmarket_key
   - type: ShipyardConsole
     shipyardChannel: Freelance
+    secretShipyardChannel: Nfsd
+    salesTax: 0.3
 
 - type: entity
   id: ComputerShipyardExpedition
@@ -221,3 +241,6 @@
       state: shipyard_blackmarket
     - map: ["computerLayerKeys"]
       state: blackmarket_key
+  # TEMP: TESTING
+  - type: ShipyardConsole
+    newJobTitle: '"Captain"'

--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers_shipyard.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers_shipyard.yml
@@ -241,6 +241,3 @@
       state: shipyard_blackmarket
     - map: ["computerLayerKeys"]
       state: blackmarket_key
-  # TEMP: TESTING
-  - type: ShipyardConsole
-    newJobTitle: '"Captain"'

--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers_shipyard_mothership.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers_shipyard_mothership.yml
@@ -15,10 +15,9 @@
   - type: ShipyardListing
 
 # The empress console
-# Does NOT extend BaseMothershipComputer because the NFSD requires special stuff.
 - type: entity
   id: EmpressMothershipComputer
-  parent: ComputerShipyardNfsd
+  parent: BaseMothershipComputer
   name: empress shipyard console
   components:
   - type: Sprite
@@ -32,12 +31,10 @@
       state: shipyard_nfsd
     - map: ["computerLayerKeys"]
       state: telesci_key
-  - type: ActivatableUI
-    key: enum.ShipyardConsoleUiKey.Custom
-  - type: UserInterface
-    interfaces:
-      enum.ShipyardConsoleUiKey.Custom:
-        type: ShipyardConsoleBoundUserInterface
+  - type: ShipyardConsole
+    newJobTitle: null
+    shipyardChannel: Nfsd
+    newAccessLevels: [Captain, Security, Brig]
   - type: ShipyardListing
     shuttles:
     - Fighter

--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers_shipyard_mothership.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers_shipyard_mothership.yml
@@ -15,9 +15,10 @@
   - type: ShipyardListing
 
 # The empress console
+# Does NOT extend BaseMothershipComputer because the NFSD requires special stuff.
 - type: entity
   id: EmpressMothershipComputer
-  parent: BaseMothershipComputer
+  parent: ComputerShipyardNfsd
   name: empress shipyard console
   components:
   - type: Sprite
@@ -31,6 +32,12 @@
       state: shipyard_nfsd
     - map: ["computerLayerKeys"]
       state: telesci_key
+  - type: ActivatableUI
+    key: enum.ShipyardConsoleUiKey.Custom
+  - type: UserInterface
+    interfaces:
+      enum.ShipyardConsoleUiKey.Custom:
+        type: ShipyardConsoleBoundUserInterface
   - type: ShipyardListing
     shuttles:
     - Fighter
@@ -46,7 +53,7 @@
   - type: ShipyardListing
     shuttles:
     - McDelivery
- 
+
 # The caduceus console
 - type: entity
   id: CaduceusMothershipComputer


### PR DESCRIPTION
## About the PR
Move a bunch of stuff from ShipyardSystem to the ShipyardConsoleComponent, to reduce hardcoded nonsense. Chiefly this reduces logic based on the UI key (very smelly code).

* `ShipyardChannel` is now *always* used for the primary purchase and sale announcement, instead of picking the channel based on the UI key.
* `SecurityShipyardChannel` is gone, and in its place we get `SecretShipyardChannel`, a secondary channel that announces redacted information. Used by black market and syndicate shipyards to alert the NFSD.
* New field: `NewJobTitle`, which updates the ID card's job title if present. Allows us to *not* update job titles for NFSD and the SR. Additional logic will be introduced **in a future PR** such that we *always* leave certain jobs alone.
* New field: `NewAccessLevels`. Pretty self-explanatory. Reduces hardcoding.
* New field: `SalesTax`, for black market and syndicate ships. If set to anything but 0, the owner is taxed this percentage of the shuttle's value when the ship is sold, and the tax levied is credited to the station, as before.
* Change strings to `ProtoId` where appropriate so we get validation and nice serialization for free.
* There is a new abstract prototype `ComputerShipyardBase` that defines everything needed for a basic shipyard console, and `ComputerShipyard` extends it with what's necessary for civilian ships.

## Why / Balance
The shipyard console code was a downright mess of hardcoded stuff in places.

## How to test
1. Spawn in every shipyard console.
2. Equip yourself with a CentCom headset, then give it freelance and syndicate comms.
3. Insert a fresh passenger ID card into each shipyard console, buy a ship, sell it.
4. For the NFSD, security and Empress shipyard consoles, verify that:
    * The job title remains "Passenger"; and
    * The ID card has Captain, Brig and Security access; and
    * The purchase and sale are announced in the NFSD channel only.
5. For the black market and syndicate shipyard consoles, verify that:
    * The job title is changed to "Captain"; and
    * The ID card has Captain access; and
    * The purchase and sale are announced in the Freelance and Syndicate channels, respectively, and in the NFSD channel with redacted information; and
    * The sales tax is applied correctly – the shuttle should be nearly worthless, and the station should be credited with money upon selling the shuttle.
6. For every other shipyard console, verify that:
    * The job title is changed to "Captain"; and
    * The ID card has Captain access; and
    * The purchase and sale are announced in the Traffic channel only.
7. Verify that the black market and syndicate shipyard consoles can be destroyed.
8. Verify that no shipyard console can be unanchored or deconstructed (should block all tool use).

I have done all these things myself and everything *seems* to be working fine.

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
The Empress shipyard console now no longer sets your job title to "Captain". This is technically a breaking change, but should not have any real effect.

**Changelog**
:cl:
- fix: Empress shipyard console no longer sets users' job ID to Captain.