### PR TITLE
Bookworm (Update): QoL stuff

### DIFF
--- a/Resources/Locale/en-US/_NF/guidebook/guides.ftl
+++ b/Resources/Locale/en-US/_NF/guidebook/guides.ftl
@@ -23,6 +23,7 @@ guide-entry-expedition-xenos = Xenos
 # Shipyard entries
 guide-entry-shipyard-ambition = Ambition
 guide-entry-shipyard-bocadillo = Bocadillo
+guide-entry-shipyard-bookworm = Bookworm
 guide-entry-shipyard-brigand = Brigand
 guide-entry-shipyard-bulker = Bulker
 guide-entry-shipyard-ceres = Ceres

--- a/Resources/Maps/_NF/Shuttles/bookworm.yml
+++ b/Resources/Maps/_NF/Shuttles/bookworm.yml
@@ -33,7 +33,7 @@ entities:
           version: 6
         0,-1:
           ind: 0,-1
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAfQAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAAACHgAAAAACfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAALgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAAABHgAAAAADHgAAAAAAfQAAAAAAeQAAAAABeQAAAAADeQAAAAADeQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAAAAHgAAAAACHgAAAAADfQAAAAAAeQAAAAAAeQAAAAAAeQAAAAADeQAAAAADfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAHgAAAAADfQAAAAAAeQAAAAAAeQAAAAADeQAAAAADeQAAAAACeQAAAAABfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAIgAAAAACfQAAAAAAeQAAAAACeQAAAAACeQAAAAABeQAAAAABeQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAIgAAAAAAfQAAAAAAfQAAAAAAHgAAAAACfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXAAAAAAAXAAAAAADXAAAAAAAXAAAAAACXAAAAAAAYQAAAAAAYQAAAAAAYQAAAAAAfQAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYQAAAAAAYQAAAAAAXAAAAAABXAAAAAABXAAAAAAAXAAAAAAAXAAAAAACXAAAAAADfQAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAfQAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAAACHgAAAAACfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAALgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAAABHgAAAAADHgAAAAAAawAAAAAAeQAAAAABeQAAAAADeQAAAAADeQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAAAAHgAAAAACHgAAAAADfQAAAAAAeQAAAAAAeQAAAAAAeQAAAAADeQAAAAADfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAHgAAAAADfQAAAAAAeQAAAAAAeQAAAAADeQAAAAADeQAAAAACeQAAAAABfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAIgAAAAACfQAAAAAAeQAAAAACeQAAAAACeQAAAAABeQAAAAABeQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAIgAAAAAAfQAAAAAAfQAAAAAAHgAAAAACfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXAAAAAAAXAAAAAADXAAAAAAAXAAAAAACXAAAAAAAYQAAAAAAYQAAAAAAYQAAAAAAfQAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYQAAAAAAYQAAAAAAXAAAAAABXAAAAAABXAAAAAAAXAAAAAAAXAAAAAACXAAAAAADfQAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
           version: 6
         -1,-1:
           ind: -1,-1
@@ -67,7 +67,7 @@ entities:
             color: '#FFFFFFFF'
             id: Bot
           decals:
-            137: -2,-4
+            135: -2,-4
         - node:
             color: '#FFFFFFFF'
             id: Box
@@ -183,12 +183,12 @@ entities:
             color: '#EFB341FF'
             id: BrickTileSteelInnerNe
           decals:
-            141: -4,-3
+            139: -4,-3
         - node:
             color: '#EFB341FF'
             id: BrickTileSteelInnerNw
           decals:
-            140: -2,-3
+            138: -2,-3
         - node:
             color: '#FFFFFFFF'
             id: BrickTileSteelLineE
@@ -198,13 +198,13 @@ entities:
             color: '#EFB341FF'
             id: BrickTileSteelLineN
           decals:
-            139: -3,-3
+            137: -3,-3
         - node:
             color: '#FFFFFFFF'
             id: BrickTileSteelLineN
           decals:
             68: 6,-2
-            92: 4,-3
+            91: 4,-3
         - node:
             color: '#FFFFFFFF'
             id: BrickTileSteelLineS
