### PR TITLE
Selective dropper fixes

### DIFF
--- a/Content.Shared/Chemistry/Components/InjectorComponent.cs
+++ b/Content.Shared/Chemistry/Components/InjectorComponent.cs
@@ -91,7 +91,7 @@ public sealed partial class InjectorComponent : Component
     /// A null ReagentWhitelist indicates all reagents are allowed.
     /// </summary>
     [DataField]
-    public List<ProtoId<ReagentPrototype>>? ReagentWhitelist = null;
+    public ProtoId<ReagentPrototype>[]? ReagentWhitelist = null;
 }
 
 /// <summary>

--- a/Content.Shared/_NF/Chemistry/EntitySystems/ChangeReagentWhitelistSystem.cs
+++ b/Content.Shared/_NF/Chemistry/EntitySystems/ChangeReagentWhitelistSystem.cs
@@ -67,12 +67,7 @@ public sealed class ReagentWhitelistChangeSystem : EntitySystem
             return;
         }
 
-        if (injectorComp.ReagentWhitelist is null)
-        {
-            injectorComp.ReagentWhitelist = new();
-        }
-        injectorComp.ReagentWhitelist.Clear();
-        injectorComp.ReagentWhitelist.Add(args.NewReagentProto);
+        injectorComp.ReagentWhitelist = new[] { args.NewReagentProto };
     }
 
     private void OnReagentWhitelistReset(Entity<ReagentWhitelistChangeComponent> ent, ref ReagentWhitelistResetMessage args)


### PR DESCRIPTION
## About the PR
* Fix selective dropper server/client desync by adding an explicit call to `SolutionContainers.UpdateChemicals`. This is called indirectly by the non-whitelist code, in `SolutionContainers.Draw`, and is responsible for synchronising client and server.
* Use `SplitSolutionWithOnly` instead of `SplitSolutionWithout`, since the former does the same job as what we'd reimplemented for whitelisty stuff.
* Change the whitelist to an array instead of a list. Less overhead, easier to cast to `string[]`.

## Why / Balance
Selective dropper code was a bit ugly. Server/client desync bad.

## How to test
1. Put some solutions in a beaker.
2. Set the dropper to draw one of the solutions in the beaker.
3. Draw.
4. Notice that the beaker updates its visuals correctly, and that the correct solution is present in the dropper.
5. Rejoice.

## Media
- [X] This PR does not require an ingame showcase

## Breaking changes
No.

**Changelog**
No outwardly visible change. Just a small improvement.