### PR TITLE
Update to radiation safety gear on Liquidator and Schooner

### DIFF
--- a/Resources/Maps/_NF/Shuttles/BlackMarket/schooner.yml
+++ b/Resources/Maps/_NF/Shuttles/BlackMarket/schooner.yml
@@ -540,13 +540,6 @@ entities:
     - type: RadiationGridResistance
     - type: BecomesStation
       id: Schooner
-- proto: AirCanister
-  entities:
-  - uid: 2
-    components:
-    - type: Transform
-      pos: -2.5,7.5
-      parent: 1
 - proto: AirlockGlassShuttle
   entities:
   - uid: 3
@@ -922,6 +915,14 @@ entities:
       parent: 1
     - type: Physics
       bodyType: Static
+- proto: ButtonFrameCaution
+  entities:
+  - uid: 2
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,10.5
+      parent: 1
 - proto: CableApcExtension
   entities:
   - uid: 28
@@ -1832,6 +1833,13 @@ entities:
     - type: Transform
       pos: -2.5,0.5
       parent: 1
+- proto: ClosetRadiationSuitFilled
+  entities:
+  - uid: 217
+    components:
+    - type: Transform
+      pos: 3.5,8.5
+      parent: 1
 - proto: ClosetSteelBase
   entities:
   - uid: 201
@@ -1924,14 +1932,6 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,-6.5
-      parent: 1
-- proto: ComputerPowerMonitoring
-  entities:
-  - uid: 217
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -2.5,8.5
       parent: 1
 - proto: ComputerShuttleAntag
   entities:
@@ -2181,13 +2181,11 @@ entities:
       parent: 1
 - proto: Gyroscope
   entities:
-  - uid: 264
+  - uid: 244
     components:
     - type: Transform
-      pos: 3.5,6.5
+      pos: -2.5,7.5
       parent: 1
-    - type: Thruster
-      originalPowerLoad: 1500
 - proto: HeadSkeleton
   entities:
   - uid: 265
@@ -2240,6 +2238,20 @@ entities:
     components:
     - type: Transform
       pos: -2.7120032,-0.473266
+      parent: 1
+- proto: NitrogenCanister
+  entities:
+  - uid: 207
+    components:
+    - type: Transform
+      pos: 3.5,6.5
+      parent: 1
+- proto: OxygenCanister
+  entities:
+  - uid: 264
+    components:
+    - type: Transform
+      pos: 3.5,7.5
       parent: 1
 - proto: PaintingSkeletonBoof
   entities:
@@ -2658,13 +2670,11 @@ entities:
         - Pressed: Trigger
 - proto: SheetUranium
   entities:
-  - uid: 340
+  - uid: 208
     components:
     - type: Transform
-      pos: -0.51266235,8.61944
+      pos: -0.65123916,8.543868
       parent: 1
-    - type: Stack
-      count: 15
 - proto: ShuttersNormal
   entities:
   - uid: 341
@@ -2763,6 +2773,43 @@ entities:
     - type: DeviceLinkSink
       links:
       - 354
+- proto: ShuttersRadiation
+  entities:
+  - uid: 206
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,8.5
+      parent: 1
+    - type: DeviceLinkSink
+      links:
+      - 274
+  - uid: 224
+    components:
+    - type: Transform
+      pos: -1.5,9.5
+      parent: 1
+    - type: DeviceLinkSink
+      links:
+      - 274
+  - uid: 225
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,7.5
+      parent: 1
+    - type: DeviceLinkSink
+      links:
+      - 274
+  - uid: 228
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,6.5
+      parent: 1
+    - type: DeviceLinkSink
+      links:
+      - 274
 - proto: ShuttleGunPirateCannon
   entities:
   - uid: 501
@@ -2803,6 +2850,22 @@ entities:
       - 505
 - proto: SignalButtonDirectional
   entities:
+  - uid: 274
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,10.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        224:
+        - Pressed: Toggle
+        206:
+        - Pressed: Toggle
+        225:
+        - Pressed: Toggle
+        228:
+        - Pressed: Toggle
   - uid: 353
     components:
     - type: Transform
@@ -2862,9 +2925,9 @@ entities:
     - type: Transform
       pos: 0.5,-9.5
       parent: 1
-- proto: SignEngine
+- proto: SignRadiationMed
   entities:
-  - uid: 358
+  - uid: 210
     components:
     - type: Transform
       pos: -0.5,9.5
@@ -2939,14 +3002,12 @@ entities:
       parent: 1
 - proto: SpaceVillainArcadeFilled
   entities:
-  - uid: 371
+  - uid: 280
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,8.5
+      rot: 1.5707963267948966 rad
+      pos: -2.5,8.5
       parent: 1
-    - type: SpamEmitSound
-      enabled: False
 - proto: SpawnPointPirate
   entities:
   - uid: 373
