### PR TITLE
Moth food now edible by mortals

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Consumable/Food/moth.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Consumable/Food/moth.yml
@@ -1193,11 +1193,7 @@
           Quantity: 10
         - ReagentId: Sugar
           Quantity: 10
-  - type: Tag
-    tags:
-    - MothFood
-  - type: Food
-    requiresSpecialDigestion: true
+  # Frontier - Removed Moth requirement
 #Tastes like vanilla and clouds.
 
 - type: entity
@@ -1223,11 +1219,7 @@
           Quantity: 4
         - ReagentId: Sugar
           Quantity: 2
-  - type: Tag
-    tags:
-    - MothFood
-  - type: Food
-    requiresSpecialDigestion: true
+  # Frontier - Removed Moth requirement
 #Tastes like vanilla and clouds.
 
 - type: entity
@@ -1264,10 +1256,5 @@
           Quantity: 5
         - ReagentId: Vitamin
           Quantity: 1
-  - type: Tag
-    tags:
-    - MothFood
-  - type: Food
-    requiresSpecialDigestion: true
-
+  # Frontier - Removed Moth requirement
 #Tastes like muffin, dust and lint


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Mothmallows (both tray and slices) and Moffins are now edible

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Recent update re-added the "mothfood" and "requirespecialdigestion" tags, I have removed them to make them edible again

## How to test
- Spawn Moffin, Mothmallow Slice and Tray
- Consume

## Media

- [x] This PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
n/a

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
 - fix: Safety Moth says: You can now consume mothmallows and moffins again!

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
