### PR TITLE
ATM rotation fixes

### DIFF
--- a/Resources/Maps/_NF/Shuttles/Expedition/praeda.yml
+++ b/Resources/Maps/_NF/Shuttles/Expedition/praeda.yml
@@ -6765,7 +6765,6 @@ entities:
   - uid: 1066
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 2.5,-1.5
       parent: 1
     - type: Physics

--- a/Resources/Maps/_NF/Shuttles/caduceus.yml
+++ b/Resources/Maps/_NF/Shuttles/caduceus.yml
@@ -4184,7 +4184,6 @@ entities:
   - uid: 1155
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 0.5,7.5
       parent: 1
     - type: Physics

--- a/Resources/Prototypes/_NF/Entities/Structures/atm.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/atm.yml
@@ -62,7 +62,7 @@
   id: ComputerBankATM
   components:
   - type: Sprite
-    netSync: false
+    netsync: false
     noRot: true
     sprite: _NF/Structures/Machines/atm/atm.rsi
     layers:
@@ -76,7 +76,7 @@
   id: ComputerWithdrawBankATM
   components:
   - type: Sprite
-    netSync: false
+    netsync: false
     noRot: true
     sprite: _NF/Structures/Machines/atm/atm.rsi
     layers:
@@ -91,7 +91,7 @@
   id: ComputerWallmountBankATM
   components:
   - type: Sprite
-    netSync: false
+    netsync: false
     sprite: _NF/Structures/Machines/atm/wall_atm.rsi
     layers:
       - map: ["computerLayerBody"]
@@ -105,7 +105,7 @@
   id: ComputerWallmountWithdrawBankATM
   components:
   - type: Sprite
-    netSync: false
+    netsync: false
     sprite: _NF/Structures/Machines/atm/wall_atm.rsi
     layers:
       - map: ["computerLayerBody"]
@@ -120,7 +120,7 @@
   description: Has some sketchy looking modifications and a sticker that says DEPOSIT FEE 30%
   components:
   - type: Sprite
-    netSync: false
+    netsync: false
     noRot: true
     sprite: _NF/Structures/Machines/atm/illegal_atm.rsi
     layers:
@@ -142,7 +142,7 @@
   description: Has some sketchy looking modifications and a sticker that says DEPOSIT FEE 30%
   components:
   - type: Sprite
-    netSync: false
+    netsync: false
     sprite: _NF/Structures/Machines/atm/wall_illegal_atm.rsi
     layers:
     - map: ["computerLayerBody"]
@@ -163,7 +163,7 @@
   description: Used to pay out from the station's bank account
   components:
   - type: Sprite
-    netSync: false
+    netsync: false
     sprite: Structures/Machines/computers.rsi
     layers:
     - map: ["computerLayerBody"]

--- a/Resources/Prototypes/_NF/Entities/Structures/atm.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/atm.yml
@@ -62,6 +62,8 @@
   id: ComputerBankATM
   components:
   - type: Sprite
+    netSync: false
+    noRot: true
     sprite: _NF/Structures/Machines/atm/atm.rsi
     layers:
     - map: ["computerLayerBody"]
@@ -74,6 +76,8 @@
   id: ComputerWithdrawBankATM
   components:
   - type: Sprite
+    netSync: false
+    noRot: true
     sprite: _NF/Structures/Machines/atm/atm.rsi
     layers:
     - map: ["computerLayerBody"]
@@ -87,6 +91,7 @@
   id: ComputerWallmountBankATM
   components:
   - type: Sprite
+    netSync: false
     sprite: _NF/Structures/Machines/atm/wall_atm.rsi
     layers:
       - map: ["computerLayerBody"]
@@ -100,6 +105,7 @@
   id: ComputerWallmountWithdrawBankATM
   components:
   - type: Sprite
+    netSync: false
     sprite: _NF/Structures/Machines/atm/wall_atm.rsi
     layers:
       - map: ["computerLayerBody"]
@@ -114,6 +120,8 @@
   description: Has some sketchy looking modifications and a sticker that says DEPOSIT FEE 30%
   components:
   - type: Sprite
+    netSync: false
+    noRot: true
     sprite: _NF/Structures/Machines/atm/illegal_atm.rsi
     layers:
     - map: ["computerLayerBody"]
@@ -134,8 +142,7 @@
   description: Has some sketchy looking modifications and a sticker that says DEPOSIT FEE 30%
   components:
   - type: Sprite
-    netsync: false
-    noRot: true
+    netSync: false
     sprite: _NF/Structures/Machines/atm/wall_illegal_atm.rsi
     layers:
     - map: ["computerLayerBody"]
@@ -156,6 +163,7 @@
   description: Used to pay out from the station's bank account
   components:
   - type: Sprite
+    netSync: false
     sprite: Structures/Machines/computers.rsi
     layers:
     - map: ["computerLayerBody"]


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Reverted noRot to standing ATMs (this was a mistake, sorry).
Kept noRot to false on wallmount ATMs (looks good, maps with the accessible sides)
Validated that all ATMs are placed in reasonable locations between all POIs and ships (why are there so many ships)

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Sideways standing ATM consoles look wrong.

## How to test
<!-- Describe the way it can be tested -->

1. Purchase a Caduceus, look at the ATM placement, should make sense, should be accessible from the white floor to the south.
2. Purchase a Praeda, look at the ATM placement, should make sense (jutting outside of one end of the wall).
3. Spawn a withdraw-only ATM, a bank ATM, a wallmount ATM, a black market ATM and a black market wallmount ATM.
4. Rotate the screen.  Standing ATMs should not rotate, wallmount versions should.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

Caduceus ATM placement
![caduceus](https://github.com/user-attachments/assets/84efbf4e-20d1-44c2-af88-70f86af585f4)

Praeda ATM placement (locker moved during access tests)
![praeda](https://github.com/user-attachments/assets/42151f48-1943-4a54-9775-d692b29fa232)

Spectre ATM placement (most questionable placement I saw)
![spectre_questionable](https://github.com/user-attachments/assets/ccb2e63c-98c0-46c5-841f-4f423e2beb96)


- [X] ***I have added screenshots/videos to this PR showcasing its changes ingame***, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
No changelog, shouldn't be public facing yet.