@@ -3039,92 +3100,68 @@ entities:
       rot: 3.141592653589793 rad
       pos: 5.5,-6.5
       parent: 1
-    - type: Thruster
-      originalPowerLoad: 1500
   - uid: 388
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-9.5
       parent: 1
-    - type: Thruster
-      originalPowerLoad: 1500
   - uid: 389
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-9.5
       parent: 1
-    - type: Thruster
-      originalPowerLoad: 1500
   - uid: 390
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-6.5
       parent: 1
-    - type: Thruster
-      originalPowerLoad: 1500
   - uid: 391
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,0.5
       parent: 1
-    - type: Thruster
-      originalPowerLoad: 1500
   - uid: 392
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-0.5
       parent: 1
-    - type: Thruster
-      originalPowerLoad: 1500
   - uid: 393
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,0.5
       parent: 1
-    - type: Thruster
-      originalPowerLoad: 1500
   - uid: 394
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,-0.5
       parent: 1
-    - type: Thruster
-      originalPowerLoad: 1500
   - uid: 395
     components:
     - type: Transform
       pos: 5.5,6.5
       parent: 1
-    - type: Thruster
-      originalPowerLoad: 1500
   - uid: 396
     components:
     - type: Transform
       pos: -4.5,6.5
       parent: 1
-    - type: Thruster
-      originalPowerLoad: 1500
   - uid: 397
     components:
     - type: Transform
       pos: -3.5,10.5
       parent: 1
-    - type: Thruster
-      originalPowerLoad: 1500
   - uid: 398
     components:
     - type: Transform
       pos: 4.5,10.5
       parent: 1
-    - type: Thruster
-      originalPowerLoad: 1500
 - proto: ToyFigurineCaptain
   entities:
   - uid: 399
@@ -3591,11 +3628,6 @@ entities:
     components:
     - type: Transform
       pos: 1.5,6.5
-      parent: 1
-  - uid: 494
-    components:
-    - type: Transform
-      pos: -1.5,9.5
       parent: 1
   - uid: 495
     components:

--- a/Resources/Maps/_NF/Shuttles/bazaar.yml
+++ b/Resources/Maps/_NF/Shuttles/bazaar.yml
@@ -5198,6 +5198,8 @@ entities:
       parent: 1
     - type: FuelGenerator
       on: False
+    - type: MaterialStorageMagnetPickup
+      magnetEnabled: True
     - type: Physics
       bodyType: Static
   - uid: 961
@@ -5207,6 +5209,8 @@ entities:
       parent: 1
     - type: FuelGenerator
       on: False
+    - type: MaterialStorageMagnetPickup
+      magnetEnabled: True
     - type: Physics
       bodyType: Static
 - proto: PosterLegitCarpMount
@@ -5532,19 +5536,13 @@ entities:
   - uid: 48
     components:
     - type: Transform
-      pos: -10.492079,7.4558206
+      pos: -10.480434,9.520037
       parent: 1
-    - type: Stack
-      count: 15
-- proto: SheetUranium1
-  entities:
-  - uid: 963
+  - uid: 531
     components:
     - type: Transform
-      pos: -10.538954,9.408945
+      pos: -10.496059,7.488787
       parent: 1
-    - type: Stack
-      count: 15
 - proto: ShuttersNormal
   entities:
   - uid: 525
@@ -5676,6 +5674,9 @@ entities:
     - type: Transform
       pos: -9.5,8.5
       parent: 1
+    - type: DeviceLinkSink
+      links:
+      - 41
 - proto: ShuttleWindow
   entities:
   - uid: 577
@@ -5764,6 +5765,10 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -9.5,9.5
       parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        235:
+        - Pressed: Toggle
   - uid: 571
     components:
     - type: Transform

--- a/Resources/Maps/_NF/Shuttles/liquidator.yml
+++ b/Resources/Maps/_NF/Shuttles/liquidator.yml
@@ -269,8 +269,6 @@ entities:
           0,-2:
             0: 65280
             2: 14
-          -1,-2:
-            0: 63094
           -1,-1:
             0: 8183
           1,-2:
@@ -285,6 +283,8 @@ entities:
             2: 17408
           -1,0:
             0: 1911
+          -1,-2:
+            0: 30326
         uniqueMixes:
         - volume: 2500
           temperature: 293.15
@@ -705,19 +705,19 @@ entities:
   - uid: 186
     components:
     - type: Transform
-      pos: 1.5,3.5
-      parent: 1
-    - type: DeviceLinkSink
-      links:
-      - 188
-  - uid: 326
-    components:
-    - type: Transform
       pos: 0.5,3.5
       parent: 1
     - type: DeviceLinkSink
       links:
-      - 188
+      - 145
+  - uid: 347
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 1
+    - type: DeviceLinkSink
+      links:
+      - 145
 - proto: BoxBodyBag
   entities:
   - uid: 88
@@ -759,6 +759,26 @@ entities:
     components:
     - type: Transform
       pos: 5.6002502,0.5775392
+      parent: 1
+- proto: ButtonFrameCaution
+  entities:
+  - uid: 359
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-3.5
+      parent: 1
+  - uid: 363
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-1.5
+      parent: 1
+  - uid: 368
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,2.5
       parent: 1
 - proto: CableApcExtension
   entities:
@@ -1188,19 +1208,12 @@ entities:
       rot: 3.141592653589793 rad
       pos: -2.5,1.5
       parent: 1
-- proto: CleanerGrenade
-  entities:
-  - uid: 236
-    components:
-    - type: Transform
-      pos: -3.7238417,-4.438796
-      parent: 1
 - proto: ClosetRadiationSuitFilled
   entities:
-  - uid: 232
+  - uid: 360
     components:
     - type: Transform
-      pos: 2.5,2.5
+      pos: -3.5,-4.5
       parent: 1
 - proto: ClothingNeckCloakJanitorFilled
   entities:
@@ -1269,7 +1282,7 @@ entities:
   - uid: 97
     components:
     - type: Transform
-      pos: -3.5,-3.5
+      pos: 2.5,2.5
       parent: 1
 - proto: DefibrillatorCabinetFilled
   entities:
@@ -2184,10 +2197,10 @@ entities:
       parent: 1
 - proto: Jug
   entities:
-  - uid: 357
+  - uid: 100
     components:
     - type: Transform
-      pos: -3.4069247,-4.011713
+      pos: 4.2617903,0.79023325
       parent: 1
 - proto: Lamp
   entities:
@@ -2255,6 +2268,8 @@ entities:
       parent: 1
     - type: FuelGenerator
       on: False
+    - type: MaterialStorageMagnetPickup
+      magnetEnabled: True
     - type: Physics
       bodyType: Static
 - proto: PosterLegitCleanliness
@@ -2587,91 +2602,143 @@ entities:
       parent: 1
 - proto: ShuttersNormalOpen
   entities:
-  - uid: 189
-    components:
-    - type: Transform
-      pos: -2.5,-6.5
-      parent: 1
-    - type: DeviceLinkSink
-      links:
-      - 245
-  - uid: 347
-    components:
-    - type: Transform
-      pos: -1.5,-6.5
-      parent: 1
-    - type: DeviceLinkSink
-      links:
-      - 245
-- proto: ShuttersRadiationOpen
-  entities:
-  - uid: 100
-    components:
-    - type: Transform
-      pos: 1.5,-6.5
-      parent: 1
-    - type: DeviceLinkSink
-      links:
-      - 266
   - uid: 130
     components:
     - type: Transform
-      pos: 1.5,-3.5
+      pos: -1.5,-5.5
       parent: 1
     - type: DeviceLinkSink
       links:
-      - 266
+      - 364
   - uid: 142
     components:
     - type: Transform
-      pos: 2.5,-3.5
+      pos: -2.5,-5.5
       parent: 1
     - type: DeviceLinkSink
       links:
-      - 266
-  - uid: 250
+      - 364
+  - uid: 357
+    components:
+    - type: Transform
+      pos: -1.5,-7.5
+      parent: 1
+    - type: DeviceLinkSink
+      links:
+      - 364
+  - uid: 358
+    components:
+    - type: Transform
+      pos: -2.5,-7.5
+      parent: 1
+    - type: DeviceLinkSink
+      links:
+      - 364
+- proto: ShuttersRadiation
+  entities:
+  - uid: 189
     components:
     - type: Transform
       pos: 3.5,-6.5
       parent: 1
     - type: DeviceLinkSink
       links:
-      - 266
-  - uid: 360
-    components:
-    - type: Transform
-      pos: 4.5,-4.5
-      parent: 1
-    - type: DeviceLinkSink
-      links:
-      - 266
-  - uid: 372
-    components:
-    - type: Transform
-      pos: 4.5,-5.5
-      parent: 1
-    - type: DeviceLinkSink
-      links:
-      - 266
-  - uid: 387
-    components:
-    - type: Transform
-      pos: -0.5,-4.5
-      parent: 1
-    - type: DeviceLinkSink
-      links:
-      - 266
-  - uid: 388
+      - 188
+  - uid: 232
     components:
     - type: Transform
       pos: 2.5,-6.5
       parent: 1
     - type: DeviceLinkSink
       links:
-      - 266
-- proto: SignalButton
-  entities:
+      - 188
+  - uid: 236
+    components:
+    - type: Transform
+      pos: 2.5,-3.5
+      parent: 1
+    - type: DeviceLinkSink
+      links:
+      - 188
   - uid: 245
