### PR TITLE
Raisins + some minor ingredient and microwave recipe changes

### DIFF
--- a/Content.Server/Kitchen/EntitySystems/MicrowaveSystem.cs
+++ b/Content.Server/Kitchen/EntitySystems/MicrowaveSystem.cs
@@ -652,7 +652,12 @@ namespace Content.Server.Kitchen.EntitySystems
                     for (var i = 0; i < active.PortionedRecipe.Item2; i++)
                     {
                         SubtractContents(microwave, active.PortionedRecipe.Item1);
-                        Spawn(active.PortionedRecipe.Item1.Result, coords);
+                        // Frontier: ResultCount - support multiple results per recipe
+                        for (var r = 0; r < active.PortionedRecipe.Item1.ResultCount; r++)
+                        {
+                            Spawn(active.PortionedRecipe.Item1.Result, coords);
+                        }
+                        // End Frontier
                     }
                 }
 

--- a/Content.Shared/Kitchen/MicrowaveMealRecipePrototype.cs
+++ b/Content.Shared/Kitchen/MicrowaveMealRecipePrototype.cs
@@ -28,6 +28,11 @@ namespace Content.Shared.Kitchen
         [DataField("result", customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
         public string Result { get; private set; } = string.Empty;
 
+        // Frontier
+        [DataField("resultCount")]
+        public int ResultCount { get; private set; } = 1;
+        // End Frontier
+
         [DataField("time")]
         public uint CookTime { get; private set; } = 5;
 

--- a/Resources/Locale/en-US/_NF/reagents/foods.ftl
+++ b/Resources/Locale/en-US/_NF/reagents/foods.ftl
@@ -1,1 +1,0 @@
-reagent-name-flaverol = Flaverol

--- a/Resources/Locale/en-US/_NF/reagents/meta/consumable/food/food.ftl
+++ b/Resources/Locale/en-US/_NF/reagents/meta/consumable/food/food.ftl
@@ -1,2 +1,5 @@
 reagent-name-flavorol = flavorol
 reagent-desc-flavorol = All the vitamins, minerals, and carbohydrates the body needs in pure form.
+
+reagent-name-raisins = Raisins
+reagent-desc-raisins = Are they the best or worst part of the cookie? They're a bunch of desiccated grapes is what they are.

--- a/Resources/Locale/en-US/_NF/reagents/meta/consumable/food/food.ftl
+++ b/Resources/Locale/en-US/_NF/reagents/meta/consumable/food/food.ftl
@@ -1,5 +1,5 @@
 reagent-name-flavorol = flavorol
 reagent-desc-flavorol = All the vitamins, minerals, and carbohydrates the body needs in pure form.
 
-reagent-name-raisins = Raisins
+reagent-name-raisins = raisins
 reagent-desc-raisins = Are they the best or worst part of the cookie? They're a bunch of desiccated grapes is what they are.

--- a/Resources/Prototypes/Recipes/Cooking/meal_recipes.yml
+++ b/Resources/Prototypes/Recipes/Cooking/meal_recipes.yml
@@ -1201,7 +1201,7 @@
   name: cookie recipe
   result: FoodBakedCookie
   resultCount: 3 # Frontier
-  time: 10 # Frontier - 10<5
+  time: 10 # Frontier - 5<10
   reagents:
     Flour: 5
     Sugar: 5
@@ -1214,7 +1214,7 @@
   name: sugar cookie recipe
   result: FoodBakedCookieSugar
   resultCount: 2 # Frontier
-  time: 10 # Frontier - 10<5
+  time: 10 # Frontier - 5<10
   reagents:
     Flour: 5
     Sugar: 10
@@ -1226,12 +1226,12 @@
   name: raisin cookie recipe
   result: FoodBakedCookieRaisin
   resultCount: 2 # Frontier
-  time: 10 # Frontier - 10<5
+  time: 10 # Frontier - 5<10
   reagents:
     Flour: 5
     Sugar: 5
     Raisins: 10 # Frontier
-  # solids: #
+  # solids: # Frontier
     # FoodSnackRaisins: 1 # Frontier
 
 - type: microwaveMealRecipe
@@ -1239,7 +1239,7 @@
   name: oatmeal cookie recipe
   result: FoodBakedCookieOatmeal
   resultCount: 2 # Frontier
-  time: 10 # Frontier - 10<5
+  time: 10 # Frontier - 5<10
   reagents:
     Oats: 5
     Sugar: 5

--- a/Resources/Prototypes/Recipes/Cooking/meal_recipes.yml
+++ b/Resources/Prototypes/Recipes/Cooking/meal_recipes.yml
@@ -1200,7 +1200,8 @@
   id: RecipeCookie
   name: cookie recipe
   result: FoodBakedCookie
-  time: 5
+  resultCount: 3 # Frontier
+  time: 10 # Frontier - 10<5
   reagents:
     Flour: 5
     Sugar: 5
@@ -1212,7 +1213,8 @@
   id: RecipeSugarCookie
   name: sugar cookie recipe
   result: FoodBakedCookieSugar
-  time: 5
+  resultCount: 2 # Frontier
+  time: 10 # Frontier - 10<5
   reagents:
     Flour: 5
     Sugar: 10
@@ -1223,18 +1225,21 @@
   id: RecipeRaisinCookie
   name: raisin cookie recipe
   result: FoodBakedCookieRaisin
-  time: 5
+  resultCount: 2 # Frontier
+  time: 10 # Frontier - 10<5
   reagents:
     Flour: 5
     Sugar: 5
-  solids:
-    FoodSnackRaisins: 1
+    Raisins: 5 # Frontier
+  # solids: #
+    # FoodSnackRaisins: 1 # Frontier
 
 - type: microwaveMealRecipe
   id: RecipeCookieOatmeal
   name: oatmeal cookie recipe
   result: FoodBakedCookieOatmeal
-  time: 5
+  resultCount: 2 # Frontier
+  time: 10 # Frontier - 10<5
   reagents:
     Oats: 5
     Sugar: 5

--- a/Resources/Prototypes/Recipes/Cooking/meal_recipes.yml
+++ b/Resources/Prototypes/Recipes/Cooking/meal_recipes.yml
@@ -1404,10 +1404,11 @@
   time: 15
   reagents:
     Milk: 15
+    Raisins: 5
     Cognizine: 5
   solids:
     FoodCakePlain: 1
-    FoodSnackRaisins: 1
+    # FoodSnackRaisins: 1 # Frontier
     OrganAnimalHeart: 1
 
 - type: microwaveMealRecipe

--- a/Resources/Prototypes/Recipes/Cooking/meal_recipes.yml
+++ b/Resources/Prototypes/Recipes/Cooking/meal_recipes.yml
@@ -1230,7 +1230,7 @@
   reagents:
     Flour: 5
     Sugar: 5
-    Raisins: 5 # Frontier
+    Raisins: 10 # Frontier
   # solids: #
     # FoodSnackRaisins: 1 # Frontier
 
@@ -1404,7 +1404,7 @@
   time: 15
   reagents:
     Milk: 15
-    Raisins: 5
+    Raisins: 10 # Frontier
     Cognizine: 5
   solids:
     FoodCakePlain: 1

--- a/Resources/Prototypes/_NF/Entities/Objects/Consumable/Food/ingredients.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Consumable/Food/ingredients.yml
@@ -46,7 +46,7 @@
   parent: ReagentPacketBase
   id: ReagentContainerRaisin
   name: raisin bag
-  description: A big bag of raisin. Good for baking!
+  description: A big bag of raisins. Good for baking!
   components:
   - type: Sprite
     sprite: _NF/Objects/Consumable/Food/ingredients.rsi

--- a/Resources/Prototypes/_NF/Entities/Objects/Consumable/Food/ingredients.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Consumable/Food/ingredients.yml
@@ -43,7 +43,7 @@
           Quantity: 50
 
 - type: entity
-  parent: BaseItem
+  parent: ReagentPacketBase
   id: ReagentContainerRaisin
   name: raisin bag
   description: A big bag of raisin. Good for baking!
@@ -51,14 +51,13 @@
   - type: Sprite
     sprite: _NF/Objects/Consumable/Food/ingredients.rsi
     state: raisin-big
-  - type: FlavorProfile
-    flavors:
-      - raisins
-  - type: Tag
-    tags:
-    - Fruit
-  - type: Damageable
-    damageContainer: Inorganic
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 50
+        reagents:
+        - ReagentId: Raisins
+          Quantity: 50
 
 - type: entity
   parent: ReagentPacketBase

--- a/Resources/Prototypes/_NF/Entities/Objects/Consumable/Food/ingredients.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Consumable/Food/ingredients.yml
@@ -62,8 +62,8 @@
 - type: entity
   parent: ReagentPacketBase
   id: ReagentContainerChocolate
-  name: chocolate chips bag
-  description: A big bag of chocolate chips. Good for cooking!
+  name: cocoa powder bag
+  description: A big bag of cocoa powder. Good for cooking!
   components:
   - type: Sprite
     sprite: _NF/Objects/Consumable/Food/ingredients.rsi

--- a/Resources/Prototypes/_NF/Reagents/Consumables/food.yml
+++ b/Resources/Prototypes/_NF/Reagents/Consumables/food.yml
@@ -39,7 +39,8 @@
   desc: reagent-desc-raisins
   physicalDesc: reagent-physical-desc-clumpy # ew
   flavor: raisins
-  color: "#3f1d04" # TODO
+  color: "#3f1d04"
+  recognizable: true
   metabolisms:
     Food:
       effects:

--- a/Resources/Prototypes/_NF/Reagents/Consumables/food.yml
+++ b/Resources/Prototypes/_NF/Reagents/Consumables/food.yml
@@ -31,3 +31,22 @@
   - !type:PlantAdjustHealth
     amount: 0.5
   pricePerUnit: 10
+
+- type: reagent
+  id: Raisins
+  name: reagent-name-raisins
+  group: Foods
+  desc: reagent-desc-raisins
+  physicalDesc: reagent-physical-desc-clumpy # ew
+  flavor: raisins
+  color: "#3f1d04" # TODO
+  metabolisms:
+    Food:
+      effects:
+      # Minimally filling
+      - !type:AdjustReagent
+        reagent: Sugar
+        amount: 0.2
+      - !type:AdjustReagent
+        reagent: Nutriment
+        amount: 0.1

--- a/Resources/Prototypes/_NF/Recipes/Cooking/meal_recipes.yml
+++ b/Resources/Prototypes/_NF/Recipes/Cooking/meal_recipes.yml
@@ -37,3 +37,11 @@
     Egg: 12
     TableSalt: 5
     Blackpepper: 5
+
+- type: microwaveMealRecipe
+  id: RecipeRaisins
+  name: raisins
+  result: ReagentContainerRaisin # A little bit cursed, spawning a bag
+  time: 30
+  solids:
+    FoodGrape: 5


### PR DESCRIPTION
## About the PR
* Add a new reagent: Raisins.
* Update the raisin bag to come with 50u raisins instead of being a useless empty item.
* Add a new microwave recipe for a raisin bag: 5 grapes for 30 seconds. Dries out the grapes, you know? It's a little bit cursed to spawn a bag out of nowhere, but what can you do.
* Add a new `ResultCount` to MicrowaveMealRecipePrototype, allowing us to spawn multiple things when a recipe is completed. Defaults to 1.
* Update cookie recipes to yield more than one cookie per batch. Cook time is increased as well.
* Rename "chocolate chip bag" to "cocoa powder bag", to reflect what it actually contains.

## Why / Balance
* The raisin bag is in a weird place currently: it's useless! It doesn't contain anything, can't be used in any recipe, and is overall meaningless. The new Raisins reagent makes it actually meaningful! The two recipes that use raisins are updated to use the new reagent.
* Drying grapes gives you a means of *making* raisins, if you run out of bags (unlikely) or don't have a ChefVend (possible). I chose 5 grapes because most fruits have 10u of reagent per item when juiced/ground, and the bag contains 50u of raisins. 4no raisins are otherwise very hard to obtain, given the removal of snack vending machines from everywhere but dungeons.
* The "chocolate chip bag" does not actually contain chocolate chips, but cocoa powder. Its name should reflect this, to be less confusing.
* Cookies are also in a slightly weird place, in that you expend a decent chunk of material – an entire stick of butter, an entire bar of chocolate – to get an item that has 5u or 6u of food in it. By allowing cookie recipes to yield _two_ – or, in the case of the chocolate chip cookie, _three_ – cookies per batch, hopefully they will make more sense to cook and be more attractive as an option. Cook time is increased so you can't cook too many in one go.

## How to test
1. Give yourself a microwave.
2. Spawn 5 grapes.
3. Cook the 5 grapes for 30 seconds, get a bag of raisins.
4. Eat some of the raisins. They should taste like dried grapes.
5. Bake raisin cookies (5u flour, 5u sugar, 10u raisins, 10 seconds). You should get 2 cookies.
6. Bake other cookies! Verify that you get multiple per batch.
    * chocolate chip cookies: 1 stick of butter, 1 chocolate bar, 5u flour, 5u sugar, 10 seconds. Yield: 3.
    * oatmeal cookies: 1 stick of butter, 5u oats, 5u sugar, 10 seconds. Yield: 2.
    * sugar cookies: 1 stick of butter, 5u flour, 10u sugar, 10 seconds. Yield: 2.

## Media
Raisins reagent:
![image](https://github.com/user-attachments/assets/ace56eba-d57b-43a4-9ad0-a1e14e075958)

Tastes like dried grapes:
![image](https://github.com/user-attachments/assets/7162de2b-924f-4571-ad55-9c34e4e3fcf3)

Baking cookies :)
https://github.com/user-attachments/assets/9ce3837b-5cae-450d-a4fc-c2ced03b6f37

- [X] I have added screenshots/videos to this PR showcasing its changes ingame

Since the above media were recorded, I have lowercased the reagent name to "raisins" and increased the material requirement to 10u raisins, previously 5u.

## Breaking changes
Negative.

**Changelog**
:cl:
- add: Raisins! The raisin bag now contains raisins!
- add: You can make more raisins by microwaving 5 grape bunches for 30 seconds.
- tweak: Recipes made with raisins now use 10u of raisins instead of 4no raisins.
- fix: "chocolate chip bag" is now called "cocoa powder bag" to better reflect its contents.