### PR TITLE
Spawned random human corpses drop rotten meat if butchered

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Crates/salvage.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/salvage.yml
@@ -61,7 +61,7 @@
       - id: BoxBeaker
         prob: 0.1
         #  - Heh
-      - id: SalvageHumanCorpse
+      - id: SpawnDungeonRandomHumanCorpse # Frontier - replaced SalvageHumanCorpse
         prob: 0.1
 #      - id: LidSalami
 #        prob: 0.1

--- a/Resources/Prototypes/Entities/Mobs/Corpses/corpses.yml
+++ b/Resources/Prototypes/Entities/Mobs/Corpses/corpses.yml
@@ -15,7 +15,6 @@
       - ChefGear
       - ChaplainGear
       - PassengerGear
-      - PilotGear # Frontier
 
 - type: entity
   parent: SalvageHumanCorpse
@@ -71,7 +70,6 @@
     - SecurityOfficerGear
     - DetectiveGear
     - WardenGear
-    - MercenaryGear # Frontier
 
 - type: entity
   parent: SalvageHumanCorpse

--- a/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/dungeon_items_corpses.yml
+++ b/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/dungeon_items_corpses.yml
@@ -15,11 +15,11 @@
       color: red
   - type: RandomSpawner
     prototypes:
-    - MobRandomServiceCorpse
-    - MobRandomEngineerCorpse
-    - MobRandomEngineerCorpse
-    - MobRandomCargoCorpse
-    - MobRandomMedicCorpse
-    - MobRandomScienceCorpse
+    - DungeonHumanCorpseRandomService
+    - DungeonHumanCorpseRandomEngineer
+    - DungeonHumanCorpseRandomEngineer
+    - DungeonHumanCorpseRandomCargo
+    - DungeonHumanCorpseRandomMedic
+    - DungeonHumanCorpseRandomScience
     chance: 0.9
     offset: 0.0

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/corpses.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/corpses.yml
@@ -1,0 +1,108 @@
+# Base
+- type: entity
+  parent: SalvageHumanCorpse
+  id: DungeonHumanCorpse
+  suffix: Dead, Frontier
+  save: false
+  name: unidentified corpse
+  description: I think they're dead.
+  components:
+  - type: StinkyTrait
+  - type: NpcFactionMember
+    factions:
+    - SimpleHostile
+  - type: Carriable # Carrying system from nyanotrasen.
+  - type: SalvageMobRestrictionsNF
+  - type: Butcherable
+    butcheringType: Spike
+    spawned:
+    - id: FoodMeatRotten
+      amount: 5
+
+# Corpses with gear
+- type: entity
+  parent: DungeonHumanCorpse
+  id: DungeonHumanCorpseRandomService
+  suffix: Dead, Frontier, Service
+  components:
+  - type: Loadout
+    prototypes:
+      - ClownGear
+      - MimeGear
+      - JanitorGear
+      - ServiceWorkerGear
+      - MusicianGear
+      - BotanistGear
+      - ChefGear
+      - ChaplainGear
+      - PassengerGear
+      - PilotGear
+
+- type: entity
+  parent: DungeonHumanCorpse
+  id: DungeonHumanCorpseRandomEngineer
+  suffix: Dead, Frontier, Engineer
+  components:
+  - type: Loadout
+    prototypes:
+    - TechnicalAssistantGear
+    - AtmosphericTechnicianGear
+    - StationEngineerGear
+
+- type: entity
+  parent: DungeonHumanCorpse
+  id: DungeonHumanCorpseRandomCargo
+  suffix: Dead, Frontier, Cargo
+  components:
+  - type: Loadout
+    prototypes:
+    - CargoTechGear
+    - SalvageSpecialistGear
+
+- type: entity
+  parent: DungeonHumanCorpse
+  id: DungeonHumanCorpseRandomMedic
+  suffix: Dead, Frontier, Medic
+  components:
+  - type: Loadout
+    prototypes:
+    - MedicalInternGear
+    - PsychologistGear
+    - ChemistGear
+    - DoctorGear
+
+- type: entity
+  parent: DungeonHumanCorpse
+  id: DungeonHumanCorpseRandomScience
+  suffix: Dead, Frontier, Science
+  components:
+  - type: Loadout
+    prototypes:
+    - ResearchAssistantGear
+    - ScientistGear
+
+- type: entity
+  parent: DungeonHumanCorpse
+  id: DungeonHumanCorpseRandomSecurity
+  suffix: Dead, Frontier, Security
+  components:
+  - type: Loadout
+    prototypes:
+    - SecurityCadetGear
+    - SecurityOfficerGear
+    - DetectiveGear
+    - WardenGear
+    - MercenaryGear
+
+- type: entity
+  parent: DungeonHumanCorpse
+  id: DungeonHumanCorpseRandomCommand
+  suffix: Dead, Frontier, Command
+  components:
+  - type: Loadout
+    prototypes:
+    - CaptainGear
+    - ResearchDirectorGear
+    - CMOGear
+    - ChiefEngineerGear
+    - QuartermasterGear

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/corpses.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/corpses.yml
@@ -12,7 +12,7 @@
     factions:
     - SimpleHostile
   - type: Carriable # Carrying system from nyanotrasen.
-  - type: SalvageMobRestrictionsNF
+  #- type: SalvageMobRestrictionsNF
   - type: Butcherable
     butcheringType: Spike
     spawned:


### PR DESCRIPTION
## About the PR
- Random corpses spawned at expeditions and in salvage crates now drop rotten meat if butchered.

## Why / Balance
Immersion? Plus less free human meat.

## How to test
1. Use `SpawnDungeonRandomHumanCorpse` to spawn a random corpse, butcher it, get rotten meat.
2. Spawn `CrateSalvageAssortedGoodies` until you get a body inside one, butcher it, get rotten meat.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes

**Changelog**
:cl: erhardsteinhauer
- tweak: Random corpses spawned at expeditions and in salvage crates now drop rotten meat if butchered.