### PR TITLE
Fix two minor POI bugs (Tinnia's, Trade)

### DIFF
--- a/Resources/Maps/_NF/POI/tinnia.yml
+++ b/Resources/Maps/_NF/POI/tinnia.yml
@@ -867,7 +867,7 @@ entities:
       pos: 14.5,-0.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -2014.695
+      secondsUntilStateChange: -2439.343
       state: Opening
   - uid: 196
     components:
@@ -9316,18 +9316,6 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1628
-    components:
-    - type: Transform
-      anchored: False
-      rot: 3.141592653589793 rad
-      pos: -7.5,6.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
-    - type: Physics
-      canCollide: True
-      bodyType: Dynamic
   - uid: 1629
     components:
     - type: Transform

--- a/Resources/Maps/_NF/POI/trade.yml
+++ b/Resources/Maps/_NF/POI/trade.yml
@@ -5282,22 +5282,22 @@ entities:
   - uid: 5249
     components:
     - type: Transform
-      pos: 17.5,-17.5
+      pos: 16.5,-16.5
       parent: 1
   - uid: 5250
     components:
     - type: Transform
-      pos: 18.5,-17.5
+      pos: 14.5,-17.5
       parent: 1
   - uid: 5251
     components:
     - type: Transform
-      pos: 19.5,-17.5
+      pos: 13.5,-16.5
       parent: 1
   - uid: 5252
     components:
     - type: Transform
-      pos: 20.5,-17.5
+      pos: 14.5,-16.5
       parent: 1
   - uid: 5253
     components:
@@ -5332,42 +5332,42 @@ entities:
   - uid: 5259
     components:
     - type: Transform
-      pos: 16.5,-17.5
+      pos: 15.5,-16.5
       parent: 1
   - uid: 5260
     components:
     - type: Transform
-      pos: 15.5,-17.5
+      pos: 9.5,-16.5
       parent: 1
   - uid: 5261
     components:
     - type: Transform
-      pos: 14.5,-17.5
+      pos: 10.5,-16.5
       parent: 1
   - uid: 5262
     components:
     - type: Transform
-      pos: 13.5,-17.5
+      pos: 11.5,-16.5
       parent: 1
   - uid: 5263
     components:
     - type: Transform
-      pos: 12.5,-17.5
+      pos: 8.5,-16.5
       parent: 1
   - uid: 5264
     components:
     - type: Transform
-      pos: 11.5,-17.5
+      pos: 12.5,-16.5
       parent: 1
   - uid: 5265
     components:
     - type: Transform
-      pos: 10.5,-17.5
+      pos: 18.5,-16.5
       parent: 1
   - uid: 5266
     components:
     - type: Transform
-      pos: 9.5,-17.5
+      pos: 21.5,-16.5
       parent: 1
   - uid: 5267
     components:
@@ -5407,7 +5407,7 @@ entities:
   - uid: 5274
     components:
     - type: Transform
-      pos: 11.5,-16.5
+      pos: 20.5,-16.5
       parent: 1
   - uid: 5275
     components:
@@ -7193,6 +7193,11 @@ entities:
     components:
     - type: Transform
       pos: 25.5,13.5
+      parent: 1
+  - uid: 6404
+    components:
+    - type: Transform
+      pos: 19.5,-16.5
       parent: 1
 - proto: CableHV
   entities:

--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/fax_machine.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/fax_machine.yml
@@ -74,13 +74,15 @@
     name: "Omnichurch Beacon"
 
 - type: entity
-  parent: [BaseStructureDisableToolUse, BaseStructureUnanchorable, FaxMachineSyndie]
+  parent: [BaseStructureDisableToolUse, BaseStructureUnanchorable, FaxMachineSyndie, FaxMachineShipAntag]
   id: FaxMachineNFLPBravo
   suffix: POI, LP Bravo
   noSpawn: true
   components:
   - type: FaxMachine
     name: "Listening Point: Bravo"
+  - type: ApcPowerReceiver
+    powerDisabled: true #starts off
 
 - type: entity
   parent: [BaseStructureDisableToolUse, BaseStructureUnanchorable, FaxMachineBase]


### PR DESCRIPTION
## About the PR
1. Removes that silly extra pipe from Tinnia's.
2. Powers the new cargo market computer at cargo bay 3 in the Trade Outpost. The wires are moved north by one tile to better match (most of) the other cargo bays.

## Why / Balance
Good maps good.

## How to test
1. Warp to Tinnia's. Don't see a random red pipe in hydroponics. Happy.
2. Warp to Trade Outpost, visit cargo bay 3. Notice that the new cargo market computer is powered. Happy.

## Media
Tinnia's:
![image](https://github.com/user-attachments/assets/7e6fb4d6-322a-4a0b-9a72-32be3de7b883)

Trade Outpost:
![image](https://github.com/user-attachments/assets/5da42b6a-7c54-4d0f-8a1f-b59ec24f1a64)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame

## Breaking changes
No.

**Changelog**
N/A