### PR TITLE
Cargo and NSFD PDAs now include price or contraband appraisal functionality. These and a few medical-descended PDAs also now have more complete descriptions.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -344,7 +344,7 @@
   name: quartermaster PDA
   parent: BasePDA
   id: QuartermasterPDA
-  description: PDA for the guy that orders the guns.
+  description: PDA for the guy that orders the guns. Has a built in appraisal tool. # Frontier
   components:
   - type: Pda
     id: QuartermasterIDCard
@@ -354,12 +354,16 @@
     accentVColor: "#a23e3e"
   - type: Icon
     state: pda-qm
+# Frontier
+  - type: PriceGun
+  - type: UseDelay
+    delay: 3
 
 - type: entity
   parent: BasePDA
   id: CargoPDA
   name: cargo PDA
-  description: PDA for the guys that order the pizzas.
+  description: PDA for the guys that order the pizzas. Has a built in appraisal tool. # Frontier
   components:
   - type: Pda
     id: CargoIDCard
@@ -368,6 +372,10 @@
     borderColor: "#e39751"
   - type: Icon
     state: pda-cargo
+# Frontier
+  - type: PriceGun
+  - type: UseDelay
+    delay: 3
 
 - type: entity
   parent: BasePDA
@@ -576,7 +584,7 @@
   parent: BaseMedicalPDA
   id: ChemistryPDA
   name: chemistry PDA
-  description: It has a few discolored blotches here and there.
+  description: It has a few discolored blotches here and there. has a built-in health analyzer. # Frontier
   components:
   - type: Pda
     id: ChemistIDCard

--- a/Resources/Prototypes/_NF/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Devices/pda.yml
@@ -96,7 +96,7 @@
   parent: SecurityPDA
   id: SecurityGuardPDA
   name: security guard PDA
-  description: Red to hide the stains of passenger blood.
+  description: Red to hide the stains of passenger blood. Has a built in contraband appraisal tool.
   components:
   - type: Pda
     id: SecurityGuardIDCard
@@ -105,6 +105,9 @@
     borderColor: "#A32D26"
   - type: Icon
     state: pda-security
+  - type: ContrabandPriceGun
+  - type: UseDelay
+    delay: 1
 
 - type: entity
   parent: ERTLeaderPDA
@@ -124,7 +127,7 @@
   parent: BasePDA
   id: SheriffPDA
   name: sheriff PDA
-  description: Whosoever bears this PDA is the law.
+  description: Whosoever bears this PDA is the law. Has a built in contraband appraisal tool.
   components:
   - type: Pda
     id: ShriffIDCard
@@ -154,12 +157,15 @@
   - type: Icon
     sprite: _NF/Objects/Devices/pda.rsi
     state: pda-sheriff
+  - type: ContrabandPriceGun
+  - type: UseDelay
+    delay: 1
 
 - type: entity
   parent: BasePDA
   id: CadetPDA
   name: cadet PDA
-  description: Whosoever bears this PDA could be the law.
+  description: Whosoever bears this PDA could be the law. Has a built in contraband appraisal tool.
   components:
   - type: Pda
     id: CadetIDCard
@@ -189,12 +195,15 @@
   - type: Icon
     sprite: _NF/Objects/Devices/pda.rsi
     state: pda-cadet
+  - type: ContrabandPriceGun
+  - type: UseDelay
+    delay: 1
 
 - type: entity
   parent: BasePDA
   id: DeputyPDA
   name: deputy PDA
-  description: Whosoever bears this PDA is close to being the law.
+  description: Whosoever bears this PDA is close to being the law. Has a built in contraband appraisal tool.
   components:
   - type: Pda
     id: DeputyIDCard
@@ -224,12 +233,15 @@
   - type: Icon
     sprite: _NF/Objects/Devices/pda.rsi
     state: pda-deputy
+  - type: ContrabandPriceGun
+  - type: UseDelay
+    delay: 1
 
 - type: entity
   parent: BaseMedicalPDA
   id: BrigmedicNFPDA
   name: brigmedic PDA
-  description: Whosoever bears this PDA heals the law.
+  description: Whosoever bears this PDA heals the law. Has a built-in health analyzer.
   components:
   - type: Pda
     id: BrigmedicNFIDCard
@@ -264,7 +276,7 @@
   parent: BasePDA
   id: SergeantPDA
   name: sergeant PDA
-  description: Whosoever bears this PDA puts the law on their back.
+  description: Whosoever bears this PDA puts the law on their back. Has a built in contraband appraisal tool.
   components:
   - type: Pda
     id: SergeantIDCard
@@ -294,12 +306,15 @@
   - type: Icon
     sprite: _NF/Objects/Devices/pda.rsi
     state: pda-sergeant
+  - type: ContrabandPriceGun
+  - type: UseDelay
+    delay: 1
 
 - type: entity
   parent: BasePDA
   id: BailiffPDA
   name: bailiff PDA
-  description: Whosoever bears this PDA puts the law on their back.
+  description: Whosoever bears this PDA puts the law on their back. Has a built in contraband appraisal tool.
   components:
   - type: Pda
     id: BailiffIDCard
@@ -329,12 +344,15 @@
   - type: Icon
     sprite: _NF/Objects/Devices/pda.rsi
     state: pda-bailiff
+  - type: ContrabandPriceGun
+  - type: UseDelay
+    delay: 1
 
 - type: entity
   parent: BasePDA
   id: DetectiveNFPDA
   name: detective PDA
-  description: Smells like rain... pouring down the rooftops...
+  description: Smells like rain... pouring down the rooftops... Has a built in contraband appraisal tool.
   components:
   - type: Pda
     id: DetectiveNFIDCard
@@ -363,6 +381,9 @@
   - type: Icon
     sprite: _NF/Objects/Devices/pda.rsi
     state: pda-detectivenf
+  - type: ContrabandPriceGun
+  - type: UseDelay
+    delay: 1
 
 - type: entity
   parent: BasePDA


### PR DESCRIPTION
## About the PR
This PR grabs some low hanging fruit in terms of adding to PDA functionality to give people more choices in their loadouts, and adds to descriptions of a few existing PDAs to make it clear they have extra functions. Specifically, it adds price gun functionality to cargo-related PDAs, and contraband appraisal functionality to NSFD/security related PDAs. It also adds a hint about health analyzer functionality to a few medical PDA descendants that didn't have that.

## Why / Balance
Right now with very few exceptions a medical PDA is the obvious best choice for loadouts, and most of the alternatives have little to no additional functionality.

## How to test
Spawn each PDA on the sandbox map, check its description, and verify each does what it should as far as as extended functionality.

## Media
![test1](https://github.com/user-attachments/assets/924de451-261e-4239-b990-e4d69e9aa34c)
![test2](https://github.com/user-attachments/assets/3c797aec-6634-453e-86a3-455b4eb4af7b)


## Requirements
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
Minor conflicts with upstream PDA definitions, noted with '# Frontier' comments.

**Changelog**
:cl:
- tweak: Added appraisal functionality to cargo and NSFD PDAs. Updated descriptions of a few medical PDAs to indicate inclusion of a health analyzer.