### PR TITLE
Added FuelVend to The Lodge and Grifty's

### DIFF
--- a/Resources/Locale/en-US/_NF/navmap-beacons/station-beacons.ftl
+++ b/Resources/Locale/en-US/_NF/navmap-beacons/station-beacons.ftl
@@ -15,3 +15,15 @@ station-beacon-nfsd = NFSD
 station-beacon-nfsd-brig = Brig
 station-beacon-cafe = Cafe
 station-beacon-conference = Conference
+station-beacon-office-mercenary = Office
+station-beacon-shooting-range-mercenary = Shooting Range
+
+station-beacon-dock-one = Dock 1
+station-beacon-dock-two = Dock 2
+station-beacon-dock-three = Dock 3
+station-beacon-dock-four = Dock 4
+station-beacon-dock-five = Dock 5
+station-beacon-dock-six = Dock 6
+station-beacon-dock-six-a = Dock 6a
+station-beacon-dock-six-b = Dock 6b
+station-beacon-dock-six-c = Dock 6c

--- a/Resources/Maps/_NF/POI/grifty.yml
+++ b/Resources/Maps/_NF/POI/grifty.yml
@@ -1563,11 +1563,6 @@ entities:
       enabled: False
 - proto: BookshelfFilled
   entities:
-  - uid: 672
-    components:
-    - type: Transform
-      pos: 9.5,4.5
-      parent: 1
   - uid: 674
     components:
     - type: Transform
@@ -4343,7 +4338,7 @@ entities:
       pos: -8.5,7.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -5460.6416
+      secondsUntilStateChange: -5908.0503
       state: Opening
 - proto: Lamp
   entities:
@@ -4471,8 +4466,8 @@ entities:
         immutable: False
         temperature: 293.1497
         moles:
-        - 1.8856695
-        - 7.0937095
+        - 1.8968438
+        - 7.1357465
         - 0
         - 0
         - 0
@@ -4489,13 +4484,13 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 519
-          - 518
-          - 517
-          - 516
-          - 515
-          - 514
           - 513
+          - 514
+          - 515
+          - 516
+          - 517
+          - 518
+          - 519
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -4744,7 +4739,7 @@ entities:
       parent: 1
 - proto: PosterLegitSMFires
   entities:
-  - uid: 562
+  - uid: 6
     components:
     - type: Transform
       pos: -5.5,7.5
@@ -5509,15 +5504,16 @@ entities:
       parent: 1
 - proto: SpawnMobArgocyteSmall
   entities:
+  - uid: 507
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,3.5
+      parent: 1
   - uid: 682
     components:
     - type: Transform
       pos: 6.5,4.5
-      parent: 1
-  - uid: 683
-    components:
-    - type: Transform
-      pos: -0.5,3.5
       parent: 1
   - uid: 684
     components:
@@ -5665,6 +5661,13 @@ entities:
     components:
     - type: Transform
       pos: -1.5,3.5
+      parent: 1
+- proto: VendingMachineFuelVend
+  entities:
+  - uid: 5
+    components:
+    - type: Transform
+      pos: 9.5,4.5
       parent: 1
 - proto: VendingMachineRestockBooze
   entities:
@@ -6036,6 +6039,31 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -4.5,-6.5
       parent: 1
+- proto: WallReinforcedDiagonal
+  entities:
+  - uid: 508
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,0.5
+      parent: 1
+  - uid: 562
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,7.5
+      parent: 1
+  - uid: 605
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,0.5
+      parent: 1
+  - uid: 634
+    components:
+    - type: Transform
+      pos: -10.5,7.5
+      parent: 1
 - proto: WallSolid
   entities:
   - uid: 67
@@ -6134,31 +6162,6 @@ entities:
     components:
     - type: Transform
       pos: -7.5,5.5
-      parent: 1
-- proto: WallSolidDiagonal
-  entities:
-  - uid: 5
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 10.5,0.5
-      parent: 1
-  - uid: 6
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 10.5,7.5
-      parent: 1
-  - uid: 791
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -10.5,0.5
-      parent: 1
-  - uid: 792
-    components:
-    - type: Transform
-      pos: -10.5,7.5
       parent: 1
 - proto: WarningAir
   entities:

--- a/Resources/Maps/_NF/POI/lodge.yml
+++ b/Resources/Maps/_NF/POI/lodge.yml
@@ -493,6 +493,7 @@ entities:
             689: 14,6
             1680: 7,17
             1682: 14,11
+            2019: 16,11
         - node:
             cleanable: True
             color: '#A4610696'
@@ -2122,6 +2123,7 @@ entities:
           decals:
             681: 17,10
             682: 11,10
+            2020: 16,10
         - node:
             angle: 1.5707963267948966 rad
             color: '#B8B873FF'
@@ -7705,7 +7707,7 @@ entities:
           ents: []
 - proto: ComputerPowerMonitoring
   entities:
-  - uid: 1873
+  - uid: 263
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -7722,14 +7724,6 @@ entities:
     components:
     - type: Transform
       pos: -12.5,23.5
-      parent: 1
-- proto: ComputerTabletopCrewMonitoring
-  entities:
-  - uid: 1040
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -12.5,7.5
       parent: 1
 - proto: ComputerTabletopRadar
   entities:
@@ -7785,6 +7779,14 @@ entities:
           showEnts: False
           occludes: True
           ents: []
+- proto: ComputerTabletopStationRecords
+  entities:
+  - uid: 264
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -12.5,7.5
+      parent: 1
 - proto: ComputerWallmountWithdrawBankATM
   entities:
   - uid: 2517
@@ -7968,100 +7970,130 @@ entities:
     - type: DeviceLinkSink
       links:
       - 2104
-- proto: DefaultStationBeaconArmory
-  entities:
-  - uid: 2190
-    components:
-    - type: Transform
-      pos: 10.5,15.5
-      parent: 1
-    - type: NavMapBeacon
-      text: Practice Range
 - proto: DefaultStationBeaconBar
   entities:
-  - uid: 265
+  - uid: 2189
     components:
     - type: Transform
       pos: 0.5,7.5
       parent: 1
-    - type: NavMapBeacon
-      text: Lodge
+- proto: DefaultStationBeaconCryosleep
+  entities:
+  - uid: 2547
+    components:
+    - type: Transform
+      pos: -10.5,13.5
+      parent: 1
 - proto: DefaultStationBeaconEngineering
   entities:
   - uid: 365
     components:
     - type: Transform
-      pos: 0.5,15.5
+      pos: 2.5,14.5
       parent: 1
-- proto: DefaultStationBeaconFrontierDock
+- proto: DefaultStationBeaconFrontierATM
   entities:
-  - uid: 2184
+  - uid: 2544
     components:
     - type: Transform
-      pos: -20.5,22.5
+      pos: 3.5,12.5
       parent: 1
-    - type: NavMapBeacon
-      text: Dock 1
-  - uid: 2185
+  - uid: 2545
     components:
     - type: Transform
-      pos: 0.5,25.5
+      pos: -2.5,12.5
       parent: 1
-    - type: NavMapBeacon
-      text: Dock 2
-  - uid: 2186
-    components:
-    - type: Transform
-      pos: 21.5,22.5
-      parent: 1
-    - type: NavMapBeacon
-      text: Dock 3
-  - uid: 2187
-    components:
-    - type: Transform
-      pos: 31.5,0.5
-      parent: 1
-    - type: NavMapBeacon
-      text: Dock 4
-  - uid: 2188
+- proto: DefaultStationBeaconFrontierDockFive
+  entities:
+  - uid: 1875
     components:
     - type: Transform
       pos: 0.5,-2.5
       parent: 1
