### PR TITLE
Sheriff, ERT Mail Carrier Starting Gear: vacate suitstorage

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Devices/pda.yml
@@ -113,6 +113,12 @@
   components:
   - type: Pda
     id: ERTMailCarrierIDCard
+    penSlot:
+      startingItem: PenCentcom
+      priority: -1
+      whitelist:
+        tags:
+        - Write
 
 - type: entity
   parent: BasePDA

--- a/Resources/Prototypes/_NF/Entities/Objects/Misc/mail_capsule.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Misc/mail_capsule.yml
@@ -123,3 +123,14 @@
   - type: Sprite
     layers:
       - state: box
+
+# A bag full of mail capsules, for the ERT mail carrier
+- type: entity
+  parent: MailBag
+  suffix: Capsules
+  id: MailBagCapsulePrimed
+  components:
+  - type: StorageFill
+    contents:
+      - id: MailCapsulePrimed
+        amount: 10

--- a/Resources/Prototypes/_NF/Roles/Jobs/Fun/emergencyresponseteam.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Fun/emergencyresponseteam.yml
@@ -31,7 +31,7 @@
     pocket2: DoubleEmergencyAirTankFilled
   storage:
     back:
-    - SecBreachingHammer # TODO: if the this doesn't fit
+    - SecBreachingHammer
     - WeaponMailLake
     - BoxSurvivalEngineering
     - RubberStampCentcom

--- a/Resources/Prototypes/_NF/Roles/Jobs/Fun/emergencyresponseteam.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Fun/emergencyresponseteam.yml
@@ -53,7 +53,7 @@
     pocket2: DoubleEmergencyAirTankFilled
   storage:
     back:
-    - SecBreachingHammer # TODO: Will this fit?
+    - SecBreachingHammer
     - WeaponMailLake
     - BoxSurvivalEngineering
     - RubberStampCentcom

--- a/Resources/Prototypes/_NF/Roles/Jobs/Fun/emergencyresponseteam.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Fun/emergencyresponseteam.yml
@@ -24,19 +24,17 @@
     head: ClothingHeadHelmetERTMailCarrier
     gloves: ClothingHandsGlovesCombat
     outerClothing: ClothingOuterArmorBasicSlim
-    suitstorage: SecBreachingHammer
     id: ERTMailCarrierPDA
     ears: ClothingHeadsetAltCentCom
-    belt: MailBag
+    belt: MailBagCapsulePrimed
     pocket1: Flare
     pocket2: DoubleEmergencyAirTankFilled
   storage:
     back:
-    - BoxSurvivalEngineering
+    - SecBreachingHammer # TODO: if the this doesn't fit
     - WeaponMailLake
-    - BoxMailCapsulePrimed
+    - BoxSurvivalEngineering
     - RubberStampCentcom
-    - PenCentcom
     - BoxFolderCentCom
 
 - type: startingGear
@@ -48,17 +46,15 @@
     mask: ClothingMaskGasERT
     gloves: ClothingHandsGlovesCombat
     outerClothing: ClothingOuterHardsuitERTMailCarrier
-    suitstorage: SecBreachingHammer
     id: ERTMailCarrierPDA
     ears: ClothingHeadsetAltCentCom
-    belt: MailBag
+    belt: MailBagCapsulePrimed
     pocket1: Flare
     pocket2: DoubleEmergencyAirTankFilled
   storage:
     back:
-    - BoxSurvivalEngineering
+    - SecBreachingHammer # TODO: Will this fit?
     - WeaponMailLake
-    - BoxMailCapsulePrimed
+    - BoxSurvivalEngineering
     - RubberStampCentcom
-    - PenCentcom
     - BoxFolderCentCom

--- a/Resources/Prototypes/_NF/Roles/Jobs/Nfsd/sheriff.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Nfsd/sheriff.yml
@@ -42,9 +42,9 @@
     ears: ClothingHeadsetAltNfsdCreamandBrown # Frontier
     pocket1: WeaponPistolMk58 #WeaponPistolMk58Nonlethal
     pocket2: HoloprojectorNfsd # Frontier
-    suitstorage: WeaponEnergyGunMultiphase # Frontier - DeltaV gun
   storage:
     back:
+    - WeaponEnergyGunMultiphase # Frontier - DeltaV gun
     - RubberStampSheriff
     - DoorRemoteNfsd
     - NfsdTechFabFlatpack

--- a/Resources/Prototypes/_NF/Roles/Jobs/Nfsd/sheriff.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Nfsd/sheriff.yml
@@ -44,9 +44,9 @@
     pocket2: HoloprojectorNfsd # Frontier
   storage:
     back:
-    - WeaponEnergyGunMultiphase # Frontier - DeltaV gun
-    - RubberStampSheriff
-    - DoorRemoteNfsd
     - NfsdTechFabFlatpack
+    - WeaponEnergyGunMultiphase # Frontier - DeltaV gun
+    - DoorRemoteNfsd
     - BaseSecurityUplinkRadioSheriff
     - ClothingNeckNfsdBadgeSheriff
+    - RubberStampSheriff


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

This PR changes the starting gear for ERT mail carriers and the sheriff to free up the suit storage slot for Vox.

The ERT mail carrier now has a CentCom pen in their PDA, and their mailbag starts equipped with ten mail cartridges.

The Sheriff's multiphase laser gun now starts in their bag, and their starting gear, as ordered, will fill a satchel, backpack, and messenger bag without any items spawning on the floor.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

The Vox include a suitstorage-bound item on spawn, which would collide with the job loadouts.

These were the only Frontier-specific jobs with suitstorage items.

## How to test
<!-- Describe the way it can be tested -->

1. Build and run server.
2. Spawn as sheriff with a satchel.  Note your gear, none of it should be missing.  None of it should be on the floor.
3. Run `golobby`.
4. Spawn as sheriff with a backpack.  Note your gear, none of it should be missing.  None of it should be on the floor.
3. Run `golobby`.
4. Spawn as sheriff with a messenger bag.  Note your gear, none of it should be missing.  None of it should be on the floor.
5. Spawn an ERT Mail Carrier (both EVA and normal variant).  Check their gear, they should have a breaching hammer in their backpack, a CentCom pen in their PDA, and mail bags full of capsules.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

Starting ERT mail carrier gear
![image](https://github.com/new-frontiers-14/frontier-station-14/assets/166147148/dc474f4b-70a2-4a3d-b318-a01dcbf4aa2b)

Starting sheriff gear (messenger bag)
![image](https://github.com/new-frontiers-14/frontier-station-14/assets/166147148/799a0597-0fba-4845-a729-7cd6f6420807)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Sheriffs start with their laser moved to their backpack.