### PR TITLE
Blood isn't Food

### DIFF
--- a/Content.Shared/Fluids/SharedPuddleSystem.Evaporation.cs
+++ b/Content.Shared/Fluids/SharedPuddleSystem.Evaporation.cs
@@ -17,11 +17,12 @@ public abstract partial class SharedPuddleSystem
     private const string Slime = "Slime"; // Frontier
     private const string CopperBlood = "CopperBlood"; // Frontier
     private const string Sap = "Sap"; // Frontier
+    private const string Syrup = "Syrup"; // Frontier
     private const string JuiceTomato = "JuiceTomato"; // Frontier
     private const string Fiber = "Fiber"; // Frontier
     private const string Nothing = "Nothing"; // Frontier
 
-    public static readonly string[] EvaporationReagents = [Water, Vomit, InsectBlood, AmmoniaBlood, ZombieBlood, Blood, Slime, CopperBlood, FluorosulfuricAcid, Sap, JuiceTomato, Fiber, Nothing]; // Frontier
+    public static readonly string[] EvaporationReagents = [Water, Vomit, InsectBlood, AmmoniaBlood, ZombieBlood, Blood, Slime, CopperBlood, FluorosulfuricAcid, Sap, Syrup, JuiceTomato, Fiber, Nothing]; // Frontier
 
     public bool CanFullyEvaporate(Solution solution)
     {

--- a/Resources/Prototypes/Reagents/Consumable/Food/condiments.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Food/condiments.yml
@@ -178,12 +178,12 @@
   viscosity: 0.55 #Start using syrup to attach your remote recievers to your microwaves!
   tileReactions:
     - !type:SpillTileReaction
-  metabolisms:
-    Food:
-      # 12 diona blood for 1 unit of syrup, this stuff better be worthwhile.
-      effects:
-      - !type:SatiateHunger
-        factor: 6.0 #Stronger than cookedramen
+#  metabolisms: # Frontier
+#    Food: # Frontier
+#      # 12 diona blood for 1 unit of syrup, this stuff better be worthwhile. # Frontier
+#      effects: # Frontier
+#      - !type:SatiateHunger # Frontier
+#        factor: 6.0 #Stronger than cookedramen # Frontier
   footstepSound:
     collection: FootstepBlood
     params:

--- a/Resources/Prototypes/Reagents/biological.yml
+++ b/Resources/Prototypes/Reagents/biological.yml
@@ -71,12 +71,12 @@
   viscosity: 0.25
   tileReactions:
     - !type:SpillTileReaction
-  metabolisms:
-    Food:
-      # Delicious!
-      effects:
-      - !type:SatiateHunger
-        factor: 1.5
+#  metabolisms: # Frontier
+#    Food: # Frontier
+#      # Delicious! # Frontier
+#      effects: # Frontier
+#      - !type:SatiateHunger # Frontier
+#        factor: 1.5 # Frontier
   footstepSound:
     collection: FootstepBlood
     params:
@@ -95,14 +95,14 @@
   viscosity: 0.10
   tileReactions:
     - !type:SpillTileReaction
-  metabolisms:
-    Food:
-      # Sweet!
-      effects:
-      - !type:SatiateHunger
-        factor: 1
-      - !type:SatiateThirst
-        factor: 1
+#  metabolisms: # Frontier
+#    Food: # Frontier
+#      # Sweet! # Frontier
+#      effects: # Frontier
+#      - !type:SatiateHunger # Frontier
+#        factor: 1 # Frontier
+#      - !type:SatiateThirst # Frontier
+#        factor: 1 # Frontier
   footstepSound:
     collection: FootstepBlood
     params:


### PR DESCRIPTION
## About the PR
Your blood isn't food, stop farming your own blood for food.

## Why / Balance
Slimes and diona should not be farmed for food.

## How to test
Be slime, remove blood, drink blood, get nothing.

## Media
N/A

## Breaking changes
N/A

**Changelog**
:cl: dvir01
- tweak: Slimes and Diona blood no longer satiate hunger.
