### PR TITLE
Computer YAML cleanup

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -751,25 +751,11 @@
 
 - type: entity
   id: ComputerCargoOrders
-  parent: [BaseStructureDisableToolUse, BaseStructureIndestructible, BaseStructureComputer] # Frontier
+  parent: [BaseStructureDisableToolUse, BaseStructureIndestructible, BaseComputer] # Frontier: add BaseStructureDisableToolUse, BaseStructureIndestructible
   name: cargo request computer
   description: Used to order supplies and approve requests.
-  placement:
-    mode: SnapgridCenter
   components:
-  - type: MeleeSound
-    soundGroups:
-      Brute:
-        collection: MetalGlassBreak
-  - type: Computer
-  - type: ApcPowerReceiver
-    powerLoad: 200
-  - type: ExtensionCableReceiver
-  - type: ActivatableUIRequiresPower
   - type: Sprite
-    netsync: false
-    noRot: true
-    sprite: Structures/Machines/computers.rsi
     layers:
     - map: ["computerLayerBody"]
       state: computer
@@ -789,23 +775,19 @@
     interfaces:
       enum.CargoConsoleUiKey.Orders:
         type: CargoOrderConsoleBoundUserInterface
-  - type: LitOnPowered
+  - type: Computer
+    board: CargoRequestComputerCircuitboard
   - type: PointLight
     radius: 1.5
     energy: 1.6
     color: "#b89f25"
-    enabled: false
-    mask: /Textures/Effects/LightMasks/cone.png
-    autoRot: true
-    offset: "0, 0.4" # shine from the top, not bottom of the computer
-    castShadows: false
   - type: AccessReader
-    #access: [["Cargo"]]
+    #access: [["Cargo"]] # Frontier
   - type: DeviceNetwork
     deviceNetId: Wireless
     receiveFrequencyId: BasicDevice
-#  - type: WirelessNetworkConnection
-#    range: 200
+#  - type: WirelessNetworkConnection # Frontier
+#    range: 200 # Frontier
   - type: DeviceLinkSource
     range: 200
     ports:

--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers.yml
@@ -1,24 +1,11 @@
 - type: entity
   name: cargo sale computer
   suffix: Normal
-  parent: [BaseStructureDisableToolUse, BaseStructureIndestructible, BaseStructureComputer]
+  parent: [BaseStructureDisableToolUse, BaseStructureIndestructible, BaseComputer]
   id: ComputerPalletConsoleNFNormalMarket
   description: Used to sell goods loaded onto cargo pallets
-  placement:
-    mode: SnapgridCenter
   components:
-  - type: MeleeSound
-    soundGroups:
-      Brute:
-        collection: MetalGlassBreak
-  - type: ApcPowerReceiver
-    powerLoad: 200
-  - type: ExtensionCableReceiver
-  - type: ActivatableUIRequiresPower
   - type: Sprite
-    netsync: false
-    noRot: true
-    sprite: Structures/Machines/computers.rsi
     layers:
     - map: ["computerLayerBody"]
       state: computer
@@ -28,29 +15,10 @@
       state: request
     - map: ["computerLayerKeys"]
       state: tech_key
-  - type: Appearance
-  - type: GenericVisualizer
-    visuals:
-      enum.ComputerVisuals.Powered:
-        computerLayerScreen:
-          True: { visible: true, shader: unshaded }
-          False: { visible: false }
-        computerLayerKeys:
-          True: { visible: true, shader: unshaded }
-          False: { visible: true, shader: shaded }
-  - type: LitOnPowered
   - type: PointLight
     radius: 1.5
     energy: 1.6
     color: "#b89f25"
-    enabled: false
-    mask: /Textures/Effects/LightMasks/cone.png
-    autoRot: true
-    offset: "0, 0.4" # shine from the top, not bottom of the computer
-    castShadows: false
-  - type: EmitSoundOnUIOpen
-    sound:
-      collection: Keyboard
   - type: CargoPalletConsole
   - type: ActivatableUI
     key: enum.CargoPalletConsoleUiKey.Sale
