### PR TITLE
Removed whitelists from belts

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -210,8 +210,8 @@
     sprite: Clothing/Belt/janitor.rsi
   - type: Clothing
     sprite: Clothing/Belt/janitor.rsi
-  # - type: Storage # Frontier: commented out whitelist
-    # whitelist:
+  - type: Storage
+    # whitelist: # Frontier: commented out whitelist
       # tags:
         # - Wrench
         # - Bottle

--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -90,9 +90,9 @@
     sprite: Clothing/Belt/ce.rsi
   - type: Clothing
     sprite: Clothing/Belt/ce.rsi
-  - type: Storage
-    grid:
-    - 0,0,9,1
+  #- type: Storage # Frontier
+    #grid: # Frontier
+    #- 0,0,9,1 # Frontier
     # TODO: Fill this out more.
     # whitelist: # Frontier: commented out whitelist
       # tags:
@@ -584,9 +584,9 @@
     sprite: Clothing/Belt/holster.rsi
   - type: Clothing
     sprite: Clothing/Belt/holster.rsi
-  - type: Storage
-    grid:
-    - 0,0,3,1
+  # - type: Storage # Frontier: commented out
+    # grid: # Frontier: commented out
+    # - 0,0,3,1 # Frontier: commented out
 
 - type: entity
   parent: [ClothingBeltStorageBase, ContrabandClothing] # Frontier: added ContrabandClothing as parent
@@ -600,10 +600,10 @@
     sprite: Clothing/Belt/syndieholster.rsi
   - type: Item
     size: Ginormous
-  - type: Storage
-    maxItemSize: Huge
-    grid:
-    - 0,0,3,3
+  # - type: Storage # Frontier: commented out
+    # maxItemSize: Huge # Frontier: commented out
+    # grid: # Frontier: commented out
+    # - 0,0,3,3 # Frontier: commented out
     # whitelist: # Frontier: commented out whitelist
       # components:
         # - Gun
@@ -697,9 +697,9 @@
     sprite: Clothing/Belt/wand.rsi
   - type: Clothing
     sprite: Clothing/Belt/wand.rsi
-  - type: Storage
-    grid:
-    - 0,0,15,1
+  # - type: Storage # Frontier: commented out
+    # grid: # Frontier: commented out
+    # - 0,0,15,1 # Frontier: commented out
     # whitelist: # Frontier: commented out whitelist
       # tags:
       # - WizardWand

--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -13,36 +13,36 @@
   - type: Storage
     maxItemSize: Normal
     # TODO: Fill this out more.
-    whitelist:
-      tags:
-        - Powerdrill
-        - Wirecutter
-        - Crowbar
-        - Screwdriver
-        - Flashlight
-        - Wrench
-        - GeigerCounter
-        - Flare
-        - CableCoil
-        - CigPack
-        - Radio
-        - HolofanProjector
-        - Multitool
-        - AppraisalTool
-        - JawsOfLife
-        - GPS
-        - WeldingMask
-      components:
-        - SprayPainter
-        - NetworkConfigurator
-        - RCD
-        - RCDAmmo
-        - Welder
-        - PowerCell
-        - Geiger
-        - TrayScanner
-        - GasAnalyzer
-        - HandLabeler
+    # whitelist: # Frontier: commented out whitelist
+      # tags:
+        # - Powerdrill
+        # - Wirecutter
+        # - Crowbar
+        # - Screwdriver
+        # - Flashlight
+        # - Wrench
+        # - GeigerCounter
+        # - Flare
+        # - CableCoil
+        # - CigPack
+        # - Radio
+        # - HolofanProjector
+        # - Multitool
+        # - AppraisalTool
+        # - JawsOfLife
+        # - GPS
+        # - WeldingMask
+      # components:
+        # - SprayPainter
+        # - NetworkConfigurator
+        # - RCD
+        # - RCDAmmo
+        # - Welder
+        # - PowerCell
+        # - Geiger
+        # - TrayScanner
+        # - GasAnalyzer
+        # - HandLabeler
   - type: ItemMapper
     mapLayers:
       drill:
@@ -94,35 +94,35 @@
     grid:
     - 0,0,9,1
     # TODO: Fill this out more.
