### PR TITLE
Frontier Outpost: Fix the dang medical cross colour

### DIFF
--- a/Resources/Maps/_NF/Outpost/frontier.yml
+++ b/Resources/Maps/_NF/Outpost/frontier.yml
@@ -2559,11 +2559,6 @@ entities:
             2444: -32,12
             2445: -31,12
         - node:
-            color: '#334E6DC8'
-            id: FullTileOverlayGreyscale
-          decals:
-            2041: -50,3
-        - node:
             color: '#35526FFF'
             id: FullTileOverlayGreyscale
           decals:
@@ -2576,6 +2571,7 @@ entities:
             478: -50,2
             479: -51,3
             480: -49,3
+            2041: -50,3
         - node:
             color: '#9FED5896'
             id: HalfTileOverlayGreyscale


### PR DESCRIPTION
## About the PR
This is the most important PR. It changes the centre of that one medical cross that is a _very slightly_ different shade of blue for absolutely no justifiable reason.

## Why / Balance
It drives me personally insane every single time.

## How to test
Load Frontier Outpost and behold. Tears of happiness may emerge.

## Media
Before (cleaned):
![image](https://github.com/user-attachments/assets/93b57005-1573-4e5f-91ca-85b4f102c49d)

After (also cleaned):
![image](https://github.com/user-attachments/assets/37057147-71da-412b-a6f6-43fcb51f9a5f)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
No.

**Changelog**
N/A