### PR TITLE
Adds SR Shipyard Console to Frontier Outpost

### DIFF
--- a/Resources/Maps/_NF/Outpost/frontier.yml
+++ b/Resources/Maps/_NF/Outpost/frontier.yml
@@ -14431,6 +14431,23 @@ entities:
           showEnts: False
           occludes: True
           ents: []
+- proto: ComputerShipyardSr
+  entities:
+  - uid: 514
+    components:
+    - type: Transform
+      pos: 6.5,23.5
+      parent: 2173
+    - type: ContainerContainer
+      containers:
+        ShipyardConsole-targetId: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents: []
 - proto: ComputerStationRecords
   entities:
   - uid: 4053
@@ -17454,10 +17471,10 @@ entities:
       parent: 2173
 - proto: filingCabinetRandom
   entities:
-  - uid: 3765
+  - uid: 2039
     components:
     - type: Transform
-      pos: 6.5,23.5
+      pos: 6.5,18.5
       parent: 2173
 - proto: FireAlarm
   entities:
@@ -27766,17 +27783,17 @@ entities:
       parent: 2173
 - proto: MaterialCloth
   entities:
-  - uid: 1196
+  - uid: 2040
     components:
     - type: Transform
-      pos: 6.3189855,18.603966
+      pos: 10.38581,21.775772
       parent: 2173
 - proto: MaterialDurathread
   entities:
-  - uid: 4129
+  - uid: 2041
     components:
     - type: Transform
-      pos: 6.6530757,18.317799
+      pos: 10.66706,21.478897
       parent: 2173
 - proto: MaterialReclaimer
   entities:
@@ -32830,6 +32847,11 @@ entities:
       rot: 3.141592653589793 rad
       pos: -49.5,7.5
       parent: 2173
+  - uid: 1196
+    components:
+    - type: Transform
+      pos: 10.5,21.5
+      parent: 2173
   - uid: 1214
     components:
     - type: Transform
@@ -32992,11 +33014,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 5.5,22.5
       parent: 2173
-  - uid: 5755
-    components:
-    - type: Transform
-      pos: 6.5,18.5
-      parent: 2173
 - proto: TableReinforcedGlass
   entities:
   - uid: 3032
@@ -33125,11 +33142,10 @@ entities:
         - Middle: Off
 - proto: UniformPrinter
   entities:
-  - uid: 514
+  - uid: 2038
     components:
     - type: Transform
-      rot: -3.141592653589793 rad
-      pos: 8.5,18.5
+      pos: 11.5,21.5
       parent: 2173
 - proto: VehicleKeySecway
   entities:

--- a/Resources/Prototypes/_NF/Shipyard/Sr/bottleneck.yml
+++ b/Resources/Prototypes/_NF/Shipyard/Sr/bottleneck.yml
@@ -5,6 +5,7 @@
   price: 14000
   category: Small
   group: Sr
+  access: HeadOfPersonnel
   shuttlePath: /Maps/_NF/Shuttles/Sr/bottleneck.yml
 
 - type: gameMap


### PR DESCRIPTION
## About the PR
Added the SR Shipyard Console from #1580 to Frontier Outpost station map.
Now the SR can actually purchase and use the NT Bottleneck.

## Why / Balance
Requisite addition for the SR to be able to purchase their exclusive shuttle.

I propose two options for this. (Screenshots of both options in media). _THIS PR IS USING OPTION ONE._
Option one:
The console is placed next to the gun safe in the office. I've therefore also moved the filing cabinet down a bit, and also moved the uniform printer and the table with materials over to where the mail teleporter is located so that corner doesn't feel too cramped. 

Option two:
The console is placed in the staff lounge next to the SR's bedroom. There's an unused space in the top right corner of that room.

Of course, it could be placed in other locations in different orientations, but the fancy screen sprite is most enjoyed with the console facing south :)

## How to test
<!-- Describe the way it can be tested -->
Get the branch and load the station map. 

## Media
Option one:
![2024-07-23 21_39_40-Window](https://github.com/user-attachments/assets/1e230971-2b74-462a-8647-bfe08296f657)

Option two:
![2024-07-23 21_32_39-Window](https://github.com/user-attachments/assets/e521373a-bd55-4198-9844-2b5d489c789e)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None, I should hope!

**Changelog**
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added the SR Shipyard Console to Frontier Outpost. NT Bottleneck now available for real!

