### PR TITLE
Observer radar update

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
@@ -67,6 +67,7 @@
     title: comms-console-announcement-title-centcom
     color: "#228b22"
   - type: RadarConsole
+    maxRange: 1024 #Frontier admin relevant
     followEntity: true
   - type: CargoOrderConsole
   - type: CrewMonitoringConsole

--- a/Resources/Prototypes/Entities/Mobs/Player/observer.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/observer.yml
@@ -48,6 +48,21 @@
   - type: Tag
     tags:
     - BypassInteractionRangeChecks
+  #Frontier changes to the prototype so it can access radars
+  - type: UserInterface
+    interfaces:
+      enum.RadarConsoleUiKey.Key:
+        type: RadarConsoleBoundUserInterface
+  - type: IntrinsicUI
+    uis:
+      enum.RadarConsoleUiKey.Key:
+        toggleAction: ActionObserverShowRadar
+  - type: RadarConsole
+    followEntity: true
+  - type: BypassInteractionChecks
+  - type: IgnoreUIRange
+  - type: StationLimitedNetwork
+  - type: ComplexInteraction
 
 - type: entity
   id: ActionGhostBoo
@@ -70,6 +85,19 @@
     clientExclusive: true
     checkCanInteract: false
     event: !type:ToggleLightingActionEvent
+
+#Frontier action
+- type: entity
+  id: ActionObserverShowRadar
+  name: Mass Scanner Interface
+  description: View a mass scanner interface.
+  components:
+  - type: InstantAction
+    icon: { sprite: Structures/Machines/parts.rsi, state: box_0 }
+    iconOn: Structures/Machines/parts.rsi/box_2.png
+    keywords: [ "AI", "console", "interface" ]
+    checkCanInteract: false
+    event: !type:ToggleIntrinsicUIEvent { key: enum.RadarConsoleUiKey.Key }
 
 - type: entity
   id: ActionToggleFov

--- a/Resources/Prototypes/Entities/Mobs/Player/observer.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/observer.yml
@@ -48,7 +48,7 @@
   - type: Tag
     tags:
     - BypassInteractionRangeChecks
-  #Frontier: changes to the prototype so it can access radars
+  # Frontier: changes to the prototype so it can access radars
   - type: UserInterface
     interfaces:
       enum.RadarConsoleUiKey.Key:
@@ -59,7 +59,7 @@
         toggleAction: ActionObserverShowRadar
   - type: RadarConsole
     followEntity: true
-  - type: ComplexInteraction # Needed to interact with consoles
+  - type: ComplexInteraction # Needed to interact with innate radar console
   # End Frontier
 
 - type: entity


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Title, adds an intrinsic radar action and UI for regular observer ghost so they can watch with more detail ships colliding or moving around and its location, set to the regular range of 256 like all other mass scanners, and the admin one has been set to 1024. 

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

why the regular observer one so low compared to the admin one? we dont want ghost guys trying to find secret POIs with a longer radar.

## How to test
<!-- Describe the way it can be tested -->

>start server
>become observer
>press hotkey 1


**Changelog**

:cl: Leander
- add: Observer ghost can now use their own mass scanner to watch ships around.

