### PR TITLE
Expedition: Only use bounding box of largest grid for dungeon alignment

### DIFF
--- a/Content.Server/Salvage/SpawnSalvageMissionJob.cs
+++ b/Content.Server/Salvage/SpawnSalvageMissionJob.cs
@@ -231,29 +231,9 @@ public sealed class SpawnSalvageMissionJob : Job<bool>
         Box2 shuttleBox = new Box2();
 
         if (shuttleUid is { Valid: true } vesselUid &&
-            _entManager.TryGetComponent<TransformComponent>(vesselUid, out var vesselXform))
+            _entManager.TryGetComponent<MapGridComponent>(vesselUid, out var gridComp))
         {
-            foreach (var gridUid in stationData.Grids)
-            {
-                if (!_entManager.TryGetComponent<MapGridComponent>(gridUid, out var gridComp))
-                    continue;
-
-                MapCoordinates mapBottomLeft = _xforms.ToMapCoordinates(EntityCoordinatesExtensions.ToCoordinates(gridUid, gridComp.LocalAABB.BottomLeft));
-                MapCoordinates mapTopRight = _xforms.ToMapCoordinates(EntityCoordinatesExtensions.ToCoordinates(gridUid, gridComp.LocalAABB.TopRight));
-                EntityCoordinates shuttleBottomLeft = _xforms.ToCoordinates((vesselUid, vesselXform), mapBottomLeft);
-                EntityCoordinates shuttleTopRight = _xforms.ToCoordinates((vesselUid, vesselXform), mapTopRight);
-
-                //IsEmpty check needed so box won't contain 0, 0
-                if (!shuttleBox.IsEmpty())
-                {
-                    shuttleBox = shuttleBox.ExtendToContain(shuttleBottomLeft.Position);
-                    shuttleBox = shuttleBox.ExtendToContain(shuttleTopRight.Position);
-                }
-                else
-                {
-                    shuttleBox = new Box2(shuttleBottomLeft.Position, shuttleTopRight.Position);
-                }
-            }
+            shuttleBox = gridComp.LocalAABB;
         }
 
         // Frontier: offset ship spawn point from bounding boxes


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
For salvage expeditions, alignment now only considers the largest grid for bounding box alignment.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Buggy.  If bits of the ship fall off, the overall bounding box might be huge, because you flew kilometers away from it.  Your ship might then be at one of the corners of that km-wide box, and very far away from the actual dungeon when it spawns.

## How to test
<!-- Describe the way it can be tested -->
1. Spawn at the Expeditionary Lodge.
2. Purchase a ship.
3. Climb aboard, add a lattice extension out from the ship, only needs to be a few tiles.
4. Snip the lattice from the ship, creating a new grid.
5. Pilot the ship several hundred meters away from your new grid, making sure not to bring it along with you.
6. Warp out to expedition.
7. When you arrive, the dungeon should be close to one of the sides of your ship with this fix.  Without the fix, the dungeon will likely be far away (check the transform in the F7 admin panel, dungeon should be close to 0, 0 vs. your ship's coords).

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** ***this PR does not require an ingame showcase***

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
Might not add a changelog for this, difficult to explain.  TBD.