@@ -92,23 +60,11 @@
 
 - type: entity
   name: contraband exchange computer
-  parent: [BaseStructureDisableToolUse, BaseStructureIndestructible, BaseStructureComputer]
+  parent: [BaseStructureDisableToolUse, BaseStructureIndestructible, BaseComputer]
   id: ComputerContrabandPalletConsole
   description: Used to exchange contraband
-  placement:
-    mode: SnapgridCenter
   components:
-  - type: MeleeSound
-    soundGroups:
-      Brute:
-        collection: MetalGlassBreak
-  - type: ApcPowerReceiver
-    powerLoad: 200
-  - type: ExtensionCableReceiver
-  - type: ActivatableUIRequiresPower
   - type: Sprite
-    netsync: false
-    noRot: true
     sprite: _NF/Structures/Machines/computers.rsi
     layers:
     - map: ["computerLayerBody"]
@@ -119,29 +75,6 @@
       state: contraband
     - map: ["computerLayerKeys"]
       state: telesci_key
-    - type: Appearance
-    - type: GenericVisualizer
-    visuals:
-      enum.ComputerVisuals.Powered:
-        computerLayerScreen:
-          True: { visible: true, shader: unshaded }
-          False: { visible: false }
-        computerLayerKeys:
-          True: { visible: true, shader: unshaded }
-          False: { visible: true, shader: shaded }
-  - type: LitOnPowered
-  - type: PointLight
-    radius: 1.5
-    energy: 1.6
-    color: "#b89f25"
-    enabled: false
-    mask: /Textures/Effects/LightMasks/cone.png
-    autoRot: true
-    offset: "0, 0.4" # shine from the top, not bottom of the computer
-    castShadows: false
-  - type: EmitSoundOnUIOpen
-    sound:
-      collection: Keyboard
   - type: ContrabandPalletConsole
   - type: ActivatableUI
     key: enum.ContrabandPalletConsoleUiKey.Contraband

--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers_shipyard.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers_shipyard.yml
@@ -1,24 +1,11 @@
 - type: entity
   name: shipyard console
-  parent: [BaseStructureDisableToolUse, BaseStructureIndestructible, BaseStructureComputer]
+  parent: [BaseStructureDisableToolUse, BaseStructureIndestructible, BaseComputer]
   id: ComputerShipyardBase
   description: Used to purchase and sell shuttles
-  placement:
-    mode: SnapgridCenter
   abstract: true
   components:
-  - type: MeleeSound
-    soundGroups:
-      Brute:
-        collection: MetalGlassBreak
-  - type: Computer
-  - type: ApcPowerReceiver
-    powerLoad: 200
-  - type: ExtensionCableReceiver
-  - type: ActivatableUIRequiresPower
   - type: Sprite
-    netsync: false
-    noRot: true
     sprite: _NF/Structures/Machines/computers.rsi
     layers:
     - map: ["computerLayerBody"]
@@ -29,29 +16,6 @@
       state: shipyard
     - map: ["computerLayerKeys"]
       state: telesci_key
-  - type: Appearance
-  - type: GenericVisualizer
-    visuals:
-      enum.ComputerVisuals.Powered:
-        computerLayerScreen:
-          True: { visible: true, shader: unshaded }
-          False: { visible: false }
-        computerLayerKeys:
-          True: { visible: true, shader: unshaded }
-          False: { visible: true, shader: shaded }
-  - type: LitOnPowered
-  - type: PointLight
-    radius: 1.5
-    energy: 1.6
-    color: "#b89f25"
-    enabled: false
-    mask: /Textures/Effects/LightMasks/cone.png
-    autoRot: true
-    offset: "0, 0.4" # shine from the top, not bottom of the computer
-    castShadows: false
-  - type: EmitSoundOnUIOpen
-    sound:
-      collection: Keyboard
   - type: ShipyardConsole
     targetIdSlot:
       name: id-card-console-target-id
