### PR TITLE
Ore Processors can now produce Reinforced Glass

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/sheet.yml
+++ b/Resources/Prototypes/Recipes/Lathes/sheet.yml
@@ -33,8 +33,8 @@
   result: SheetRGlass1
   completetime: 0
   materials:
-    Glass: 100
-    Steel: 50
+    RawQuartz: 100
+    RawIron: 50
     Coal: 15
 
 - type: latheRecipe


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Fixes an issue where the ore processor's reinforced glass recipe called for Steel and Glass instead of raw iron and raw quartz.

## Why / Balance
Bug fix.

## How to test
<!-- Describe the way it can be tested -->
- Build an ore processor or its industrial variant
- Load it with iron, quartz, and coal
- Produce reinforced glass
- Incredible

## Media
![image](https://github.com/user-attachments/assets/2399f587-479c-4f73-ab98-5411de774a04)

## Requirements
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Fixed a bug where ore processors could not produce reinforced glass