### PR TITLE
Remove LoneOpsSpawn rule, nukie admin verb, and unused preloaded shuttles.

### DIFF
--- a/Content.Server/Administration/Systems/AdminVerbSystem.Antags.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.Antags.cs
@@ -21,8 +21,8 @@ public sealed partial class AdminVerbSystem
     [ValidatePrototypeId<EntityPrototype>]
     private const string DefaultTraitorRule = "Traitor";
 
-    [ValidatePrototypeId<EntityPrototype>]
-    private const string DefaultNukeOpRule = "LoneOpsSpawn";
+    // [ValidatePrototypeId<EntityPrototype>] // Frontier: no nuke op verb
+    // private const string DefaultNukeOpRule = "LoneOpsSpawn"; // Frontier: no nuke op verb
 
     [ValidatePrototypeId<EntityPrototype>]
     private const string DefaultRevsRule = "Revolutionary";
@@ -77,20 +77,21 @@ public sealed partial class AdminVerbSystem
         };
         args.Verbs.Add(zombie);
 
-
-        Verb nukeOp = new()
-        {
-            Text = Loc.GetString("admin-verb-text-make-nuclear-operative"),
-            Category = VerbCategory.Antag,
-            Icon = new SpriteSpecifier.Rsi(new("/Textures/Structures/Wallmounts/signs.rsi"), "radiation"),
-            Act = () =>
-            {
-                _antag.ForceMakeAntag<NukeopsRuleComponent>(targetPlayer, DefaultNukeOpRule);
-            },
-            Impact = LogImpact.High,
-            Message = Loc.GetString("admin-verb-make-nuclear-operative"),
-        };
-        args.Verbs.Add(nukeOp);
+        // Frontier: comment this out, no nuke op verb
+        // Verb nukeOp = new()
+        // {
+        //     Text = Loc.GetString("admin-verb-text-make-nuclear-operative"),
+        //     Category = VerbCategory.Antag,
+        //     Icon = new SpriteSpecifier.Rsi(new("/Textures/Structures/Wallmounts/signs.rsi"), "radiation"),
+        //     Act = () =>
+        //     {
+        //         _antag.ForceMakeAntag<NukeopsRuleComponent>(targetPlayer, DefaultNukeOpRule);
+        //     },
+        //     Impact = LogImpact.High,
+        //     Message = Loc.GetString("admin-verb-make-nuclear-operative"),
+        // };
+        // args.Verbs.Add(nukeOp);
+        // End Frontier
 
         Verb pirate = new()
         {

--- a/Resources/Prototypes/Shuttles/shuttle_incoming_event.yml
+++ b/Resources/Prototypes/Shuttles/shuttle_incoming_event.yml
@@ -1,29 +1,31 @@
-- type: preloadedGrid
-  id: ShuttleStriker
-  path: /Maps/Shuttles/ShuttleEvent/striker.yml
-  copies: 2
+# Frontier: all of these prototypes were commented out, we do not want them preloaded.
 
-- type: preloadedGrid
-  id: ShuttleCargoLost
-  path: /Maps/Shuttles/ShuttleEvent/lost_cargo.yml
-  copies: 2
+# - type: preloadedGrid
+#   id: ShuttleStriker
+#   path: /Maps/Shuttles/ShuttleEvent/striker.yml
+#   copies: 2
 
-- type: preloadedGrid
-  id: TravelingCuisine
-  path: /Maps/Shuttles/ShuttleEvent/traveling_china_cuisine.yml
-  copies: 2
+# - type: preloadedGrid
+#   id: ShuttleCargoLost
+#   path: /Maps/Shuttles/ShuttleEvent/lost_cargo.yml
+#   copies: 2
 
-- type: preloadedGrid
-  id: DisasterEvacPod
-  path: /Maps/Shuttles/ShuttleEvent/disaster_evacpod.yml
-  copies: 3
+# - type: preloadedGrid
+#   id: TravelingCuisine
+#   path: /Maps/Shuttles/ShuttleEvent/traveling_china_cuisine.yml
+#   copies: 2
 
-- type: preloadedGrid
-  id: Honki
-  path: /Maps/Shuttles/ShuttleEvent/honki.yml
-  copies: 1
+# - type: preloadedGrid
+#   id: DisasterEvacPod
+#   path: /Maps/Shuttles/ShuttleEvent/disaster_evacpod.yml
+#   copies: 3
 
-- type: preloadedGrid
-  id: SyndieEvacPod
-  path: /Maps/Shuttles/ShuttleEvent/syndie_evacpod.yml
-  copies: 2
+# - type: preloadedGrid
+#   id: Honki
+#   path: /Maps/Shuttles/ShuttleEvent/honki.yml
+#   copies: 1
+
+# - type: preloadedGrid
+#   id: SyndieEvacPod
+#   path: /Maps/Shuttles/ShuttleEvent/syndie_evacpod.yml
+#   copies: 2

--- a/Resources/Prototypes/_NF/Events/events.yml
+++ b/Resources/Prototypes/_NF/Events/events.yml
@@ -413,41 +413,40 @@
 #       - type: InitialInfectedRole
 #         prototype: InitialInfected
 
-# Frontier: may be used in admemes, should not spawn normally (note: addgamerule adds bogus ghost roles)
-- type: entity
-  parent: BaseNukeopsRule
-  abstract: true
-  id: LoneOpsSpawn
-  components:
-  # - type: StationEvent
-  #   earliestStart: 35
-  #   weight: 5.5
-  #   minimumPlayers: 20
-  #   duration: 1
-  # - type: RuleGrids
-  # - type: LoadMapRule # Frontier: do not load the map, it was removed
-  #   preloadedGrid: ShuttleStriker # Frontier: do not load the map, it was removed
-  - type: NukeopsRule
-    roundEndBehavior: Nothing
-  - type: AntagSelection
-    definitions:
-    - spawnerPrototype: SpawnPointLoneNukeOperative
-      min: 1
-      max: 1
-      pickPlayer: false
-      startingGear: SyndicateLoneOperativeGearFull
-      components:
-      - type: NukeOperative
-      - type: RandomMetadata
-        nameSegments:
-        - SyndicateNamesPrefix
-        - SyndicateNamesNormal
-      - type: NpcFactionMember
-        factions:
-        - Syndicate
-      mindComponents:
-      - type: NukeopsRole
-        prototype: Nukeops
+# - type: entity
+#   parent: BaseNukeopsRule
+#   abstract: true
+#   id: LoneOpsSpawn
+#   components:
+#   - type: StationEvent
+#     earliestStart: 35
+#     weight: 5.5
+#     minimumPlayers: 20
+#     duration: 1
+#   - type: RuleGrids
+#   # - type: LoadMapRule # Frontier: do not load the map, it was removed
+#   #   preloadedGrid: ShuttleStriker # Frontier: do not load the map, it was removed
+#   - type: NukeopsRule
+#     roundEndBehavior: Nothing
+#   - type: AntagSelection
+#     definitions:
+#     - spawnerPrototype: SpawnPointLoneNukeOperative
+#       min: 1
+#       max: 1
+#       pickPlayer: false
+#       startingGear: SyndicateLoneOperativeGearFull
+#       components:
+#       - type: NukeOperative
+#       - type: RandomMetadata
+#         nameSegments:
+#         - SyndicateNamesPrefix
+#         - SyndicateNamesNormal
+#       - type: NpcFactionMember
+#         factions:
+#         - Syndicate
+#       mindComponents:
+#       - type: NukeopsRole
+#         prototype: Nukeops
 
 # - type: entity
 #   parent: BaseTraitorRule

--- a/Resources/Prototypes/_NF/Events/events.yml
+++ b/Resources/Prototypes/_NF/Events/events.yml
@@ -413,19 +413,20 @@
 #       - type: InitialInfectedRole
 #         prototype: InitialInfected
 
-# Frontier: Have to keep this ones existing as abstract for no errors?
+# Frontier: may be used in admemes, should not spawn normally (note: addgamerule adds bogus ghost roles)
 - type: entity
   parent: BaseNukeopsRule
+  abstract: true
   id: LoneOpsSpawn
   components:
-  - type: StationEvent
-    earliestStart: 35
-    weight: 5.5
-    minimumPlayers: 20
-    duration: 1
-  - type: RuleGrids
-  - type: LoadMapRule
-    preloadedGrid: ShuttleStriker
+  # - type: StationEvent
+  #   earliestStart: 35
+  #   weight: 5.5
+  #   minimumPlayers: 20
+  #   duration: 1
+  # - type: RuleGrids
+  # - type: LoadMapRule # Frontier: do not load the map, it was removed
+  #   preloadedGrid: ShuttleStriker # Frontier: do not load the map, it was removed
   - type: NukeopsRule
     roundEndBehavior: Nothing
   - type: AntagSelection


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Removes the LoneOpsSpawn along with the admin verb that creates them.

Unwanted, preloaded shuttle grids have also been commented out.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Regression - event was concrete, could spawn in normal gameplay.  Preloaded shuttles clutter the objects menu, and are not spawned through events.

## How to test
<!-- Describe the way it can be tested -->

1. Build and run local server.
2. Try to run `addgamerule LoneOpsSpawn` in the debug menu (`)
3. It should fail, autocomplete should not populate "LoneOpsSpawn" in the suggestions.
4. Right-click your character, open the "Antag Ctrl"
5. Open the admin bar (F7), check the objects menu.
6. You should not see "SLV Salami-Salami" or other preloaded shuttle names - only POIs and a few asteroids/wrecks should be visible.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

No nukie verb:
![no-nukies](https://github.com/new-frontiers-14/frontier-station-14/assets/166147148/807b1190-a5b5-4b48-a627-cede045e9ed5)

Clean objects list:
![clean-objects-list](https://github.com/new-frontiers-14/frontier-station-14/assets/166147148/00142f90-6db3-435d-acb9-a45364e1f987)

- [X] ***I have added screenshots/videos to this PR showcasing its changes ingame***, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Lone operative ghost roles should no longer spawn.