### PR TITLE
Allow some mobs to not despawn with events

### DIFF
--- a/Content.Server/Salvage/SalvageSystem.ExpeditionConsole.cs
+++ b/Content.Server/Salvage/SalvageSystem.ExpeditionConsole.cs
@@ -139,7 +139,7 @@ public sealed partial class SalvageSystem
                 continue;
 
             // NPC, definitely not a person
-            if (HasComp<ActiveNPCComponent>(uid) || HasComp<SalvageMobRestrictionsNFComponent>(uid))
+            if (HasComp<ActiveNPCComponent>(uid) || HasComp<NFSalvageMobRestrictionsComponent>(uid))
                 continue;
 
             // Hostile ghost role, continue

--- a/Content.Server/StationEvents/Events/BluespaceErrorRule.cs
+++ b/Content.Server/StationEvents/Events/BluespaceErrorRule.cs
@@ -77,11 +77,19 @@ public sealed class BluespaceErrorRule : StationEventSystem<BluespaceErrorRuleCo
         var gridValue = _pricing.AppraiseGrid(gridUid, null);
 
         // Handle mobrestrictions getting deleted
-        var query = AllEntityQuery<SalvageMobRestrictionsNFComponent>();
+        var query = AllEntityQuery<NFSalvageMobRestrictionsComponent>();
 
         while (query.MoveNext(out var salvUid, out var salvMob))
         {
-            if (gridTransform.GridUid == salvMob.LinkedGridEntity)
+            if (!salvMob.DespawnIfOffEventGrid)
+            {
+                var transform = Transform(salvUid);
+                if (transform.GridUid != salvMob.LinkedGridEntity)
+                {
+                    RemComp<NFSalvageMobRestrictionsComponent>(salvUid);
+                }
+            }
+            else if (gridTransform.GridUid == salvMob.LinkedGridEntity)
             {
                 QueueDel(salvUid);
             }

--- a/Content.Server/StationEvents/Events/BluespaceErrorRule.cs
+++ b/Content.Server/StationEvents/Events/BluespaceErrorRule.cs
@@ -81,7 +81,7 @@ public sealed class BluespaceErrorRule : StationEventSystem<BluespaceErrorRuleCo
 
         while (query.MoveNext(out var salvUid, out var salvMob))
         {
-            if (!salvMob.DespawnIfOffEventGrid)
+            if (!salvMob.DespawnIfOffLinkedGrid)
             {
                 var transform = Transform(salvUid);
                 if (transform.GridUid != salvMob.LinkedGridEntity)

--- a/Content.Server/StationEvents/Events/BluespaceErrorRule.cs
+++ b/Content.Server/StationEvents/Events/BluespaceErrorRule.cs
@@ -87,9 +87,11 @@ public sealed class BluespaceErrorRule : StationEventSystem<BluespaceErrorRuleCo
                 if (transform.GridUid != salvMob.LinkedGridEntity)
                 {
                     RemComp<NFSalvageMobRestrictionsComponent>(salvUid);
+                    continue;
                 }
             }
-            else if (gridTransform.GridUid == salvMob.LinkedGridEntity)
+
+            if (gridTransform.GridUid == salvMob.LinkedGridEntity)
             {
                 QueueDel(salvUid);
             }

--- a/Content.Server/Worldgen/Systems/LocalityLoaderSystem.cs
+++ b/Content.Server/Worldgen/Systems/LocalityLoaderSystem.cs
@@ -81,7 +81,7 @@ public sealed class LocalityLoaderSystem : BaseWorldSystem
         if (entity != null)
         {
             // Handle mobrestrictions getting deleted
-            var query = AllEntityQuery<SalvageMobRestrictionsNFComponent>();
+            var query = AllEntityQuery<NFSalvageMobRestrictionsComponent>();
 
             while (query.MoveNext(out var salvUid, out var salvMob))
             {

--- a/Content.Server/_NF/Salvage/NFSalvageMobRestrictionsComponent.cs
+++ b/Content.Server/_NF/Salvage/NFSalvageMobRestrictionsComponent.cs
@@ -1,9 +1,3 @@
-using Robust.Shared.GameObjects;
-using Robust.Shared.Maths;
-using Robust.Shared.Serialization.Manager.Attributes;
-using Robust.Shared.ViewVariables;
-using System;
-
 namespace Content.Server._NF.Salvage;
 
 /// <summary>
@@ -19,6 +13,10 @@ public sealed partial class NFSalvageMobRestrictionsComponent : Component
     [DataField, ViewVariables(VVAccess.ReadOnly)]
     public EntityUid LinkedGridEntity = EntityUid.Invalid;
 
+    /// <summary>
+    /// If set to false, this mob will not be despawned when its linked entity is despawned.
+    /// Useful for event ghost roles, for instance.
+    /// </summary>
     [DataField]
-    public bool DespawnIfOffEventGrid = true;
+    public bool DespawnIfOffLinkedGrid = true;
 }

--- a/Content.Server/_NF/Salvage/NFSalvageMobRestrictionsComponent.cs
+++ b/Content.Server/_NF/Salvage/NFSalvageMobRestrictionsComponent.cs
@@ -14,9 +14,11 @@ namespace Content.Server._NF.Salvage;
 ///     whatever it's currently parented to.
 /// </summary>
 [RegisterComponent]
-public sealed partial class SalvageMobRestrictionsNFComponent : Component
+public sealed partial class NFSalvageMobRestrictionsComponent : Component
 {
-    [ViewVariables(VVAccess.ReadOnly)]
-    [DataField("linkedGridEntity")]
+    [DataField, ViewVariables(VVAccess.ReadOnly)]
     public EntityUid LinkedGridEntity = EntityUid.Invalid;
+
+    [DataField]
+    public bool DespawnIfOffEventGrid = true;
 }

--- a/Content.Server/_NF/Salvage/SalvageMobRestrictionsSystem.cs
+++ b/Content.Server/_NF/Salvage/SalvageMobRestrictionsSystem.cs
@@ -15,12 +15,12 @@ public sealed class SalvageMobRestrictionsSystem : EntitySystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<SalvageMobRestrictionsNFComponent, ComponentInit>(OnInit);
-        SubscribeLocalEvent<SalvageMobRestrictionsNFComponent, ComponentRemove>(OnRemove);
+        SubscribeLocalEvent<NFSalvageMobRestrictionsComponent, ComponentInit>(OnInit);
+        SubscribeLocalEvent<NFSalvageMobRestrictionsComponent, ComponentRemove>(OnRemove);
         SubscribeLocalEvent<SalvageMobRestrictionsGridComponent, ComponentRemove>(OnRemoveGrid);
     }
 
-    private void OnInit(EntityUid uid, SalvageMobRestrictionsNFComponent component, ComponentInit args)
+    private void OnInit(EntityUid uid, NFSalvageMobRestrictionsComponent component, ComponentInit args)
     {
         var gridUid = Transform(uid).ParentUid;
         if (!EntityManager.EntityExists(gridUid))
@@ -38,7 +38,7 @@ public sealed class SalvageMobRestrictionsSystem : EntitySystem
         component.LinkedGridEntity = gridUid;
     }
 
-    private void OnRemove(EntityUid uid, SalvageMobRestrictionsNFComponent component, ComponentRemove args)
+    private void OnRemove(EntityUid uid, NFSalvageMobRestrictionsComponent component, ComponentRemove args)
     {
         if (TryComp(component.LinkedGridEntity, out SalvageMobRestrictionsGridComponent? rg))
         {

--- a/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
@@ -149,7 +149,7 @@
   parent: MobCarp
   suffix: "Salvage Ruleset"
   components:
-    - type: SalvageMobRestrictionsNF
+    - type: NFSalvageMobRestrictions # Frontier
 
 - type: entity
   name: space carp
@@ -238,4 +238,4 @@
   parent: MobShark
   suffix: "Salvage Ruleset"
   components:
-    - type: SalvageMobRestrictionsNF
+    - type: NFSalvageMobRestrictions

--- a/Resources/Prototypes/Entities/Mobs/NPCs/flesh.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/flesh.yml
@@ -252,7 +252,7 @@
         Slash: 6
   - type: ReplacementAccent
     accent: genericAggressive
-  - type: SalvageMobRestrictionsNF
+  - type: NFSalvageMobRestrictions # Frontier
 
 - type: entity
   parent: BaseMobFleshSalvage

--- a/Resources/Prototypes/Entities/Mobs/NPCs/space.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/space.yml
@@ -116,7 +116,7 @@
   parent: MobBearSpace
   suffix: "Salvage Ruleset"
   components:
-  - type: SalvageMobRestrictionsNF
+  - type: NFSalvageMobRestrictions # Frontier
 
 - type: entity
   name: space kangaroo
@@ -173,7 +173,7 @@
   parent: MobKangarooSpace
   suffix: "Salvage Ruleset"
   components:
-  - type: SalvageMobRestrictionsNF
+  - type: NFSalvageMobRestrictions # Frontier
 
 - type: entity
   name: space spider
@@ -271,7 +271,7 @@
   parent: MobSpiderSpace
   suffix: "Salvage Ruleset"
   components:
-  - type: SalvageMobRestrictionsNF
+  - type: NFSalvageMobRestrictions
 
 - type: entity
   name: space cobra
@@ -368,4 +368,4 @@
   parent: MobCobraSpace
   suffix: "Salvage Ruleset"
   components:
-    - type: SalvageMobRestrictionsNF
+    - type: NFSalvageMobRestrictions

--- a/Resources/Prototypes/Entities/Mobs/NPCs/spacetick.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/spacetick.yml
@@ -85,5 +85,5 @@
   parent: MobTick
   suffix: "Salvage Ruleset"
   components:
-  - type: SalvageMobRestrictionsNF
+  - type: NFSalvageMobRestrictions # Frontier
 

--- a/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
@@ -120,7 +120,7 @@
     molsPerSecondPerUnitMass: 0.0005
   - type: Speech
     speechVerb: LargeMob
-  - type: SalvageMobRestrictionsNF # Frontier
+  - type: NFSalvageMobRestrictions # Frontier
   - type: ReplacementAccent # Frontier
     accent: genericAggressive # Frontier
 
@@ -430,7 +430,7 @@
     tags:
     - DoorBumpOpener
     - FootstepSound
-  - type: SalvageMobRestrictionsNF # Frontier
+  - type: NFSalvageMobRestrictions # Frontier
   - type: ReplacementAccent # Frontier
     accent: genericAggressive # Frontier
 

--- a/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
@@ -217,7 +217,7 @@
   - type: ActionGun #Frontier
     action: ActionDragonsBreath #Frontier
     gunProto: DragonsBreathGun #Frontier
-  - type: SalvageMobRestrictionsNF # Frontier
+  - type: NFSalvageMobRestrictions # Frontier
 
 - type: entity
   id: ActionSpawnRift

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/corpses.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/corpses.yml
@@ -12,7 +12,7 @@
     factions:
     - SimpleHostile
   - type: Carriable # Carrying system from nyanotrasen.
-  #- type: SalvageMobRestrictionsNF
+  #- type: NFSalvageMobRestrictions
   - type: Butcherable
     butcheringType: Spike
     spawned:

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/elemental.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/elemental.yml
@@ -145,7 +145,7 @@
     factions:
     - SimpleHostile # Because AI stupid ass hell right now
   - type: MovementIgnoreGravity # Or they just can't do something
-  - type: SalvageMobRestrictionsNF
+  - type: NFSalvageMobRestrictions
 
 - type: entity
   parent: MobOreCrabNF
@@ -390,7 +390,7 @@
   - type: Damageable
     damageContainer: StructuralInorganic
   - type: MovementIgnoreGravity # Or they just can't do something
-  - type: SalvageMobRestrictionsNF
+  - type: NFSalvageMobRestrictions
   - type: Appearance # Next three components make the mob fall over when dead
   - type: StandingState
   - type: RotationVisuals

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_base.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_base.yml
@@ -227,7 +227,7 @@
     minimumWait: 120 # 1 * 2
     maximumWait: 240 # 2 * 60
     nextAdvertisementTime: 0
-  - type: SalvageMobRestrictionsNF
+  - type: NFSalvageMobRestrictions
   - type: FTLKnockdownImmune
   - type: Respirator
     updateInterval: 99999 # Shouldn't run often, if ever.
@@ -304,7 +304,7 @@
   - type: MobPrice
     price: 1500
     deathPenalty: 0.5
-  - type: SalvageMobRestrictionsNF
+  - type: NFSalvageMobRestrictions
   - type: Tag
     tags:
     - CanPilot

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_expeditions_xeno.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_expeditions_xeno.yml
@@ -284,7 +284,7 @@
   - type: Tag
     tags:
     - CannotSuicide
-  - type: SalvageMobRestrictionsNF
+  - type: NFSalvageMobRestrictions
   - type: ReplacementAccent
     accent: xeno
   - type: GhostRole


### PR DESCRIPTION
## About the PR
Edit to the grid-tied salvage spawns.

## Why / Balance
Allow us to keep some event mobs without deleting them if they moved off grid.

## How to test
Spawn event with mobs
Give one of the mobs the "DespawnIfOffEventGrid" ``false``
Move it off grid, it will not despawn on event end

## Media
N/A

## Requirements
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
N/A

**Changelog**
N/A