-    whitelist:
-      tags:
-        - Wirecutter
-        - Crowbar
-        - Screwdriver
-        - Flashlight
-        - Wrench
-        - GeigerCounter
-        - Flare
-        - CableCoil
-        - Powerdrill
-        - JawsOfLife
-        - CigPack
-        - Radio
-        - HolofanProjector
-        - Multitool
-        - AppraisalTool
-      components:
-        - SprayPainter
-        - NetworkConfigurator
-        - RCD
-        - RCDAmmo
-        - Welder
-        - Flash
-        - Handcuff
-        - PowerCell
-        - Geiger
-        - TrayScanner
-        - GasAnalyzer
+    # whitelist: # Frontier: commented out whitelist
+      # tags:
+        # - Wirecutter
+        # - Crowbar
+        # - Screwdriver
+        # - Flashlight
+        # - Wrench
+        # - GeigerCounter
+        # - Flare
+        # - CableCoil
+        # - Powerdrill
+        # - JawsOfLife
+        # - CigPack
+        # - Radio
+        # - HolofanProjector
+        # - Multitool
+        # - AppraisalTool
+      # components:
+        # - SprayPainter
+        # - NetworkConfigurator
+        # - RCD
+        # - RCDAmmo
+        # - Welder
+        # - Flash
+        # - Handcuff
+        # - PowerCell
+        # - Geiger
+        # - TrayScanner
+        # - GasAnalyzer
   - type: ItemMapper
     mapLayers:
       drill:
@@ -170,19 +170,19 @@
     sprite: Clothing/Belt/assault.rsi
   - type: Clothing
     sprite: Clothing/Belt/assault.rsi
-  - type: Storage
-    whitelist:
-      tags:
-        - CigPack
-        - Taser
-      components:
-        - Stunbaton
-        - FlashOnTrigger
-        - SmokeOnTrigger
-        - Flash
-        - Handcuff
-        - BallisticAmmoProvider
-        - Ammo
+  # - type: Storage # Frontier: commented out whitelist
+    # whitelist:
+      # tags:
+        # - CigPack
+        # - Taser
+      # components:
+        # - Stunbaton
+        # - FlashOnTrigger
+        # - SmokeOnTrigger
+        # - Flash
+        # - Handcuff
+        # - BallisticAmmoProvider
+        # - Ammo
   - type: ItemMapper
     mapLayers:
       flashbang:
@@ -210,24 +210,24 @@
     sprite: Clothing/Belt/janitor.rsi
   - type: Clothing
     sprite: Clothing/Belt/janitor.rsi
-  - type: Storage
-    whitelist:
-      tags:
-        - Wrench
-        - Bottle
-        - Spray
-        - Soap
-        - Flashlight
-        - CigPack
-        - TrashBag
-        - WetFloorSign
-        - HolosignProjector
-        - Plunger
-        - LightReplacer
-        - JanicartKeys
-      components:
-        - LightReplacer
-        - SmokeOnTrigger
+  # - type: Storage # Frontier: commented out whitelist
+    # whitelist:
+      # tags:
+        # - Wrench
+        # - Bottle
+        # - Spray
+        # - Soap
+        # - Flashlight
+        # - CigPack
+        # - TrashBag
+        # - WetFloorSign
+        # - HolosignProjector
+        # - Plunger
+        # - LightReplacer
+        # - JanicartKeys
+      # components:
+        # - LightReplacer
+        # - SmokeOnTrigger
     maxItemSize: Large
   - type: ItemMapper
     mapLayers:
@@ -256,26 +256,26 @@
     sprite: Clothing/Belt/medical.rsi
   - type: Clothing
     sprite: Clothing/Belt/medical.rsi
-  - type: Storage
-    whitelist:
-      tags:
-        - Wrench
-        - Bottle
-        - Spray
-        - Brutepack
-        - Bloodpack
-        - Gauze
-        - Ointment
-        - CigPack
-        - PillCanister
-        - Radio
-        - DiscreteHealthAnalyzer
-        - SurgeryTool
-      components:
-        - Hypospray
-        - Injector
-        - Pill
-        - HandLabeler
+  # - type: Storage # Frontier: commented out whitelist
+    # whitelist:
+      # tags:
+        # - Wrench
+        # - Bottle
+        # - Spray
+        # - Brutepack
+        # - Bloodpack
+        # - Gauze
+        # - Ointment
+        # - CigPack
+        # - PillCanister
+        # - Radio
+        # - DiscreteHealthAnalyzer
+        # - SurgeryTool
+      # components:
+        # - Hypospray
+        # - Injector
+        # - Pill
+        # - HandLabeler
   - type: ItemMapper
     mapLayers:
       bottle:
@@ -332,23 +332,23 @@
     sprite: Clothing/Belt/plant.rsi
   - type: Clothing
     sprite: Clothing/Belt/plant.rsi
-  - type: Storage
-    whitelist:
-      tags:
-        # - PlantAnalyzer
-        - PlantSampleTaker
-        - BotanyShovel
-        - BotanyHoe
-        - BotanyHatchet
-        - PlantSampleTaker
-        - PlantBGone
-        - Bottle
-        - Syringe
-        - CigPack
-      components:
-        - Seed
-        - Smokable
-        - HandLabeler
+  # - type: Storage # Frontier: commented out whitelist
+    # whitelist:
+      # tags:
+        # # - PlantAnalyzer
+        # - PlantSampleTaker
+        # - BotanyShovel
+        # - BotanyHoe
+        # - BotanyHatchet
+        # - PlantSampleTaker
+        # - PlantBGone
+        # - Bottle
+        # - Syringe
+        # - CigPack
+      # components:
+        # - Seed
+        # - Smokable
+        # - HandLabeler
   - type: ItemMapper
     mapLayers:
       hatchet:
@@ -388,28 +388,28 @@
     sprite: Clothing/Belt/chef.rsi
   - type: Clothing
     sprite: Clothing/Belt/chef.rsi
-  - type: Storage
-    whitelist:
-      tags:
-        - KitchenKnife
-        - Cleaver
-        - RollingPin
-        - Coldsauce
-        - Enzyme
-        - Hotsauce
-        - Ketchup
-        - BBQsauce
-        - SaltShaker
-        - PepperShaker
-        - CigPack
-        - Packet
-        - Skewer
-        - MonkeyCube
-        - Mayo
-      components:
-        - Mousetrap
-        - Smokable
-        - Utensil
+  # - type: Storage # Frontier: commented out whitelist
+    # whitelist:
+      # tags:
+        # - KitchenKnife
+        # - Cleaver
+        # - RollingPin
+        # - Coldsauce
+        # - Enzyme
+        # - Hotsauce
+        # - Ketchup
+        # - BBQsauce
+        # - SaltShaker
+        # - PepperShaker
+        # - CigPack
+        # - Packet
+        # - Skewer
+        # - MonkeyCube
+        # - Mayo
+      # components:
+        # - Mousetrap
+        # - Smokable
+        # - Utensil
   - type: ItemMapper
     mapLayers:
       kitchenknife:
@@ -465,31 +465,31 @@
     sprite: Clothing/Belt/security.rsi
   - type: Clothing
     sprite: Clothing/Belt/security.rsi
-  - type: Storage
-    whitelist:
-      tags:
-        - CigPack
-        - Taser
-        - SecBeltEquip
-        - Radio
-        - Sidearm
-        - MagazinePistol
-        - MagazineMagnum
-        - CombatKnife
-        - Truncheon
-        - AppraisalTool # Frontier
-      components:
-        - Stunbaton
-        - FlashOnTrigger
-        - SmokeOnTrigger
-        - Flash
-        - Handcuff
-        - BallisticAmmoProvider
-        - CartridgeAmmo
-        - DoorRemote
-        - Whistle
-        - HolosignProjector
-        - BalloonPopper
+  # - type: Storage # Frontier: commented out whitelist
+    # whitelist:
+      # tags:
+        # - CigPack
+        # - Taser
+        # - SecBeltEquip
+        # - Radio
+        # - Sidearm
+        # - MagazinePistol
+        # - MagazineMagnum
+        # - CombatKnife
+        # - Truncheon
+        # - AppraisalTool # Frontier
+      # components:
+        # - Stunbaton
+        # - FlashOnTrigger
+        # - SmokeOnTrigger
+        # - Flash
+        # - Handcuff
+        # - BallisticAmmoProvider
+        # - CartridgeAmmo
+        # - DoorRemote
+        # - Whistle
+        # - HolosignProjector
+        # - BalloonPopper
   - type: ItemMapper
     mapLayers:
       flashbang:
@@ -604,11 +604,11 @@
     maxItemSize: Huge
     grid:
     - 0,0,3,3
-    whitelist:
-      components:
-        - Gun
-        - BallisticAmmoProvider
-        - CartridgeAmmo
+    # whitelist: # Frontier: commented out whitelist
+      # components:
+        # - Gun
+        # - BallisticAmmoProvider
+        # - CartridgeAmmo
 
 - type: entity
   parent: ClothingBeltStorageBase #Frontier - ClothingBeltSecurity<ClothingBeltStorageBase
@@ -690,7 +690,7 @@
 - type: entity
   parent: [ClothingBeltStorageBase, ContrabandClothing] # Frontier: added ContrabandClothing as parent
   id: ClothingBeltWand
-  name: wand belt
+  name: wizard belt # Frontier: changed the name from 'wand belt' -> 'wizard belt'
   description: A belt designed to hold various rods of power. A veritable fanny pack of exotic magic.
   components:
   - type: Sprite
@@ -700,6 +700,6 @@
   - type: Storage
     grid:
     - 0,0,15,1
-    whitelist:
-      tags:
-      - WizardWand
+    # whitelist: # Frontier: commented out whitelist
+      # tags:
+      # - WizardWand

--- a/Resources/Prototypes/_NF/Catalog/Fills/Items/belt.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/Items/belt.yml
@@ -7,6 +7,7 @@
     contents:
       - id: CrowbarRed
       - id: Wrench
+      - id: Screwdriver
       - id: Multitool
       - id: HandHeldMassScanner
       - id: WeaponGrapplingGun

--- a/Resources/Prototypes/_NF/Catalog/Fills/Items/belt.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/Items/belt.yml
@@ -10,7 +10,6 @@
       - id: Screwdriver
       - id: Multitool
       - id: HandHeldMassScanner
-      - id: WeaponGrapplingGun
       - id: RemoteSignaller
       - id: InflatableWallStack5
       - id: InflatableDoorStack1

--- a/Resources/Prototypes/_NF/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Belt/belts.yml
@@ -21,10 +21,6 @@
     sprite: _NF/Clothing/Belt/chaplain_sash.rsi
   - type: Clothing
     sprite: _NF/Clothing/Belt/chaplain_sash.rsi
-  - type: Storage
-    maxItemSize: Small
-    grid:
-    - 0,0,3,2
   - type: ItemMapper
     mapLayers:
       book:
@@ -41,6 +37,7 @@
           - DrinkBottle
           components:
           - Drink
+          - Hypospray
       censer:
         whitelist:
           tags:

--- a/Resources/Prototypes/_NF/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Belt/belts.yml
@@ -25,34 +25,6 @@
     maxItemSize: Small
     grid:
     - 0,0,3,2
-    # TODO: Fill this out more.
-    whitelist:
-      tags:
-      - ObjectOfSpiritualSignificance
-      - Censer
-      - ReligiousSymbol
-      - Crucifix
-      - WeaponMeleeStake
-      - Book
-      - Smokable
-      - Matchstick
-      - Flashlight
-      - Trash
-      - CigPack
-      - Radio
-      - Crayon
-      - Bottle
-      - DrinkBottle
-      components:
-      - BibleComponent
-      - Drink
-      - Smokable
-      - MeleeWeapon
-      - HandheldLight
-      - ExpendableLight
-      - ToggleableLightVisuals
-      - Paper
-      - Stamp
   - type: ItemMapper
     mapLayers:
       book:


### PR DESCRIPTION
## About the PR
- Commented out whitelists on every single belt.
- Belts now have uniform storage capacity.
- Renamed 'wand belt' -> 'wizard belt'.
- Swapped grappling gun with screwdriver in pilot webbing.

## Why / Balance
With webbings so widely available, belts become completely irrelevant, this PR fixes it.

## How to test
Grab a belt, use it like you'd use a webbing

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes

**Changelog**
:cl: erhardsteinhauer
- tweak: Belts now function like webbings.