-    - type: NavMapBeacon
-      text: Dock 5
-  - uid: 2189
+- proto: DefaultStationBeaconFrontierDockFour
+  entities:
+  - uid: 265
+    components:
+    - type: Transform
+      pos: 31.5,0.5
+      parent: 1
+- proto: DefaultStationBeaconFrontierDockOne
+  entities:
+  - uid: 1040
+    components:
+    - type: Transform
+      pos: -20.5,22.5
+      parent: 1
+- proto: DefaultStationBeaconFrontierDockSix
+  entities:
+  - uid: 2184
     components:
     - type: Transform
       pos: -30.5,0.5
       parent: 1
-    - type: NavMapBeacon
-      text: Dock 6
+- proto: DefaultStationBeaconFrontierDockThree
+  entities:
+  - uid: 1873
+    components:
+    - type: Transform
+      pos: 21.5,22.5
+      parent: 1
+- proto: DefaultStationBeaconFrontierDockTwo
+  entities:
+  - uid: 1048
+    components:
+    - type: Transform
+      pos: 0.5,25.5
+      parent: 1
+- proto: DefaultStationBeaconFrontierOfficeMercenary
+  entities:
+  - uid: 1992
+    components:
+    - type: Transform
+      pos: -11.5,8.5
+      parent: 1
+- proto: DefaultStationBeaconFrontierShipyard
+  entities:
+  - uid: 2543
+    components:
+    - type: Transform
+      pos: 14.5,11.5
+      parent: 1
+- proto: DefaultStationBeaconFrontierShootingRangeMercenary
+  entities:
+  - uid: 2186
+    components:
+    - type: Transform
+      pos: 15.5,15.5
+      parent: 1
+- proto: DefaultStationBeaconFrontierVend
+  entities:
+  - uid: 2542
+    components:
+    - type: Transform
+      pos: -11.5,4.5
+      parent: 1
 - proto: DefaultStationBeaconJanitorsCloset
   entities:
   - uid: 915
     components:
     - type: Transform
-      pos: -7.5,17.5
+      pos: -6.5,15.5
       parent: 1
 - proto: DefaultStationBeaconMedbay
   entities:
-  - uid: 263
+  - uid: 2546
     components:
     - type: Transform
-      pos: -10.5,14.5
+      pos: -10.5,17.5
       parent: 1
-    - type: NavMapBeacon
-      text: Medbay
 - proto: DefaultStationBeaconSupply
   entities:
-  - uid: 264
+  - uid: 2185
     components:
     - type: Transform
-      pos: 14.5,8.5
+      pos: 14.5,7.5
       parent: 1
-    - type: NavMapBeacon
-      text: Cargo
 - proto: DefibrillatorCabinetFilled
   entities:
   - uid: 2194
@@ -14376,11 +14408,6 @@ entities:
     - type: Transform
       pos: -1.5,20.5
       parent: 1
-  - uid: 2542
-    components:
-    - type: Transform
-      pos: 16.5,11.5
-      parent: 1
 - proto: PowerCellRecharger
   entities:
   - uid: 2191
@@ -16477,15 +16504,15 @@ entities:
       parent: 1
 - proto: VendingMachineAstroVend
   entities:
-  - uid: 1992
-    components:
-    - type: Transform
-      pos: -5.5,23.5
-      parent: 1
   - uid: 2052
     components:
     - type: Transform
       pos: -10.5,4.5
+      parent: 1
+  - uid: 2188
+    components:
+    - type: Transform
+      pos: -5.5,23.5
       parent: 1
 - proto: VendingMachineBooze
   entities:
@@ -16519,6 +16546,13 @@ entities:
     components:
     - type: Transform
       pos: -5.5,19.5
+      parent: 1
+- proto: VendingMachineFuelVend
+  entities:
+  - uid: 2187
+    components:
+    - type: Transform
+      pos: 16.5,11.5
       parent: 1
 - proto: VendingMachineMedical
   entities:
@@ -17990,12 +18024,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 10.5,16.5
       parent: 1
-  - uid: 1048
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 16.5,11.5
-      parent: 1
   - uid: 1050
     components:
     - type: Transform
@@ -18007,12 +18035,6 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -17.5,2.5
-      parent: 1
-  - uid: 1875
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 12.5,11.5
       parent: 1
   - uid: 1892
     components:

--- a/Resources/Prototypes/_NF/Entities/Objects/Devices/station_beacon.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Devices/station_beacon.yml
@@ -129,3 +129,94 @@
   components:
   - type: NavMapBeacon
     defaultText: station-beacon-conference
+
+- type: entity
+  parent: DefaultStationBeacon
+  id: DefaultStationBeaconFrontierOfficeMercenary
+  suffix: Office, Mercenary
+  components:
+  - type: NavMapBeacon
+    defaultText: station-beacon-office-mercenary
+    color: "#b8b873"
+
+- type: entity
+  parent: DefaultStationBeacon
+  id: DefaultStationBeaconFrontierShootingRangeMercenary
+  suffix: Shooting range, Mercenary
+  components:
+  - type: NavMapBeacon
+    defaultText: station-beacon-shooting-range-mercenary
+    color: "#b8b873"
+
+# Docks
+- type: entity
+  parent: DefaultStationBeacon
+  id: DefaultStationBeaconFrontierDockOne
+  suffix: Dock 1
+  components:
+  - type: NavMapBeacon
+    defaultText: station-beacon-dock-one
+
+- type: entity
+  parent: DefaultStationBeacon
+  id: DefaultStationBeaconFrontierDockTwo
+  suffix: Dock 2
+  components:
+  - type: NavMapBeacon
+    defaultText: station-beacon-dock-two
+
+- type: entity
+  parent: DefaultStationBeacon
+  id: DefaultStationBeaconFrontierDockThree
+  suffix: Dock 3
+  components:
+  - type: NavMapBeacon
+    defaultText: station-beacon-dock-three
+
+- type: entity
+  parent: DefaultStationBeacon
+  id: DefaultStationBeaconFrontierDockFour
+  suffix: Dock 4
+  components:
+  - type: NavMapBeacon
+    defaultText: station-beacon-dock-four
+
+- type: entity
+  parent: DefaultStationBeacon
+  id: DefaultStationBeaconFrontierDockFive
+  suffix: Dock 5
+  components:
+  - type: NavMapBeacon
+    defaultText: station-beacon-dock-five
+
+- type: entity
+  parent: DefaultStationBeacon
+  id: DefaultStationBeaconFrontierDockSix
+  suffix: Dock 6
+  components:
+  - type: NavMapBeacon
+    defaultText: station-beacon-dock-six
+
+- type: entity
+  parent: DefaultStationBeacon
+  id: DefaultStationBeaconFrontierDockSixA
+  suffix: Dock 6a
+  components:
+  - type: NavMapBeacon
+    defaultText: station-beacon-dock-six-a
+
+- type: entity
+  parent: DefaultStationBeacon
+  id: DefaultStationBeaconFrontierDockSixB
+  suffix: Dock 6b
+  components:
+  - type: NavMapBeacon
+    defaultText: station-beacon-dock-six-b
+
+- type: entity
+  parent: DefaultStationBeacon
+  id: DefaultStationBeaconFrontierDockSixC
+  suffix: Dock 6c
+  components:
+  - type: NavMapBeacon
+    defaultText: station-beacon-dock-six-c


### PR DESCRIPTION
## About the PR
- Added FuelVend to The Lodge and Grifty's.
- Fixed station beacons at the Lodge.

## Why / Balance
QoL

## How to test
1. Spawn at the Lodge, use station map, use fuel vend.
2. Warp to the Grifty's.

## Media
![2024-7-23_10 09 48](https://github.com/user-attachments/assets/220a5def-fa41-4be7-8782-224900ec6004)
![2024-7-23_10 09 25](https://github.com/user-attachments/assets/2abd9b2d-3d60-4877-b33e-a1d7949886d0)
![2024-7-23_09 26 56](https://github.com/user-attachments/assets/8240bfda-253c-4842-b136-510a5b216663)
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
none

**Changelog**
:cl: erhardsteinhauer
- add: Added FuelVend to the Lodge and Grifty's.
- fix: Fixed map beacons at the Lodge.
