### PR TITLE
Update meta.json for pride drobe

### DIFF
--- a/Resources/Textures/Structures/Machines/VendingMachines/pride.rsi/meta.json
+++ b/Resources/Textures/Structures/Machines/VendingMachines/pride.rsi/meta.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "license": "CC-BY-SA-4.0",
-  "copyright": "The art belongs to Woods#1999 on discord",
+  "copyright": "Sprite by 2013toyotacorolla on discord",
   "size": {
     "x": 32,
     "y": 32


### PR DESCRIPTION
## About the PR
updates the pride-o-mat json to have my current discord tag, i am the spriter for it

## Why / Balance
discord no longer has username#number, and this is outdated