@@ -220,8 +220,8 @@ entities:
             color: '#FFFFFFFF'
             id: Caution
           decals:
-            97: -6,-8
-            98: -6,-6
+            96: -6,-8
+            97: -6,-6
         - node:
             color: '#FFFFFFFF'
             id: Delivery
@@ -232,7 +232,7 @@ entities:
             color: '#EFB34196'
             id: DeliveryGreyscale
           decals:
-            138: -3,-2
+            136: -3,-2
         - node:
             color: '#52B4E9FF'
             id: DiagonalCheckerAOverlay
@@ -273,11 +273,11 @@ entities:
           decals:
             7: -5,4
             8: -4,4
-            101: -5,5
-            102: -4,5
-            122: -6,4
-            123: -6,5
-            135: -4,3
+            100: -5,5
+            101: -4,5
+            121: -6,4
+            122: -6,5
+            134: -4,3
         - node:
             color: '#37789BFF'
             id: DiagonalCheckerBOverlay
@@ -316,9 +316,9 @@ entities:
             color: '#334E6DC8'
             id: DiagonalOverlay
           decals:
-            103: -4,6
-            104: -5,6
-            124: -6,6
+            102: -4,6
+            103: -5,6
+            123: -6,6
         - node:
             color: '#639137CC'
             id: MiniTileCheckerAOverlay
@@ -329,62 +329,62 @@ entities:
             color: '#FFFFFFFF'
             id: MiniTileDarkInnerNe
           decals:
-            96: 4,0
+            95: 4,0
         - node:
             color: '#FFFFFFFF'
             id: MiniTileDarkInnerNw
           decals:
-            127: 6,0
+            126: 6,0
         - node:
             color: '#FFFFFFFF'
             id: MiniTileDarkInnerSe
           decals:
-            94: 4,2
+            93: 4,2
         - node:
             color: '#FFFFFFFF'
             id: MiniTileDarkInnerSw
           decals:
-            126: 6,2
+            125: 6,2
         - node:
             color: '#FFFFFFFF'
             id: MiniTileDarkLineE
           decals:
-            93: 4,1
+            92: 4,1
         - node:
             color: '#FFFFFFFF'
             id: MiniTileDarkLineN
           decals:
-            95: 5,0
+            94: 5,0
         - node:
             color: '#FFFFFFFF'
             id: MiniTileDarkLineW
           decals:
-            133: 6,1
+            132: 6,1
         - node:
             color: '#FFFF00FF'
             id: WarnLineGreyscaleW
           decals:
-            99: -6,-8
-            100: -6,-6
+            98: -6,-8
+            99: -6,-6
         - node:
             color: '#FFFFFFFF'
             id: WoodTrimThinCornerNe
           decals:
             10: 7,-4
-            117: -3,2
+            116: -3,2
         - node:
             color: '#FFFFFFFF'
             id: WoodTrimThinCornerNw
           decals:
             0: -5,2
             9: 3,-4
-            118: -6,2
+            117: -6,2
         - node:
             color: '#FFFFFFFF'
             id: WoodTrimThinCornerSe
           decals:
             1: -3,-1
-            112: 7,-7
+            111: 7,-7
         - node:
             color: '#FFFFFFFF'
             id: WoodTrimThinCornerSw
@@ -392,34 +392,34 @@ entities:
             2: -5,-1
             11: 3,-5
             82: 3,3
-            107: 4,-7
-            116: -6,0
-            128: 7,0
+            106: 4,-7
+            115: -6,0
+            127: 7,0
         - node:
             color: '#FFFFFFFF'
             id: WoodTrimThinEndN
           decals:
-            113: -4,1
+            112: -4,1
         - node:
             color: '#FFFFFFFF'
             id: WoodTrimThinEndS
           decals:
-            114: -4,0
+            113: -4,0
         - node:
             color: '#FFFFFFFF'
             id: WoodTrimThinInnerSw
           decals:
-            105: 4,-5
-            121: -5,0
-            131: 7,3
+            104: 4,-5
+            120: -5,0
+            130: 7,3
         - node:
             color: '#FFFFFFFF'
             id: WoodTrimThinLineE
           decals:
             4: -3,1
             5: -3,0
