### PR TITLE
Oni Accuracy: Wieldable Check

### DIFF
--- a/Content.Server/Nyanotrasen/Abilities/Oni/OniSystem.cs
+++ b/Content.Server/Nyanotrasen/Abilities/Oni/OniSystem.cs
@@ -32,8 +32,8 @@ namespace Content.Server.Abilities.Oni
 
             if (TryComp<GunComponent>(args.Entity, out var gun))
             {
-                // Frontier: adjust penalty for wielded malus
-                if (TryComp<GunWieldBonusComponent>(args.Entity, out var bonus))
+                // Frontier: adjust penalty for wielded malus (ensuring it's actually wieldable)
+                if (TryComp<GunWieldBonusComponent>(args.Entity, out var bonus) && TryComp<WieldableComponent>(args.Entity, out var _))
                 {
                     //GunWieldBonus values are stored as negative.
                     heldComp.minAngleAdded = (gun.MinAngle + bonus.MinAngle) * GunInaccuracyFactor;

--- a/Content.Server/Nyanotrasen/Abilities/Oni/OniSystem.cs
+++ b/Content.Server/Nyanotrasen/Abilities/Oni/OniSystem.cs
@@ -3,8 +3,9 @@ using Content.Shared.Tools.Components;
 using Content.Shared.Damage.Events;
 using Content.Shared.Weapons.Melee.Events;
 using Content.Shared.Weapons.Ranged.Components;
-using Robust.Shared.Containers;
 using Content.Shared.Weapons.Ranged.Systems;
+using Content.Shared.Wieldable.Components;
+using Robust.Shared.Containers;
 
 namespace Content.Server.Abilities.Oni
 {
@@ -33,7 +34,7 @@ namespace Content.Server.Abilities.Oni
             if (TryComp<GunComponent>(args.Entity, out var gun))
             {
                 // Frontier: adjust penalty for wielded malus (ensuring it's actually wieldable)
-                if (TryComp<GunWieldBonusComponent>(args.Entity, out var bonus) && TryComp<WieldableComponent>(args.Entity, out var _))
+                if (TryComp<GunWieldBonusComponent>(args.Entity, out var bonus) && HasComp<WieldableComponent>(args.Entity))
                 {
                     //GunWieldBonus values are stored as negative.
                     heldComp.minAngleAdded = (gun.MinAngle + bonus.MinAngle) * GunInaccuracyFactor;


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Added a wieldable component check to OniSystem.cs

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Turns out the sawn-off PKA has a GunWieldBonusComponent with values, but isn't actually wieldable.  As such, the bonuses were being considered for the sawn-off PKA when they shouldn't be (as they never get used).

## How to test
<!-- Describe the way it can be tested -->

1. Spawn in as an oni
2. Spawn in a sawn-off PKA
3. Shoot it
4. Blow out the windows behind yourself.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** ***this PR does not require an ingame showcase***

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Oni accuracy debuffs now properly affect the sawn-off PKA.