+    components:
+    - type: Transform
+      pos: 1.5,-6.5
+      parent: 1
+    - type: DeviceLinkSink
+      links:
+      - 188
+  - uid: 250
+    components:
+    - type: Transform
+      pos: 4.5,-4.5
+      parent: 1
+    - type: DeviceLinkSink
+      links:
+      - 188
+  - uid: 266
+    components:
+    - type: Transform
+      pos: 4.5,-5.5
+      parent: 1
+    - type: DeviceLinkSink
+      links:
+      - 188
+  - uid: 326
+    components:
+    - type: Transform
+      pos: 1.5,-3.5
+      parent: 1
+    - type: DeviceLinkSink
+      links:
+      - 188
+  - uid: 365
+    components:
+    - type: Transform
+      pos: -0.5,-4.5
+      parent: 1
+    - type: DeviceLinkSink
+      links:
+      - 188
+- proto: SignalButtonDirectional
+  entities:
+  - uid: 145
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,2.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        186:
+        - Pressed: Toggle
+        347:
+        - Pressed: Toggle
+  - uid: 188
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-3.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        365:
+        - Pressed: Toggle
+        236:
+        - Pressed: Toggle
+        326:
+        - Pressed: Toggle
+        245:
+        - Pressed: Toggle
+        232:
+        - Pressed: Toggle
+        189:
+        - Pressed: Toggle
+        250:
+        - Pressed: Toggle
+        266:
+        - Pressed: Toggle
+  - uid: 364
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2679,50 +2746,13 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        189:
-        - Pressed: Toggle
-        347:
-        - Pressed: Toggle
-  - uid: 266
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -0.52770877,-3.1912308
-      parent: 1
-    - type: DeviceLinkSource
-      linkedPorts:
-        130:
-        - Pressed: Toggle
         142:
         - Pressed: Toggle
-        360:
+        130:
         - Pressed: Toggle
-        372:
+        358:
         - Pressed: Toggle
-        250:
-        - Pressed: Toggle
-        388:
-        - Pressed: Toggle
-        100:
-        - Pressed: Toggle
-        387:
-        - Pressed: Toggle
-- proto: SignalButtonDirectional
-  entities:
-  - uid: 188
-    components:
-    - type: MetaData
-      desc: 'Reminder: keep... Uhh.. I forgot..'
-      name: blast doors switch
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -0.5,2.5
-      parent: 1
-    - type: DeviceLinkSource
-      linkedPorts:
-        326:
-        - Pressed: Toggle
-        186:
+        357:
         - Pressed: Toggle
 - proto: SignJanitor
   entities:
@@ -2750,11 +2780,11 @@ entities:
       parent: 1
 - proto: SignRadiationMed
   entities:
-  - uid: 397
+  - uid: 367
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -0.5,-3.5
+      pos: -0.16389537,-3.5
       parent: 1
 - proto: SinkWide
   entities:
@@ -2774,20 +2804,20 @@ entities:
       parent: 1
 - proto: SprayBottleSpaceCleaner
   entities:
+  - uid: 23
+    components:
+    - type: Transform
+      pos: -1.7382097,2.2121081
+      parent: 1
   - uid: 120
     components:
     - type: Transform
-      pos: -3.4173415,-4.345046
+      pos: -1.9413347,2.3996081
       parent: 1
-  - uid: 145
+  - uid: 369
     components:
     - type: Transform
-      pos: -3.4485915,-4.4596295
-      parent: 1
-  - uid: 358
-    components:
-    - type: Transform
-      pos: -3.2819247,-4.3971295
+      pos: 4.9649153,0.72773325
       parent: 1
 - proto: SubstationBasic
   entities:
@@ -2808,11 +2838,6 @@ entities:
       canCollide: False
 - proto: Table
   entities:
-  - uid: 23
-    components:
-    - type: Transform
-      pos: -3.5,-4.5
-      parent: 1
   - uid: 72
     components:
     - type: Transform


### PR DESCRIPTION
## About the PR
Updated radiation safety equipment on Liquidator (shutters start in closed position), Schooner (added radiation protection shutters and suits), fixed small issue with Bazaar (radiation shutter wasn't linked to button).

## Why / Balance
Safety!

## How to test
Buy Liquidator, Schooner, Bazaar.

## Media
![2024-7-20_15 36 09](https://github.com/user-attachments/assets/3402f307-d5b0-4226-9bc1-a8ac957ba62e)
![2024-7-20_15 12 23](https://github.com/user-attachments/assets/8f05247e-0f25-43b4-8cf4-23439f622b1e)
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes

**Changelog**
:cl: erhardsteinhauer
- tweak: Updated radiation safety measures on Liquidator and Schooner.
