### PR TITLE
ContrabandClothing faction

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
@@ -170,6 +170,8 @@
   - type: Storage
     grid:
     - 0,0,8,4
+  - type: FactionClothing # frontier
+    faction: ContrabandClothing # frontier
 
 - type: entity
   parent: ClothingBackpackDuffelSyndicate

--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -610,6 +610,8 @@
         - BallisticAmmoProvider
         - CartridgeAmmo
   - type: Contraband #frontier
+  - type: FactionClothing # frontier
+    faction: ContrabandClothing # frontier
 
 - type: entity
   parent: ClothingBeltStorageBase #Frontier - ClothingBeltSecurity<ClothingBeltStorageBase
@@ -705,3 +707,5 @@
       tags:
       - WizardWand
   - type: Contraband #frontier
+  - type: FactionClothing # frontier
+    faction: ContrabandClothing # frontier

--- a/Resources/Prototypes/Entities/Clothing/Ears/headsets_alt.yml
+++ b/Resources/Prototypes/Entities/Clothing/Ears/headsets_alt.yml
@@ -149,6 +149,8 @@
   - type: Clothing
     sprite: Clothing/Ears/Headsets/syndicate.rsi
   - type: Contraband #frontier
+  - type: FactionClothing #frontier
+    faction: ContrabandClothing #frontier
 
 - type: entity
   parent: ClothingHeadsetAlt

--- a/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
@@ -237,3 +237,5 @@
   - type: Clothing
     sprite: Clothing/Eyes/Glasses/ninjavisor.rsi
   - type: FlashImmunity
+  - type: FactionClothing # frontier
+    faction: ContrabandClothing # frontier

--- a/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
@@ -217,6 +217,8 @@
     damageContainers:
     - Biological
   - type: Contraband #frontier
+  - type: FactionClothing #frontier
+    faction: ContrabandClothing #frontier
 
 - type: entity
   parent: [ClothingEyesGlassesSunglasses, ShowSecurityIcons]
@@ -224,6 +226,8 @@
   suffix: Syndicate
   components:
   - type: Contraband #frontier
+  - type: FactionClothing #frontier
+    faction: ContrabandClothing #frontier
 
 - type: entity
   parent: [ClothingEyesHudMedical, ClothingHeadEyeBaseFlippable]

--- a/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
@@ -199,6 +199,8 @@
     sprite: Clothing/Eyes/Hud/synd.rsi
   - type: ShowSyndicateIcons
   - type: Contraband #frontier
+  - type: FactionClothing # frontier
+    faction: ContrabandClothing # frontier
 
 - type: entity
   parent: [ClothingEyesBase, ShowSecurityIcons]

--- a/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
@@ -235,6 +235,9 @@
     stripTimeReduction: 1
     stealthy: true
   - type: NinjaGloves
+  - type: Contraband #frontier
+  - type: FactionClothing #frontier
+    faction: ContrabandClothing #frontier
 
 - type: entity
   parent: ClothingHandsGlovesColorBlack
@@ -342,7 +345,9 @@
     stripTimeReduction: 1.5
     stealthy: true
   - type: FingerprintMask # Frontier
-  - type: Contraband # Frontier
+  - type: Contraband #frontier
+  - type: FactionClothing #frontier
+    faction: ContrabandClothing #frontier
 
 - type: entity
   parent: ClothingHandsGlovesColorWhite
@@ -389,6 +394,8 @@
   - type: StaticPrice
     price: 0
   - type: Contraband #frontier
+  - type: FactionClothing #frontier
+    faction: ContrabandClothing #frontier
 
 - type: entity
   parent: ClothingHandsBase

--- a/Resources/Prototypes/Entities/Clothing/Head/eva-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/eva-helmets.yml
@@ -40,6 +40,8 @@
   - type: Clothing
     sprite: Clothing/Head/Helmets/eva_syndicate.rsi
   - type: Contraband #frontier
+  - type: FactionClothing # frontier
+    faction: ContrabandClothing # frontier
 
 #Cosmonaut Helmet
 - type: entity

--- a/Resources/Prototypes/Entities/Clothing/Head/hats.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hats.yml
@@ -625,6 +625,8 @@
     sprite: Clothing/Head/Hats/pyjamasyndicateblack.rsi
   - type: Clothing
     sprite: Clothing/Head/Hats/pyjamasyndicateblack.rsi
+  - type: FactionClothing # frontier
+    faction: ContrabandClothing # frontier
 
 - type: entity
   parent: ClothingHeadBase
@@ -636,6 +638,8 @@
     sprite: Clothing/Head/Hats/pyjamasyndicatepink.rsi
   - type: Clothing
     sprite: Clothing/Head/Hats/pyjamasyndicatepink.rsi
+  - type: FactionClothing # frontier
+    faction: ContrabandClothing # frontier
 
 - type: entity
   parent: ClothingHeadBase
@@ -647,6 +651,8 @@
     sprite: Clothing/Head/Hats/pyjamasyndicatered.rsi
   - type: Clothing
     sprite: Clothing/Head/Hats/pyjamasyndicatered.rsi
+  - type: FactionClothing # frontier
+    faction: ContrabandClothing # frontier
 
 - type: entity
   parent: ClothingHeadBase
@@ -793,6 +799,8 @@
     sprite: Clothing/Head/Hats/syndiecap.rsi
   - type: Clothing
     sprite: Clothing/Head/Hats/syndiecap.rsi
+  - type: FactionClothing # frontier
+    faction: ContrabandClothing # frontier
 
 - type: entity
   parent: ClothingHeadBase
@@ -804,6 +812,8 @@
     sprite: Clothing/Head/Hats/syndiecap_maa.rsi
   - type: Clothing
     sprite: Clothing/Head/Hats/syndiecap_maa.rsi
+  - type: FactionClothing # frontier
+    faction: ContrabandClothing # frontier
 
 - type: entity
   parent: ClothingHeadBase

