### PR TITLE
Expeditions: unstick consoles on failure

### DIFF
--- a/Content.Server/Salvage/SalvageSystem.ExpeditionConsole.cs
+++ b/Content.Server/Salvage/SalvageSystem.ExpeditionConsole.cs
@@ -1,3 +1,4 @@
+using Content.Server._NF.Salvage; // Frontier: graceful exped spawn failures
 using Content.Server.Station.Components;
 using Content.Shared.Popups;
 using Content.Shared.Shuttles.Components;
@@ -71,7 +72,7 @@ public sealed partial class SalvageSystem
 
         // Frontier  change - disable coordinate disks for expedition missions
         //var cdUid = Spawn(CoordinatesDisk, Transform(uid).Coordinates);
-        SpawnMission(missionparams, station.Value, null);
+        SpawnMission(missionparams, station.Value, null, uid); // Frontier: add uid
 
         data.ActiveMission = args.Index;
         var mission = GetMission(missionparams.MissionType, missionparams.Difficulty, missionparams.Seed);

--- a/Content.Server/Salvage/SalvageSystem.ExpeditionConsole.cs
+++ b/Content.Server/Salvage/SalvageSystem.ExpeditionConsole.cs
@@ -72,7 +72,7 @@ public sealed partial class SalvageSystem
 
         // Frontier  change - disable coordinate disks for expedition missions
         //var cdUid = Spawn(CoordinatesDisk, Transform(uid).Coordinates);
-        SpawnMission(missionparams, station.Value, null, uid); // Frontier: add uid
+        SpawnMission(missionparams, station.Value, null);
 
         data.ActiveMission = args.Index;
         var mission = GetMission(missionparams.MissionType, missionparams.Difficulty, missionparams.Seed);

--- a/Content.Server/Salvage/SalvageSystem.Expeditions.cs
+++ b/Content.Server/Salvage/SalvageSystem.Expeditions.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using System.Threading;
+using Content.Server._NF.Salvage; // Frontier: graceful exped spawn failures
 using Content.Server.Cargo.Components;
 using Content.Server.Cargo.Systems;
 using Content.Server.Salvage.Expeditions;
@@ -47,6 +48,7 @@ public sealed partial class SalvageSystem
         SubscribeLocalEvent<SalvageExpeditionConsoleComponent, ComponentInit>(OnSalvageConsoleInit);
         SubscribeLocalEvent<SalvageExpeditionConsoleComponent, EntParentChangedMessage>(OnSalvageConsoleParent);
         SubscribeLocalEvent<SalvageExpeditionConsoleComponent, ClaimSalvageMessage>(OnSalvageClaimMessage);
+        SubscribeLocalEvent<SalvageExpeditionDataComponent, ExpeditionSpawnCompleteEvent>(OnExpeditionSpawnComplete); // Frontier: more gracefully handle expedition generation failures
 
         SubscribeLocalEvent<SalvageExpeditionComponent, MapInitEvent>(OnExpeditionMapInit);
 //        SubscribeLocalEvent<SalvageExpeditionDataComponent, EntityUnpausedEvent>(OnDataUnpaused);
@@ -290,7 +292,7 @@ public sealed partial class SalvageSystem
         return new SalvageExpeditionConsoleState(component.NextOffer, component.Claimed, component.Cooldown, component.ActiveMission, missions);
     }
 
-    private void SpawnMission(SalvageMissionParams missionParams, EntityUid station, EntityUid? coordinatesDisk)
+    private void SpawnMission(SalvageMissionParams missionParams, EntityUid station, EntityUid? coordinatesDisk, EntityUid console) // Frontier: add console
     {
         var cancelToken = new CancellationTokenSource();
         var job = new SpawnSalvageMissionJob(
@@ -340,6 +342,23 @@ public sealed partial class SalvageSystem
         foreach (var reward in comp.Rewards)
         {
             Spawn(reward, (Transform(_random.Pick(palletList)).MapPosition));
+        }
+    }
+
+    // Frontier: handle exped spawn job failures gracefully - reset the console
+    private void OnExpeditionSpawnComplete(EntityUid uid, SalvageExpeditionDataComponent component, ExpeditionSpawnCompleteEvent ev)
+    {
+        if (!TryComp<SalvageExpeditionDataComponent>(uid, out var data))
+        {
+            Log.Info($"OnExpeditionSpawnComplete: station {uid} has no expedition data");
+            return;
+        }
+
+        if (data.ActiveMission == ev.MissionIndex && !ev.Success)
+        {
+            data.ActiveMission = 0;
+            data.Cooldown = false;
+            UpdateConsoles(component);
         }
     }
 }

--- a/Content.Server/Salvage/SalvageSystem.Expeditions.cs
+++ b/Content.Server/Salvage/SalvageSystem.Expeditions.cs
@@ -292,7 +292,7 @@ public sealed partial class SalvageSystem
         return new SalvageExpeditionConsoleState(component.NextOffer, component.Claimed, component.Cooldown, component.ActiveMission, missions);
     }
 
