### PR TITLE
Hauler (Hotfix): Death trap closet is no longer an instant killer

### DIFF
--- a/Resources/Maps/_NF/Shuttles/hauler.yml
+++ b/Resources/Maps/_NF/Shuttles/hauler.yml
@@ -572,8 +572,6 @@ entities:
       - 546
       - 574
       - 573
-    - type: AtmosDevice
-      joinedGrid: 1
   - uid: 645
     components:
     - type: Transform
@@ -586,8 +584,6 @@ entities:
       - 608
       - 640
       - 639
-    - type: AtmosDevice
-      joinedGrid: 1
   - uid: 646
     components:
     - type: Transform
@@ -599,8 +595,6 @@ entities:
       - 641
       - 619
       - 618
-    - type: AtmosDevice
-      joinedGrid: 1
   - uid: 647
     components:
     - type: Transform
@@ -614,8 +608,6 @@ entities:
       - 718
       - 591
       - 605
-    - type: AtmosDevice
-      joinedGrid: 1
 - proto: AirCanister
   entities:
   - uid: 541
@@ -625,58 +617,42 @@ entities:
       parent: 1
     - type: GasCanister
       releasePressure: 10.1325
-    - type: AtmosDevice
-      joinedGrid: 1
 - proto: Airlock
   entities:
   - uid: 60
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 0.5,11.5
       parent: 1
   - uid: 66
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,6.5
       parent: 1
   - uid: 68
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,1.5
       parent: 1
   - uid: 92
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -0.5,5.5
       parent: 1
   - uid: 396
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 2.5,25.5
       parent: 1
   - uid: 397
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 4.5,23.5
       parent: 1
   - uid: 440
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 4.5,20.5
       parent: 1
@@ -684,8 +660,6 @@ entities:
   entities:
   - uid: 326
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 0.5,23.5
       parent: 1
@@ -693,8 +667,6 @@ entities:
   entities:
   - uid: 69
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 2.5,1.5
       parent: 1
@@ -702,15 +674,11 @@ entities:
   entities:
   - uid: 2
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 0.5,-0.5
       parent: 1
   - uid: 933
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-2.5
@@ -759,15 +727,11 @@ entities:
   entities:
   - uid: 443
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -1.5,25.5
       parent: 1
   - uid: 483
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,23.5
@@ -898,6 +862,11 @@ entities:
     components:
     - type: Transform
       pos: -1.5,0.5
+      parent: 1
+  - uid: 487
+    components:
+    - type: Transform
+      pos: -2.5,24.5
       parent: 1
 - proto: BedsheetBlack
   entities:
@@ -2321,8 +2290,6 @@ entities:
   entities:
   - uid: 890
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 67
     - type: Physics
@@ -2373,47 +2340,11 @@ entities:
           ent: null
 - proto: ClosetWallBlack
   entities:
-  - uid: 64
+  - uid: 58
     components:
     - type: Transform
       pos: -2.5,2.5
       parent: 1
-    - type: EntityStorage
-      air:
-        volume: 200
-        immutable: False
-        temperature: 293.1496
-        moles:
-        - 1.8856695
-        - 7.0937095
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-    - type: ContainerContainer
-      containers:
-        entity_storage: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 889
-          - 888
-          - 887
-          - 886
-          - 58
-          - 129
-          - 525
-          - 662
-          - 789
-          - 883
-          - 884
-          - 885
 - proto: ClosetWallEmergencyFilledRandom
   entities:
   - uid: 790
@@ -2433,83 +2364,6 @@ entities:
     - type: Transform
       pos: -2.5,23.5
       parent: 1
