### PR TITLE
Add 'Server/Client (Release)' build for VSCode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -50,6 +50,16 @@
                 "Client"
             ],
             "preLaunchTask": "build"
+        },
+        // Frontier begin
+        {
+            "name": "Server/Client (Release)",
+            "configurations": [
+                "Server",
+                "Client"
+            ],
+            "preLaunchTask": "build-release"
         }
+        // Frontier end
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -21,6 +21,26 @@
             },
             "problemMatcher": "$msCompile"
         },
+        // Frontier begin
+        {
+            "label": "build-release",
+            "command": "dotnet",
+            "type": "shell",
+            "args": [
+                "build",
+                "--configuration=Release", // Build in release mode. Note: --, not /. /configuration doesn't work, because Microsoft.
+                "/property:GenerateFullPaths=true", // Ask dotnet build to generate full paths for file names.
+                "/consoleloggerparameters:NoSummary" // Do not generate summary otherwise it leads to duplicate errors in Problems panel
+            ],
+            "group": {
+                "kind": "build"
+            },
+            "presentation": {
+                "reveal": "silent"
+            },
+            "problemMatcher": "$msCompile"
+        },
+        // Frontier end
         {
             "label": "build-yaml-linter",
             "command": "dotnet",


### PR DESCRIPTION
## About the PR
This PR adds a new build target specifically to the VSCode config: "Server/Client (Release)".

## Why / Balance
Over the past many months of mapping for Frontier and helping others map for Frontier, I've noticed one recurring problem: people map in debug mode, and get annoyed or discouraged when the game keeps crashing. Unlike Visual Studio, the very popular and generally easier-to-use VSCode does _not_ have any easy way of forcing a release build. Visual Studio has a Debug/Release dropdown, VSCode has nothing. "Run Without Debugging" still creates a debug build and just doesn't attach a debugger to it. To run a server in release mode, additional hoops must be jumped through, making mapping needlessly complicated for non-coders.

To help people have a better time whilst mapping, this is my solution: just add the thing people actually want. What could be easier than a single button press? It's also easier to shut down the server by pressing a nice stop button than remembering to use the unintuitive key combination Ctrl+C inside the terminal.

### "You should upstream this"
Upstream has _way_ fewer active mappers. Those who develop for the game generally _want_ to test in debug mode to catch errors and such. I believe this change is more meaningful to Frontier than to upstream. In practical terms, these files basically never change and conflicts are likely to be rare and easily resolved.

## How to test
1. Set up Frontier in VSCode.
2. The 'Run and debug' dropdown should have a new option: "Server/Client (Release)".
3. Run with and without debugging. Verify that it starts in release mode. One way of doing that is to make note of whether the lobby screen appears: in debug mode, you get thrown straight into the game (unless you've specifically set the cvar `game.lobbyenabled` to true).

## Media
![image](https://github.com/user-attachments/assets/c94c2fd7-6ae4-45e3-b0c1-541f35235e8e)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
Nopers.

**Changelog**
N/A, developer-facing change