### PR TITLE
Shuttle cannons can now be targeted by mobs and turrets

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Shuttles/cannons.yml
+++ b/Resources/Prototypes/Entities/Structures/Shuttles/cannons.yml
@@ -49,6 +49,10 @@
   - type: GunSignalControl
   - type: StaticPrice
     price: 1500
+  - type: MobState # Frontier (otherwise NPCs won't attack the entity)
+  - type: NpcFactionMember # Frontier
+    factions: # Frontier
+    - NanoTrasen # Frontier
 
 # ---- Laser weapon branch ----
 # naming: LSE (Laser) + conventional power + suffix (c for PowerCage, e for wired energy) + Name
@@ -311,6 +315,9 @@
     proto: CannonBall
     soundInsert:
       path: /Audio/Weapons/Guns/Gunshots/grenade_launcher.ogg
+  - type: NpcFactionMember # Frontier
+    factions: # Frontier
+    - PirateNF # Frontier
 
 - type: entity
   id: ShuttleGunKinetic


### PR DESCRIPTION
## About the PR
Added `MobState` and `NpcFactionMember` to shuttle cannon parent, all cannons (bar pirate one) are NT-aligned.

## Why / Balance
Mobs (and turrets) should recognize cannons as dangerous object and treat it like a valid target

## How to test
Spawn shuttle guns
```
ShuttleGunSvalinnMachineGun
ShuttleGunPerforator
ShuttleGunFriendship
ShuttleGunDuster
ShuttleGunPirateCannon
ShuttleGunKinetic
```
Spawn any mob/turret, that's hostile to NT

## Media
![2024-7-01_18 41 34](https://github.com/new-frontiers-14/frontier-station-14/assets/65374927/dbc9e3fc-3a00-488f-b409-ecaf84b8758f)
![2024-7-01_18 41 46](https://github.com/new-frontiers-14/frontier-station-14/assets/65374927/6cca27f3-90f0-4d4a-b9d4-5f589a104a91)
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
edits to base game file

**Changelog**
:cl: erhardsteinhauer (discord)
- tweak: Shuttle cannons can now be targeted by mobs and turrets.