### PR TITLE
AME Fuel Jar Size Revert

### DIFF
--- a/Content.Shared/Ame/Components/AmeFuelContainerComponent.cs
+++ b/Content.Shared/Ame/Components/AmeFuelContainerComponent.cs
@@ -9,11 +9,11 @@ public sealed partial class AmeFuelContainerComponent : Component
     /// The amount of fuel in the container.
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
-    public int FuelAmount = 500;
+    public int FuelAmount = 1000;   /// Frontier, Revert Jar Size
 
     /// <summary>
     /// The maximum fuel capacity of the container.
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
-    public int FuelCapacity = 500;
+    public int FuelCapacity = 1000; /// Frontier, Revert Jar Size
 }


### PR DESCRIPTION
## About the PR
Reverts the upstream change to AME Fuel Jars

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Was either this or halve price of Jars, general consensus was revert the change instead of halve price.

## How to test
<!-- Describe the way it can be tested -->
- Spawn Jar
- 1000 fuel now

- [x] This PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
n/a

**Changelog**

- tweak: Changed AME Fuel Jar size back to original Capacity
