### PR TITLE
Remove DC Cleithro

### DIFF
--- a/Resources/Prototypes/_NF/Shipyard/cleithro.yml
+++ b/Resources/Prototypes/_NF/Shipyard/cleithro.yml
@@ -3,33 +3,33 @@
 # Discord: dvir01 (84770870936997888)
 
 # Shuttle Notes:
-# 
+#
 
-- type: vessel
-  id: Cleithro
-  name: DC Cleithro
-  description: "A simple psychologist ship, ready to help anyone in need, nothing seems weird about it"
-  price: 30000 # 10+% up from sell
-  category: Medium
-  group: Civilian
-  shuttlePath: /Maps/_NF/Shuttles/cleithro.yml
+# - type: vessel
+#   id: Cleithro
+#   name: DC Cleithro
+#   description: "A simple psychologist ship, ready to help anyone in need, nothing seems weird about it"
+#   price: 30000 # 10+% up from sell
+#   category: Medium
+#   group: Civilian
+#   shuttlePath: /Maps/_NF/Shuttles/cleithro.yml
 
-- type: gameMap
-  id: Cleithro
-  mapName: 'DC Cleithro'
-  mapPath: /Maps/_NF/Shuttles/cleithro.yml
-  minPlayers: 0
-  stations:
-    Cleithro:
-      stationProto: StandardFrontierVessel
-      components:
-        - type: StationNameSetup
-          mapNameTemplate: 'Cleithro {1}'
-          nameGenerator:
-            !type:NanotrasenNameGenerator
-            prefixCreator: '14'
-        - type: StationJobs
-          availableJobs:
-            Contractor: [ 0, 0 ]
-            Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+# - type: gameMap
+#   id: Cleithro
+#   mapName: 'DC Cleithro'
+#   mapPath: /Maps/_NF/Shuttles/cleithro.yml
+#   minPlayers: 0
+#   stations:
+#     Cleithro:
+#       stationProto: StandardFrontierVessel
+#       components:
+#         - type: StationNameSetup
+#           mapNameTemplate: 'Cleithro {1}'
+#           nameGenerator:
+#             !type:NanotrasenNameGenerator
+#             prefixCreator: '14'
+#         - type: StationJobs
+#           availableJobs:
+#             Contractor: [ 0, 0 ]
+#             Pilot: [ 0, 0 ]
+#             Mercenary: [ 0, 0 ]


### PR DESCRIPTION
## About the PR
Makes DC Cleithro unavailable. Keeps the map file for Darin to do whatever he wants to with it.

## Why / Balance
Requested by Darin. The joke was never that funny and the ship isn't great.

## How to test
- Ensure Cleithro is no longer buyable.

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
No.

**Changelog**
:cl:
- remove: The DC Cleithro is no longer available.