-    private void SpawnMission(SalvageMissionParams missionParams, EntityUid station, EntityUid? coordinatesDisk, EntityUid console) // Frontier: add console
+    private void SpawnMission(SalvageMissionParams missionParams, EntityUid station, EntityUid? coordinatesDisk)
     {
         var cancelToken = new CancellationTokenSource();
         var job = new SpawnSalvageMissionJob(
@@ -361,4 +361,5 @@ public sealed partial class SalvageSystem
             UpdateConsoles(component);
         }
     }
+    // End Frontier
 }

--- a/Content.Server/Salvage/SpawnSalvageMissionJob.cs
+++ b/Content.Server/Salvage/SpawnSalvageMissionJob.cs
@@ -101,6 +101,7 @@ public sealed class SpawnSalvageMissionJob : Job<bool>
 
     protected override async Task<bool> Process()
     {
+        // Frontier: gracefully handle expedition failures
         bool success = false;
         try
         {
@@ -117,6 +118,7 @@ public sealed class SpawnSalvageMissionJob : Job<bool>
             _entManager.EventBus.RaiseLocalEvent(Station, ev); // We have no idea who spawned this, so broadcast our success/failure.
         }
         return success;
+        // End Frontier: gracefully handle expedition failures
     }
 
     private async Task<bool> InternalProcess() // Frontier: make process an internal function (for a try block indenting an entire)

--- a/Content.Server/Salvage/SpawnSalvageMissionJob.cs
+++ b/Content.Server/Salvage/SpawnSalvageMissionJob.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using System.Numerics;
 using System.Threading;
 using System.Threading.Tasks;
+using Content.Server._NF.Salvage; // Frontier: job complete event
 using Content.Server.Atmos;
 using Content.Server.Atmos.Components;
 using Content.Server.Atmos.EntitySystems;
@@ -99,6 +100,26 @@ public sealed class SpawnSalvageMissionJob : Job<bool>
     }
 
     protected override async Task<bool> Process()