@@ -78,7 +42,6 @@
 
 # Hardcoded consoles
 - type: entity
-  name: shipyard console
   parent: ComputerShipyardBase
   id: ComputerShipyard
   components:

--- a/Resources/Prototypes/_NF/Entities/Structures/atm.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/atm.yml
@@ -1,47 +1,16 @@
 - type: entity
   id: ComputerBankATMBase
+  parent: BaseComputer
   abstract: true
-  placement:
-    mode: SnapgridCenter
   components:
-  - type: GenericVisualizer
-    visuals:
-      enum.ComputerVisuals.Powered:
-        computerLayerScreen:
-          True: { visible: true, shader: unshaded }
-          False: { visible: false }
-        computerLayerKeys:
-          True: { visible: true, shader: unshaded }
-          False: { visible: true, shader: shaded }
-  - type: MeleeSound
-    soundGroups:
-      Brute:
-        collection: MetalGlassBreak
-  - type: Computer
-  - type: ApcPowerReceiver
-    powerLoad: 200
-  - type: ExtensionCableReceiver
   - type: ActivatableUIRequiresPower
   - type: ActivatableUI
     singleUser: true
-  - type: LitOnPowered
-  - type: PointLight
-    radius: 1.5
-    energy: 1.6
-    color: "#b89f25"
-    enabled: false
-    mask: /Textures/Effects/LightMasks/cone.png
-    autoRot: true
-    offset: "0, 0.4" # shine from the top, not bottom of the computer
-    castShadows: false
-  - type: EmitSoundOnUIOpen
-    sound:
-      collection: Keyboard
-  - type: Appearance
 
 - type: entity
-  name: bank atm
+  name: bank ATM
   id: ComputerBankATMDeposit
+  parent: ComputerBankATMBase
   description: Used to deposit and withdraw funds from a personal bank account.
   abstract: true
   components:
@@ -67,8 +36,9 @@
       bank-ATM-cashSlot: !type:ContainerSlot {}
 
 - type: entity
-  name: bank atm withdraw-only
+  name: withdraw-only bank ATM
   id: ComputerBankATMWithdraw
+  parent: ComputerBankATMBase
   description: Used to withdraw funds from a personal bank account, unable to deposit.
   abstract: true
   components:
@@ -88,12 +58,10 @@
         type: WithdrawBankATMMenuBoundUserInterface
 
 - type: entity
-  parent: [ComputerBankATMBase, ComputerBankATMDeposit, BaseStructureDisableToolUse, BaseStructureIndestructible, BaseStructureComputer]
+  parent: [ComputerBankATMDeposit, BaseStructureDisableToolUse, BaseStructureIndestructible]
   id: ComputerBankATM
   components:
   - type: Sprite
-    netsync: false
-    noRot: true
     sprite: _NF/Structures/Machines/atm/atm.rsi
     layers:
     - map: ["computerLayerBody"]
@@ -102,12 +70,10 @@
       state: unshaded
 
 - type: entity
-  parent: [ComputerBankATMBase, ComputerBankATMWithdraw, BaseStructureDisableToolUse, BaseStructureIndestructible, BaseStructureComputer]
+  parent: [ComputerBankATMWithdraw, BaseStructureDisableToolUse, BaseStructureIndestructible]
   id: ComputerWithdrawBankATM
   components:
   - type: Sprite
-    netsync: false
-    noRot: true
     sprite: _NF/Structures/Machines/atm/atm.rsi
     layers:
     - map: ["computerLayerBody"]
@@ -117,12 +83,10 @@
 
 - type: entity
   suffix: Wallmount
-  parent: [ComputerBankATMBase, ComputerBankATMDeposit, BaseStructureDisableToolUse, BaseStructureIndestructible, BaseStructureWallmount, BaseStructureComputer]
+  parent: [ComputerBankATMDeposit, BaseStructureDisableToolUse, BaseStructureIndestructible, BaseStructureWallmount]
   id: ComputerWallmountBankATM
   components:
   - type: Sprite
