### PR TITLE
IFF strobes to loadouts

### DIFF
--- a/Resources/Prototypes/_NF/Loadouts/Jobs/Contractor/neck.yml
+++ b/Resources/Prototypes/_NF/Loadouts/Jobs/Contractor/neck.yml
@@ -363,6 +363,96 @@
   equipment:
     neck: BedsheetRainbow
 
+- type: loadout
+  id: ContractorClothingNeckIFFNeutral
+  equipment: ContractorClothingNeckIFFNeutral
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: ContractorT2
+  price: 1000
+
+- type: startingGear
+  id: ContractorClothingNeckIFFNeutral
+  equipment:
+    neck: ClothingNeckIFFNeutral
+
+- type: loadout
+  id: ContractorClothingNeckIFFGreen
+  equipment: ContractorClothingNeckIFFGreen
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: ContractorT2
+  price: 1000
+
+- type: startingGear
+  id: ContractorClothingNeckIFFGreen
+  equipment:
+    neck: ClothingNeckIFFGreen
+
+- type: loadout
+  id: ContractorClothingNeckIFFRed
+  equipment: ContractorClothingNeckIFFRed
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: ContractorT2
+  price: 1000
+
+- type: startingGear
+  id: ContractorClothingNeckIFFRed
+  equipment:
+    neck: ClothingNeckIFFRed
+
+- type: loadout
+  id: ContractorClothingNeckIFFBlue
+  equipment: ContractorClothingNeckIFFBlue
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: ContractorT2
+  price: 1000
+
+- type: startingGear
+  id: ContractorClothingNeckIFFBlue
+  equipment:
+    neck: ClothingNeckIFFBlue
+
+- type: loadout
+  id: ContractorClothingNeckIFFCyan
+  equipment: ContractorClothingNeckIFFCyan
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: ContractorT2
+  price: 1000
+
+- type: startingGear
+  id: ContractorClothingNeckIFFCyan
+  equipment:
+    neck: ClothingNeckIFFCyan
+
+- type: loadout
+  id: ContractorClothingNeckIFFOrange
+  equipment: ContractorClothingNeckIFFOrange
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: ContractorT2
+  price: 1000
+
+- type: startingGear
+  id: ContractorClothingNeckIFFOrange
+  equipment:
+    neck: ClothingNeckIFFOrange
+
+- type: loadout
+  id: ContractorClothingNeckIFFPurple
+  equipment: ContractorClothingNeckIFFPurple
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: ContractorT2
+  price: 1000
+
+- type: startingGear
+  id: ContractorClothingNeckIFFPurple
+  equipment:
+    neck: ClothingNeckIFFPurple
 
 #T3 for lols
 - type: loadout

--- a/Resources/Prototypes/_NF/Loadouts/contractor_loadout_groups.yml
+++ b/Resources/Prototypes/_NF/Loadouts/contractor_loadout_groups.yml
@@ -553,6 +553,13 @@
   - ContractorClothingNeckCloakGay
   - ContractorClothingNeckCloakLesbian
   - ContractorBedsheetRainbow
+  - ContractorClothingNeckIFFNeutral
+  - ContractorClothingNeckIFFGreen
+  - ContractorClothingNeckIFFRed
+  - ContractorClothingNeckIFFBlue
+  - ContractorClothingNeckIFFCyan
+  - ContractorClothingNeckIFFOrange
+  - ContractorClothingNeckIFFPurple
   - ContractorClothingNeckCloakCapFormal
   - ContractorClothingNeckMantleCap
   - ContractorClothingNeckCloakQm


### PR DESCRIPTION
## About the PR
Added IFF strobes to loadout menu

## Why / Balance
QoL

## How to test
Check `neck` section of loadouts menu.

## Media
![image](https://github.com/new-frontiers-14/frontier-station-14/assets/65374927/82abc70a-bd16-4f22-87b0-855c6d25c4cb)
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes


**Changelog**
:cl: erhardesteinhauer
- add: Added IFF strobes to loadouts menu.