--- a/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
@@ -71,6 +71,8 @@
   - type: Clothing
     sprite: Clothing/Head/Helmets/swat_syndicate.rsi
   - type: Contraband #frontier
+  - type: FactionClothing # frontier
+    faction: ContrabandClothing # frontier
 
 #Light Riot Helmet
 - type: entity
@@ -149,6 +151,8 @@
         Piercing: 0.9
         Heat: 0.9
   - type: Contraband #frontier
+  - type: FactionClothing # frontier
+    faction: ContrabandClothing # frontier
 
 #Space Ninja Helmet
 - type: entity
@@ -211,6 +215,8 @@
   - type: IngestionBlocker
   - type: IdentityBlocker
   - type: Contraband #frontier
+  - type: FactionClothing # frontier
+    faction: ContrabandClothing # frontier
 
 #Fire Helmet
 - type: entity

--- a/Resources/Prototypes/Entities/Clothing/Head/hoods.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hoods.yml
@@ -120,6 +120,8 @@
     slots:
     - Hair
   - type: Contraband #frontier
+  - type: FactionClothing # frontier
+    faction: ContrabandClothing # frontier
 
 - type: entity
   parent: ClothingHeadBase

--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -60,6 +60,8 @@
         Piercing: 0.95
         Heat: 0.95
   - type: Contraband #frontier
+  - type: FactionClothing # frontier
+    faction: ContrabandClothing # frontier
 
 - type: entity
   parent: ClothingMaskGas

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -119,7 +119,9 @@
         Piercing: 0.6
         Heat: 0.5
   - type: GroupExamine
-  - type: Contraband #frontier
+  - type: Contraband # frontier
+  - type: FactionClothing # frontier
+    faction: ContrabandClothing # frontier
 
 - type: entity
   parent: [ClothingOuterBaseLarge, AllowSuitStorageClothing]
@@ -177,7 +179,9 @@
     sprite: Clothing/OuterClothing/Armor/magusblue.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Armor/magusblue.rsi
-  - type: Contraband #frontier
+  - type: Contraband # frontier
+  - type: FactionClothing # frontier
+    faction: ContrabandClothing # frontier
 
 - type: entity
   parent: ClothingOuterArmorHeavy
@@ -189,7 +193,9 @@
     sprite: Clothing/OuterClothing/Armor/magusred.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Armor/magusred.rsi
-  - type: Contraband #frontier
+  - type: Contraband # frontier
+  - type: FactionClothing # frontier
+    faction: ContrabandClothing # frontier
 
 - type: entity
   parent: [ClothingOuterBaseLarge, AllowSuitStorageClothing]

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
@@ -388,7 +388,9 @@
     sprite: Clothing/OuterClothing/Coats/syndicate/coatsyndiecap.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Coats/syndicate/coatsyndiecap.rsi
-  - type: Contraband #frontier
+  - type: Contraband # frontier
+  - type: FactionClothing # frontier
+    faction: ContrabandClothing # frontier
 
 - type: entity
   parent: ClothingOuterCoatHoSTrench
@@ -400,7 +402,9 @@
     sprite: Clothing/OuterClothing/Coats/syndicate/coatsyndiecaparmored.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Coats/syndicate/coatsyndiecaparmored.rsi
-  - type: Contraband #frontier
+  - type: Contraband # frontier
+  - type: FactionClothing # frontier
+    faction: ContrabandClothing # frontier
 
 - type: entity
   parent: ClothingOuterStorageBase

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -510,6 +510,8 @@
     - Hardsuit
     - WhitelistChameleon
   - type: Contraband #frontier
+  - type: FactionClothing # frontier
+    faction: ContrabandClothing # frontier
 
 # Syndicate Medic Hardsuit
 - type: entity
@@ -529,6 +531,8 @@
     - Hardsuit
     - WhitelistChameleon
   - type: Contraband #frontier
+  - type: FactionClothing # frontier
+    faction: ContrabandClothing # frontier
 
 #Syndicate Elite Hardsuit
 - type: entity
@@ -568,6 +572,8 @@
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSyndieElite
   - type: Contraband #frontier
+  - type: FactionClothing # frontier
+    faction: ContrabandClothing # frontier
 
 #Syndicate Commander Hardsuit
 - type: entity
@@ -601,6 +607,8 @@
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSyndieCommander
   - type: Contraband #frontier
+  - type: FactionClothing # frontier
+    faction: ContrabandClothing # frontier
 
 #Cybersun Juggernaut Hardsuit
 - type: entity
@@ -634,6 +642,8 @@
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitCybersun
   - type: Contraband #frontier
+  - type: FactionClothing # frontier
+    faction: ContrabandClothing # frontier
 
 #Wizard Hardsuit
 - type: entity
@@ -667,6 +677,8 @@
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitWizard
   - type: Contraband #frontier
+  - type: FactionClothing # frontier
+    faction: ContrabandClothing # frontier
 
 #Ling Space Suit
 - type: entity
@@ -698,6 +710,8 @@
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitLing
   - type: Contraband #frontier
+  - type: FactionClothing # frontier
+    faction: ContrabandClothing # frontier
 
 #Pirate EVA Suit (Deep Space EVA Suit)
 #Despite visually appearing like a softsuit, it functions exactly like a hardsuit would (parents off of base hardsuit, has resistances and toggleable clothing, etc.) so it goes here.
@@ -731,6 +745,8 @@
   - type: StaticPrice
     price: 0
   - type: Contraband #frontier
+  - type: FactionClothing # frontier
+    faction: ContrabandClothing # frontier
 
 #Pirate Captain Hardsuit
 - type: entity
@@ -765,6 +781,8 @@
   - type: StaticPrice
     price: 0
   - type: Contraband #frontier
