### PR TITLE
30% markup for expedition shuttles

### DIFF
--- a/Resources/Prototypes/_NF/Shipyard/Expedition/ambition.yml
+++ b/Resources/Prototypes/_NF/Shipyard/Expedition/ambition.yml
@@ -1,12 +1,18 @@
 # Author Info
 # GitHub: Cu1r (https://github.com/Cu1r/)
 # Discord: cu1r
-#
+
+# Maintainer Info
+# GitHub: ???
+# Discord: ???
+
+# Shuttle Notes:
+# 
 - type: vessel
   id: Ambition
   name: UAC Ambition
   description: Declassified gas production and distribution platform seized in a hostile takeover of an Atmosian conglomerate. For the ultimate insurgent.
-  price: 140000
+  price: 156000 # ~120000$ on mapinit + ~36000$ from 30% markup
   category: Large
   group: Expedition
   shuttlePath: /Maps/_NF/Shuttles/Expedition/ambition.yml

--- a/Resources/Prototypes/_NF/Shipyard/Expedition/brigand.yml
+++ b/Resources/Prototypes/_NF/Shipyard/Expedition/brigand.yml
@@ -12,7 +12,7 @@
   id: Brigand
   name: NT Brigand
   description: Civilian conversion of an old military light frigate from the early days of humanity's expansion to the stars, predating FTL technology.
-  price: 55010 # ~47835$ on mapinit + ~7175$ from 15% markup
+  price: 61000 # ~46525$ on mapinit + ~14000$ from 30% markup
   category: Medium
   group: Expedition
   shuttlePath: /Maps/_NF/Shuttles/Expedition/brigand.yml

--- a/Resources/Prototypes/_NF/Shipyard/Expedition/dartx.yml
+++ b/Resources/Prototypes/_NF/Shipyard/Expedition/dartx.yml
@@ -12,7 +12,7 @@
   id: DartX
   name: NT Dart-X
   description: A light emergency response cruiser outfitted for extended rescue missions.
-  price: 83500 #~72400 after mapinit +15% (10860)
+  price: 83500 # ~64000$ on mapinit + ~19200$ from 30% markup
   category: Medium
   group: Expedition
   shuttlePath: /Maps/_NF/Shuttles/Expedition/dartx.yml

--- a/Resources/Prototypes/_NF/Shipyard/Expedition/decadedove.yml
+++ b/Resources/Prototypes/_NF/Shipyard/Expedition/decadedove.yml
@@ -1,8 +1,18 @@
+# Author Info
+# GitHub: crystalHex (https://github.com/crystalHex)
+# Discord: ???
+
+# Maintainer Info
+# GitHub: crystalHex (https://github.com/crystalHex)
+# Discord: ???
+
+# Shuttle Notes:
+# 
 - type: vessel
   id: DecadeDove
   name: DYS Dove
   description: Versatile expedition-capable multi-purpose light freighter.
-  price: 75000
+  price: 78500 # ~60100$ on mapinit + ~18000$ from 30% markup
   category: Medium
   group: Expedition
   shuttlePath: /Maps/_NF/Shuttles/Expedition/decadedove.yml

--- a/Resources/Prototypes/_NF/Shipyard/Expedition/dragonfly.yml
+++ b/Resources/Prototypes/_NF/Shipyard/Expedition/dragonfly.yml
@@ -1,3 +1,13 @@
+# Author Info
+# GitHub: crystalHex (https://github.com/crystalHex)
+# Discord: ???
+
+# Maintainer Info
+# GitHub: crystalHex (https://github.com/crystalHex)
+# Discord: ???
+
+# Shuttle Notes:
+# 
 - type: vessel
   id: Dragonfly
   name: DYS Dragonfly

