### PR TITLE
IFF update

### DIFF
--- a/Content.Server/Shuttles/Systems/ShuttleSystem.IFF.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.IFF.cs
@@ -2,6 +2,7 @@ using Content.Server.Shuttles.Components;
 using Content.Shared.Shuttles.BUIStates;
 using Content.Shared.Shuttles.Components;
 using Content.Shared.Shuttles.Events;
+using Content.Shared.Tiles;
 
 namespace Content.Server.Shuttles.Systems;
 
@@ -39,6 +40,9 @@ public sealed partial class ShuttleSystem
         {
             return;
         }
+
+        if (xform.GridUid.HasValue && HasComp<ProtectedGridComponent>(xform.GridUid.Value))
+            return;
 
         if (!args.Show)
         {


### PR DESCRIPTION
_Actually, why was this PR done?_

In the official Corvax Forge community on the Frontier, there was a problem with the fact that not the best people take the IFF console and switch the display of points of interest to it. This is the Syndicate console, so after that it becomes impossible to find these points, which greatly spoils the game for players.

_What does this code do?_

The code checks if the grid has a **"ProtectedGridComponent"**, if it finds it, it does not switch the invisibility flag for the grid. 
Most of the points of interest have this component, so this will protect them from the so-called **"Bad"** players.

Therefore, this small solution should correct this small problem that has arisen.