+  - type: FactionClothing # frontier
+    faction: ContrabandClothing # frontier
 
 #CENTCOMM / ERT HARDSUITS
 #ERT Leader Hardsuit

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/misc.yml
@@ -131,6 +131,8 @@
   - type: Clothing
     sprite: Clothing/OuterClothing/Misc/cultrobes.rsi
   - type: Contraband #frontier
+  - type: FactionClothing # frontier
+    faction: ContrabandClothing # frontier
 
 - type: entity
   parent: ClothingOuterBase
@@ -186,6 +188,8 @@
   - type: Clothing
     sprite: Clothing/OuterClothing/Misc/violetwizard.rsi
   - type: Contraband #frontier
+  - type: FactionClothing # frontier
+    faction: ContrabandClothing # frontier
 
 - type: entity
   parent: ClothingOuterWizardBase
@@ -198,6 +202,8 @@
   - type: Clothing
     sprite: Clothing/OuterClothing/Misc/wizard.rsi
   - type: Contraband #frontier
+  - type: FactionClothing # frontier
+    faction: ContrabandClothing # frontier
 
 - type: entity
   parent: ClothingOuterWizardBase
@@ -210,6 +216,8 @@
   - type: Clothing
     sprite: Clothing/OuterClothing/Misc/redwizard.rsi
   - type: Contraband #frontier
+  - type: FactionClothing # frontier
+    faction: ContrabandClothing # frontier
 
 - type: entity
   parent: ClothingOuterBase

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/softsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/softsuits.yml
@@ -34,6 +34,8 @@
     - MonkeyWearable
     - WhitelistChameleon
   - type: Contraband #frontier
+  - type: FactionClothing # frontier
+    faction: ContrabandClothing # frontier
 
 #Emergency EVA
 - type: entity

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
@@ -476,6 +476,8 @@
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHatHoodWinterSyndie
   - type: Contraband #frontier
+  - type: FactionClothing # frontier
+    faction: ContrabandClothing # frontier
 
 - type: entity
   parent: ClothingOuterWinterWarden
@@ -490,6 +492,8 @@
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHatHoodWinterSyndie
   - type: Contraband #frontier
+  - type: FactionClothing # frontier
+    faction: ContrabandClothing # frontier
 
 - type: entity
   parent: ClothingOuterWinterCoatToggleable
@@ -504,6 +508,8 @@
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHatHoodWinterSyndie
   - type: Contraband #frontier
+  - type: FactionClothing # frontier
+    faction: ContrabandClothing # frontier
 
 - type: entity
   parent: ClothingOuterWinterCoat

--- a/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
@@ -107,6 +107,8 @@
         - 0.153853429 # oxygen
         - 0.153853429 # nitrogen
   - type: Contraband #frontier
+  - type: FactionClothing # frontier
+    faction: ContrabandClothing # frontier
   - type: Item
     sprite: null
     size: Normal

--- a/Resources/Prototypes/Entities/Clothing/Shoes/specific.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/specific.yml
@@ -97,6 +97,9 @@
     sprite: Clothing/Shoes/Specific/cult.rsi
   - type: Clothing
     sprite: Clothing/Shoes/Specific/cult.rsi
+  - type: Contraband #frontier
+  - type: FactionClothing # frontier
+    faction: ContrabandClothing # frontier
 
 - type: entity
   parent: ClothingShoesBase
@@ -126,6 +129,8 @@
     walkModifier: 1.1
     sprintModifier: 1.3
   - type: Contraband #frontier
+  - type: FactionClothing # frontier
+    faction: ContrabandClothing # frontier
 
 - type: entity
   parent: ClothingShoesBaseButcherable
@@ -200,6 +205,8 @@
   - type: StaticPrice
     price: 25
   - type: Contraband #frontier
+  - type: FactionClothing # frontier
+    faction: ContrabandClothing # frontier
 
 - type: entity
   parent: ClothingShoesClown

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/jumpskirts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/jumpskirts.yml
@@ -466,6 +466,8 @@
   - type: Clothing
     sprite: Clothing/Uniforms/Jumpskirt/operative_s.rsi
   - type: Contraband #frontier
+  - type: FactionClothing # frontier
+    faction: ContrabandClothing # frontier
 
 - type: entity
   parent: ClothingUniformSkirtBase
@@ -581,6 +583,8 @@
     - type: Clothing
       sprite: Clothing/Uniforms/Jumpskirt/syndieformaldress.rsi
     - type: Contraband #frontier
+    - type: FactionClothing # frontier
+      faction: ContrabandClothing # frontier
 
 - type: entity
   parent: ClothingUniformSkirtBase

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/jumpsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/jumpsuits.yml
@@ -720,7 +720,9 @@
     sprite: Clothing/Uniforms/Jumpsuit/pyjamasyndicateblack.rsi
   - type: Clothing
     sprite: Clothing/Uniforms/Jumpsuit/pyjamasyndicateblack.rsi
-  - type: Contraband #frontier
+  - type: Contraband # frontier
+  - type: FactionClothing # frontier
+    faction: ContrabandClothing # frontier
 
 - type: entity
   parent: UnsensoredClothingUniformBase
@@ -733,6 +735,8 @@
   - type: Clothing
     sprite: Clothing/Uniforms/Jumpsuit/pyjamasyndicatepink.rsi
   - type: Contraband #frontier
+  - type: FactionClothing # frontier
+    faction: ContrabandClothing # frontier
 
 - type: entity
   parent: UnsensoredClothingUniformBase
@@ -745,6 +749,8 @@
   - type: Clothing
     sprite: Clothing/Uniforms/Jumpsuit/pyjamasyndicatered.rsi
   - type: Contraband #frontier
+  - type: FactionClothing # frontier
+    faction: ContrabandClothing # frontier
 
 - type: entity
   parent: ClothingUniformBase
@@ -801,6 +807,8 @@
   - type: Clothing
     sprite: Clothing/Uniforms/Jumpsuit/operative.rsi
   - type: Contraband #frontier
