### PR TITLE
Change Frontier and NFSD offset

### DIFF
--- a/Resources/Prototypes/_NF/Maps/Outpost/frontier.yml
+++ b/Resources/Prototypes/_NF/Maps/Outpost/frontier.yml
@@ -4,6 +4,8 @@
   mapPath: /Maps/_NF/Outpost/frontier.yml
   minPlayers: 0
   maxPlayers: 100
+  randomRotation: false
+  maxRandomOffset: 0
   stations:
     Frontier:
       stationProto: StandardFrontierStation

--- a/Resources/Prototypes/_NF/PointsOfInterest/nfsd.yml
+++ b/Resources/Prototypes/_NF/PointsOfInterest/nfsd.yml
@@ -11,8 +11,8 @@
 - type: pointOfInterest
   id: Nfsd
   name: 'NFSD Outpost'
-  rangeMin: 500
-  rangeMax: 750
+  rangeMin: 750
+  rangeMax: 1000
   iffColor: "#8e6444" #brown to match the color of uniform and the color of the pants of the nearest pirates
   alwaysSpawn: true
   gridPath: /Maps/_NF/POI/nfsd.yml


### PR DESCRIPTION
## About the PR
Two things:
* Sets Frontier Outpost to spawn at (0, 0) with no rotation, always.
* Slightly increases the distance between Frontier Outpost and NFSD Outpost.

## Why / Balance
Due to upstream changes, stations by default spawn at a random position with a random rotation. Combined with our recent POI rework, NFSD Outpost could end up inside Frontier, or mere metres from it. Not ideal.

Frontier Outpost should be at (0, 0) always. We can just say all "global" coordinates in the game are actually relative to Frontier, easy peasy. :)

NFSD Outpost is moved out a little bit to give the system more room to breathe. The previous minimum of 500 metres isn't _tiny_ by any means, but imo feels a little too close.

## How to test
1. Start a round
2. `tp 0 0 1` and observe how you end up on Frontier Outpost
3. Look at a mass scanner and note that NFSD is between 750 and 1,000 metres away.
4. Rejoice.

## Media
- [X] This PR does not require an ingame showcase

## Breaking changes
No.

**Changelog**
:cl:
- fix: Frontier Outpost is once again the centre of the universe, at position 0, 0.
- fix: NFSD Outpost will no longer spawn weirdly close to or inside Frontier Outpost.