### PR TITLE
Stellaris (Update): Reclassify as Civilian

### DIFF
--- a/Resources/Prototypes/_NF/Shipyard/stellaris.yml
+++ b/Resources/Prototypes/_NF/Shipyard/stellaris.yml
@@ -8,7 +8,7 @@
   shuttlePath: /Maps/_NF/Shuttles/stellaris.yml
   guidebookPage: Null
   class:
-  - Science
+  - Civilian
 
 - type: gameMap
   id: Stellaris


### PR DESCRIPTION
## About the PR
Reclassify the Stellaris as Civilian, not Science.

## Why / Balance
Sir, this is a ~~Wendy's~~ theatre.

## How to test
1. Filter the shipyard console by "Class: Civilian". There is a Stellaris.
2. Filter the shipyard console by "Class: Science". There is no Stellaris.

## Media
N/A

## Requirements
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
No.

**Changelog**
N/A