### PR TITLE
Pen signing: Undupe messages, sound

### DIFF
--- a/Content.Shared/Paper/PaperSystem.cs
+++ b/Content.Shared/Paper/PaperSystem.cs
@@ -12,7 +12,6 @@ using static Content.Shared.Paper.PaperComponent;
 using Content.Shared.Timing; // Frontier
 using Content.Shared.Access.Systems; // Frontier
 using Content.Shared.Verbs; // Frontier
-using Content.Shared.Crayon; // Frontier
 using Content.Shared.Ghost; // Frontier
 
 namespace Content.Shared.Paper;
@@ -327,7 +326,7 @@ public sealed class PaperSystem : EntitySystem
                 true
             );
 
-            _popupSystem.PopupEntity(
+            _popupSystem.PopupClient(
                 Loc.GetString(
                     "paper-component-action-signed-self",
                     ("target", paper.Owner)
@@ -336,7 +335,7 @@ public sealed class PaperSystem : EntitySystem
                 signer
             );
 
-            _audio.PlayPvs(paper.Comp.Sound, paper);
+            _audio.PlayPredicted(paper.Comp.Sound, paper, signer);
 
             _adminLogger.Add(LogType.Verb, LogImpact.Low,
                 $"{ToPrettyString(signer):player} has signed {ToPrettyString(paper):paper}.");


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Gets the pen to display "You sign the paper" once, and play the sound once, when signing a piece of paper.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Annoying, buggy, inconsistent with stamp.

## How to test
<!-- Describe the way it can be tested -->

1. Sign paper.  Message should appear once, sound should play once.
2. Bonus points: connect with another client.  Sign on first client.  On the second client, message should appear once, sound should play once.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->

https://github.com/user-attachments/assets/a6b21d59-4b27-4db8-94f2-668f8c2ca79b

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Signing a piece of paper no longer duplicates audio and popup messages.