-    netsync: false
-    noRot: false
     sprite: _NF/Structures/Machines/atm/wall_atm.rsi
     layers:
       - map: ["computerLayerBody"]
@@ -132,12 +96,10 @@
 
 - type: entity
   suffix: Wallmount
-  parent: [ComputerBankATMBase, ComputerBankATMWithdraw, BaseStructureDisableToolUse, BaseStructureIndestructible, BaseStructureWallmount, BaseStructureComputer]
+  parent: [ComputerBankATMWithdraw, BaseStructureDisableToolUse, BaseStructureIndestructible, BaseStructureWallmount]
   id: ComputerWallmountWithdrawBankATM
   components:
   - type: Sprite
-    netsync: false
-    noRot: false
     sprite: _NF/Structures/Machines/atm/wall_atm.rsi
     layers:
       - map: ["computerLayerBody"]
@@ -147,13 +109,11 @@
 
 - type: entity
   suffix: BlackMarket
-  parent: [ComputerBankATMBase, ComputerBankATMDeposit, BaseStructureDisableToolUse, BaseStructureDestructible, BaseStructureComputer]
+  parent: [ComputerBankATMDeposit, BaseStructureDisableToolUse, BaseStructureDestructible]
   id: ComputerBlackMarketBankATM
   description: Has some sketchy looking modifications and a sticker that says DEPOSIT FEE 30%
   components:
   - type: Sprite
-    netsync: false
-    noRot: true
     sprite: _NF/Structures/Machines/atm/illegal_atm.rsi
     layers:
     - map: ["computerLayerBody"]
@@ -169,7 +129,7 @@
 
 - type: entity
   suffix: Wallmount, BlackMarket
-  parent: [ComputerBankATMBase, ComputerBankATMDeposit, BaseStructureDisableToolUse, BaseStructureDestructible, BaseStructureWallmount, BaseStructureComputer]
+  parent: [ComputerBankATMDeposit, BaseStructureDisableToolUse, BaseStructureDestructible, BaseStructureWallmount]
   id: ComputerWallmountBlackMarketBankATM
   description: Has some sketchy looking modifications and a sticker that says DEPOSIT FEE 30%
   components:
@@ -191,13 +151,11 @@
 
 - type: entity
   name: station administration console
-  parent: [ComputerBankATMBase, BaseStructureDisableToolUse, BaseStructureIndestructible, BaseStructureAccessReaderImmuneToEmag, BaseStructureComputer]
+  parent: [ComputerBankATMBase, BaseStructureDisableToolUse, BaseStructureIndestructible, BaseStructureAccessReaderImmuneToEmag]
   id: StationAdminBankATM
   description: Used to pay out from the station's bank account
   components:
   - type: Sprite
-    netsync: false
-    noRot: true
     sprite: Structures/Machines/computers.rsi
     layers:
     - map: ["computerLayerBody"]

--- a/Resources/Prototypes/_NF/Entities/Structures/atm.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/atm.yml
@@ -58,7 +58,7 @@
         type: WithdrawBankATMMenuBoundUserInterface
 
 - type: entity
-  parent: [ComputerBankATMDeposit, BaseStructureDisableToolUse, BaseStructureIndestructible]
+  parent: [BaseStructureDisableToolUse, BaseStructureIndestructible, ComputerBankATMDeposit]
   id: ComputerBankATM
   components:
   - type: Sprite
@@ -70,7 +70,7 @@
       state: unshaded
 
 - type: entity
-  parent: [ComputerBankATMWithdraw, BaseStructureDisableToolUse, BaseStructureIndestructible]
+  parent: [BaseStructureDisableToolUse, BaseStructureIndestructible, ComputerBankATMWithdraw]
   id: ComputerWithdrawBankATM
   components:
   - type: Sprite
@@ -83,7 +83,7 @@
 
 - type: entity
   suffix: Wallmount