-            110: 7,-5
-            111: 7,-6
+            109: 7,-5
+            110: 7,-6
         - node:
             color: '#FFFFFFFF'
             id: WoodTrimThinLineN
@@ -428,7 +428,7 @@ entities:
             12: 4,-4
             13: 5,-4
             14: 6,-4
-            119: -5,2
+            118: -5,2
         - node:
             color: '#FFFFFFFF'
             id: WoodTrimThinLineS
@@ -436,22 +436,22 @@ entities:
             6: -4,-1
             48: 4,3
             49: 5,3
-            91: 4,-3
-            108: 5,-7
-            109: 6,-7
-            115: -4,-1
-            132: 6,3
-            134: 8,0
+            90: 4,-3
+            107: 5,-7
+            108: 6,-7
+            114: -4,-1
+            131: 6,3
+            133: 8,0
         - node:
             color: '#FFFFFFFF'
             id: WoodTrimThinLineW
           decals:
             47: 3,4
-            106: 4,-6
-            120: -6,1
-            125: 3,5
-            129: 7,1
-            130: 7,2
+            105: 4,-6
+            119: -6,1
+            124: 3,5
+            128: 7,1
+            129: 7,2
     - type: GridAtmosphere
       version: 2
       data:
@@ -563,17 +563,16 @@ entities:
       - 512
       - 193
       - 197
-    - type: AtmosDevice
-      joinedGrid: 2
 - proto: AirCanister
   entities:
   - uid: 299
     components:
     - type: Transform
+      anchored: True
       pos: -3.5,-3.5
       parent: 2
-    - type: AtmosDevice
-      joinedGrid: 2
+    - type: Physics
+      bodyType: Static
 - proto: Airlock
   entities:
   - uid: 3
@@ -597,7 +596,7 @@ entities:
       parent: 2
 - proto: AirlockEngineering
   entities:
-  - uid: 541
+  - uid: 542
     components:
     - type: Transform
       pos: -2.5,-1.5
@@ -655,7 +654,7 @@ entities:
       rot: 4.71238898038469 rad
       pos: 2.5,-2.5
       parent: 2
-  - uid: 311
+  - uid: 323
     components:
     - type: Transform
       pos: -3.5,-1.5
@@ -1125,7 +1124,7 @@ entities:
       parent: 2
 - proto: CableHV
   entities:
-  - uid: 150
+  - uid: 285
     components:
     - type: Transform
       pos: -1.5,-2.5
@@ -1140,19 +1139,19 @@ entities:
     - type: Transform
       pos: -0.5,-3.5
       parent: 2
-  - uid: 538
+  - uid: 539
     components:
     - type: Transform
       pos: -2.5,-2.5
       parent: 2
-  - uid: 539
+  - uid: 540
     components:
     - type: Transform
       pos: -3.5,-2.5
       parent: 2
 - proto: CableMV
   entities:
-  - uid: 133
+  - uid: 150
     components:
     - type: Transform
       pos: -3.5,-0.5
@@ -1177,7 +1176,7 @@ entities:
     - type: Transform
       pos: -2.5,-2.5
       parent: 2
-  - uid: 310
+  - uid: 311
     components:
     - type: Transform
       pos: -3.5,0.5
@@ -1227,12 +1226,12 @@ entities:
     - type: Transform
       pos: 2.5,-2.5
       parent: 2
-  - uid: 536
+  - uid: 537
     components:
     - type: Transform
       pos: -3.5,-1.5
       parent: 2
-  - uid: 537
+  - uid: 538
     components:
     - type: Transform
       pos: -3.5,-2.5
@@ -1455,7 +1454,7 @@ entities:
       parent: 2
 - proto: ComputerPowerMonitoring
   entities:
-  - uid: 540
+  - uid: 541
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1544,7 +1543,7 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -2.5,-0.5
       parent: 2
-  - uid: 298
+  - uid: 310
     components:
     - type: Transform
       pos: -1.5,-2.5
@@ -1601,7 +1600,7 @@ entities:
       parent: 2
 - proto: Firelock
   entities:
-  - uid: 1
+  - uid: 23
     components:
     - type: Transform
       pos: -2.5,-1.5
@@ -1675,8 +1674,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -5.5,-2.5
       parent: 2
-    - type: AtmosDevice
-      joinedGrid: 2
     - type: AtmosPipeColor
       color: '#990000FF'
 - proto: GasPipeBend
@@ -2201,18 +2198,14 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -3.5,-3.5
       parent: 2
-    - type: AtmosDevice
-      joinedGrid: 2
-- proto: GasPressurePump
+- proto: GasPressurePumpOn
   entities:
-  - uid: 169
+  - uid: 62
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-3.5
       parent: 2
-    - type: AtmosDevice
-      joinedGrid: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
 - proto: GasVentPump
@@ -2222,8 +2215,6 @@ entities:
     - type: Transform
       pos: -3.5,4.5
       parent: 2
-    - type: AtmosDevice
-      joinedGrid: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 90
@@ -2232,8 +2223,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 6.5,-3.5
       parent: 2
-    - type: AtmosDevice
-      joinedGrid: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 167
@@ -2254,8 +2243,6 @@ entities:
       - invalid
       deviceLists:
       - 480
-    - type: AtmosDevice
-      joinedGrid: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 213
@@ -2264,8 +2251,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 0.5,-5.5
       parent: 2
-    - type: AtmosDevice
-      joinedGrid: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 320
@@ -2274,8 +2259,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -2.5,1.5
       parent: 2
-    - type: AtmosDevice
-      joinedGrid: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 421
@@ -2284,8 +2267,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -4.5,-5.5
       parent: 2
-    - type: AtmosDevice
-      joinedGrid: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
 - proto: GasVentScrubber
@@ -2296,8 +2277,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -2.5,-2.5
       parent: 2
-    - type: AtmosDevice
-      joinedGrid: 2
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 180
@@ -2306,8 +2285,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -5.5,0.5
       parent: 2
-    - type: AtmosDevice
-      joinedGrid: 2
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 197
@@ -2321,8 +2298,6 @@ entities:
       - invalid
       deviceLists:
       - 480
-    - type: AtmosDevice
-      joinedGrid: 2
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 209
@@ -2331,8 +2306,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 3.5,-3.5
       parent: 2
-    - type: AtmosDevice
-      joinedGrid: 2
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 217
@@ -2341,8 +2314,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 0.5,-7.5
       parent: 2
-    - type: AtmosDevice
-      joinedGrid: 2
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 393
@@ -2351,8 +2322,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -5.5,4.5
       parent: 2
-    - type: AtmosDevice
-      joinedGrid: 2
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 420
@@ -2361,8 +2330,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -4.5,-7.5
       parent: 2
-    - type: AtmosDevice
-      joinedGrid: 2
     - type: AtmosPipeColor
       color: '#990000FF'
 - proto: GrassBattlemap
@@ -2541,6 +2508,8 @@ entities:
     - type: Transform
       pos: -0.5,3.5
       parent: 2
+    - type: Thruster
+      originalPowerLoad: 1500
 - proto: LampGold
   entities:
   - uid: 84
@@ -2621,92 +2590,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -5.4437475,1.8539064
       parent: 2
