### PR TITLE
Remove superfluous keys from shuttle telecom server

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/telecomms.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/telecomms.yml
@@ -7,12 +7,7 @@
     containers:
       key_slots:
       - EncryptionKeyCommon
-      - EncryptionKeyCargo
-      - EncryptionKeyEngineering
       - EncryptionKeyMedical
-      - EncryptionKeyScience
-      - EncryptionKeyService
-      - EncryptionKeyTraffic
 
 - type: entity
   parent: TelecomServer


### PR DESCRIPTION
## About the PR
Removes superfluous encryption keys from shuttle telecom server. The server gets to keep its common and medical keys.

## Why / Balance
This prototype exists only for expeditionary vessels. When you're on an expedition, realistically speaking, you don't need anything other than common and _maybe_ medical for implants. Once you're back from the expedition, you don't need your own server at all, so all the extra keys are extra useless.

## How to test
1. Spawn a `TelecomServerFilledShuttle`.
2. Verify that it only contains Common and Medical.

## Media
- [X] This PR does not require an ingame showcase

## Breaking changes
No.

**Changelog**
N/A