### PR TITLE
Add SR shipyard console to Frontier Outpost

### DIFF
--- a/Resources/Maps/_NF/Outpost/frontier.yml
+++ b/Resources/Maps/_NF/Outpost/frontier.yml
@@ -34,6 +34,7 @@ entities:
   - uid: 2173
     components:
     - type: MetaData
+      name: Frontier Outpost
     - type: Transform
       pos: 0.121950805,-0.15609694
       parent: 5691

--- a/Resources/Maps/_NF/Outpost/frontier.yml
+++ b/Resources/Maps/_NF/Outpost/frontier.yml
@@ -14439,6 +14439,23 @@ entities:
           showEnts: False
           occludes: True
           ents: []
+- proto: ComputerShipyardSr
+  entities:
+  - uid: 514
+    components:
+    - type: Transform
+      pos: 6.5,23.5
+      parent: 2173
+    - type: ContainerContainer
+      containers:
+        ShipyardConsole-targetId: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents: []
 - proto: ComputerStationRecords
   entities:
   - uid: 4053
@@ -14455,10 +14472,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 10.5,10.5
       parent: 2173
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          ents: []
 - proto: ComputerTabletopComms
   entities:
   - uid: 816
@@ -17462,10 +17475,10 @@ entities:
       parent: 2173
 - proto: filingCabinetRandom
   entities:
-  - uid: 3765
+  - uid: 2041
     components:
     - type: Transform
-      pos: 6.5,23.5
+      pos: 6.5,18.5
       parent: 2173
 - proto: FireAlarm
   entities:
@@ -27278,6 +27291,8 @@ entities:
       anchored: True
       pos: 7.5,23.5
       parent: 2173
+    - type: Physics
+      bodyType: Static
 - proto: HandheldGPSBasic
   entities:
   - uid: 4455
@@ -27750,14 +27765,14 @@ entities:
   - uid: 1196
     components:
     - type: Transform
-      pos: 6.3189855,18.603966
+      pos: 10.3198,21.657822
       parent: 2173
 - proto: MaterialDurathread
   entities:
   - uid: 4129
     components:
     - type: Transform
-      pos: 6.6530757,18.317799
+      pos: 10.684384,21.407648
       parent: 2173
 - proto: MaterialReclaimer
   entities:
@@ -32823,6 +32838,11 @@ entities:
       rot: 3.141592653589793 rad
       pos: 4.5,24.5
       parent: 2173
+  - uid: 2043
+    components:
+    - type: Transform
+      pos: 10.5,21.5
+      parent: 2173
   - uid: 2410
     components:
     - type: Transform
@@ -32979,11 +32999,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 5.5,22.5
       parent: 2173
-  - uid: 5755
-    components:
-    - type: Transform
-      pos: 6.5,18.5
-      parent: 2173
 - proto: TableReinforcedGlass
   entities:
   - uid: 3032
@@ -33112,11 +33127,10 @@ entities:
         - Middle: Off
 - proto: UniformPrinter
   entities:
-  - uid: 514
+  - uid: 2042
     components:
     - type: Transform
-      rot: -3.141592653589793 rad
-      pos: 8.5,18.5
+      pos: 11.5,21.5
       parent: 2173
 - proto: VehicleKeySecway
   entities:

--- a/Resources/Prototypes/_NF/Shipyard/Sr/bottleneck.yml
+++ b/Resources/Prototypes/_NF/Shipyard/Sr/bottleneck.yml
@@ -15,6 +15,7 @@
   price: 14000
   category: Small
   group: Sr
+  access: HeadOfPersonnel
   shuttlePath: /Maps/_NF/Shuttles/Sr/bottleneck.yml
 
 - type: gameMap


### PR DESCRIPTION
Recreation of #1725. Unfortunately, since the original PR, the Frontier Outpost map had received additional updates and an entity ID was duplicated. This broke everything. I replicated Tych0's mapping changes:

![image](https://github.com/user-attachments/assets/83af0f9e-a59e-4519-a3db-f9d4532be474)