### PR TITLE
Fix railing

### DIFF
--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/railing.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/railing.yml
@@ -7,7 +7,7 @@
         - to: railing
           completed:
             - !type:SnapToGrid
-              southRotation: true
+              # southRotation: true # Frontier: commented out
           steps:
             - material: MetalRod
               amount: 1
@@ -15,7 +15,7 @@
         - to: railingCorner
           completed:
             - !type:SnapToGrid
-              southRotation: true
+              # southRotation: true # Frontier: commented out
           steps:
             - material: MetalRod
               amount: 2
@@ -23,7 +23,7 @@
         - to: railingCornerSmall
           completed:
             - !type:SnapToGrid
-              southRotation: true
+              # southRotation: true # Frontier: commented out
           steps:
             - material: MetalRod
               amount: 1
@@ -31,7 +31,7 @@
         - to: railingRound
           completed:
             - !type:SnapToGrid
-              southRotation: true
+              # southRotation: true # Frontier: commented out
           steps:
             - material: MetalRod
               amount: 2


### PR DESCRIPTION
## About the PR
Commented out `southRotation: true` in railing construction graph so it is possible to build railing facing any direction.

## Why / Balance
bug fix

## How to test
use construction menu to build railings facing different directions

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
base game file changes

**Changelog**
:cl: erhardsteinhauer
- fix: Fixed railings always facing south upon construction.