-- proto: ClothingOuterCoatBomber
-  entities:
-  - uid: 525
-    components:
-    - type: MetaData
-      flags: InContainer
-    - type: Transform
-      parent: 64
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-- proto: ClothingOuterWinterCoatPlaid
-  entities:
-  - uid: 883
-    components:
-    - type: MetaData
-      flags: InContainer
-    - type: Transform
-      parent: 64
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-- proto: ClothingShoesBootsSalvage
-  entities:
-  - uid: 885
-    components:
-    - type: MetaData
-      flags: InContainer
-    - type: Transform
-      parent: 64
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-- proto: ClothingShoesBootsWinter
-  entities:
-  - uid: 887
-    components:
-    - type: MetaData
-      flags: InContainer
-    - type: Transform
-      parent: 64
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-- proto: ClothingShoesBootsWork
-  entities:
-  - uid: 58
-    components:
-    - type: MetaData
-      flags: InContainer
-    - type: Transform
-      parent: 64
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-- proto: ClothingUniformJumpsuitTshirtJeans
-  entities:
-  - uid: 129
-    components:
-    - type: MetaData
-      flags: InContainer
-    - type: Transform
-      parent: 64
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-- proto: ClothingUniformJumpsuitTshirtJeansGray
-  entities:
-  - uid: 888
-    components:
-    - type: MetaData
-      flags: InContainer
-    - type: Transform
-      parent: 64
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
 - proto: Cobweb1
   entities:
   - uid: 472
@@ -2926,8 +2780,6 @@ entities:
       - 467
       - 468
       - 512
-    - type: AtmosDevice
-      joinedGrid: 1
   - uid: 185
     components:
     - type: Transform
@@ -2942,8 +2794,6 @@ entities:
       - 291
       - 319
       - 414
-    - type: AtmosDevice
-      joinedGrid: 1
   - uid: 864
     components:
     - type: Transform
@@ -2960,8 +2810,6 @@ entities:
       - 319
       - 291
       - 471
-    - type: AtmosDevice
-      joinedGrid: 1
 - proto: Firelock
   entities:
   - uid: 54
@@ -3063,17 +2911,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 2.5,1.5
       parent: 1
-- proto: FlashlightLantern
-  entities:
-  - uid: 886
-    components:
-    - type: MetaData
-      flags: InContainer
-    - type: Transform
-      parent: 64
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
 - proto: GasPassiveVent
   entities:
   - uid: 934
@@ -3082,8 +2919,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 1.5,-3.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
 - proto: GasPipeBend
@@ -3762,8 +3597,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 4.5,4.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
 - proto: GasPressurePump
@@ -3774,8 +3607,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 3.5,4.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
 - proto: GasValve
@@ -3786,8 +3617,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 1.5,-1.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
 - proto: GasVentPump
@@ -3798,8 +3627,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -2.5,1.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
   - uid: 574
@@ -3807,8 +3634,6 @@ entities:
     - type: Transform
       pos: 1.5,9.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
   - uid: 607
@@ -3816,8 +3641,6 @@ entities:
     - type: Transform
       pos: 1.5,27.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
   - uid: 618
@@ -3825,8 +3648,6 @@ entities:
     - type: Transform
       pos: -2.5,26.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
   - uid: 639
@@ -3835,8 +3656,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 4.5,25.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
   - uid: 718
@@ -3845,8 +3664,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 1.5,13.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
   - uid: 780
@@ -3854,8 +3671,6 @@ entities:
     - type: Transform
       pos: 3.5,18.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
 - proto: GasVentScrubber
@@ -3866,8 +3681,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -0.5,8.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
   - uid: 591
@@ -3876,8 +3689,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -0.5,13.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
   - uid: 608
@@ -3885,8 +3696,6 @@ entities:
     - type: Transform
       pos: -0.5,27.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
   - uid: 619
@@ -3894,8 +3703,6 @@ entities:
     - type: Transform
       pos: -3.5,26.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
   - uid: 771
@@ -3904,8 +3711,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 3.5,19.5
       parent: 1
-    - type: AtmosDevice
-      joinedGrid: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
 - proto: GravityGeneratorMini
@@ -4230,13 +4035,6 @@ entities:
     - type: Transform
       pos: -0.5,12.5
       parent: 1
-- proto: Bed
-  entities:
-  - uid: 487
-    components:
-    - type: Transform
-      pos: -2.5,24.5
-      parent: 1
 - proto: OreBox
   entities:
   - uid: 159
@@ -4265,9 +4063,11 @@ entities:
     - type: Paper
       stampState: paper_stamp-ce
       stampedBy:
-      - stampedColor: '#C69B17FF'
+      - stampType: RubberStamp
+        stampedColor: '#C69B17FF'
         stampedName: stamp-component-stamped-name-ce
-      - stampedColor: '#00BE00FF'
+      - stampType: RubberStamp
+        stampedColor: '#00BE00FF'
         stampedName: stamp-component-stamped-name-approved
       content: >-
         [head=1]  =======================[/head]
@@ -4354,43 +4154,31 @@ entities:
   entities:
   - uid: 100
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -6.5,12.5
       parent: 1
   - uid: 102
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 6.5,9.5
       parent: 1
   - uid: 805
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -2.5,16.5
       parent: 1
   - uid: 905
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 6.5,13.5
       parent: 1
   - uid: 907
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 8.5,9.5
       parent: 1
   - uid: 912
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 8.5,13.5
       parent: 1
@@ -4467,213 +4255,157 @@ entities:
   entities:
   - uid: 36
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,-1.5
       parent: 1
   - uid: 105
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 7.5,13.5
       parent: 1
   - uid: 186
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 3.5,26.5
       parent: 1
   - uid: 210
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -4.5,15.5
       parent: 1
   - uid: 236
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,-0.5
       parent: 1
   - uid: 269
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -2.5,26.5
       parent: 1
   - uid: 502
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,24.5
       parent: 1
   - uid: 524
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -1.5,30.5
       parent: 1
   - uid: 537
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,24.5
       parent: 1
   - uid: 675
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,18.5
       parent: 1
   - uid: 676
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,21.5
       parent: 1
   - uid: 677
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,21.5
       parent: 1
   - uid: 678
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,18.5
       parent: 1
   - uid: 680
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,13.5
       parent: 1
   - uid: 681
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,8.5
       parent: 1
   - uid: 682
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,7.5
       parent: 1
   - uid: 683
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -0.5,10.5
       parent: 1
   - uid: 684
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 3.5,5.5
       parent: 1
   - uid: 685
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -1.5,5.5
       parent: 1
   - uid: 686
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,1.5
       parent: 1
   - uid: 687
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,2.5
       parent: 1
   - uid: 688
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 2.5,30.5
       parent: 1
   - uid: 690
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 3.5,22.5
       parent: 1
   - uid: 695
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,13.5
       parent: 1
   - uid: 778
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,14.5
       parent: 1
   - uid: 779
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 4.5,15.5
       parent: 1
   - uid: 847
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,24.5
       parent: 1
   - uid: 897
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,9.5
@@ -4682,77 +4414,57 @@ entities:
   entities:
   - uid: 203
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -7.5,12.5
       parent: 1
   - uid: 455
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -0.5,-3.5
       parent: 1
   - uid: 679
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,3.5
       parent: 1
   - uid: 848
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,19.5
       parent: 1
   - uid: 849
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,19.5
       parent: 1
   - uid: 850
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,3.5
       parent: 1
   - uid: 852
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,25.5
       parent: 1
   - uid: 853
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,25.5
       parent: 1
   - uid: 909
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -3.5,-3.5
       parent: 1
   - uid: 938
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 4.5,-3.5
       parent: 1
@@ -4837,8 +4549,6 @@ entities:
   entities:
   - uid: 224
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 8.5,9.5
       parent: 1
@@ -4847,8 +4557,6 @@ entities:
       - 901
   - uid: 234
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 8.5,13.5
       parent: 1
@@ -4857,8 +4565,6 @@ entities:
       - 901
   - uid: 333
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -6.5,12.5
       parent: 1
@@ -4867,8 +4573,6 @@ entities:
       - 878
   - uid: 503
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 4.5,6.5
       parent: 1
@@ -4877,8 +4581,6 @@ entities:
       - 539
   - uid: 666
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 2.5,8.5
       parent: 1
@@ -4887,8 +4589,6 @@ entities:
       - 539
   - uid: 844
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 2.5,9.5
       parent: 1
@@ -5133,8 +4833,6 @@ entities:
   entities:
   - uid: 902
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -3.5,-0.5
       parent: 1
@@ -5505,7 +5203,7 @@ entities:
     - type: Transform
       pos: 3.4578516,21.501606
       parent: 1
