### PR TITLE
SR paperwork templates

### DIFF
--- a/Resources/Maps/_NF/Outpost/frontier.yml
+++ b/Resources/Maps/_NF/Outpost/frontier.yml
@@ -3511,7 +3511,7 @@ entities:
             0: 47903
           -9,3:
             0: 34831
-            3: 8704
+            2: 8704
           -8,4:
             0: 2187
             1: 768
@@ -3651,13 +3651,13 @@ entities:
             0: 63931
           -10,3:
             0: 13087
-            2: 34816
+            3: 34816
           -10,4:
             0: 3
-            2: 8
+            3: 8
             1: 3840
           -9,4:
-            3: 2
+            2: 2
             0: 8
             1: 3840
           -16,0:
@@ -3883,8 +3883,8 @@ entities:
         - volume: 2500
           temperature: 293.15
           moles:
-          - 0
           - 6666.982
+          - 0
           - 0
           - 0
           - 0
@@ -3898,8 +3898,8 @@ entities:
         - volume: 2500
           temperature: 293.15
           moles:
-          - 6666.982
           - 0
+          - 6666.982
           - 0
           - 0
           - 0
@@ -19368,6 +19368,8 @@ entities:
     - type: Transform
       pos: -33.5,10.5
       parent: 2173
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 2152
     components:
     - type: Transform
@@ -24059,6 +24061,8 @@ entities:
       rot: 3.141592653589793 rad
       pos: -33.5,9.5
       parent: 2173
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 1938
     components:
     - type: Transform
@@ -24079,6 +24083,8 @@ entities:
     - type: Transform
       pos: -33.5,11.5
       parent: 2173
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 2516
     components:
     - type: Transform

--- a/Resources/Maps/_NF/Outpost/frontier.yml
+++ b/Resources/Maps/_NF/Outpost/frontier.yml
@@ -3511,7 +3511,7 @@ entities:
             0: 47903
           -9,3:
             0: 34831
-            2: 8704
+            3: 8704
           -8,4:
             0: 2187
             1: 768
@@ -3651,13 +3651,13 @@ entities:
             0: 63931
           -10,3:
             0: 13087
-            3: 34816
+            2: 34816
           -10,4:
             0: 3
-            3: 8
+            2: 8
             1: 3840
           -9,4:
-            2: 2
+            3: 2
             0: 8
             1: 3840
           -16,0:
@@ -3883,8 +3883,8 @@ entities:
         - volume: 2500
           temperature: 293.15
           moles:
-          - 6666.982
           - 0
+          - 6666.982
           - 0
           - 0
           - 0
@@ -3898,8 +3898,8 @@ entities:
         - volume: 2500
           temperature: 293.15
           moles:
-          - 0
           - 6666.982
+          - 0
           - 0
           - 0
           - 0
@@ -6316,6 +6316,14 @@ entities:
     components:
     - type: Transform
       pos: 12.810785,16.716284
+      parent: 2173
+- proto: BoxFolderSr
+  entities:
+  - uid: 2039
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.009785,21.581205
       parent: 2173
 - proto: BoxFolderWhite
   entities:
@@ -27986,11 +27994,17 @@ entities:
       parent: 2173
 - proto: Paper
   entities:
-  - uid: 4974
+  - uid: 2038
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 7.9261327,21.56176
+      pos: 7.43772,21.63533
+      parent: 2173
+  - uid: 2040
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.534942,21.551996
       parent: 2173
 - proto: PaperBin10
   entities:

--- a/Resources/Prototypes/_NF/Catalog/Fills/Paper/forms_sr.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/Paper/forms_sr.yml
@@ -1,6 +1,7 @@
 # Station Representative Forms
 # Sources: https://discord.com/channels/1123826877245694004/1182366744266932224/1182366744266932224
 #          https://docs.google.com/document/d/1jDX9numj-VHKBJ2FiiEo1GIlHESffOUIHIIXaqhEnls/edit?pli=1#heading=h.ru93r8n0fb7m
+# These forms should be kept up-to-date with changes to Space Law.
 
 # Filled Folder
 - type: entity
@@ -33,7 +34,7 @@
 # Forms
 - type: entity # Based on form made by Willzile1 (Jon-Gah)
   id: PaperWrittenFrontierFormEmployment
-  name: employment contract
+  name: Employment Contract
   suffix: MappedPaper
   parent: Paper
   components:
@@ -46,7 +47,6 @@
 
         [bold]Name:[/bold]
         [bold]Species:[/bold]
-        [bold]Ship:[/bold]
         [bold]Position Title:[/bold]
         [bold]Position Responsibilities:[/bold]
         [bullet/]
@@ -55,17 +55,15 @@
 
         [bold]Hourly Wage:[/bold]
 
-        [bold]Issued by:[/bold]
-
         [bold]Shift Time:[/bold]
 
 
 
