### PR TITLE
NoSpawn for shuttle maps

### DIFF
--- a/Resources/Prototypes/_NF/Guidebook/shuttle_maps.yml
+++ b/Resources/Prototypes/_NF/Guidebook/shuttle_maps.yml
@@ -3,6 +3,7 @@
   id: ShuttleMapAmbition
   name: "UAC Ambition"
   description: "Detailed map of a Ambition shuttle."
+  noSpawn: true
   components:
   - type: Sprite
     sprite: _NF/Guidebook/shuttle_maps/128x96.rsi
@@ -14,6 +15,7 @@
   id: ShuttleMapBocadillo
   name: "NC Bocadillo"
   description: "Detailed map of a Bocadillo shuttle."
+  noSpawn: true
   components:
   - type: Sprite
     sprite: _NF/Guidebook/shuttle_maps/128x96.rsi
@@ -25,6 +27,7 @@
   id: ShuttleMapBrigand
   name: "NT Brigand"
   description: "Detailed map of a Brigand shuttle."
+  noSpawn: true
   components:
   - type: Sprite
     sprite: _NF/Guidebook/shuttle_maps/128x96.rsi
@@ -36,6 +39,7 @@
   id: ShuttleMapBulker
   name: "KL Bulker"
   description: "Detailed map of a Bulker shuttle."
+  noSpawn: true
   components:
   - type: Sprite
     sprite: _NF/Guidebook/shuttle_maps/128x96.rsi
@@ -47,6 +51,7 @@
   id: ShuttleMapCeres
   name: "SBB Ceres"
   description: "Detailed map of a Ceres shuttle."
+  noSpawn: true
   components:
   - type: Sprite
     sprite: _NF/Guidebook/shuttle_maps/128x96.rsi
@@ -58,6 +63,7 @@
   id: ShuttleMapChisel
   name: "ICR Chisel"
   description: "Detailed map of a Chisel shuttle."
+  noSpawn: true
   components:
   - type: Sprite
     sprite: _NF/Guidebook/shuttle_maps/128x96.rsi
@@ -69,6 +75,7 @@
   id: ShuttleMapComet
   name: "NT Comet"
   description: "Detailed map of a Comet shuttle."
+  noSpawn: true
   components:
   - type: Sprite
     sprite: _NF/Guidebook/shuttle_maps/128x96.rsi
@@ -80,6 +87,7 @@
   id: ShuttleMapConstruct
   name: "NT Construct"
   description: "Detailed map of a Construct shuttle."
+  noSpawn: true
   components:
   - type: Sprite
     sprite: _NF/Guidebook/shuttle_maps/128x96.rsi
@@ -91,6 +99,7 @@
   id: ShuttleMapGarden
   name: "NT Garden"
   description: "Detailed map of a Garden shuttle."
+  noSpawn: true
   components:
   - type: Sprite
     sprite: _NF/Guidebook/shuttle_maps/128x96.rsi
@@ -102,6 +111,7 @@
   id: ShuttleMapGasbender
   name: "NT Gasbender"
   description: "Detailed map of a Gasbender shuttle."
+  noSpawn: true
   components:
   - type: Sprite
     sprite: _NF/Guidebook/shuttle_maps/128x96.rsi
@@ -113,6 +123,7 @@
   id: ShuttleMapHarbormaster
   name: "NC Harbormaster"
   description: "Detailed map of a Harbormaster shuttle."
+  noSpawn: true
   components:
   - type: Sprite
     sprite: _NF/Guidebook/shuttle_maps/128x96.rsi
@@ -124,6 +135,7 @@
   id: ShuttleMapKestrel
   name: "NT Kestrel"
   description: "Detailed map of a Kestrel shuttle."
+  noSpawn: true
   components:
   - type: Sprite
     sprite: _NF/Guidebook/shuttle_maps/128x96.rsi
@@ -135,6 +147,7 @@
   id: ShuttleMapKilderkin
   name: "NC Kilderkin"
   description: "Detailed map of a Kilderkin shuttle."
+  noSpawn: true
   components:
   - type: Sprite
     sprite: _NF/Guidebook/shuttle_maps/128x96.rsi
@@ -146,6 +159,7 @@
   id: ShuttleMapLantern
   name: "NC Lantern"
   description: "Detailed map of a Lantern shuttle."
+  noSpawn: true
   components:
   - type: Sprite
     sprite: _NF/Guidebook/shuttle_maps/128x96.rsi
@@ -157,6 +171,7 @@
   id: ShuttleMapLegman
   name: "NC Legman"
   description: "Detailed map of a Legman shuttle."
+  noSpawn: true
   components:
   - type: Sprite
     sprite: _NF/Guidebook/shuttle_maps/128x96.rsi
@@ -168,6 +183,7 @@
   id: ShuttleMapLiquidator
   name: "NC Liquidator"
   description: "Detailed map of a Liquidator shuttle."
+  noSpawn: true
   components:
   - type: Sprite
     sprite: _NF/Guidebook/shuttle_maps/128x96.rsi
@@ -179,6 +195,7 @@
   id: ShuttleMapLoader
   name: "NC Loader"
   description: "Detailed map of a Loader shuttle."
+  noSpawn: true
   components:
   - type: Sprite
     sprite: _NF/Guidebook/shuttle_maps/128x96.rsi
@@ -190,6 +207,7 @@
   id: ShuttleMapPathfinder
   name: "KC Pathfinder"
   description: "Detailed map of a Pathfinder shuttle."
+  noSpawn: true
   components:
   - type: Sprite
     sprite: _NF/Guidebook/shuttle_maps/128x96.rsi
@@ -201,6 +219,7 @@
   id: ShuttleMapPioneer
   name: "NC Pioneer"
   description: "Detailed map of a Pioneer shuttle."
+  noSpawn: true
   components:
   - type: Sprite
     sprite: _NF/Guidebook/shuttle_maps/128x96.rsi
@@ -212,6 +231,7 @@
   id: ShuttleMapProspector
   name: "NC Prospector"
   description: "Detailed map of a Prospector shuttle."
+  noSpawn: true
   components:
   - type: Sprite
     sprite: _NF/Guidebook/shuttle_maps/128x96.rsi
@@ -223,6 +243,7 @@
   id: ShuttleMapSearchlight
   name: "NM Searchlight"
   description: "Detailed map of a Searchlight shuttle."
+  noSpawn: true
   components:
   - type: Sprite
     sprite: _NF/Guidebook/shuttle_maps/128x96.rsi
@@ -234,6 +255,7 @@
   id: ShuttleMapVagabond
   name: "NT Vagabond"
   description: "Detailed map of a Vagabond shuttle."
+  noSpawn: true
   components:
   - type: Sprite
     sprite: _NF/Guidebook/shuttle_maps/128x96.rsi


### PR DESCRIPTION
## About the PR
Added `noSpawn: true` to all guidebook shuttle maps

## Why / Balance
Fixing oversight

## How to test
Load the environment, try (and fail) to spawn shuttle maps through entity spawn menu

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None 

**Changelog**
Not needed