-- proto: soda_dispenser
+- proto: SodaDispenser
   entities:
   - uid: 150
     components:
@@ -5939,946 +5637,700 @@ entities:
   entities:
   - uid: 3
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,4.5
       parent: 1
   - uid: 4
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,0.5
       parent: 1
   - uid: 7
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,2.5
       parent: 1
   - uid: 8
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,3.5
       parent: 1
   - uid: 9
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,3.5
       parent: 1
   - uid: 10
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,3.5
       parent: 1
   - uid: 11
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-0.5
       parent: 1
   - uid: 13
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,-0.5
       parent: 1
   - uid: 14
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,2.5
       parent: 1
   - uid: 15
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,3.5
       parent: 1
   - uid: 16
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,3.5
       parent: 1
   - uid: 18
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,0.5
       parent: 1
   - uid: 31
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -2.5,0.5
       parent: 1
   - uid: 38
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 5.5,0.5
       parent: 1
   - uid: 40
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 5.5,2.5
       parent: 1
   - uid: 41
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 5.5,3.5
       parent: 1
   - uid: 42
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 4.5,3.5
       parent: 1
   - uid: 49
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 5.5,6.5
       parent: 1
   - uid: 62
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -4.5,16.5
       parent: 1
   - uid: 71
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -4.5,4.5
       parent: 1
   - uid: 82
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 3.5,3.5
       parent: 1
   - uid: 83
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -0.5,4.5
       parent: 1
   - uid: 87
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -1.5,6.5
       parent: 1
   - uid: 88
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -3.5,6.5
       parent: 1
   - uid: 108
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,0.5
       parent: 1
   - uid: 109
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,-1.5
       parent: 1
   - uid: 110
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,-2.5
       parent: 1
   - uid: 113
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 2.5,2.5
       parent: 1
   - uid: 114
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,-2.5
       parent: 1
   - uid: 117
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,11.5
       parent: 1
   - uid: 118
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,6.5
       parent: 1
   - uid: 125
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,8.5
       parent: 1
   - uid: 126
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,7.5
       parent: 1
   - uid: 128
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -1.5,16.5
       parent: 1
   - uid: 130
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,16.5
       parent: 1
   - uid: 135
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 5.5,16.5
       parent: 1
   - uid: 136
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 6.5,15.5
       parent: 1
   - uid: 139
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,14.5
       parent: 1
   - uid: 140
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,16.5
       parent: 1
   - uid: 143
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -4.5,11.5
       parent: 1
   - uid: 148
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -1.5,11.5
       parent: 1
   - uid: 149
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,18.5
       parent: 1
   - uid: 152
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,11.5
       parent: 1
   - uid: 157
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,19.5
       parent: 1
   - uid: 158
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,20.5
       parent: 1
   - uid: 161
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,23.5
       parent: 1
   - uid: 163
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,23.5
       parent: 1
   - uid: 164
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,23.5
       parent: 1
   - uid: 166
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -1.5,24.5
       parent: 1
   - uid: 167
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,23.5
       parent: 1
   - uid: 168
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,23.5
       parent: 1
   - uid: 170
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,23.5
       parent: 1
   - uid: 171
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,23.5
       parent: 1
   - uid: 172
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,22.5
       parent: 1
   - uid: 173
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,21.5
       parent: 1
   - uid: 174
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,20.5
       parent: 1
   - uid: 175
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,19.5
       parent: 1
   - uid: 176
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,18.5
       parent: 1
   - uid: 187
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,23.5
       parent: 1
   - uid: 188
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,24.5
       parent: 1
   - uid: 189
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,23.5
       parent: 1
   - uid: 190
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,24.5
       parent: 1
   - uid: 192
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,6.5
       parent: 1
   - uid: 198
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,15.5
       parent: 1
   - uid: 215
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 4.5,16.5
       parent: 1
   - uid: 216
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,11.5
       parent: 1
   - uid: 217
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,11.5
       parent: 1
   - uid: 235
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,2.5
       parent: 1
   - uid: 323
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,7.5
       parent: 1
   - uid: 337
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -4.5,27.5
       parent: 1
   - uid: 353
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,27.5
       parent: 1
   - uid: 357
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,11.5
       parent: 1
   - uid: 371
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -1.5,26.5
       parent: 1
   - uid: 373
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -2.5,27.5
       parent: 1
   - uid: 379
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 7.5,24.5
       parent: 1
   - uid: 380
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -6.5,24.5
       parent: 1
   - uid: 384
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 1.5,23.5
       parent: 1
   - uid: 385
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -1.5,12.5
       parent: 1
   - uid: 421
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,22.5
       parent: 1
   - uid: 422
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,21.5
       parent: 1
   - uid: 446
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-1.5
       parent: 1
   - uid: 459
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -1.5,15.5
       parent: 1
   - uid: 470
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -3.5,11.5
       parent: 1
   - uid: 479
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,24.5
       parent: 1
   - uid: 489
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 3.5,27.5
       parent: 1
   - uid: 492
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,27.5
       parent: 1
   - uid: 535
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,21.5
       parent: 1
   - uid: 536
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,17.5
       parent: 1
   - uid: 538
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,16.5
       parent: 1
   - uid: 548
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,20.5
       parent: 1
   - uid: 549
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 4.5,27.5
       parent: 1
   - uid: 658
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 2.5,26.5
       parent: 1
   - uid: 673
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,-1.5
       parent: 1
   - uid: 704
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,22.5
       parent: 1
   - uid: 752
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-2.5
       parent: 1
   - uid: 753
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,-0.5
       parent: 1
   - uid: 754
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-0.5
       parent: 1
   - uid: 755
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-0.5
       parent: 1
   - uid: 756
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,-2.5
       parent: 1
   - uid: 759
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,-0.5
       parent: 1
   - uid: 774
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,12.5
       parent: 1
   - uid: 776
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,17.5
       parent: 1
   - uid: 816
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,-2.5
       parent: 1
   - uid: 817
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-1.5
       parent: 1
   - uid: 818
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,-2.5
       parent: 1
   - uid: 824
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 7.5,8.5
       parent: 1
   - uid: 854
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,13.5
       parent: 1
   - uid: 855
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,16.5
       parent: 1
   - uid: 857
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,11.5
       parent: 1
   - uid: 894
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -3.5,16.5
       parent: 1
   - uid: 915
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,14.5
       parent: 1
   - uid: 917
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,13.5
       parent: 1
   - uid: 918
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,13.5
       parent: 1
   - uid: 920
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-2.5
       parent: 1
   - uid: 921
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-2.5
       parent: 1
   - uid: 925
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-2.5
       parent: 1
   - uid: 927
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -5.5,-3.5
       parent: 1
   - uid: 929
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 6.5,-3.5
       parent: 1
   - uid: 930
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -1.5,-3.5
       parent: 1
   - uid: 932
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-2.5
       parent: 1
   - uid: 939
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 2.5,-3.5
       parent: 1
   - uid: 941
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-0.5
       parent: 1
   - uid: 942
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-2.5
@@ -7128,8 +6580,6 @@ entities:
   entities:
   - uid: 669
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 454
     - type: Physics


### PR DESCRIPTION
## About the PR
Hauler had a black wall closet that would _instantly trap_ anyone who tried to open it, and then you would be crushed to death. In a recent round on Maunder, 4 or 5 people died, some permanently, to this one closet.

This was caused by a custom fill that referenced invalid entity IDs. For some reason, that causes the locker to close instantly. I first tested with the invalid entities removed, and that resolved the instant closing. Then, because the locker just contained some useless clothing and a lantern, I deleted the whole thing and replaced it with an empty locker.

## Why / Balance
Death trap bad. Custom fill bad. Change approved by Safety Moth.

## How to test
1. Buy a Hauler.
2. Open the closet in the screenshot below.
3. Don't suffocate inside a wall with no hope of escape.

## Media
![image](https://github.com/user-attachments/assets/a49315fb-7f64-44ab-81f0-5bd2570355e7)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame

## Breaking changes
If anything, this will *stop* breaking things.

**Changelog**
:cl:
- fix: Hauler's black wall closet no longer instantly kills you if you dare try to open it.