-  - uid: 323
-    components:
-    - type: MetaData
-      name: pre-flight checklist
-    - type: Transform
-      pos: -2.2431207,-2.5094283
-      parent: 2
-    - type: Paper
-      stampState: paper_stamp-ce
-      stampedBy:
-      - stampedColor: '#C69B17FF'
-        stampedName: stamp-component-stamped-name-ce
-      content: >2
-
-        [color=#1B8CD6][head=1]=BB=[/head]
-
-        [head=2]BlueBird Starship Design & Construction[/head][/color]
-
-
-        [head=2][bold][color=#9413ED]Bookworm[/color][/bold][/head]
-
-        Dear Captain,
-
-        Thank you for your purchase of the BB Bookworm!
-
-        We hope this ship will serve you well as a place of respite for travellers from near and far.
-
-
-        [head=3][color=#1B8CD6]Pre-Flight Checklist[/head][/color]
-
-        1. Check all machines, generators and canisters are [bold]anchored[/bold].
-
-        2. Top off generator fuel.
-
-        3. Set [bold]generator output to 17 kW[/bold].
-
-        4. Start generator.
-
-        5. Check distro mixer and pump settings, then turn on.
-
-        6. Check gyro is turned on.
-
-        7. Check all APCs are functioning and charged.
-  - uid: 387
-    components:
-    - type: MetaData
-      name: pre-flight checklist
-    - type: Transform
-      pos: -5.435256,6.066874
-      parent: 2
-    - type: Paper
-      stampState: paper_stamp-ce
-      stampedBy:
-      - stampedColor: '#C69B17FF'
-        stampedName: stamp-component-stamped-name-ce
-      content: >2
-
-        [color=#1B8CD6][head=1]=BB=[/head]
-
-        [head=2]BlueBird Starship Design & Construction[/head][/color]
-
-
-        [head=2][bold][color=#9413ED]Bookworm[/color][/bold][/head]
-
-        Dear Captain,
-
-        Thank you for your purchase of the BB Bookworm!
-
-        We hope this ship will serve you well as a place of respite for travellers from near and far.
-
-
-        [head=3][color=#1B8CD6]Pre-Flight Checklist[/head][/color]
-
-        1. Check all machines, generators and canisters are [bold]anchored[/bold].
-
-        2. Top off generator fuel.
-
-        3. Set [bold]generator output to 17 kW[/bold].
-
-        4. Start generator.
-
-        5. Check distro mixer and pump settings, then turn on.
-
-        6. Check gyro is turned on.
-
-        7. Check all APCs are functioning and charged.
 - proto: PaperBin20
   entities:
   - uid: 483
@@ -3124,6 +3007,13 @@ entities:
     - type: Transform
       pos: -1.5,-2.5
       parent: 2
+- proto: ShipyardBookwormInfo
+  entities:
+  - uid: 1
+    components:
+    - type: Transform
+      pos: -1.4975295,-2.5484562
+      parent: 2
 - proto: ShuttersNormalOpen
   entities:
   - uid: 15
@@ -3371,7 +3261,7 @@ entities:
       parent: 2
 - proto: SignElectricalMed
   entities:
-  - uid: 285
+  - uid: 298
     components:
     - type: Transform
       pos: -0.5,-1.5
@@ -3388,26 +3278,45 @@ entities:
     - type: Transform
       pos: -6.5,-8.5
       parent: 2
+- proto: SmallThruster
+  entities:
+  - uid: 261
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,6.5
+      parent: 2
+    - type: Thruster
+      originalPowerLoad: 500
+  - uid: 375
+    components:
+    - type: Transform
+      pos: -0.5,4.5
+      parent: 2
+    - type: Thruster
+      originalPowerLoad: 500
+  - uid: 387
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-8.5
+      parent: 2
+    - type: Thruster
+      originalPowerLoad: 500
+- proto: SolidSecretDoor
+  entities:
+  - uid: 169
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-6.5
+      parent: 2
 - proto: SpawnPointLatejoin
-  entities:
-  - uid: 398
-    components:
-    - type: Transform
-      pos: -3.5,0.5
-      parent: 2
-- proto: SpawnPointLibrarian
-  entities:
-  - uid: 62
-    components:
-    - type: Transform
-      pos: -3.5,1.5
-      parent: 2
-- proto: SpawnPointPilot
   entities:
   - uid: 136
     components:
     - type: Transform
-      pos: -4.5,4.5
+      pos: -3.5,1.5
       parent: 2
 - proto: SteelBench
   entities:
@@ -3553,46 +3462,39 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 9.5,-1.5
       parent: 2
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 38
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-3.5
       parent: 2
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 49
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-8.5
       parent: 2
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 215
     components:
     - type: Transform
       pos: -1.5,4.5
       parent: 2
-  - uid: 261
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,-8.5
-      parent: 2
+    - type: Thruster
+      originalPowerLoad: 1500
   - uid: 364
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-8.5
       parent: 2
-  - uid: 375
-    components:
-    - type: Transform
-      pos: -0.5,4.5
-      parent: 2
-  - uid: 510
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 1.5,6.5
-      parent: 2
+    - type: Thruster
+      originalPowerLoad: 1500
 - proto: ToyFigurineLibrarian
   entities:
   - uid: 31
@@ -3623,7 +3525,7 @@ entities:
       parent: 2
 - proto: VendingMachineCuraDrobe
   entities:
-  - uid: 23
+  - uid: 103
     components:
     - type: Transform
       pos: -3.5,-0.5
@@ -3886,11 +3788,6 @@ entities:
     - type: Transform
       pos: -2.5,-4.5
       parent: 2
-  - uid: 103
-    components:
-    - type: Transform
-      pos: -3.5,-1.5
-      parent: 2
   - uid: 104
     components:
     - type: Transform
@@ -3976,6 +3873,11 @@ entities:
     - type: Transform
       pos: -4.5,3.5
       parent: 2
+  - uid: 133
+    components:
+    - type: Transform
+      pos: -3.5,-1.5
+      parent: 2
   - uid: 157
     components:
     - type: Transform
@@ -3985,11 +3887,6 @@ entities:
     components:
     - type: Transform
       pos: -5.5,3.5
-      parent: 2
-  - uid: 451
-    components:
-    - type: Transform
-      pos: 3.5,-6.5
       parent: 2
 - proto: WallSolidDiagonal
   entities:

--- a/Resources/Prototypes/_NF/Catalog/Fills/Paper/Shipyard/manuals.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/Paper/Shipyard/manuals.yml
@@ -1,3 +1,24 @@
+- type: entity
+  parent: BaseItem
+  id: ShipyardBookwormInfo
+  name: bookworm user manual
+  description: preflight checklist
+  components:
+  - type: Sprite
+    sprite: Objects/Misc/books.rsi
+    layers:
+    - state: paper
+    - state: cover_base
+      color: "#6c4718"
+    - state: decor_wingette
+      color: "#b5913c"
+    - state: icon_wrench
+    - state: icon_corner
+      color: gold
+  - type: GuideHelp
+    openOnActivation: true
+    guides:
+    - ShipyardBookworm
 
 - type: entity
   parent: BaseItem

--- a/Resources/Prototypes/_NF/Guidebook/shipyard.yml
+++ b/Resources/Prototypes/_NF/Guidebook/shipyard.yml
@@ -6,6 +6,7 @@
   children:
   - ShipyardAmbition
   - ShipyardBocadillo
+  - ShipyardBookworm
   - ShipyardBrigand
   - ShipyardBulker
   - ShipyardCeres
@@ -37,6 +38,11 @@
   id: ShipyardBocadillo
   name: guide-entry-shipyard-bocadillo
   text: "/ServerInfo/_NF/Guidebook/Shipyard/Bocadillo.xml"
+
+- type: guideEntry
+  id: ShipyardBookworm
+  name: guide-entry-shipyard-bookworm
+  text: "/ServerInfo/_NF/Guidebook/Shipyard/Bookworm.xml"
 
 - type: guideEntry
   id: ShipyardBrigand

--- a/Resources/ServerInfo/_NF/Guidebook/Shipyard/Bookworm.xml
+++ b/Resources/ServerInfo/_NF/Guidebook/Shipyard/Bookworm.xml
@@ -1,0 +1,71 @@
+<Document>
+  # BOOKWORM-CLASS SERVICE SHUTTLE
+  <Box>
+  <GuideEntityEmbed Entity="ToyFigurineLibrarian"/>
+  <GuideEntityEmbed Entity="Bookshelf"/>
+  <GuideEntityEmbed Entity="BookBase"/>
+  <GuideEntityEmbed Entity="MagicDiceBag"/>
+  <GuideEntityEmbed Entity="LuxuryPen"/>
+  </Box>
+  [color=#a4885c]Ship Size:[/color] Medium
+
+  [color=#a4885c]Recommended Crew:[/color] 1-3
+
+  [color=#a4885c]Power Gen Type:[/color] Plasma
+
+  [color=#a4885c]Expeditions:[/color] None
+
+  [color=#a4885c]IFF Console:[/color] None
+
+  "A cozy medium-size library for travellers who wish to relax with a book or perhaps a board game."
+
+  [italic]Brought to you by BlueBird Starship Design & Construction.[/italic]
+
+  # PREFLIGHT CHECKLIST
+
+  ## 1. Power supply
+
+  ## 1.1. Battery units
+  <Box>
+  <GuideEntityEmbed Entity="SubstationBasic"/>
+  <GuideEntityEmbed Entity="APCBasic"/>
+  </Box>
+
+  - Check that the substation unit is anchored to the floor.
+  - Check that the APC units' Main Breaker is toggled on.
+  - Check the APC units' current Load (W).
+
+  ## 1.2. P.A.C.M.A.N. generator unit
+  <Box>
+  <GuideEntityEmbed Entity="PortableGeneratorPacmanShuttle"/>
+  <GuideEntityEmbed Entity="SheetPlasma"/>
+  </Box>
+
+  - Check that P.A.C.M.A.N. generator units are anchored to the floor.
+  - Check that P.A.C.M.A.N. generator units are fueled. For extended flights make sure that you have enough fuel stockpiled to sustain prolonged power generation.
+  - Check that P.A.C.M.A.N. generator units are set to HV output.
+  - Set Target Power to 14 [bold]kW[/bold] on each  generator unit.
+  - Start P.A.C.M.A.N. generator units.
+
+  ## 2. Atmospherics
+
+  ## 2.1. Distribution Loop
+  <Box>
+  <GuideEntityEmbed Entity="AirCanister"/>
+  <GuideEntityEmbed Entity="GasPort"/>
+  <GuideEntityEmbed Entity="GasPressurePump"/>
+  </Box>
+
+  - Check that the air canister is anchored to connector port.
+  - Check that the distribution pump is set to 101kPa.
+  - Enable the distribution pump.
+
+  ## 3. Other checks
+  <Box>
+  <GuideEntityEmbed Entity="Gyroscope"/>
+  <GuideEntityEmbed Entity="GravityGeneratorMini"/>
+  </Box>
+
+  - Check that the gyroscope is anchored, powered, and enabled.
+  - Check that the mini gravity generator is anchored, powered, and enabled.
+</Document>


### PR DESCRIPTION
## About the PR
This PR addresses some feedback I have received from players, mostly in game, on the SBB Bookworm shuttle. The biggest complaint is that the Bookworm on purchase simply uses _too much power_. The poor single PACMAN has to run at 18 kW to keep up, which eats through plasma like nobody's business. Summary of changes:

* Replace three thrusters with small thrusters (lateral + reverse). This reduces the power consumption by 3 kW and does not drastically alter the shuttle's flight characteristics. As a result, the PACMAN can now be turned _down_ to 14 kW instead of up to 18.
* Use the new on-by-default air pump for distro, and anchor the canister.
* Remove librarian and pilot spawn points, move latejoin spawn point up one tile.
* Move preflight checklist to a newly created guidebook entry, add book entity and put in engineering room.
* Sneaky secret door to the games room, for fun and stuff. :)

No changes to subfloor or wiring.

## Why / Balance
Based on player feedback.

## How to test
Buy the ship in game!

## Media
Preinit, with spawners and subfloor:
![image_2024-07-04_13-54-41](https://github.com/new-frontiers-14/frontier-station-14/assets/30327355/8cfa7d50-778a-4a05-a5f4-618237eda81a)

Postinit:
![image_2024-07-04_13-54-41 (2)](https://github.com/new-frontiers-14/frontier-station-14/assets/30327355/0c595d6a-ae9a-4ac1-b715-9718eda0e962)

Guidebook entry (rest is standard checklist stuff):
![image_2024-07-04_14-19-25](https://github.com/new-frontiers-14/frontier-station-14/assets/30327355/b4df4ca6-f0ee-44fb-bdb7-bae81c74d0e9)

Location of secret door:
![image](https://github.com/new-frontiers-14/frontier-station-14/assets/30327355/8007f209-3f0f-4772-86b9-da5ff3005964)

## Breaking changes
None!

**Changelog**
:cl:
- tweak: SBB Bookworm has received a few tweaks and no longer runs at a power deficit.