+  - type: FactionClothing # frontier
+    faction: ContrabandClothing # frontier
 
 - type: entity
   parent: ClothingUniformBase

--- a/Resources/Prototypes/Entities/Objects/Weapons/base_turret.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/base_turret.yml
@@ -1,0 +1,113 @@
+# BASE
+- type: entity # 'Gun', 'AmmoProvider' and 'ContainerContainer' components are not defined in this one
+  parent: BaseStructure
+  id: BaseWeaponTurretNF
+  name: turret
+  suffix: Frontier
+  abstract: true
+  components:
+  - type: Clickable
+  - type: InteractionOutline
+  - type: Actions
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.45,-0.45,0.45,0.45"
+        density: 60
+        mask:
+          - MachineMask
+        layer:
+          - MachineLayer
+  - type: Sprite
+    sprite: Objects/Weapons/Guns/Turrets/turrets.rsi
+    drawdepth: Mobs
+    layers:
+      - state: syndie_lethal
+  - type: InteractionPopup
+    interactDelay: 0.2
+    successChance: 0.8
+    interactSuccessString: petting-success-generic
+    interactFailureString: petting-failure-generic
+    interactSuccessSound:
+      path: /Audio/Effects/double_beep.ogg
+  - type: CombatMode
+    toggleMouseRotator: false
+  - type: Damageable
+    damageContainer: Inorganic
+  - type: Destructible
+    thresholds:
+      - trigger:
+          !type:DamageTrigger
+          damage: 600
+        behaviors:
+          - !type:DoActsBehavior
+            acts: [ "Destruction" ]
+      - trigger:
+          !type:DamageTrigger
+          damage: 300
+        # TODO: Construction graph
+        behaviors:
+          - !type:DoActsBehavior
+            acts: [ "Destruction" ]
+          - !type:PlaySoundBehavior
+            sound:
+              collection: MetalGlassBreak
+          - !type:SpawnEntitiesBehavior
+            spawn:
+              SheetSteel1:
+                min: 3
+                max: 5
+  - type: HTN
+    rootTask:
+      task: TurretCompound
+    blackboard:
+      RotateSpeed: !type:Single
+        3.141
+      SoundTargetInLOS: !type:SoundPathSpecifier
+        path: /Audio/Effects/double_beep.ogg
+  - type: MouseRotator
+    angleTolerance: 5
+    rotationSpeed: 180
+    simple4DirMode: false
+  - type: NoRotateOnInteract
+  - type: NoRotateOnMove
+  - type: Input
+    context: "human"
+  - type: MobState # Frontier (otherwise NPCs won't attack the entity)
+
+- type: entity # Basic ballistic turret
+  parent: BaseWeaponTurretNF
+  id: BaseWeaponTurretBallisticNF
+  name: ballistic turret
+  abstract: true
+  components:
+  - type: ContainerContainer
+    containers:
+      ballistic-ammo: !type:Container
+  - type: Gun
+    fireRate: 6
+    selectedMode: FullAuto
+    availableModes:
+      - FullAuto
+    soundGunshot: /Audio/Weapons/Guns/Gunshots/gun_sentry.ogg
+  - type: BallisticAmmoProvider
+    proto: CartridgeCaselessRifle
+    capacity: 500
+
+- type: entity # Basic energy turret
+  parent: BaseWeaponTurretNF
+  id: BaseWeaponTurretEnergyNF
+  name: energy turret
+  abstract: true
+  components:
+  - type: Gun
+    fireRate: 6
+    selectedMode: FullAuto
+    availableModes:
+      - FullAuto
+    soundGunshot: /Audio/Weapons/Guns/Gunshots/laser.ogg
+  - type: Battery
+    maxCharge: 5000
+    startingCharge: 5000

--- a/Resources/Prototypes/Entities/Objects/Weapons/turrets.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/turrets.yml
@@ -1,0 +1,68 @@
+# VARIATIONS
+# Contraband denying turret
+- type: entity # Targets players wearing contra and all hostile to NT factions, rough examble
+  parent: BaseWeaponTurretEnergyNF
+  id: WeaponTurretEnergyNF
+  name: contraband denying turret
+  components:
+  - type: Gun
+    fireRate: 2
+    soundGunshot:
+      path: /Audio/Weapons/Guns/Gunshots/taser2.ogg
+      params:
+        variation: 0.125
+  - type: ProjectileBatteryAmmoProvider
+    proto: BulletDisablerStaminaOnly
+    fireCost: 10
+  - type: Battery
+    maxCharge: 500
+    startingCharge: 500
+  - type: BatterySelfRecharger
+    autoRecharge: true
+    autoRechargeRate: 40
+  - type: NpcFactionMember
+    factions:
+    - ContrabandDetection
+
+# Basic laser turrets
+- type: entity
+  parent: BaseWeaponTurretEnergyNF
+  id: WeaponTurretLaserNanoTrasenNF
+  name: laser turret
+  suffix: Frontier, NT
+  components:
+  - type: Gun
+    fireRate: 2
+    soundGunshot:
+      path: /Audio/Weapons/Guns/Gunshots/laser.ogg
+      params:
+        variation: 0.125
+  - type: HitscanBatteryAmmoProvider
+    proto: RedLightLaser
+    fireCost: 10
+  - type: Battery
+    maxCharge: 5000
+    startingCharge: 5000
+  - type: NpcFactionMember
+    factions:
+    - NanoTrasen
+
+- type: entity
+  parent: WeaponTurretLaserNanoTrasenNF
+  id: WeaponTurretLaserSyndicateNF
+  name: laser turret
+  suffix: Frontier, Syndicate
+  components:
+  - type: NpcFactionMember
+    factions:
+    - Syndicate
+
+- type: entity
+  parent: WeaponTurretLaserNanoTrasenNF
+  id: WeaponTurretLaserHostileNF
+  name: laser turret
+  suffix: Frontier, Hostile
+  components:
+  - type: NpcFactionMember
+    factions:
+    - SimpleHostile