-  parent: [ComputerBankATMDeposit, BaseStructureDisableToolUse, BaseStructureIndestructible, BaseStructureWallmount]
+  parent: [BaseStructureDisableToolUse, BaseStructureIndestructible, BaseStructureWallmount, ComputerBankATMDeposit]
   id: ComputerWallmountBankATM
   components:
   - type: Sprite
@@ -96,7 +96,7 @@
 
 - type: entity
   suffix: Wallmount
-  parent: [ComputerBankATMWithdraw, BaseStructureDisableToolUse, BaseStructureIndestructible, BaseStructureWallmount]
+  parent: [BaseStructureDisableToolUse, BaseStructureIndestructible, BaseStructureWallmount, ComputerBankATMWithdraw]
   id: ComputerWallmountWithdrawBankATM
   components:
   - type: Sprite
@@ -109,7 +109,7 @@
 
 - type: entity
   suffix: BlackMarket
-  parent: [ComputerBankATMDeposit, BaseStructureDisableToolUse, BaseStructureDestructible]
+  parent: [BaseStructureDisableToolUse, BaseStructureDestructible, ComputerBankATMDeposit]
   id: ComputerBlackMarketBankATM
   description: Has some sketchy looking modifications and a sticker that says DEPOSIT FEE 30%
   components:
@@ -129,7 +129,7 @@
 
 - type: entity
   suffix: Wallmount, BlackMarket
-  parent: [ComputerBankATMDeposit, BaseStructureDisableToolUse, BaseStructureDestructible, BaseStructureWallmount]
+  parent: [BaseStructureDisableToolUse, BaseStructureDestructible, BaseStructureWallmount, ComputerBankATMDeposit]
   id: ComputerWallmountBlackMarketBankATM
   description: Has some sketchy looking modifications and a sticker that says DEPOSIT FEE 30%
   components:
@@ -151,7 +151,7 @@
 
 - type: entity
   name: station administration console
-  parent: [ComputerBankATMBase, BaseStructureDisableToolUse, BaseStructureIndestructible, BaseStructureAccessReaderImmuneToEmag]
+  parent: [BaseStructureDisableToolUse, BaseStructureIndestructible, BaseStructureAccessReaderImmuneToEmag, ComputerBankATMBase]
   id: StationAdminBankATM
   description: Used to pay out from the station's bank account
   components:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Fixes a lot of strange parenting and redundancy in computers.  All computers should now inherit from BaseComputer (a computer) instead of BaseStructureComputer (the frame), and many fewer things need to be specified.

ComputerCargoOrders was restored to its upstream component set before the june merge.

Capitalized "bank ATM" and changed wording to "withdraw-only bank ATM".  Resolved ATM inheritance order.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Less object-specific behaviour to maintain, better parenting, cleaner YAML.

I noticed that many of the consoles inheriting from weren't lit up correctly, e.g. the contraband pallet computer, and this stemmed from the inheritance from BaseStructureComputer and the redefinition of fields.

## How to test
<!-- Describe the way it can be tested -->

1. Find (or spawn) a wallmount ATM (in a wall).
2. Interact with it.
3. Remove cash.
4. Deposit cash.
5. Go to the station admin console in the SR's office.
6. Remove cash.
7. Deposit cash (ensure you have a valid reason and the amount matches what's in the cash slot)
8. Warp to the Cargo Depot.
9. Spawn a stack of plasma.
10. Sell it, it should sell for $954.
11. Warp to the Trade Outpost.
12. Check a cargo request computer.
13. It should be lit up.
14. Purchase something, it should spawn as normal.
15. Warp to the NFSD Outpost.
16. Go to the contraband console.
17. Spawn a pair of syndie pyjamas on the contraband pallets.
18. Sell it for 1 FUC.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

This shows the lit up state of various consoles.  These are all inherited from BaseComputer (apart from the colour of the PointLight on the cargo consoles).
![image](https://github.com/user-attachments/assets/a3ac89fe-b92c-41f6-bce2-f6a7bef8f5dc)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
Mostly internal, no CL.