### PR TITLE
No more free mattress steel

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Furniture/beds.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/beds.yml
@@ -122,6 +122,10 @@
     state: mattress
   - type: Damageable
     damageModifierSet: Inflatable
+  # Frontier: deconstruct into just cloth, no free steel
+  - type: Construction
+    graph: bedNF
+    node: mattress
 
 - type: entity
   parent: Bed

--- a/Resources/Prototypes/Entities/Structures/Furniture/beds.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/beds.yml
@@ -126,6 +126,20 @@
   - type: Construction
     graph: bedNF
     node: mattress
+  # Frontier: break into cloth, not steel.
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 75
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          MaterialCloth1:
+            min: 1
+            max: 2
 
 - type: entity
   parent: Bed


### PR DESCRIPTION
## About the PR
* Update the disgusting dirty mattress to use our own unique construction graph, `bedNF`, with the correct node.
* Update the `Destructible` component so the mattress breaks into 1–2 cloth, not 1–2 steel.

## Why / Balance
On upstream, mattresses can be neither constructed nor deconstructed. They're also not encountered often. Here on Frontier, we have our own construction graph for mattresses, which requires 2 cloth per mattress. If we don't override the mattress construction graph to `bedNF`, then it can be deconstructed into 2 cloth + 1 steel, same as a bed. The 2 cloth can be used to make another mattress, and now you have an infinite steel glitch.

Similarly, the destruction trigger is updated to match the actual material cost of the mattress.

With the arrival of the McHobo, with its 4 million mattresses, this could be abused to farm steel. Hopefully no one _actually_ does this, unless they _really_ want a ban for exploiting a bug.

## How to test
1. Spawn a mattress and a screwdriver. Apply screwdriver to mattress. Behold 2 cloth.
2. Use the cloth to make another mattress. Screwdriver that too. Still just 2 cloth.
3. Beat the crap out of a mattress until it gets destroyed. 1–2 cloth should spawn and no steel.

## Media
https://github.com/user-attachments/assets/a1b19164-0dcb-40da-8482-a3c38dd5b595

## Requirements
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
Might break someone's exploit meta, but should have no other effects.

**Changelog**
:cl:
- fix: Mattresses now break into just cloth, no more steel.