--- a/Resources/Prototypes/_NF/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Back/backpacks.yml
@@ -6,6 +6,8 @@
   components:
   - type: Sprite
     sprite: _NF/Clothing/Back/Backpacks/arcadia.rsi
+  - type: FactionClothing
+    faction: ContrabandClothing
 
 - type: entity
   parent: ClothingBackpack

--- a/Resources/Prototypes/_NF/Entities/Clothing/Back/duffel.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Back/duffel.yml
@@ -15,6 +15,8 @@
   components:
   - type: Sprite
     sprite: _NF/Clothing/Back/Duffels/arcadia.rsi
+  - type: FactionClothing
+    faction: ContrabandClothing
 
 - type: entity
   parent: ClothingBackpackDuffel

--- a/Resources/Prototypes/_NF/Entities/Clothing/Back/messenger.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Back/messenger.yml
@@ -642,6 +642,8 @@
         color: "#424242"
       - state: clasp-inhand-right
         color: "#7f0101"
+  - type: FactionClothing
+    faction: ContrabandClothing
 
 - type: entity
   parent: ClothingBackpackMessengerContractor
@@ -680,6 +682,8 @@
         color: "#562f2f"
       - state: clasp-inhand-right
         color: "#96907c"
+  - type: FactionClothing
+    faction: ContrabandClothing
 
 - type: entity
   parent: ClothingBackpackMessengerContractor
@@ -733,6 +737,8 @@
         color: "#c12d30"
       - state: clasp-inhand-right
         color: "#1f1f1f"
+  - type: FactionClothing
+    faction: ContrabandClothing
 
 ## NFSD
 - type: entity

--- a/Resources/Prototypes/_NF/Entities/Clothing/Back/satchel.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Back/satchel.yml
@@ -15,6 +15,8 @@
   components:
   - type: Sprite
     sprite: _NF/Clothing/Back/Satchels/arcadia.rsi
+  - type: FactionClothing
+    faction: ContrabandClothing
 
 - type: entity
   parent: ClothingBackpackSatchel

--- a/Resources/Prototypes/_NF/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Belt/belts.yml
@@ -8,6 +8,8 @@
     sprite: _NF/Clothing/Belt/arcadia.rsi
   - type: Clothing
     sprite: _NF/Clothing/Belt/arcadia.rsi
+  - type: FactionClothing
+    faction: ContrabandClothing
 
 - type: entity
   parent: ClothingBeltStorageBase
@@ -132,6 +134,8 @@
     enabled: true
     reflectProb: .1
     spread: 90
+  - type: FactionClothing
+    faction: ContrabandClothing
 
 - type: entity
   parent: ClothingBeltStorageBase
@@ -143,3 +147,5 @@
     sprite: _NF/Clothing/Belt/cult_webbing.rsi
   - type: Clothing
     sprite: _NF/Clothing/Belt/cult_webbing.rsi
+  - type: FactionClothing
+    faction: ContrabandClothing

--- a/Resources/Prototypes/_NF/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Head/helmets.yml
@@ -24,6 +24,8 @@
   - type: Clothing
     sprite: _NF/Clothing/Head/Helmets/syndicate_bombsuit.rsi
   - type: Contraband
+  - type: FactionClothing
+    faction: ContrabandClothing
 
 # Syndicate NPC helmets, unremoveable
 - type: entity
@@ -75,3 +77,5 @@
     - ClothMade
     - HidesHair
     - WhitelistChameleon
+  - type: FactionClothing
+    faction: ContrabandClothing

--- a/Resources/Prototypes/_NF/Entities/Clothing/Head/hoods.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Head/hoods.yml
@@ -100,6 +100,8 @@
     sprite: Clothing/Head/Hoods/Coat/hoodsyndicate.rsi
   - type: Clothing
     sprite: Clothing/Head/Hoods/Coat/hoodsyndicate.rsi
+  - type: FactionClothing
+    faction: ContrabandClothing
 
 - type: entity
   parent: ClothingHeadBase
@@ -118,6 +120,8 @@
   - type: Contraband
   - type: FactionClothing
     faction: ContrabandClothing
+  - type: FactionClothing
+    faction: ContrabandClothing
 
 - type: entity # for looks only
   parent: [ ClothingHeadHatHoodBloodCulthood, ClothingHeadHelmetBasic ] # hehe
@@ -126,3 +130,5 @@
   name: cult hood
   components:
   - type: Unremoveable
+  - type: FactionClothing
+    faction: ContrabandClothing

--- a/Resources/Prototypes/_NF/Entities/Clothing/Head/hoods.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Head/hoods.yml
@@ -120,8 +120,6 @@
   - type: Contraband
   - type: FactionClothing
     faction: ContrabandClothing
-  - type: FactionClothing
-    faction: ContrabandClothing
 
 - type: entity # for looks only
   parent: [ ClothingHeadHatHoodBloodCulthood, ClothingHeadHelmetBasic ] # hehe

--- a/Resources/Prototypes/_NF/Entities/Clothing/Head/hoods.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Head/hoods.yml
@@ -8,6 +8,8 @@
     sprite: _NF/Clothing/Head/Hoods/Coat/arcadia.rsi
   - type: Clothing
     sprite: _NF/Clothing/Head/Hoods/Coat/arcadia.rsi
+  - type: FactionClothing
+    faction: ContrabandClothing
 
 # Acid raincoat hoods
 - type: entity
@@ -84,6 +86,8 @@
   - type: Clothing
     sprite: _NF/Clothing/Head/Hoods/Bio/syndicate.rsi
   - type: Contraband
+  - type: FactionClothing
+    faction: ContrabandClothing
 
 - type: entity # for looks only
   parent: ClothingHeadHatHoodWinterBase
@@ -112,6 +116,8 @@
     - HidesHair
     - WhitelistChameleon
   - type: Contraband