+    {
+        bool success = false;
+        try
+        {
+            Task<bool> task = InternalProcess();
+            await task.ContinueWith((t) => { }, TaskContinuationOptions.OnlyOnFaulted);
+        }
+        catch (Exception e)
+        {
+            Logger.ErrorS("salvage", $"Expedition generation failed with exception: {e?.StackTrace}!");
+        }
+        finally
+        {
+            ExpeditionSpawnCompleteEvent ev = new(Station, success, _missionParams.Index);
+            _entManager.EventBus.RaiseLocalEvent(Station, ev); // We have no idea who spawned this, so broadcast our success/failure.
+        }
+        return success;
+    }
+
+    private async Task<bool> InternalProcess() // Frontier: make process an internal function (for a try block indenting an entire)
     {
         Logger.DebugS("salvage", $"Spawning salvage mission with seed {_missionParams.Seed}");
         var config = _missionParams.MissionType;
@@ -241,7 +262,6 @@ public sealed class SpawnSalvageMissionJob : Job<bool>
         Vector2 shuttleProjection = new Vector2(shuttleBox.Width * (float) -Math.Sin(dungeonRotation) / 2, shuttleBox.Height * (float) Math.Cos(dungeonRotation) / 2); // Note: sine is negative because of CCW rotation (starting north, then west)
         Vector2 coords = dungeonBox.Center - dungeonProjection - dungeonOffset - shuttleProjection - shuttleBox.Center; // Coordinates to spawn the ship at to center it with the dungeon's bounding boxes
 
-        // Attempt to c
         // Frontier: delay ship FTL
         if (shuttleUid is { Valid: true })
         {
@@ -289,7 +309,6 @@ public sealed class SpawnSalvageMissionJob : Job<bool>
         // Handle loot
         // We'll always add this loot if possible
         foreach (var lootProto in _prototypeManager.EnumeratePrototypes<SalvageLootPrototype>())
-
         {
             if (!lootProto.Guaranteed)
                 continue;

--- a/Content.Server/_NF/Salvage/ExpeditionSpawnCompleteEvent.cs
+++ b/Content.Server/_NF/Salvage/ExpeditionSpawnCompleteEvent.cs
@@ -1,0 +1,17 @@
+namespace Content.Server._NF.Salvage;
+
+/// <summary>
+///     This event is raised when an expedition spawn job has completed (either successfully or in failure), and informs whether the job was successful or not.
+/// </summary>
+public sealed class ExpeditionSpawnCompleteEvent : EntityEventArgs
+{
+    public EntityUid Station;
+    public bool Success;
+    public ushort MissionIndex;
+    public ExpeditionSpawnCompleteEvent(EntityUid station, bool success, ushort missionIndex)
+    {
+        Station = station;
+        Success = success;
+        MissionIndex = missionIndex;
+    }
+}

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_expeditions_dinosaurs.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_expeditions_dinosaurs.yml
@@ -113,8 +113,8 @@
         Slash: 8
         Structural: 20
   - type: MovementSpeedModifier
-    baseSprintSpeed : 4.5
-    baseWalkSpeed: 4.5
+    baseSprintSpeed : 4.1
+    baseWalkSpeed: 4.1
   - type: FootstepModifier
     footstepSoundCollection:
       collection: FootstepAsteroid
@@ -155,12 +155,12 @@
     animation: WeaponArcBite
     damage:
       types:
-        Slash: 6
-        Caustic: 1
-        Structural: 20
+        Slash: 8
+        Caustic: 2
+        Structural: 25
   - type: MovementSpeedModifier
-    baseSprintSpeed : 5.5
-    baseWalkSpeed: 5.5
+    baseSprintSpeed : 4.3
+    baseWalkSpeed: 4.3
 
 - type: entity
   parent: BaseMobDinosaurExpeditions
@@ -198,11 +198,11 @@
     animation: WeaponArcClaw
     damage:
       types:
-        Slash: 12
-        Structural: 20
+        Slash: 18
+        Structural: 30
   - type: MovementSpeedModifier
-    baseSprintSpeed : 6.5
-    baseWalkSpeed: 6.5
+    baseSprintSpeed : 4.5
+    baseWalkSpeed: 4.5
 
 - type: entity
   parent: BaseMobDinosaurExpeditions

--- a/Resources/ServerInfo/_NF/Guidebook/MobsHostileExpedition/dinosaurs.xml
+++ b/Resources/ServerInfo/_NF/Guidebook/MobsHostileExpedition/dinosaurs.xml
@@ -16,7 +16,7 @@
   <GuideEntityEmbed Entity="MobDinosaurCompyExpeditions"/>
   </Box>
   - [bold][color=#a4885c]Health thresholds:[/color][/bold] 50 (death)
-  - [bold][color=#a4885c]Run (walk) speed:[/color][/bold] 4.5 m/s (4.5 m/s)[bold][color=#a4885c]*[/color][/bold]
+  - [bold][color=#a4885c]Run (walk) speed:[/color][/bold] 4.1 m/s (4.1 m/s)[bold][color=#a4885c]*[/color][/bold]
   - [bold][color=#a4885c]Damage (type):[/color][/bold] 8 [color=red]Slash[/color]
   - [bold][color=#a4885c]Damage resistances:[/color][/bold] none
   - [bold][color=#a4885c]Special abilities:[/color][/bold] none
@@ -33,8 +33,8 @@
   <GuideEntityEmbed Entity="MobDinosaurDiloExpeditions"/>
   </Box>
   - [bold][color=#a4885c]Health thresholds:[/color][/bold] 50 (death)
-  - [bold][color=#a4885c]Run (walk) speed:[/color][/bold] 5.5 m/s (5.5 m/s)
-  - [bold][color=#a4885c]Damage (type):[/color][/bold] 6 [color=red]Slash[/color], 1 [color=orange]Caustic[/color]
+  - [bold][color=#a4885c]Run (walk) speed:[/color][/bold] 4.3 m/s (4.3 m/s)
+  - [bold][color=#a4885c]Damage (type):[/color][/bold] 8 [color=red]Slash[/color], 2 [color=orange]Caustic[/color]
   - [bold][color=#a4885c]Damage resistances:[/color][/bold] none
   - [bold][color=#a4885c]Special abilities:[/color][/bold] none
   
@@ -48,8 +48,8 @@
   <GuideEntityEmbed Entity="MobDinosaurRaptorExpeditions"/>
   </Box>
   - [bold][color=#a4885c]Health thresholds:[/color][/bold] 80 (death)
-  - [bold][color=#a4885c]Run (walk) speed:[/color][/bold] 6.5 m/s (6.5 m/s)
-  - [bold][color=#a4885c]Damage (type):[/color][/bold] 12 [color=red]Slash[/color]
+  - [bold][color=#a4885c]Run (walk) speed:[/color][/bold] 4.5 m/s (4.5 m/s)
+  - [bold][color=#a4885c]Damage (type):[/color][/bold] 18 [color=red]Slash[/color]
   - [bold][color=#a4885c]Damage resistances:[/color][/bold] none
   - [bold][color=#a4885c]Special abilities:[/color][/bold] none
   


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Adds a new event, ExpeditionSpawnCompleteEvent, that is fired when an expedition job either completes (hooray), or fails.  Handling this failure case allows us to unstick the expedition console on errors (e.g. ones occurring during dungeon generation, or FTL init failures, or if dungeons are generated).

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Expedition consoles getting stuck is no fun.

## How to test
<!-- Describe the way it can be tested -->

1. On line 266 on Content.Server\Salvage\SpawnSalvageMissionJob.cs, add `throw new NullReferenceException();`.
2. Build and run the server and client.
3. Buy an expedition ship.
4. Fly out from the station, try to warp to a mission.
5. The dungeon will start to generate, and take a second or so, 

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** ***this PR does not require an ingame showcase***

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: When expeditions fail to generate, for any reason, the expedition console should not get stuck.