### PR TITLE
Cleanup SalvageMobRestrictionsNF

### DIFF
--- a/Content.Server/_NF/Salvage/SalvageMobRestrictionsSystem.cs
+++ b/Content.Server/_NF/Salvage/SalvageMobRestrictionsSystem.cs
@@ -1,27 +1,7 @@
-using Content.Shared.CCVar;
-using Content.Shared.Examine;
-using Content.Shared.Interaction;
 using Content.Shared.Damage;
-using Content.Shared.Damage;
-using Content.Server.Body.Components;
-using Robust.Server.Maps;
-using Robust.Shared.Configuration;
-using Robust.Shared.GameObjects;
-using Robust.Shared.IoC;
-using Robust.Shared.Localization;
-using Robust.Shared.Log;
-using Robust.Shared.Map;
-using Robust.Shared.Maths;
-using Robust.Shared.Player;
-using Robust.Shared.Prototypes;
-using Robust.Shared.Random;
-using Robust.Shared.Timing;
-using Robust.Shared.Utility;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using Content.Shared.Body.Components;
 using Content.Server.Body.Systems;
+using Content.Server.Explosion.EntitySystems;
 
 namespace Content.Server._NF.Salvage;
 
@@ -29,6 +9,8 @@ public sealed class SalvageMobRestrictionsSystem : EntitySystem
 {
     [Dependency] private readonly DamageableSystem _damageableSystem = default!;
     [Dependency] private readonly BodySystem _body = default!;
+    [Dependency] private readonly ExplosionSystem _explosion = default!;
+
     public override void Initialize()
     {
         base.Initialize();
@@ -75,10 +57,15 @@ public sealed class SalvageMobRestrictionsSystem : EntitySystem
                 foreach (var gib in gibs)
                     Del(gib);
             }
-            else if (TryComp(target, out DamageableComponent? dc))
+            else
             {
-                _damageableSystem.SetAllDamage(target, dc, 200);
+                _explosion.QueueExplosion(target, ExplosionSystem.DefaultExplosionPrototypeId, 5, 10, 5);
+                Del(target);
             }
+            //else if (TryComp(target, out DamageableComponent? dc))
+            //{
+            //    _damageableSystem.SetAllDamage(target, dc, 200);
+            //}
         }
     }
 }

--- a/Content.Server/_NF/Salvage/SalvageMobRestrictionsSystem.cs
+++ b/Content.Server/_NF/Salvage/SalvageMobRestrictionsSystem.cs
@@ -52,16 +52,18 @@ public sealed class SalvageMobRestrictionsSystem : EntitySystem
         {
             if (TryComp(target, out BodyComponent? body))
             {
-                // Just because.
+                // Creates a pool of blood on death, but remove the organs.
                 var gibs = _body.GibBody(target, body: body, gibOrgans: true);
                 foreach (var gib in gibs)
                     Del(gib);
             }
             else
             {
+                // No body, probably a robot - explode it and delete the body
                 _explosion.QueueExplosion(target, ExplosionSystem.DefaultExplosionPrototypeId, 5, 10, 5);
                 Del(target);
             }
+            // Old implementation
             //else if (TryComp(target, out DamageableComponent? dc))
             //{
             //    _damageableSystem.SetAllDamage(target, dc, 200);

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_rogue_ai.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_rogue_ai.yml
@@ -192,6 +192,7 @@
       48: 0.5
   - type: Stamina
     critThreshold: 600
+#  - type: SalvageMobRestrictionsNF
 
 - type: entity
   id: MobRogueSiliconProjectileBatteryAmmo

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_rogue_ai.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_rogue_ai.yml
@@ -192,7 +192,6 @@
       48: 0.5
   - type: Stamina
     critThreshold: 600
-#  - type: SalvageMobRestrictionsNF
 
 - type: entity
   id: MobRogueSiliconProjectileBatteryAmmo


### PR DESCRIPTION
## About the PR
Fix an issue that made some mobs not use the SalvageMobRestrictionsNF

## Why / Balance
Needed to fix silicon bug

## How to test
Spawn in debug
Get a ship
Take silicon expo
Take a silicon back with you to ship
See it explode when you early finish

## Media
N/A

## Breaking changes
N/A

**Changelog**
:cl:
- tweak: Silicon mobs now explode when leaving expeditions.  Make sure to keep them off your ship.