+  - type: FactionClothing
+    faction: ContrabandClothing
 
 - type: entity # for looks only
   parent: [ ClothingHeadHatHoodBloodCulthood, ClothingHeadHelmetBasic ] # hehe

--- a/Resources/Prototypes/_NF/Entities/Clothing/Neck/misc.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Neck/misc.yml
@@ -60,6 +60,8 @@
   - type: Tag
     tags:
     - ObjectOfSpiritualSignificance
+  - type: FactionClothing
+    faction: ContrabandClothing
 
 - type: entity
   parent: ClothingNeckBase

--- a/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/armor.yml
@@ -48,6 +48,8 @@
   - type: ExplosionResistance
     damageCoefficient: 0.60
   - type: Contraband
+  - type: FactionClothing
+    faction: ContrabandClothing
 
 - type: entity
   parent: ClothingOuterBaseLarge

--- a/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/coats.yml
@@ -118,6 +118,8 @@
   - type: Clothing
     sprite: _NF/Clothing/OuterClothing/Coats/cult_janitor_robe.rsi
   - type: Contraband
+  - type: FactionClothing
+    faction: ContrabandClothing
 
 - type: entity
   parent: [ ClothingOuterStorageToggleableBase, ClothingOuterArmorBasic ]
@@ -133,6 +135,8 @@
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHatHoodBloodCulthood
   - type: Contraband
+  - type: FactionClothing
+    faction: ContrabandClothing
 
 - type: entity
   parent: ClothingOuterWinterHoP

--- a/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/suits.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/suits.yml
@@ -9,3 +9,5 @@
   - type: Clothing
     sprite: _NF/Clothing/OuterClothing/Suits/syndicate_bombsuit.rsi
   - type: Contraband
+  - type: FactionClothing
+    faction: ContrabandClothing

--- a/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/wintercoats.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/wintercoats.yml
@@ -10,3 +10,5 @@
     sprite: _NF/Clothing/OuterClothing/WinterCoats/arcadia.rsi
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHatHoodArcadia
+  - type: FactionClothing
+    faction: ContrabandClothing

--- a/Resources/Prototypes/_NF/Entities/Clothing/Uniforms/jumpsuits.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Uniforms/jumpsuits.yml
@@ -151,6 +151,8 @@
     randomMode: false
     mode: SensorOff
   - type: Contraband
+  - type: FactionClothing
+    faction: ContrabandClothing
 
 - type: entity
   parent: ClothingUniformJumpsuitRepairmanSyndie
@@ -160,6 +162,8 @@
     randomMode: false
     mode: SensorOff
   - type: Contraband
+  - type: FactionClothing
+    faction: ContrabandClothing
 
 - type: entity
   parent: ClothingUniformJumpsuitParamedicSyndie
@@ -169,6 +173,8 @@
     randomMode: false
     mode: SensorOff
   - type: Contraband
+  - type: FactionClothing
+    faction: ContrabandClothing
 
 - type: entity
   parent: ClothingUniformJumpsuitChiefEngineerSyndie
@@ -178,6 +184,8 @@
     randomMode: false
     mode: SensorOff
   - type: Contraband
+  - type: FactionClothing
+    faction: ContrabandClothing
 
 - type: entity
   parent: ClothingUniformJumpsuitSyndieFormal
@@ -187,6 +195,8 @@
     randomMode: false
     mode: SensorOff
   - type: Contraband
+  - type: FactionClothing
+    faction: ContrabandClothing
 
 - type: entity
   parent: ClothingUniformBase

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Projectiles/energy.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Projectiles/energy.yml
@@ -1,0 +1,14 @@
+- type: entity
+  parent: BulletDisabler
+  id: BulletDisablerStaminaOnly
+  name: disabler bolt
+  noSpawn: true
+  components:
+  - type: Projectile
+    impactEffect: BulletImpactEffectDisabler
+    damage:
+      types:
+        Heat: 0
+    soundHit:
+      collection: WeakHit
+    forceSound: true

--- a/Resources/Prototypes/_NF/ai_factions.yml
+++ b/Resources/Prototypes/_NF/ai_factions.yml
@@ -71,6 +71,7 @@
   - SiliconsExpeditionNF
   - AberrantFleshExpeditionNF
   - ContrabandClothing
+  - ContrabandDetection
 
 - type: npcFaction
   id: BloodCultNF
@@ -97,6 +98,7 @@
   - SiliconsExpeditionNF
   - AberrantFleshExpeditionNF
   - ContrabandClothing
+  - ContrabandDetection
 
 - type: npcFaction
   id: PirateNF
@@ -123,6 +125,7 @@
   - SiliconsExpeditionNF
   - AberrantFleshExpeditionNF
   - ContrabandClothing
+  - ContrabandDetection
 
 - type: npcFaction
   id: ArtifactConstruct
@@ -149,6 +152,7 @@
   - SiliconsExpeditionNF
   - AberrantFleshExpeditionNF
   - ContrabandClothing
+  - ContrabandDetection
 
 - type: npcFaction
   id: StreetGangNF
@@ -175,6 +179,7 @@
   - SiliconsExpeditionNF
   - AberrantFleshExpeditionNF
   - ContrabandClothing
+  - ContrabandDetection
 
 - type: npcFaction
   id: DinosaursNF
@@ -201,6 +206,7 @@
   - SiliconsExpeditionNF
   - AberrantFleshExpeditionNF
   - ContrabandClothing
+  - ContrabandDetection
 
 - type: npcFaction
   id: ExplorersExpeditionNF
@@ -227,6 +233,7 @@
   - SiliconsExpeditionNF
   - AberrantFleshExpeditionNF
   - ContrabandClothing
+  - ContrabandDetection
 
 - type: npcFaction
   id: MercenariesExpeditionNF
@@ -253,6 +260,7 @@
   - SiliconsExpeditionNF
   - AberrantFleshExpeditionNF
   - ContrabandClothing
