### PR TITLE
Minor bug fixes

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_base.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_base.yml
@@ -191,6 +191,8 @@
   - MobHumanoidHostileAIComplex
   id: MobHumanoidHostileBase
   components:
+  - type: NPCRetaliation
+    attackMemoryLength: 10
   - type: MobMover
   - type: StandingState
   - type: RandomHumanoidAppearance
@@ -243,6 +245,8 @@
   - MobHumanoidHostileAIComplex
   id: MobNonHumanHostileBase
   components:
+  - type: NPCRetaliation
+    attackMemoryLength: 10
   - type: Reactive
     groups:
       Flammable: [Touch]

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/base_turret.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/base_turret.yml
@@ -78,7 +78,6 @@
   - type: MobState # Frontier (otherwise NPCs won't attack the entity)
 
 - type: entity # A search light for turrets
-  parent: BaseStructure
   id: BaseTurretSearchBeam
   abstract: true
   components:

--- a/Resources/Prototypes/_NF/ai_factions.yml
+++ b/Resources/Prototypes/_NF/ai_factions.yml
@@ -53,6 +53,7 @@
   - NanoTrasen
   - Syndicate
   - SimpleHostile
+  - SimpleNeutral
   - Passive
   - PetsNT
   - Zombie
@@ -80,6 +81,7 @@
   - NanoTrasen
   - Syndicate
   - SimpleHostile
+  - SimpleNeutral
   - Passive
   - PetsNT
   - Zombie
@@ -107,6 +109,7 @@
   - NanoTrasen
   - Syndicate
   - SimpleHostile
+  - SimpleNeutral
   - Passive
   - PetsNT
   - Zombie
@@ -116,7 +119,7 @@
   #- Goblin
   - WizFedFaction
   - BloodCultNF
-  - PirateNF
+  #- PirateNF
   - ExplorersExpeditionNF
   - ArtifactConstruct
   - StreetGangNF
@@ -134,6 +137,7 @@
   - NanoTrasen
   - Syndicate
   - SimpleHostile
+  - SimpleNeutral
   - Passive
   - PetsNT
   - Zombie
@@ -161,6 +165,7 @@
   - NanoTrasen
   - Syndicate
   - SimpleHostile
+  - SimpleNeutral
   - Passive
   - PetsNT
   - Zombie
@@ -188,6 +193,7 @@
   - NanoTrasen
   - Syndicate
   - SimpleHostile
+  - SimpleNeutral
   - Passive
   - PetsNT
   - Zombie
@@ -215,6 +221,7 @@
   - NanoTrasen
   - Syndicate
   - SimpleHostile
+  - SimpleNeutral
   - Passive
   - PetsNT
   - Zombie
@@ -242,6 +249,7 @@
   - NanoTrasen
   - Syndicate
   - SimpleHostile
+  - SimpleNeutral
   - Passive
   - PetsNT
   - Zombie
@@ -269,6 +277,7 @@
   - NanoTrasen
   - Syndicate
   - SimpleHostile
+  - SimpleNeutral
   - Passive
   - PetsNT
   - Zombie
@@ -296,6 +305,7 @@
   - NanoTrasen
   - Syndicate
   - SimpleHostile
+  - SimpleNeutral
   - Passive
   - PetsNT
   - Zombie
@@ -323,6 +333,7 @@
   - NanoTrasen
   - Syndicate
   - SimpleHostile
+  - SimpleNeutral
   - Passive
   - PetsNT
   - Zombie
@@ -350,6 +361,7 @@
   #- NanoTrasen
   - Syndicate
   - SimpleHostile
+  #- SimpleNeutral
   #- Passive
   #- PetsNT
   - Zombie
@@ -376,6 +388,7 @@
   - NanoTrasen
   - Syndicate
   - SimpleHostile
+  - SimpleNeutral
   - Passive
   - PetsNT
   - Zombie


### PR DESCRIPTION
## About the PR
- Added `SimpleNeutral` to the list of factions targeted by frontier specific hostile factions (like blood cult, wizard federation etc.), which means that NPCs on expeditions will target Medibots/Cleanbots/other bots and Shadow cats.
- Added retaliation behavior to expedition NPCs. Normally shouldn't do anything, but if players somehow becomes neutral towards NPC and then attacks that NPC, NPC should fight back.
- Fixed laser turret fixture.

## Why / Balance
Bug fixes

## How to test
- Spawn medibot, spawn blood cultist, blood cultist should be able to target medibot.
- Spawn laser turret, spawn drozd, you should be able to hit and destroy the turret with drozd.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes

**Changelog**
:cl: erhardsteinhauer
- fix: Fixed laser turret fixture.
- fix: Medibots/Cleanbots/other craftable bots can now be targeted by expedition mobs.
