### PR TITLE
Armor FIxup

### DIFF
--- a/Resources/Changelog/Changelog.yml
+++ b/Resources/Changelog/Changelog.yml
@@ -6485,3 +6485,17 @@ Entries:
       message: Added grenades, a hardsuit and a breaching anchor to pirate uplink.
   id: 5222
   time: '2024-08-24T14:21:30.0000000+00:00'
+- author: Salvantrix
+  changes:
+    - type: Tweak
+      message: >-
+        NFSD time requirements have been increased, with alternate sets
+        available for longtime players.
+    - type: Tweak
+      message: >-
+        Pirates, First Mate and Prisoner now require 3 hours of NFSD gametime,
+        with Pirate Captain needing 3 hours of Sergeant.
+    - type: Tweak
+      message: Station Representative now requires 3 hours of Security Guard playtime.
+  id: 5223
+  time: '2024-08-24T15:00:29.0000000+00:00'

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -53,7 +53,7 @@
         Slash: 0.4
         Piercing: 0.7
         Heat: 0.9
-        Caustic: 0.9
+        Caustic: 0.9 # Frontier
   - type: ExplosionResistance
     damageCoefficient: 0.9
   - type: GroupExamine
@@ -200,16 +200,16 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.70
-        Slash: 0.70
-        Piercing: 0.70
-        Heat: 0.80
+        Blunt: 0.7 # Frontier 0.5<0.7
+        Slash: 0.7 # Frontier 0.5<0.7
+        Piercing: 0.7 # Frontier 0.6<0.7
+        Heat: 0.8 # Frontier 0.5<0.8
         Caustic: 0.9
   - type: ClothingSpeedModifier
     walkModifier: 1.0
     sprintModifier: 1.0
   - type: ExplosionResistance
-    damageCoefficient: 0.90
+    damageCoefficient: 0.9 # Frontier 0.65<0.9
   - type: GroupExamine
 
 - type: entity

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -298,10 +298,10 @@
       coefficients:
         Blunt: 0.8
         Slash: 0.8
-        Piercing: 0.6
-        Heat: 0.5
-        Radiation: 0.5
-        Caustic: 0.6
+        Piercing: 0.7 #Frontier 0.6<0.7
+        Heat: 0.75 #Frontier 0.5<0.75
+        Radiation: 0.5 #Frontier 0.5<0.75
+        Caustic: 0.6 #Frontier 0.6<0.85
   - type: ClothingSpeedModifier
     walkModifier: 0.8
     sprintModifier: 0.8

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -300,8 +300,8 @@
         Slash: 0.8
         Piercing: 0.7 #Frontier 0.6<0.7
         Heat: 0.75 #Frontier 0.5<0.75
-        Radiation: 0.5 #Frontier 0.5<0.75
-        Caustic: 0.6 #Frontier 0.6<0.85
+        Radiation: 0.75 #Frontier 0.5<0.75
+        Caustic: 0.85 #Frontier 0.6<0.85
   - type: ClothingSpeedModifier
     walkModifier: 0.8
     sprintModifier: 0.8


### PR DESCRIPTION
Restore https://github.com/new-frontiers-14/frontier-station-14/pull/459
Removed by mistake since it was missing notes

:cl:
- tweak: The piercing, heat, radiation and caustic armor of the captain's armored spacesuit has been reduced to its old values.