### PR TITLE
Make plastic more findable and buff recipe

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Crates/salvage.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/salvage.yml
@@ -40,7 +40,7 @@
         prob: 0.1
       - id: IngotSilver
         prob: 0.1
-      - id: SheetPlasma
+      - id: SheetPlastic # Frontier: replaced SheetPlasma
         prob: 0.1
       - id: WelderIndustrialAdvanced
         prob: 0.1

--- a/Resources/Prototypes/Recipes/Reactions/fun.yml
+++ b/Resources/Prototypes/Recipes/Reactions/fun.yml
@@ -106,7 +106,7 @@
       amount: 2
   effects:
     - !type:CreateEntityReactionEffect
-      entity: SheetPlastic1
+      entity: SheetPlastic10 # Frontier: make 10 plastic instead of 1, recipe is pain
 
 - type: reaction
   id: FlashFreezeIce


### PR DESCRIPTION
## About the PR
* Adds plastic to `CrateSalvageAssortedGoodies`, removes one occurrence of plasma.
* Makes the plastic chem recipe produce 10 sheets instead of just 1.

## Why / Balance
This PR is aimed at making plastic more obtainable. It's currently a total crapshoot whether you find plastic on any given wreck, as the only source is a plastic sheet crate. The plastic chem recipe is basically just a meme. As a result, you see people doing shit like this:

![image](https://github.com/user-attachments/assets/ed1ee954-b735-4615-a70b-d3a709b9856c)
Buying dozens of janitorial supplies crates just to deconstruct the box. LRP and lame as hell.

Re `CrateSalvageAssortedGoodies`: The spawn list contained `SheetPlasma` twice. I believe this is a mistake on the part of whoever originally wrote it; one of those is almost certainly meant to be `SheetPlastic`. By making this change, it's now possible to find single stacks of plastic among other random salvage goodies. It also makes plasma less common.

Re the recipe: it requires oil, ash and sulfuric acid. It's a massive pain to make. You can't buy welding fuel, so you have to find it, and then you need to add more stuff to turn it to oil. Ash requires you to burn something – usually paper. Sulfuric acid has many components. Then you make the plastic and get... one sheet. One! To reward people for their efforts, I increased the yield to 10. I feel that 30 would be too much.

Plastic is an essential part of manufacturing all manner of things – not just machine parts, but boards and stuff too. I've played many shifts where everyone's starved for plastic and it kinda sucks.

### Unresolved balance question
A sheet of plastic can be ground down into 5 oil and 5 phosphorous (so random). Since the plastic recipe uses 5 oil, you would actually be able to turn 5 oil into 50 oil with a reagent grinder. Maybe it would be better to change the plastic recipe altogether?

## How to test
1. Spawn a bunch of `CrateSalvageAssortedGoodies` (set its `noSpawn` to false), ensure plastic occurs among the random materials.
2. Make plastic using the chem recipe (heat 5 oil, 3 ash and 2 sulfuric acid) and get a stack of 10 sheets instead of 1
3. Rejoice.

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
No.

**Changelog**
N/A