### PR TITLE
Changes to the bus schedule

### DIFF
--- a/Content.Shared/_NF/CCVars/CCVars.cs
+++ b/Content.Shared/_NF/CCVars/CCVars.cs
@@ -48,11 +48,11 @@ public sealed class NF14CVars
     /// The amount of time the bus waits at a station.
     /// </summary>
     public static readonly CVarDef<float> PublicTransitWaitTime =
-        CVarDef.Create("nf14.publictransit.wait_time", 150f, CVar.SERVERONLY);
+        CVarDef.Create("nf14.publictransit.wait_time", 180f, CVar.SERVERONLY);
 
     /// <summary>
     /// The amount of time the flies through FTL space.
     /// </summary>
     public static readonly CVarDef<float> PublicTransitFlyTime =
-        CVarDef.Create("nf14.publictransit.fly_time", 145f, CVar.SERVERONLY);
+        CVarDef.Create("nf14.publictransit.fly_time", 50f, CVar.SERVERONLY);
 }


### PR DESCRIPTION
## About the PR
Wait at a stop timer increased 150 -> 180
Time in FTL decreased 145 -> 50

## Why / Balance
QoL: harder to miss the buss

## How to test
Get on the bus

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
none afaik

**Changelog**
:cl: erhardsteinhauer
- tweak: Changed bus schedule: 50 seconds in FTL, 3 mins at a stop.
