### PR TITLE
Remove microwave from SV Orange

### DIFF
--- a/Resources/Maps/_NF/Shuttles/Scrap/orange.yml
+++ b/Resources/Maps/_NF/Shuttles/Scrap/orange.yml
@@ -1562,13 +1562,6 @@ entities:
     - pos: -2.6341748,4.333044
       parent: 1
       type: Transform
-- proto: KitchenMicrowave
-  entities:
-  - uid: 163
-    components:
-    - pos: 14.5,4.5
-      parent: 1
-      type: Transform
 - proto: LockerQuarterMasterFilled
   entities:
   - uid: 164


### PR DESCRIPTION
## About the PR
Removes the microwave from SV Orange.

## Why / Balance
Missed in #1684. The SV Orange is not a food ship by any stretch of the imagination. :D

## How to test
1. Buy an Orange
2. Try not to die when you enter it
3. Make sure there's no microwave

## Media
![image](https://github.com/user-attachments/assets/c1b50122-bda4-4b0a-a23b-2134f0bb4d0f)
- [X] I have added screenshots/videos to this PR showcasing its changes ingame

## Breaking changes
No. :)

**Changelog**
:cl:
- remove: The SV Orange no longer comes with a microwave.