--- a/Resources/Prototypes/_NF/Shipyard/Expedition/dragonfly.yml
+++ b/Resources/Prototypes/_NF/Shipyard/Expedition/dragonfly.yml
@@ -12,7 +12,7 @@
   id: Dragonfly
   name: DYS Dragonfly
   description: Highly modular salvaging vessel welded together from smaller re-purposed hulls.
-  price: 85000
+  price: 81000 # ~62075$ on mapinit + ~18650$ from 30% markup
   category: Medium
   group: Expedition
   shuttlePath: /Maps/_NF/Shuttles/Expedition/dragonfly.yml

--- a/Resources/Prototypes/_NF/Shipyard/Expedition/gasbender.yml
+++ b/Resources/Prototypes/_NF/Shipyard/Expedition/gasbender.yml
@@ -12,7 +12,7 @@
   id: gasbender
   name: NT Gasbender
   description: The Gasbender is a medium-sized engineering vessel outfitted for deep space construction projects. Features atmospherics setup with mixing/ignition chamber. Designed to work in pair with smaller salvage ship.
-  price: 78400 # ~68140$ on mapinit + 10220$ from 15% markup
+  price: 88500 # ~68140$ on mapinit + 20500$ from 30% markup
   category: Medium
   group: Expedition
   shuttlePath: /Maps/_NF/Shuttles/Expedition/gasbender.yml

--- a/Resources/Prototypes/_NF/Shipyard/Expedition/gourd.yml
+++ b/Resources/Prototypes/_NF/Shipyard/Expedition/gourd.yml
@@ -12,7 +12,7 @@
   id: Gourd
   name: SLI Gourd
   description: The Gourd is a Science/Expedition vessel with a dedicated blast chamber.
-  price: 135000 # ~115000$ on mapinit + ~17000$ from 15% markup
+  price: 150000 # ~115000$ on mapinit + ~34000$ from 30% markup
   category: Large
   group: Expedition
   shuttlePath: /Maps/_NF/Shuttles/Expedition/gourd.yml

--- a/Resources/Prototypes/_NF/Shipyard/Expedition/praeda.yml
+++ b/Resources/Prototypes/_NF/Shipyard/Expedition/praeda.yml
@@ -12,7 +12,7 @@
   id: Praeda
   name: NT Praeda
   description: This is the Praeda, a large modular ship commissioned by Nanotrasen as part of a series of variants based on the same command module. The Praeda is a dedicated reclamation and salvage vessel capable of processing enough material to build a full sized station within a relative short amount of time.
-  price: 150000
+  price: 170500 # ~131000$ on mapinit + ~39300$ from 30% markup
   category: Large
   group: Expedition
   shuttlePath: /Maps/_NF/Shuttles/Expedition/praeda.yml

--- a/Resources/Prototypes/_NF/Shipyard/Expedition/sprinter.yml
+++ b/Resources/Prototypes/_NF/Shipyard/Expedition/sprinter.yml
@@ -1,8 +1,18 @@
+# Author Info
+# GitHub: Kesiath (https://github.com/Kesiath)
+# Discord: @kesiath
+
+# Maintainer Info
+# GitHub: ???
+# Discord: ???
+
+# Shuttle Notes:
+#
 - type: vessel
   id: Sprinter
   name: KC Sprinter
   description: A light freighter often picked by bounty hunters due to its quick acceleration, expedition capable.
-  price: 61500 # 15% tax
+  price: 66500 # ~51200$ on mapinit + ~15360$ from 30% markup
   category: Medium
   group: Expedition
   shuttlePath: /Maps/_NF/Shuttles/Expedition/sprinter.yml


### PR DESCRIPTION
## About the PR
Went through available for purchase expedition shuttles and increased final price markup to 30% (from 15%). Added some missing notes about shuttle creators/maintainers.

## Why / Balance
Hidden guidelines.

## How to test
1. Look through shuttle listing on expedition shipyard.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
Mah wallet

**Changelog**
:cl: erhardsteinhauer
- tweak: Adjusted expedition shipyard prices according to guidelines.