-        [color=#AAAAAA]This Form is void without signs of both Parties and a stamp of Frontier Command (Sheriff or Station Representative)[/color]
+        [color=#AAAAAA]This Form is void without the signatures of both Parties and a stamp of Frontier Command (Sheriff or Station Representative)[/color]
 
 - type: entity
   id: PaperWrittenFrontierFormEmployeePayHistory
-  name: employee's pay history
+  name: Employee Pay History
   suffix: MappedPaper
   parent: Paper
   components:
@@ -73,7 +71,7 @@
     content: |2
         [color=#2e9935ff]◥[bold]N[/bold]◣ [bold]Frontier Outpost Command[/bold][/color]
         [color=#2e9935ff]‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾[/color]
-        [head=2]Employee's Pay History[/head]
+        [head=2]Employee Pay History[/head]
 
 
         [bold]Name:[/bold]
@@ -89,11 +87,11 @@
 
 
 
-        [color=#AAAAAA]This Form is void without sign and a stamp of Frontier Command (Sheriff or Station Representative)[/color]
+        [color=#AAAAAA]This Form is void without the signature and stamp of Frontier Command (Sheriff or Station Representative)[/color]
 
 - type: entity # Based on form made by Willzile1 (Jon-Gah)
   id: PaperWrittenFrontierFormFundRequisition
-  name: fund requisition form
+  name: Fund Requisition
   suffix: MappedPaper
   parent: Paper
   components:
@@ -104,19 +102,18 @@
         [head=2]Fund Requisition[/head]
 
 
-        [bold]Name:[/bold]
-        [bold]Ammount:[/bold]
-        [bold]Reason:[/bold]
-        
-        [bold]Shift Time:[/bold]
+        [bold]Name:[/bold] 
+        [bold]Amount:[/bold] 
+        [bold]Reason:[/bold] 
+        [bold]Shift Time:[/bold] 
 
 
 
-        [color=#AAAAAA]This Form is void without signs and a stamp of Frontier Command (Sheriff or Station Representative)[/color]
+        [color=#AAAAAA]This Form is void without the signature and stamp of Frontier Command (Sheriff or Station Representative)[/color]
 
 - type: entity # Based on form made by Starly (Shaw Clifflower)
   id: PaperWrittenFrontierFormAuthorization
-  name: authorization contract
+  name: Authorization for Bluespace Threats
   suffix: MappedPaper
   parent: Paper
   components:
@@ -124,34 +121,36 @@
     content: |2
         [color=#2e9935ff]◥[bold]N[/bold]◣ [bold]Frontier Outpost Command[/bold][/color]
         [color=#2e9935ff]‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾[/color]
-        [head=2]Authorization for Bluespace Threats to Frontier[/head]
+        [head=2]Authorization for Bluespace Threats[/head]
 
 
         [bold]Vessel Captain:[/bold]
         [bold]Vessel IFF:[/bold]
-        [bold]Shift time at issuance:[/bold]
+        [bold]Shift Time:[/bold]
 
-        Issuing outpost command:
+        Issuing Frontier Command:
         [bullet]XXXXXXXX, Station Representative
         [bullet]XXXXXXXX, Sheriff
 
-        This document authorizes captain XXXXX XXXXXXX of vessel XX-XXX to assist and cooperate with NFSD and Frontier authorities in neutralizing hostile threats to Frontier that bluespace into its space. These include, but are not limited to:
+        This document authorizes the above vessel and its captain to assist and cooperate with NFSD and Frontier authorities in neutralizing hostile bluespace threats to Frontier. These include, but are not limited to:
         [bullet] Cultist vessels
         [bullet] Syndicate vessels
-        [bullet] Wizard vessels
-        [bullet] Arcadia Ind. vessels
+        [bullet] Wizard Federation vessels
+        [bullet] Arcadia Industries vessels
 
-        This document does NOT deputize you or grant you special privileges within the ranks of NFSD to arrest, detain, and prosecute employees of Frontier Station. [bold]Any contraband seized during your operations aboard any hostile vessel must be turned into either NFSD or the Station Representative's office for a cash bounty. Keeping any articles of contraband will lead to forfeiture of this agreement, and you may be liable to be charged with various crimes.[/bold] Keep a copy of this document on you at all times. Remember to maintain contact with either NFSD command or the Station Representative in order to minimize casualties.
+        This document does NOT deputize the authorized party. The authorized party is not granted special privileges to arrest, detain, and prosecute individuals associated with Nanotrasen. [bold]Any contraband seized during operations aboard hostile vessels must be surrendered, either to the NFSD or the Station Representative, for a cash bounty. Failure to surrender contraband will lead to the forfeiture of this agreement, and the authorized party may be liable for criminal charges.[/bold]
+        
+        The authorized party is to keep a copy of this document for inspection. The authorized party is expected to maintain contact with NFSD command and/or the Station Representative to minimize casualties.
 
-        Should NFSD be present, a staging area will be designated to allow for better coordination. Your staging area is three hundred (300) metres away from the hostile vessel, between the hostile vessel and Frontier Outpost. Depending on the circumstances of the shift, [bold]this can change.[/bold] Please stay in regular contact with both NFSD command and the Station Representative's office for updates on a staging area.
+        Before engaging with hostile vessels, the authorized party is expected to follow any instructions given by the NFSD for staging or other preparation prior to boarding.
 
 
 
-        [color=#AAAAAA]This Form is void without signs of both Parties and a stamp of Frontier Command (Sheriff or Station Representative)[/color]
+        [color=#AAAAAA]This Form is void without the signatures of both Parties and a stamp of Frontier Command (Sheriff or Station Representative)[/color]
 
 - type: entity # Based on form made by Willzile1 (Jon-Gah)
   id: PaperWrittenFrontierFormShuttleTitleChange
-  name: shuttle title change form
+  name: Shuttle Title Change
   suffix: MappedPaper
   parent: Paper
   components:
@@ -169,11 +168,11 @@
 
 
 
-        [color=#AAAAAA]This Form is void without signs of both Parties and a stamp of Frontier Command (Sheriff or Station Representative)[/color]
+        [color=#AAAAAA]This Form is void without the signatures of both Parties and a stamp of Frontier Command (Sheriff or Station Representative)[/color]
 
 - type: entity # Based on form made by Blumbee (Aki Suboshi)
   id: PaperWrittenFrontierFormShuttleDerelict
-  name: derelict ship form
+  name: Notice of Derelict Ship
   suffix: MappedPaper
   parent: Paper
   components:
@@ -184,24 +183,23 @@
         [head=2]Notice of Derelict Ship and Declaration of Salvage[/head]
 
 
-        [bold]Ship callsign:[/bold] [color=#2200BD][/color]
-        [bold]First hail at:[/bold] [color=#2200BD][/color]
-        [bold]Issued at:[/bold] [color=#2200BD][/color]
-        [bold]Issued by:[/bold] [color=#2200BD][/color]
+        [bold]Ship IFF:[/bold] [color=#2200BD][/color]
+        [bold]Time of First Hail:[/bold] [color=#2200BD][/color]
+        [bold]Shift Time:[/bold] [color=#2200BD][/color]
 
-        This is a formal declaration from Frontier's Station Traffic Controller, hereby declaring the vessel [italic] XX-XXX [/italic] to be abandoned by its captain, and recognized as salvage. Your vessel has been unresponsive on the radio for over twenty (20) minutes and has either not responded to written faxes, or is unable to receive faxes from Frontier. Henceforth, this office deems it fit to declare it as salvage.
+        This is a formal declaration from Frontier's Station Traffic Controller, hereby declaring the above vessel to be abandoned by its captain, and recognized as salvage. Your vessel has been unresponsive on the radio for over twenty (20) minutes and has either not responded to written faxes, or is unable to receive faxes from Frontier. Henceforth, this office deems it fit to declare it as salvage.
 
-        Pursuant to Space Law Section Nine, Article Three, this vessel will be moved out to three hundred (300) meters from Frontier Station by a Valet or NFSD, and will be salvageable by any other vessel operating within Frontier's space.
+        Pursuant to Space Law §9.3, this vessel will be moved out to three hundred (300) meters from Frontier Station by a Valet or NFSD, and will be salvageable by any other vessel operating within Frontier's space.
 
-        Frontier Station and/or the Nanotrasen Corporation will not reimburse you or any parties affiliated with this vessel for any losses.
-
+        Neither Frontier Station nor the Nanotrasen Corporation will reimburse any party affiliated with this vessel for losses incurred.
 
 
-        [color=#AAAAAA]This Form is void without signs of both Parties and a stamp of Frontier Command (Sheriff or Station Representative)[/color]
+
+        [color=#AAAAAA]This Form is void without the signatures of both Parties and a stamp of Frontier Command (Sheriff or Station Representative)[/color]
 
 - type: entity # Based on form made by Blumbee (Aki Suboshi)
   id: PaperWrittenFrontierFormContrabandTurnover
-  name: contraband turnover form
+  name: Contraband Turnover Form
   suffix: MappedPaper
   parent: Paper
   components:
@@ -213,23 +211,21 @@
 
 
         [bold]Contraband Holder:[/bold] 
-        [bold]Frontier Uplink Coin's amount:[/bold] 
-        [bold]Payout per F.U.C.:[/bold] [color=#ff0000]2.000 spesos[/color]
-        [bold]Payout total:[/bold] 
+        [bold]Contraband F.U.C Value:[/bold] 
+        [bold]Payout per F.U.C.:[/bold] [color=#ff0000]2 000 spesos[/color]
+        [bold]Payout Total:[/bold] 
 
-        [bold]Contraband C2:[/bold]
-        [bullet/] 
-        [bullet/] 
-        [bullet/] 
-
-        [bold]Contraband C3:[/bold]
+        [bold]C2 Contraband:[/bold]
         [bullet/] 
         [bullet/] 
         [bullet/] 
 
+        [bold]C3 Contraband:[/bold]
+        [bullet/] 
+        [bullet/] 
+        [bullet/] 
 
-        [bold]Command on duty:[/bold] 
-        [bold]Time of Turnover:[/bold] 
+        [bold]Shift Time:[/bold] 
 
         This document is a contract between [bold][italic]Contraband Holder[/italic][/bold] and [bold][italic]Frontier Command[/italic][/bold].
         Any and all Contraband class [color=red]2[/color] and [color=red]3[/color] must be turned over to [bold][italic]Frontier Command[/italic][/bold], unless otherwise contracted with a C2 holding permit.
@@ -238,11 +234,11 @@
 
 
 
-        [color=#AAAAAA]This Form is void without signs of both Parties and a stamp of Frontier Command (Sheriff or Station Representative)[/color]
+        [color=#AAAAAA]This Form is void without the signatures of both Parties and a stamp of Frontier Command (Sheriff or Station Representative)[/color]
 
 - type: entity # Based on form made by Blumbee (Aki Suboshi)
   id: PaperWrittenFrontierFormContrabandPermit
-  name: contraband permit form
+  name: Tier 2 Contraband Permit
   suffix: MappedPaper
   parent: Paper
   components:
@@ -259,14 +255,13 @@
         [bullet/] 
         [bullet/] 
 
-        [bold]Sheriff on Duty:[/bold] 
-        [bold]Time of issuing:[/bold] 
+        [bold]Shift Time:[/bold] 
 
 
-        This Permit allows the Holder and his crew,[italic] as written above[/italic], to hold and use C2 Contraband.
+        This Permit allows the Holder and crew, [italic]as listed above[/italic], to possess and use C2 Contraband.
         Non-compliance with Contraband Turnover orders void this Permit.
         [bold]Class 2 Contraband contains:[/bold] [color=red]all explosive devices not otherwise covered by higher classifications; objects which can be used to non-destructively or non-invasively gain unauthorized access to Nanotrasen secured areas; exclusively restricted and/or authorized use weapons or equipment, uniforms and EMPs; and, security vessels.[/color]
 
 
 
-        [color=#AAAAAA]This Form is void without signs of both Parties and a stamp of NFSD acting Sheriff[/color]
+        [color=#AAAAAA]This Form is void without the signature of the Holder and the signature and stamp of the Sheriff[/color]

--- a/Resources/Prototypes/_NF/Catalog/Fills/Paper/forms_sr.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/Paper/forms_sr.yml
@@ -24,6 +24,7 @@
     - id: PaperWrittenFrontierFormShuttleTitleChange
     - id: PaperWrittenFrontierFormAuthorization
     - id: PaperWrittenFrontierFormShuttleDerelict
+    - id: PaperWrittenFrontierFormContrabandAmnesty
     - id: PaperWrittenFrontierFormContrabandTurnover
     - id: PaperWrittenFrontierFormContrabandPermit
     - id: Paper
@@ -40,26 +41,25 @@
   components:
   - type: Paper
     content: |2
-        [color=#2e9935ff]◥[bold]N[/bold]◣ [bold]Frontier Outpost Command[/bold][/color]
-        [color=#2e9935ff]‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾[/color]
-        [head=2]Employment Contract[/head]
+      [color=#2e9935ff]◥[bold]N[/bold]◣ [bold]Frontier Outpost Command[/bold][/color]
+      [color=#2e9935ff]‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾[/color]
+      [head=2]Employment Contract[/head]
+
+      [bold]Name:[/bold]
+      [bold]Species:[/bold]
+      [bold]Position Title:[/bold]
+      [bold]Position Responsibilities:[/bold]
+          [bullet/]
+          [bullet/]
+          [bullet/]
+
+      [bold]Hourly Wage:[/bold]
+
+      [bold]Shift Time:[/bold]
 
 
-        [bold]Name:[/bold]
-        [bold]Species:[/bold]
-        [bold]Position Title:[/bold]
-        [bold]Position Responsibilities:[/bold]
-        [bullet/]
-        [bullet/]
-        [bullet/]
 
-        [bold]Hourly Wage:[/bold]
-
-        [bold]Shift Time:[/bold]
-
-
-
-        [color=#AAAAAA]This Form is void without the signatures of both Parties and a stamp of Frontier Command (Sheriff or Station Representative)[/color]
+      [color=#AAAAAA]This Form is void without the signatures of both Parties and a stamp of Frontier Command (Sheriff or Station Representative)[/color]
 
 - type: entity
   id: PaperWrittenFrontierFormEmployeePayHistory
@@ -69,25 +69,24 @@
   components:
   - type: Paper
     content: |2
-        [color=#2e9935ff]◥[bold]N[/bold]◣ [bold]Frontier Outpost Command[/bold][/color]
-        [color=#2e9935ff]‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾[/color]
-        [head=2]Employee Pay History[/head]
+      [color=#2e9935ff]◥[bold]N[/bold]◣ [bold]Frontier Outpost Command[/bold][/color]
+      [color=#2e9935ff]‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾[/color]
+      [head=2]Employee Pay History[/head]
+
+      [bold]Name:[/bold]
+      [bold]Position Title:[/bold]
+      [bold]Hourly Wage:[/bold]
+      [bold]Pay history (Shift time / Wage recieved):[/bold]
+          [bullet/]
+          [bullet/]
+          [bullet/]
+          [bullet/]
+          [bullet/]
+          [bullet/]
 
 
-        [bold]Name:[/bold]
-        [bold]Position Title:[/bold]
-        [bold]Hourly Wage:[/bold]
-        [bold]Pay history (Shift time / Wage recieved):[/bold]
-        [bullet/]
-        [bullet/]
-        [bullet/]
-        [bullet/]
-        [bullet/]
-        [bullet/]
 
-
-
-        [color=#AAAAAA]This Form is void without the signature and stamp of Frontier Command (Sheriff or Station Representative)[/color]
+      [color=#AAAAAA]This Form is void without the signature and stamp of Frontier Command (Sheriff or Station Representative)[/color]
 
 - type: entity # Based on form made by Willzile1 (Jon-Gah)
   id: PaperWrittenFrontierFormFundRequisition
@@ -97,19 +96,18 @@
   components:
   - type: Paper
     content: |2
-        [color=#2e9935ff]◥[bold]N[/bold]◣ [bold]Frontier Outpost Command[/bold][/color]
-        [color=#2e9935ff]‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾[/color]
-        [head=2]Fund Requisition[/head]
+      [color=#2e9935ff]◥[bold]N[/bold]◣ [bold]Frontier Outpost Command[/bold][/color]
+      [color=#2e9935ff]‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾[/color]
+      [head=2]Fund Requisition[/head]
+
+      [bold]Name:[/bold] 
+      [bold]Amount:[/bold] 
+      [bold]Reason:[/bold] 
+      [bold]Shift Time:[/bold] 
 
 
-        [bold]Name:[/bold] 
-        [bold]Amount:[/bold] 
-        [bold]Reason:[/bold] 
-        [bold]Shift Time:[/bold] 
 
-
-
-        [color=#AAAAAA]This Form is void without the signature and stamp of Frontier Command (Sheriff or Station Representative)[/color]
+      [color=#AAAAAA]This Form is void without the signature and stamp of Frontier Command (Sheriff or Station Representative)[/color]
 
 - type: entity # Based on form made by Starly (Shaw Clifflower)
   id: PaperWrittenFrontierFormAuthorization
@@ -119,34 +117,35 @@
   components:
   - type: Paper
     content: |2
-        [color=#2e9935ff]◥[bold]N[/bold]◣ [bold]Frontier Outpost Command[/bold][/color]
-        [color=#2e9935ff]‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾[/color]
-        [head=2]Authorization for Bluespace Threats[/head]
+      [color=#2e9935ff]◥[bold]N[/bold]◣ [bold]Frontier Outpost Command[/bold][/color]
+      [color=#2e9935ff]‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾[/color]
+      [head=2]Authorization for Bluespace Threats[/head]
 
+      [bold]Vessel Captain:[/bold]
+      [bold]Vessel IFF:[/bold]
+      [bold]Shift Time:[/bold]
 
-        [bold]Vessel Captain:[/bold]
-        [bold]Vessel IFF:[/bold]
-        [bold]Shift Time:[/bold]
+      [bold]Issuing Frontier Command:[/bold]
+          [bullet]XXXXXXXX, Station Representative
+          [bullet]XXXXXXXX, Sheriff
 
-        Issuing Frontier Command:
-        [bullet]XXXXXXXX, Station Representative
-        [bullet]XXXXXXXX, Sheriff
+      This document authorizes the above vessel and its captain to assist and cooperate with the NFSD and Frontier authorities in neutralizing hostile bluespace threats to Frontier. These include, but are not limited to:
+          [bullet] Cultist vessels
+          [bullet] Syndicate vessels
+          [bullet] Wizard Federation vessels
+          [bullet] Arcadia Industries vessels
 
-        This document authorizes the above vessel and its captain to assist and cooperate with NFSD and Frontier authorities in neutralizing hostile bluespace threats to Frontier. These include, but are not limited to:
-        [bullet] Cultist vessels
-        [bullet] Syndicate vessels
-        [bullet] Wizard Federation vessels
-        [bullet] Arcadia Industries vessels
+      This document does NOT deputize the authorized party. The authorized party is not granted special privileges to arrest, detain, and prosecute individuals associated with Nanotrasen.
 
-        This document does NOT deputize the authorized party. The authorized party is not granted special privileges to arrest, detain, and prosecute individuals associated with Nanotrasen. [bold]Any contraband seized during operations aboard hostile vessels must be surrendered, either to the NFSD or the Station Representative, for a cash bounty. Failure to surrender contraband will lead to the forfeiture of this agreement, and the authorized party may be liable for criminal charges.[/bold]
+      [bold]Any contraband seized during operations aboard hostile vessels must be surrendered, either to the NFSD or the Station Representative, for a cash bounty. Failure to surrender contraband will lead to the forfeiture of this agreement, and the authorized party may be liable for criminal charges.[/bold]
         
-        The authorized party is to keep a copy of this document for inspection. The authorized party is expected to maintain contact with NFSD command and/or the Station Representative to minimize casualties.
+      The authorized party is to keep a copy of this document for inspection. The authorized party is expected to maintain contact with NFSD command and/or the Station Representative to minimize casualties.
 
-        Before engaging with hostile vessels, the authorized party is expected to follow any instructions given by the NFSD for staging or other preparation prior to boarding.
+      Before engaging with hostile vessels, the authorized party is expected to follow any instructions given by the NFSD for staging or other preparation prior to boarding.
 
 
 
-        [color=#AAAAAA]This Form is void without the signatures of both Parties and a stamp of Frontier Command (Sheriff or Station Representative)[/color]
+      [color=#AAAAAA]This Form is void without the signatures of both Parties and a stamp of Frontier Command (Sheriff or Station Representative)[/color]
 
 - type: entity # Based on form made by Willzile1 (Jon-Gah)
   id: PaperWrittenFrontierFormShuttleTitleChange
@@ -156,112 +155,134 @@
   components:
   - type: Paper
     content: |2
-        [color=#2e9935ff]◥[bold]N[/bold]◣ [bold]Frontier Outpost Command[/bold][/color]
-        [color=#2e9935ff]‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾[/color]
-        [head=2]Shuttle Title Change[/head]
+      [color=#2e9935ff]◥[bold]N[/bold]◣ [bold]Frontier Outpost Command[/bold][/color]
+      [color=#2e9935ff]‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾[/color]
+      [head=2]Shuttle Title Change[/head]
+
+      [bold]Name of Captain:[/bold]
+      [bold]Old Ship Title:[/bold]
+      [bold]New Ship Title:[/bold]
+      [bold]Shift Time:[/bold]
 
 
-        [bold]Name of Captain:[/bold]
-        [bold]Old Ship Title:[/bold]
-        [bold]New Ship Title:[/bold]
-        [bold]Shift Time:[/bold]
 
-
-
-        [color=#AAAAAA]This Form is void without the signatures of both Parties and a stamp of Frontier Command (Sheriff or Station Representative)[/color]
+      [color=#AAAAAA]This Form is void without the signatures of both Parties and a stamp of Frontier Command (Sheriff or Station Representative)[/color]
 
 - type: entity # Based on form made by Blumbee (Aki Suboshi)
   id: PaperWrittenFrontierFormShuttleDerelict
-  name: Notice of Derelict Ship
+  name: Declaration of Salvage
   suffix: MappedPaper
   parent: Paper
   components:
   - type: Paper
     content: |2
-        [color=#2e9935ff]◥[bold]N[/bold]◣ [bold]Frontier Outpost Command[/bold][/color]
-        [color=#2e9935ff]‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾[/color]
-        [head=2]Notice of Derelict Ship and Declaration of Salvage[/head]
+      [color=#2e9935ff]◥[bold]N[/bold]◣ [bold]Frontier Outpost Command[/bold][/color]
+      [color=#2e9935ff]‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾[/color]
+      [head=2]Declaration of Salvage[/head]
+
+      [bold]Vessel IFF:[/bold] [color=#2200BD][/color]
+      [bold]Time of First Hail:[/bold] [color=#2200BD][/color]
+      [bold]Shift Time:[/bold] [color=#2200BD][/color]
+
+      This is a formal declaration from Frontier's Station Traffic Controller, hereby declaring the above vessel to be abandoned by its captain, and recognized as salvage. This vessel has been unresponsive on both radio and fax for over twenty (20) minutes.
+
+      Pursuant to Space Law §9.3, this vessel will be moved out to three hundred (300) meters from Frontier Station by an agent representing Frontier Station or the NFSD, and will be salvageable by any other vessel operating within the sector.
+
+      Neither Frontier Station nor the Nanotrasen Corporation will reimburse any party affiliated with this vessel for losses incurred.
 
 
-        [bold]Ship IFF:[/bold] [color=#2200BD][/color]
-        [bold]Time of First Hail:[/bold] [color=#2200BD][/color]
-        [bold]Shift Time:[/bold] [color=#2200BD][/color]
 
-        This is a formal declaration from Frontier's Station Traffic Controller, hereby declaring the above vessel to be abandoned by its captain, and recognized as salvage. Your vessel has been unresponsive on the radio for over twenty (20) minutes and has either not responded to written faxes, or is unable to receive faxes from Frontier. Henceforth, this office deems it fit to declare it as salvage.
+      [color=#AAAAAA]This Form is void without the signatures of both Parties and a stamp of Frontier Command (Sheriff or Station Representative)[/color]
 
-        Pursuant to Space Law §9.3, this vessel will be moved out to three hundred (300) meters from Frontier Station by a Valet or NFSD, and will be salvageable by any other vessel operating within Frontier's space.
+- type: entity # Based on form made by Blumbee (Aki Suboshi)
+  id: PaperWrittenFrontierFormContrabandAmnesty
+  name: Contraband Amnesty Agreement
+  suffix: MappedPaper
+  parent: Paper
+  components:
+  - type: Paper
+    content: |2
+      [color=#2e9935ff]◥[bold]N[/bold]◣ [bold]Frontier Outpost Command[/bold][/color]
+      [color=#2e9935ff]‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾[/color]
+      [head=2]Contraband Amnesty Agreement[/head]
 
-        Neither Frontier Station nor the Nanotrasen Corporation will reimburse any party affiliated with this vessel for losses incurred.
+      [head=3]Contraband Holder[/head]
+          [bold]Name:[/bold] 
+          [bold]Species:[/bold] 
+          [bold]Vessel IFF:[/bold] 
+
+      [bold]Payout per F.U.C.:[/bold] [color=#ff0000]2 000 spesos[/color]
+      [bold]Shift Time:[/bold] 
+
+      This document is a contract between the above Contraband Holder and Frontier Command.
+
+      Any crimes of contraband possession for the Contraband Holder will be waived so long as all Class 3 contraband items, and any Class 2 contraband items not subject to a Class 2 Contraband Permit are turned in within reasonable time (subject to the clause below), and not used for malicious purposes. Noncompliance with this document results in voiding any standing Class 2 Contraband Permits.
+
+      If the Contraband Holder is not paid in full at the above rate for any contraband turned in, they may remain in possession of the contraband without penalty at their discretion.
 
 
 
-        [color=#AAAAAA]This Form is void without the signatures of both Parties and a stamp of Frontier Command (Sheriff or Station Representative)[/color]
+      [color=#AAAAAA]This Form is void without the signatures of both Parties and the stamp of the Sheriff[/color]
+
 
 - type: entity # Based on form made by Blumbee (Aki Suboshi)
   id: PaperWrittenFrontierFormContrabandTurnover
-  name: Contraband Turnover Form
+  name: Contraband Turnover Receipt
   suffix: MappedPaper
   parent: Paper
   components:
   - type: Paper
     content: |2
-        [color=#2e9935ff]◥[bold]N[/bold]◣ [bold]Frontier Outpost Command[/bold][/color]
-        [color=#2e9935ff]‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾[/color]
-        [head=2]Contraband Turnover Form[/head]
+      [color=#2e9935ff]◥[bold]N[/bold]◣ [bold]Frontier Outpost Command[/bold][/color]
+      [color=#2e9935ff]‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾[/color]
+      [head=2]Contraband Turnover Receipt[/head]
 
+      [bold]Contraband Holder:[/bold] 
+      [bold]Contraband F.U.C. Value:[/bold] 
+      [bold]Payout per F.U.C.:[/bold] [color=#ff0000]2 000 spesos[/color]
+      [bold]Payout Total:[/bold] 
 
-        [bold]Contraband Holder:[/bold] 
-        [bold]Contraband F.U.C Value:[/bold] 
-        [bold]Payout per F.U.C.:[/bold] [color=#ff0000]2 000 spesos[/color]
-        [bold]Payout Total:[/bold] 
+      [bold]C2 Contraband:[/bold]
+          [bullet/] 
+          [bullet/] 
+          [bullet/] 
 
-        [bold]C2 Contraband:[/bold]
-        [bullet/] 
-        [bullet/] 
-        [bullet/] 
+      [bold]C3 Contraband:[/bold]
+          [bullet/] 
+          [bullet/] 
+          [bullet/] 
 
-        [bold]C3 Contraband:[/bold]
-        [bullet/] 
-        [bullet/] 
-        [bullet/] 
-
-        [bold]Shift Time:[/bold] 
-
-        This document is a contract between [bold][italic]Contraband Holder[/italic][/bold] and [bold][italic]Frontier Command[/italic][/bold].
-        Any and all Contraband class [color=red]2[/color] and [color=red]3[/color] must be turned over to [bold][italic]Frontier Command[/italic][/bold], unless otherwise contracted with a C2 holding permit.
-        Noncompliance with this document results in voiding of any standing C2 permits.
-        [bold][italic]Contraband Holder[/italic][/bold] must be paid out in full by [bold][italic]Frontier Command[/italic][/bold] or this contract is void.
+      [bold]Shift Time:[/bold] 
 
 
 
-        [color=#AAAAAA]This Form is void without the signatures of both Parties and a stamp of Frontier Command (Sheriff or Station Representative)[/color]
+      [color=#AAAAAA]This Form is void without the signatures of both Parties and a stamp of Frontier Command (Sheriff or Station Representative)[/color]
 
 - type: entity # Based on form made by Blumbee (Aki Suboshi)
   id: PaperWrittenFrontierFormContrabandPermit
-  name: Tier 2 Contraband Permit
+  name: Class 2 Contraband Permit
   suffix: MappedPaper
   parent: Paper
   components:
   - type: Paper
     content: |2
-        [color=#2e9935ff]◥[bold]N[/bold]◣ [bold]Frontier Outpost Command[/bold][/color]
-        [color=#2e9935ff]‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾[/color]
-        [head=2]Tier 2 Contraband Permit[/head]
+      [color=#2e9935ff]◥[bold]N[/bold]◣ [bold]Frontier Outpost Command[/bold][/color]
+      [color=#2e9935ff]‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾[/color]
+      [head=2]Class 2 Contraband Permit[/head]
+
+      [bold]Permit Holder:[/bold] 
+      [bold]Holder Crew:
+      [bullet/] 
+      [bullet/] 
+      [bullet/] 
+
+      [bold]Shift Time:[/bold] 
 
 
-        [bold]Permit Holder:[/bold] 
-        [bold]Holder Crew:
-        [bullet/] 
-        [bullet/] 
-        [bullet/] 
-
-        [bold]Shift Time:[/bold] 
-
-
-        This Permit allows the Holder and crew, [italic]as listed above[/italic], to possess and use C2 Contraband.
-        Non-compliance with Contraband Turnover orders void this Permit.
-        [bold]Class 2 Contraband contains:[/bold] [color=red]all explosive devices not otherwise covered by higher classifications; objects which can be used to non-destructively or non-invasively gain unauthorized access to Nanotrasen secured areas; exclusively restricted and/or authorized use weapons or equipment, uniforms and EMPs; and, security vessels.[/color]
+      This Permit allows the Holder and crew, as listed above, to possess and use Class 2 contraband.
+      Non-compliance with a Contraband Amnesty agreement void this Permit.
+      Refer to §6.1.4 of Space Law for a full definition of Class 2 contraband.
 
 
 
-        [color=#AAAAAA]This Form is void without the signature of the Holder and the signature and stamp of the Sheriff[/color]
+      [color=#AAAAAA]This Permit is void without the signature of the Holder and the signature and stamp of the Sheriff[/color]

--- a/Resources/Prototypes/_NF/Catalog/Fills/Paper/forms_sr.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/Paper/forms_sr.yml
@@ -1,0 +1,272 @@
+# Station Representative Forms
+# Sources: https://discord.com/channels/1123826877245694004/1182366744266932224/1182366744266932224
+#          https://docs.google.com/document/d/1jDX9numj-VHKBJ2FiiEo1GIlHESffOUIHIIXaqhEnls/edit?pli=1#heading=h.ru93r8n0fb7m
+
+# Filled Folder
+- type: entity
+  id: BoxFolderSr
+  parent: BoxFolderBase
+  name: SR folder
+  description: A folder filled with paperwork templates.
+  suffix: Forms
+  components:
+  - type: Sprite
+    layers:
+    - state: folder-colormap
+      color: "#1f6626ff"
+    - state: folder-base
+  - type: StorageFill
+    contents:
+    - id: PaperWrittenFrontierFormEmployment
+    - id: PaperWrittenFrontierFormEmployeePayHistory
+    - id: PaperWrittenFrontierFormFundRequisition
+    - id: PaperWrittenFrontierFormShuttleTitleChange
+    - id: PaperWrittenFrontierFormAuthorization
+    - id: PaperWrittenFrontierFormShuttleDerelict
+    - id: PaperWrittenFrontierFormContrabandTurnover
+    - id: PaperWrittenFrontierFormContrabandPermit
+    - id: Paper
+      prob: 0.5
+    - id: Paper
+      prob: 0.5
+
+# Forms
+- type: entity # Based on form made by Willzile1 (Jon-Gah)
+  id: PaperWrittenFrontierFormEmployment
+  name: employment contract
+  suffix: MappedPaper
+  parent: Paper
+  components:
+  - type: Paper
+    content: |2
+        [color=#2e9935ff]◥[bold]N[/bold]◣ [bold]Frontier Outpost Command[/bold][/color]
+        [color=#2e9935ff]‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾[/color]
+        [head=2]Employment Contract[/head]
+
+
+        [bold]Name:[/bold]
+        [bold]Species:[/bold]
+        [bold]Ship:[/bold]
+        [bold]Position Title:[/bold]
+        [bold]Position Responsibilities:[/bold]
+        [bullet/]
+        [bullet/]
+        [bullet/]
+
+        [bold]Hourly Wage:[/bold]
+
+        [bold]Issued by:[/bold]
+
+        [bold]Shift Time:[/bold]
+
+
+
+        [color=#AAAAAA]This Form is void without signs of both Parties and a stamp of Frontier Command (Sheriff or Station Representative)[/color]
+
+- type: entity
+  id: PaperWrittenFrontierFormEmployeePayHistory
+  name: employee's pay history
+  suffix: MappedPaper
+  parent: Paper
+  components:
+  - type: Paper
+    content: |2
+        [color=#2e9935ff]◥[bold]N[/bold]◣ [bold]Frontier Outpost Command[/bold][/color]
+        [color=#2e9935ff]‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾[/color]
+        [head=2]Employee's Pay History[/head]
+
+
+        [bold]Name:[/bold]
+        [bold]Position Title:[/bold]
+        [bold]Hourly Wage:[/bold]
+        [bold]Pay history (Shift time / Wage recieved):[/bold]
+        [bullet/]
+        [bullet/]
+        [bullet/]
+        [bullet/]
+        [bullet/]
+        [bullet/]
+
+
+
+        [color=#AAAAAA]This Form is void without sign and a stamp of Frontier Command (Sheriff or Station Representative)[/color]
+
+- type: entity # Based on form made by Willzile1 (Jon-Gah)
+  id: PaperWrittenFrontierFormFundRequisition
+  name: fund requisition form
+  suffix: MappedPaper
+  parent: Paper
+  components:
+  - type: Paper
+    content: |2
+        [color=#2e9935ff]◥[bold]N[/bold]◣ [bold]Frontier Outpost Command[/bold][/color]
+        [color=#2e9935ff]‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾[/color]
+        [head=2]Fund Requisition[/head]
+
+
+        [bold]Name:[/bold]
+        [bold]Ammount:[/bold]
+        [bold]Reason:[/bold]
+        
+        [bold]Shift Time:[/bold]
+
+
+
+        [color=#AAAAAA]This Form is void without signs and a stamp of Frontier Command (Sheriff or Station Representative)[/color]
+
+- type: entity # Based on form made by Starly (Shaw Clifflower)
+  id: PaperWrittenFrontierFormAuthorization
+  name: authorization contract
+  suffix: MappedPaper
+  parent: Paper
+  components:
+  - type: Paper
+    content: |2
+        [color=#2e9935ff]◥[bold]N[/bold]◣ [bold]Frontier Outpost Command[/bold][/color]
+        [color=#2e9935ff]‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾[/color]
+        [head=2]Authorization for Bluespace Threats to Frontier[/head]
+
+
+        [bold]Vessel Captain:[/bold]
+        [bold]Vessel IFF:[/bold]
+        [bold]Shift time at issuance:[/bold]
+
+        Issuing outpost command:
+        [bullet]XXXXXXXX, Station Representative
+        [bullet]XXXXXXXX, Sheriff
+
+        This document authorizes captain XXXXX XXXXXXX of vessel XX-XXX to assist and cooperate with NFSD and Frontier authorities in neutralizing hostile threats to Frontier that bluespace into its space. These include, but are not limited to:
+        [bullet] Cultist vessels
+        [bullet] Syndicate vessels
+        [bullet] Wizard vessels
+        [bullet] Arcadia Ind. vessels
+
+        This document does NOT deputize you or grant you special privileges within the ranks of NFSD to arrest, detain, and prosecute employees of Frontier Station. [bold]Any contraband seized during your operations aboard any hostile vessel must be turned into either NFSD or the Station Representative's office for a cash bounty. Keeping any articles of contraband will lead to forfeiture of this agreement, and you may be liable to be charged with various crimes.[/bold] Keep a copy of this document on you at all times. Remember to maintain contact with either NFSD command or the Station Representative in order to minimize casualties.
+
+        Should NFSD be present, a staging area will be designated to allow for better coordination. Your staging area is three hundred (300) metres away from the hostile vessel, between the hostile vessel and Frontier Outpost. Depending on the circumstances of the shift, [bold]this can change.[/bold] Please stay in regular contact with both NFSD command and the Station Representative's office for updates on a staging area.
+
+
+
+        [color=#AAAAAA]This Form is void without signs of both Parties and a stamp of Frontier Command (Sheriff or Station Representative)[/color]
+
+- type: entity # Based on form made by Willzile1 (Jon-Gah)
+  id: PaperWrittenFrontierFormShuttleTitleChange
+  name: shuttle title change form
+  suffix: MappedPaper
+  parent: Paper
+  components:
+  - type: Paper
+    content: |2
+        [color=#2e9935ff]◥[bold]N[/bold]◣ [bold]Frontier Outpost Command[/bold][/color]
+        [color=#2e9935ff]‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾[/color]
+        [head=2]Shuttle Title Change[/head]
+
+
+        [bold]Name of Captain:[/bold]
+        [bold]Old Ship Title:[/bold]
+        [bold]New Ship Title:[/bold]
+        [bold]Shift Time:[/bold]
+
+
+
+        [color=#AAAAAA]This Form is void without signs of both Parties and a stamp of Frontier Command (Sheriff or Station Representative)[/color]
+
+- type: entity # Based on form made by Blumbee (Aki Suboshi)
+  id: PaperWrittenFrontierFormShuttleDerelict
+  name: derelict ship form
+  suffix: MappedPaper
+  parent: Paper
+  components:
+  - type: Paper
+    content: |2
+        [color=#2e9935ff]◥[bold]N[/bold]◣ [bold]Frontier Outpost Command[/bold][/color]
+        [color=#2e9935ff]‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾[/color]
+        [head=2]Notice of Derelict Ship and Declaration of Salvage[/head]
+
+
+        [bold]Ship callsign:[/bold] [color=#2200BD][/color]
+        [bold]First hail at:[/bold] [color=#2200BD][/color]
+        [bold]Issued at:[/bold] [color=#2200BD][/color]
+        [bold]Issued by:[/bold] [color=#2200BD][/color]
+
+        This is a formal declaration from Frontier's Station Traffic Controller, hereby declaring the vessel [italic] XX-XXX [/italic] to be abandoned by its captain, and recognized as salvage. Your vessel has been unresponsive on the radio for over twenty (20) minutes and has either not responded to written faxes, or is unable to receive faxes from Frontier. Henceforth, this office deems it fit to declare it as salvage.
+
+        Pursuant to Space Law Section Nine, Article Three, this vessel will be moved out to three hundred (300) meters from Frontier Station by a Valet or NFSD, and will be salvageable by any other vessel operating within Frontier's space.
+
+        Frontier Station and/or the Nanotrasen Corporation will not reimburse you or any parties affiliated with this vessel for any losses.
+
+
+
+        [color=#AAAAAA]This Form is void without signs of both Parties and a stamp of Frontier Command (Sheriff or Station Representative)[/color]
+
+- type: entity # Based on form made by Blumbee (Aki Suboshi)
+  id: PaperWrittenFrontierFormContrabandTurnover
+  name: contraband turnover form
+  suffix: MappedPaper
+  parent: Paper
+  components:
+  - type: Paper
+    content: |2
+        [color=#2e9935ff]◥[bold]N[/bold]◣ [bold]Frontier Outpost Command[/bold][/color]
+        [color=#2e9935ff]‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾[/color]
+        [head=2]Contraband Turnover Form[/head]
+
+
+        [bold]Contraband Holder:[/bold] 
+        [bold]Frontier Uplink Coin's amount:[/bold] 
+        [bold]Payout per F.U.C.:[/bold] [color=#ff0000]2.000 spesos[/color]
+        [bold]Payout total:[/bold] 
+
+        [bold]Contraband C2:[/bold]
+        [bullet/] 
+        [bullet/] 
+        [bullet/] 
+
+        [bold]Contraband C3:[/bold]
+        [bullet/] 
+        [bullet/] 
+        [bullet/] 
+
+
+        [bold]Command on duty:[/bold] 
+        [bold]Time of Turnover:[/bold] 
+
+        This document is a contract between [bold][italic]Contraband Holder[/italic][/bold] and [bold][italic]Frontier Command[/italic][/bold].
+        Any and all Contraband class [color=red]2[/color] and [color=red]3[/color] must be turned over to [bold][italic]Frontier Command[/italic][/bold], unless otherwise contracted with a C2 holding permit.
+        Noncompliance with this document results in voiding of any standing C2 permits.
+        [bold][italic]Contraband Holder[/italic][/bold] must be paid out in full by [bold][italic]Frontier Command[/italic][/bold] or this contract is void.
+
+
+
+        [color=#AAAAAA]This Form is void without signs of both Parties and a stamp of Frontier Command (Sheriff or Station Representative)[/color]
+
+- type: entity # Based on form made by Blumbee (Aki Suboshi)
+  id: PaperWrittenFrontierFormContrabandPermit
+  name: contraband permit form
+  suffix: MappedPaper
+  parent: Paper
+  components:
+  - type: Paper
+    content: |2
+        [color=#2e9935ff]◥[bold]N[/bold]◣ [bold]Frontier Outpost Command[/bold][/color]
+        [color=#2e9935ff]‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾[/color]
+        [head=2]Tier 2 Contraband Permit[/head]
+
+
+        [bold]Permit Holder:[/bold] 
+        [bold]Holder Crew:
+        [bullet/] 
+        [bullet/] 
+        [bullet/] 
+
+        [bold]Sheriff on Duty:[/bold] 
+        [bold]Time of issuing:[/bold] 
+
+
+        This Permit allows the Holder and his crew,[italic] as written above[/italic], to hold and use C2 Contraband.
+        Non-compliance with Contraband Turnover orders void this Permit.
+        [bold]Class 2 Contraband contains:[/bold] [color=red]all explosive devices not otherwise covered by higher classifications; objects which can be used to non-destructively or non-invasively gain unauthorized access to Nanotrasen secured areas; exclusively restricted and/or authorized use weapons or equipment, uniforms and EMPs; and, security vessels.[/color]
+
+
+
+        [color=#AAAAAA]This Form is void without signs of both Parties and a stamp of NFSD acting Sheriff[/color]


### PR DESCRIPTION
## About the PR
- Added 8 paper templates for SR with forms for: employment contract, employee's pay history, fund requisition form, authorization contract, shuttle title change form, derelict ship form, contraband turnover form, contraband permit form (in case no sheriff on duty).
- Mapped SR folder with said templates to SR's office.

## Why / Balance
QoL

## How to test
1. Spawn as SR, look for green folder in the office, inspect papers inside that folder.

## Media
![2024-7-24_11 26 04](https://github.com/user-attachments/assets/37791136-7c0b-49be-91fc-c9760752cf17)
![2024-7-24_11 26 57](https://github.com/user-attachments/assets/f8471524-d989-412c-ade7-51f1ee0a0a84)
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes

**Changelog**
:cl: erhardsteinhauer
- add: Added a folder with paperwork templates to SR's office.
