### PR TITLE
Fix signing, undupe signatures in description.

### DIFF
--- a/Content.Server/Paper/PaperSystem.cs
+++ b/Content.Server/Paper/PaperSystem.cs
@@ -101,14 +101,14 @@ namespace Content.Server.Paper
                 if (paperComp.StampedBy.Count > 0)
                 {
                     // BEGIN FRONTIER MODIFICATION - Make stamps and signatures render separately.
-                    // Separate into stamps and signatures.
+                    // Separate into stamps and signatures, display each name/stamp only once.
                     var stamps = paperComp.StampedBy.FindAll(s => s.Type == StampType.RubberStamp);
                     var signatures = paperComp.StampedBy.FindAll(s => s.Type == StampType.Signature);
 
                     // If we have stamps, render them.
                     if (stamps.Count > 0)
                     {
-                        var joined = string.Join(", ", stamps.Select(s => Loc.GetString(s.StampedName)));
+                        var joined = string.Join(", ", stamps.Select(s => Loc.GetString(s.StampedName)).Distinct());
                         args.PushMarkup(
                             Loc.GetString(
                                 "paper-component-examine-detail-stamped-by",
@@ -121,7 +121,7 @@ namespace Content.Server.Paper
                     // Ditto for signatures.
                     if (signatures.Count > 0)
                     {
-                        var joined = string.Join(", ", signatures.Select(s => s.StampedName));
+                        var joined = string.Join(", ", signatures.Select(s => s.StampedName).Distinct());
                         args.PushMarkup(
                             Loc.GetString(
                                 "paper-component-examine-detail-signed-by",
@@ -169,8 +169,10 @@ namespace Content.Server.Paper
             {
                 var stampInfo = GetStampInfo(stampComp); // Frontier: assign DisplayStampInfo before stamp
                 if (_tagSystem.HasTag(args.Used, "Write"))
-                    stampInfo.Type = StampType.Signature;
-                if (TryStamp(uid, stampInfo, stampComp.StampState, paperComp))
+                {
+                    TrySign(uid, args.User, args.Used, paperComp);
+                }
+                else if (TryStamp(uid, stampInfo, stampComp.StampState, paperComp))
                 {
                     // End of Frontier modifications
                     // successfully stamped, play popup

--- a/Resources/Prototypes/Entities/Objects/Misc/pen.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/pen.yml
@@ -19,7 +19,7 @@
     materialComposition:
       Steel: 25
   - type: Stamp # Frontier
-    stampedColor: "#000001" # Frontier
+    stampedColor: "#333333" # Frontier
     stampState: "paper_stamp-nf-signature" # Frontier
     sound: # Frontier
       path: /Audio/Items/Paper/paper_scribble1.ogg # Frontier


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Uses TrySign when using a pen instead of TryStamp, removes duplicate signatures when reading the description for a piece of paper.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Fixes issues with writing "default-component-stamp".  Signature unduplication just for QOL.

## How to test
<!-- Describe the way it can be tested -->

1. Spawn three pieces of paper, a pen, an APPROVED stamp, and a few crayons.
2. Sign the first piece of paper with alt-click.
3. Stamp the second piece of paper first and then click it with the pen to sign it.
4. Sign the third piece of paper with all of the crayons and stamp it with the APPROVED stamp multiple times.
5. Use the first two pieces of paper, they should both be signed with your character's name.
6. Examine the third piece of paper.  It should be signed by your character (listed once), and stamped by the APPROVED stamp (listed once).
7. Open the third piece of paper.  How could you have made such a mess (there should be multiple signatures, one for each crayon, and however many approved stamps you applied up to 10 max)

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

An example sheet of paper that has been signed multiple times with crayons and stamped multiple times.  The description only reads out once.
![image](https://github.com/user-attachments/assets/785b6d83-8839-4baa-b6d8-aea258d4014b)

- [X] ***I have added screenshots/videos to this PR showcasing its changes ingame***, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Using pens should now properly sign your name when used on previously stamped paper.
- add: Paper descriptions now only list each unique signature/stamp.