### PR TITLE
Suit storage slot for outer clothing

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
@@ -1,6 +1,6 @@
 - type: entity
   abstract: true
-  parent: Clothing
+  parent: [ Clothing, AllowSuitStorageClothing ] # Frontier: added AllowSuitStorageClothing as a second parent
   id: ClothingOuterBase
   components:
   - type: Clothing

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/vests.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/vests.yml
@@ -21,7 +21,7 @@
 
 #Mercenary web vest
 - type: entity
-  parent: ClothingOuterStorageBase #web vest so it should have some pockets for ammo # Frontier: ClothingOuterVestWeb<ClothingOuterStorageBase
+  parent: [ClothingOuterStorageBase, AllowSuitStorageClothing] #web vest so it should have some pockets for ammo # Frontier: added AllowSuitStorageClothing
   id: ClothingOuterVestWebMercenary # Frontier - Merc to Mercenary
   name: mercenary web vest # Frontier - merc to mercenary
   description: A high-quality armored vest made from a hard synthetic material. It's surprisingly flexible and light, despite formidable armor plating.

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/vests.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/vests.yml
@@ -21,7 +21,7 @@
 
 #Mercenary web vest
 - type: entity
-  parent: [ClothingOuterStorageBase, AllowSuitStorageClothing] #web vest so it should have some pockets for ammo # Frontier: added AllowSuitStorageClothing
+  parent: ClothingOuterStorageBase #web vest so it should have some pockets for ammo # Frontier: ClothingOuterVestWeb<ClothingOuterStorageBase
   id: ClothingOuterVestWebMercenary # Frontier - Merc to Mercenary
   name: mercenary web vest # Frontier - merc to mercenary
   description: A high-quality armored vest made from a hard synthetic material. It's surprisingly flexible and light, despite formidable armor plating.


### PR DESCRIPTION
## About the PR
- Adds `AllowSuitStorageClothing` as a second parent to `ClothingOuterBase`

## Why / Balance
imo if the item has `SuitStorage` it should be able to store items with `suitStorage` there

## How to test
1. equip any outer clothing article
2. put gas tank in your suit storage slot

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
changes to `base_clothingouter.yml`

**Changelog**
:cl: erhardesteinhauer
- fix: Restored suit storage slot functionality in outer clothing articles.