### PR TITLE
Fix pirates rule

### DIFF
--- a/Resources/ServerInfo/_NF/Guidebook/Rules/12_PVP.xml
+++ b/Resources/ServerInfo/_NF/Guidebook/Rules/12_PVP.xml
@@ -1,7 +1,6 @@
 <Document>
 # 12. PVP & Piracy Guidelines
 
-    - Pirates/antagonists must ahelp (F1) before starting a crew and receive permission to begin antag activity. Spamming ahelp asking to be a pirate or pirating without permission will likely lead to being banned.
     - Pirate crews may never exceed a total force of four members, including the Captain.
     - Non-hostile vessels that surrender: cannot be killed, left stranded, completely bankrupt, or otherwise. The safety of non-hostile merchant vessels is to be guaranteed by all parties. All vessels being boarded must first attempt to negotiate before any hostile actions may take place.
     - Hostile forces that are known, declared, and confirmed, may be considered 'belligerent', boarded non-conventionally, and have their systems disabled in attempts to bring them to justice. All suspects taken alive must be adequately cared for and unharmed according to Space Law.


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Remove clause for players needing to ahelp to become pirate since it is no longer relevant with the new system of latejoins.

**Changelog**

:cl:
- fix: The rule stating that pirates must ahelp has been removed.