### PR TITLE
Actually removing empty weapon cases from weapon spawners

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/dungeon_items_mercenary.yml
+++ b/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/dungeon_items_mercenary.yml
@@ -102,12 +102,10 @@
     chance: 0.5
     offset: 0.0
     rarePrototypes:
-    - WeaponCaseShort
-    - WeaponCaseLong
     - SpawnDungeonLootMeleeT2
     - SpawnDungeonLootGunT2
     - SpawnDungeonLootExplosivesT1
-    rareChance: 0.25
+    rareChance: 0.05
 
 - type: entity
   name: random weapon
@@ -132,12 +130,10 @@
     chance: 0.7
     offset: 0.0
     rarePrototypes:
-    - WeaponCaseShort
-    - WeaponCaseLong
     - SpawnDungeonLootMeleeT3
     - SpawnDungeonLootGunT3
     - SpawnDungeonLootExplosivesT2
-    rareChance: 0.25
+    rareChance: 0.05
 
 - type: entity
   name: random weapon
@@ -162,7 +158,7 @@
     offset: 0.0
     rarePrototypes:
     - SpawnDungeonLootMeleeT3
-    rareChance: 0.1
+    rareChance: 0.05
 
 - type: entity
   name: random weapon
@@ -187,12 +183,10 @@
     chance: 0.9
     offset: 0.0
     rarePrototypes:
-    - WeaponCaseShort
-    - WeaponCaseLong
     - SpawnDungeonLootMeleeT4
     - SpawnDungeonLootGunT4
     - SpawnDungeonLootExplosivesT3
-    rareChance: 0.45
+    rareChance: 0.025
 
 - type: entity
   name: random weapon


### PR DESCRIPTION
## About the PR
Some how forgor to remove couple lines with empty cases in [Dungeon Weapon Spawner Rebalance PR](https://github.com/new-frontiers-14/frontier-station-14/pull/1543). This PR fixes that old overlook.

## Why / Balance
Removing somewhat frustrating for players mechanics with empty cases.

## How to test
Use random weapon [Dungeon, ...] spawners, observe the results: should not spawn empty cases at all.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes

**Changelog**
:cl: erhardsteinhauer
- fix: Removed empty weapon cases from expeditions fr this time.
