### PR TITLE
Remove extraneous using declaration

### DIFF
--- a/Content.Server/Shipyard/Systems/ShipyardSystem.Consoles.cs
+++ b/Content.Server/Shipyard/Systems/ShipyardSystem.Consoles.cs
@@ -39,7 +39,6 @@ using System.Text.RegularExpressions;
 using Content.Shared.UserInterface;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
-using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Content.Server.Shipyard.Systems;
 


### PR DESCRIPTION
## About the PR
Remove an extraneous `using` declaration. Yeah, I'm being nitpicky, but it's confusing and unnecessary!

## Why / Balance
This little fucker snuck in in #1581. >:( Stupid auto-import-while-typing or something.

## How to test
N/A

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
no