+  - ContrabandDetection
 
 - type: npcFaction
   id: SiliconsExpeditionNF
@@ -279,6 +287,7 @@
   #- SiliconsExpeditionNF
   - AberrantFleshExpeditionNF
   - ContrabandClothing
+  - ContrabandDetection
 
 - type: npcFaction
   id: AberrantFleshExpeditionNF
@@ -305,6 +314,7 @@
   - SiliconsExpeditionNF
   #- AberrantFleshExpeditionNF
   - ContrabandClothing
+  - ContrabandDetection
 
 - type: npcFaction
   id: ContrabandClothing
@@ -331,3 +341,30 @@
   - SiliconsExpeditionNF
   - AberrantFleshExpeditionNF
   #- ContrabandClothing
+  - ContrabandDetection
+
+- type: npcFaction
+  id: ContrabandDetection
+  hostile:
+  ## SS14 factions
+  #- NanoTrasen
+  - Syndicate
+  - SimpleHostile
+  #- Passive
+  #- PetsNT
+  - Zombie
+  - Revolutionary
+  - Xeno
+  ## Frontier Factions
+  #- Goblin
+  - WizFedFaction
+  - BloodCultNF
+  - PirateNF
+  - ExplorersExpeditionNF
+  - ArtifactConstruct
+  - StreetGangNF
+  - DinosaursNF
+  - MercenariesExpeditionNF
+  - SiliconsExpeditionNF
+  - AberrantFleshExpeditionNF
+  - ContrabandClothing

--- a/Resources/Prototypes/_NF/ai_factions.yml
+++ b/Resources/Prototypes/_NF/ai_factions.yml
@@ -11,6 +11,7 @@
   - Cat
   - Chicken
   - Monkey
+  ## Frontier Factions
   - Goblin
   - WizFedFaction
   - BloodCultNF
@@ -22,6 +23,7 @@
   - MercenariesExpeditionNF
   - SiliconsExpeditionNF
   - AberrantFleshExpeditionNF
+  - ContrabandClothing
 
 - type: npcFaction
   id: Dwarf
@@ -68,6 +70,7 @@
   - MercenariesExpeditionNF
   - SiliconsExpeditionNF
   - AberrantFleshExpeditionNF
+  - ContrabandClothing
 
 - type: npcFaction
   id: BloodCultNF
@@ -93,6 +96,7 @@
   - MercenariesExpeditionNF
   - SiliconsExpeditionNF
   - AberrantFleshExpeditionNF
+  - ContrabandClothing
 
 - type: npcFaction
   id: PirateNF
@@ -107,6 +111,7 @@
   - Revolutionary
   - Xeno
   ## Frontier Factions
+  #- Goblin
   - WizFedFaction
   - BloodCultNF
   - PirateNF
@@ -117,6 +122,7 @@
   - MercenariesExpeditionNF
   - SiliconsExpeditionNF
   - AberrantFleshExpeditionNF
+  - ContrabandClothing
 
 - type: npcFaction
   id: ArtifactConstruct
@@ -131,6 +137,7 @@
   - Revolutionary
   - Xeno
   ## Frontier Factions
+  #- Goblin
   #- WizFedFaction # Magic
   - BloodCultNF
   - PirateNF
@@ -141,6 +148,7 @@
   - MercenariesExpeditionNF
   - SiliconsExpeditionNF
   - AberrantFleshExpeditionNF
+  - ContrabandClothing
 
 - type: npcFaction
   id: StreetGangNF
@@ -155,6 +163,7 @@
   #- Revolutionary # Like their style
   - Xeno
   ## Frontier Factions
+  #- Goblin
   - WizFedFaction
   - BloodCultNF
   - PirateNF
@@ -165,6 +174,7 @@
   - MercenariesExpeditionNF
   - SiliconsExpeditionNF
   - AberrantFleshExpeditionNF
+  - ContrabandClothing
 
 - type: npcFaction
   id: DinosaursNF
@@ -179,6 +189,7 @@
   - Revolutionary
   - Xeno
   ## Frontier Factions
+  #- Goblin
   - WizFedFaction
   - BloodCultNF
   - PirateNF
@@ -189,6 +200,7 @@
   - MercenariesExpeditionNF
   - SiliconsExpeditionNF
   - AberrantFleshExpeditionNF
+  - ContrabandClothing
 
 - type: npcFaction
   id: ExplorersExpeditionNF
@@ -203,6 +215,7 @@
   - Revolutionary
   - Xeno
   ## Frontier Factions
+  #- Goblin
   - WizFedFaction
   - BloodCultNF
   - PirateNF
@@ -213,6 +226,7 @@
   - MercenariesExpeditionNF
   - SiliconsExpeditionNF
   - AberrantFleshExpeditionNF
+  - ContrabandClothing
 
 - type: npcFaction
   id: MercenariesExpeditionNF
@@ -227,6 +241,7 @@
   - Revolutionary
   - Xeno
   ## Frontier Factions
+  #- Goblin
   - WizFedFaction
   - BloodCultNF
   - PirateNF
@@ -237,6 +252,7 @@
   #- MercenariesExpeditionNF
   - SiliconsExpeditionNF
   - AberrantFleshExpeditionNF
+  - ContrabandClothing
 
 - type: npcFaction
   id: SiliconsExpeditionNF
@@ -251,6 +267,7 @@
   - Revolutionary
   - Xeno
   ## Frontier Factions
+  #- Goblin
   - WizFedFaction
   - BloodCultNF
   - PirateNF
@@ -261,6 +278,7 @@
   - MercenariesExpeditionNF
   #- SiliconsExpeditionNF
   - AberrantFleshExpeditionNF
+  - ContrabandClothing
 
 - type: npcFaction
   id: AberrantFleshExpeditionNF
@@ -275,6 +293,7 @@
   - Revolutionary
   - Xeno
   ## Frontier Factions
