### PR TITLE
Fix gib for syndicate, wizfed and cultist mobs

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_bloodcultist.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_bloodcultist.yml
@@ -27,6 +27,12 @@
     maximumWait: 120
     nextAdvertisementTime: 10
   - type: AutoWakeUp
+  - type: TriggerOnBeingGibbed
+  - type: GibOnTrigger
+    deleteItems: true
+    deleteOrgans: true
+    gib: false
+    useArgumentEntity: true
 
 # Humans
 # Blood Cult Priest, ranged mab, bolts deal 10 slash damage

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_syndicate.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_syndicate.yml
@@ -45,6 +45,12 @@
     maximumWait: 120
     nextAdvertisementTime: 10
   - type: AutoWakeUp
+  - type: TriggerOnBeingGibbed
+  - type: GibOnTrigger
+    deleteItems: true
+    deleteOrgans: true
+    gib: false
+    useArgumentEntity: true
 
 # Humans
 # Syndicate Captain, "armed" with AP Python

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_wizardfederation.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_wizardfederation.yml
@@ -51,6 +51,12 @@
     maximumWait: 120
     nextAdvertisementTime: 10
   - type: AutoWakeUp
+  - type: TriggerOnBeingGibbed
+  - type: GibOnTrigger
+    deleteItems: true
+    deleteOrgans: true
+    gib: false
+    useArgumentEntity: true
 
 # Humans
 # Blue Wizard, summons 2 Blue Curacao Elementals


### PR DESCRIPTION
## About the PR
Added new gibbing system to syndicate, wizard federation and blood cultist humanoid mobs.

## Why / Balance
BaLaNcE.

## How to test
1. Spawn any human mob, like syndicate naval captain for example.
2. Kill and gib it. There shouldn't be any equipment left.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
gaemer loot :(

**Changelog**
:cl: erhardsteinhauer
- fix: Removed equipment spawn on gib event from mobs.
