### PR TITLE
Fixed faction on experimental nfsd hardsuit

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -255,6 +255,8 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.75
     sprintModifier: 0.65
+  - type: FactionClothing
+    faction: NanoTrasen
 
 #Security Combat Hardsuit
 - type: entity


### PR DESCRIPTION
## About the PR
Experimental NFSD hardsuit inherited `ContrabandClothing` from its parent and because of that anyone who used that hardsuit was targeted by contraband denying turrets. This PR fixes this issue.

## Why / Balance
Bug fix

## How to test
1. Spawn Experimental NFSD hardsuit
2. Spawn CDET
3. Wear Experimental NFSD hardsuit

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes

**Changelog**
:cl: erhardsteinhauer
- fix: Experimental NFSD hardsuit is no longer targeted by CDET.