+  #- Goblin
   - WizFedFaction
   - BloodCultNF
   - PirateNF
@@ -285,3 +304,30 @@
   - MercenariesExpeditionNF
   - SiliconsExpeditionNF
   #- AberrantFleshExpeditionNF
+  - ContrabandClothing
+
+- type: npcFaction
+  id: ContrabandClothing
+  hostile:
+  ## SS14 factions
+  - NanoTrasen
+  - Syndicate
+  - SimpleHostile
+  - Passive
+  - PetsNT
+  - Zombie
+  - Revolutionary
+  - Xeno
+  ## Frontier Factions
+  #- Goblin
+  - WizFedFaction
+  - BloodCultNF
+  - PirateNF
+  - ExplorersExpeditionNF
+  - ArtifactConstruct
+  - StreetGangNF
+  - DinosaursNF
+  - MercenariesExpeditionNF
+  - SiliconsExpeditionNF
+  - AberrantFleshExpeditionNF
+  #- ContrabandClothing

--- a/Resources/Prototypes/ai_factions.yml
+++ b/Resources/Prototypes/ai_factions.yml
@@ -18,6 +18,7 @@
     - SiliconsExpeditionNF # Frontier
     - AberrantFleshExpeditionNF # Frontier
     - ContrabandClothing # Frontier
+    - ContrabandDetection # Frontier
 
 - type: npcFaction
   id: NanoTrasen
@@ -86,6 +87,7 @@
   - SiliconsExpeditionNF # Frontier
   - AberrantFleshExpeditionNF # Frontier
   - ContrabandClothing # Frontier
+  - ContrabandDetection # Frontier
 
 - type: npcFaction
   id: SimpleNeutral
@@ -109,6 +111,7 @@
   - SiliconsExpeditionNF # Frontier
   - AberrantFleshExpeditionNF # Frontier
   - ContrabandClothing # Frontier
+  - ContrabandDetection # Frontier
 
 - type: npcFaction
   id: Xeno
@@ -130,6 +133,7 @@
   - SiliconsExpeditionNF # Frontier
   - AberrantFleshExpeditionNF # Frontier
   - ContrabandClothing # Frontier
+  - ContrabandDetection # Frontier
 
 - type: npcFaction
   id: Zombie
@@ -152,6 +156,7 @@
   - SiliconsExpeditionNF # Frontier
   - AberrantFleshExpeditionNF # Frontier
   - ContrabandClothing # Frontier
+  - ContrabandDetection # Frontier
 
 - type: npcFaction
   id: Revolutionary
@@ -171,3 +176,4 @@
   - SiliconsExpeditionNF # Frontier
   - AberrantFleshExpeditionNF # Frontier
   - ContrabandClothing # Frontier
+  - ContrabandDetection # Frontier

--- a/Resources/Prototypes/ai_factions.yml
+++ b/Resources/Prototypes/ai_factions.yml
@@ -17,6 +17,7 @@
     - MercenariesExpeditionNF # Frontier
     - SiliconsExpeditionNF # Frontier
     - AberrantFleshExpeditionNF # Frontier
+    - ContrabandClothing # Frontier
 
 - type: npcFaction
   id: NanoTrasen
@@ -36,6 +37,7 @@
   - MercenariesExpeditionNF # Frontier
   - SiliconsExpeditionNF # Frontier
   - AberrantFleshExpeditionNF # Frontier
+  - ContrabandClothing # Frontier
 
 - type: npcFaction
   id: Mouse
@@ -62,6 +64,7 @@
   - MercenariesExpeditionNF # Frontier
   - SiliconsExpeditionNF # Frontier
   - AberrantFleshExpeditionNF # Frontier
+  - ContrabandClothing # Frontier
 
 - type: npcFaction
   id: SimpleHostile
@@ -82,6 +85,7 @@
   - MercenariesExpeditionNF # Frontier
   - SiliconsExpeditionNF # Frontier
   - AberrantFleshExpeditionNF # Frontier
+  - ContrabandClothing # Frontier
 
 - type: npcFaction
   id: SimpleNeutral
@@ -104,6 +108,7 @@
   - MercenariesExpeditionNF # Frontier
   - SiliconsExpeditionNF # Frontier
   - AberrantFleshExpeditionNF # Frontier
+  - ContrabandClothing # Frontier
 
 - type: npcFaction
   id: Xeno
@@ -124,6 +129,7 @@
   - MercenariesExpeditionNF # Frontier
   - SiliconsExpeditionNF # Frontier
   - AberrantFleshExpeditionNF # Frontier
+  - ContrabandClothing # Frontier
 
 - type: npcFaction
   id: Zombie
@@ -145,6 +151,7 @@
   - MercenariesExpeditionNF # Frontier
   - SiliconsExpeditionNF # Frontier
   - AberrantFleshExpeditionNF # Frontier
+  - ContrabandClothing # Frontier
 
 - type: npcFaction
   id: Revolutionary
@@ -163,3 +170,4 @@
   - MercenariesExpeditionNF # Frontier
   - SiliconsExpeditionNF # Frontier
   - AberrantFleshExpeditionNF # Frontier
+  - ContrabandClothing # Frontier


### PR DESCRIPTION
## About the PR
- Added 2 ai factions: `ContrabandClothing`, `ContrabandDetection`
- Distributed `FactionClothing` component through wearable contraband clothes: now when players wear contraband armor they gain `ContrabandClothing` faction.
- Made contraband denying turret: shoots disabler bolts at members of  `ContrabandClothing` (and ant hostile to NanoTrasen faction members).

## Why / Balance
Horrible idea

## How to test
1. Obtain clothes classified as contraband (cult robes/syndie/wizard).
2. Map 'contraband denying turret'.
3. Wear those closes, get shot.
4. Stop wearing contra, don't get shot.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
some edits to base game files

**Changelog**
:cl: erhardsteinhauer
- add: Added contraband denying turret that stuns players wearing contraband.
