### PR TITLE
Ceres (Update): Directional fans + other goodies

### DIFF
--- a/Resources/Maps/_NF/Shuttles/ceres.yml
+++ b/Resources/Maps/_NF/Shuttles/ceres.yml
@@ -51,7 +51,7 @@ entities:
           version: 6
         -1,-2:
           ind: -1,-2
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALgAAAAADfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAALgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALgAAAAADfQAAAAAAIwAAAAAAIwAAAAABIwAAAAADIgAAAAAAfQAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAIwAAAAADHgAAAAABHgAAAAADHgAAAAACIgAAAAAAfQAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAIwAAAAABHgAAAAABfQAAAAAAZwAAAAABfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAIwAAAAAAHgAAAAACZwAAAAABXgAAAAADXgAAAAABXgAAAAACXgAAAAACXgAAAAADXgAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALgAAAAACfQAAAAAAfQAAAAAAfQAAAAAAXgAAAAAAXgAAAAADXgAAAAABXgAAAAAAXgAAAAABXgAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAfQAAAAAAXgAAAAADXgAAAAADXgAAAAACXgAAAAACXgAAAAADXgAAAAACXgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAXgAAAAABXgAAAAACXgAAAAAAXgAAAAAAXgAAAAACXgAAAAABXgAAAAAC
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALgAAAAADIwAAAAAAfQAAAAAAIwAAAAAAfQAAAAAALgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALgAAAAADfQAAAAAAIwAAAAAAIwAAAAABIwAAAAADIgAAAAAAfQAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIwAAAAAAIwAAAAADHgAAAAABHgAAAAADHgAAAAACIgAAAAAAfQAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAIwAAAAABHgAAAAABfQAAAAAAZwAAAAABfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIwAAAAAAIwAAAAAAHgAAAAACZwAAAAABXgAAAAADXgAAAAABXgAAAAACXgAAAAACXgAAAAADXgAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALgAAAAACfQAAAAAAfQAAAAAAfQAAAAAAXgAAAAAAXgAAAAADXgAAAAABXgAAAAAAXgAAAAABXgAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAfQAAAAAAXgAAAAADXgAAAAADXgAAAAACXgAAAAACXgAAAAADXgAAAAACXgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAXgAAAAABXgAAAAACXgAAAAAAXgAAAAAAXgAAAAACXgAAAAABXgAAAAAC
           version: 6
         0,-2:
           ind: 0,-2
@@ -474,6 +474,18 @@ entities:
             155: -3,-12
             156: -3,-11
         - node:
+            color: '#FFFF00BF'
+            id: WarnLineGreyscaleS
+          decals:
+            167: -8,-24
+            168: -6,-24
+        - node:
+            color: '#FFFF00BF'
+            id: WarnLineGreyscaleW
+          decals:
+            169: -10,-22
+            170: -10,-20
+        - node:
             color: '#FFFFFFFF'
             id: WarnLineN
           decals:
@@ -787,7 +799,7 @@ entities:
       parent: 2
 - proto: AirlockFreezer
   entities:
-  - uid: 694
+  - uid: 622
     components:
     - type: Transform
       pos: 7.5,-19.5
@@ -811,27 +823,27 @@ entities:
       parent: 2
 - proto: AirlockGlassShuttle
   entities:
-  - uid: 107
-    components:
-    - type: Transform
-      pos: -7.5,-23.5
-      parent: 2
-  - uid: 109
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -9.5,-21.5
-      parent: 2
-  - uid: 586
+  - uid: 94
     components:
     - type: Transform
       pos: -5.5,-23.5
       parent: 2
-  - uid: 750
+  - uid: 107
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -9.5,-19.5
+      parent: 2
+  - uid: 109
+    components:
+    - type: Transform
+      pos: -7.5,-23.5
+      parent: 2
+  - uid: 387
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,-21.5
       parent: 2
 - proto: APCBasic
   entities:
@@ -846,32 +858,35 @@ entities:
       rot: 3.141592653589793 rad
       pos: 1.5,-12.5
       parent: 2
-- proto: AtmosDeviceFanTiny
+- proto: AtmosDeviceFanDirectional
   entities:
-  - uid: 587
+  - uid: 88
     components:
     - type: Transform
-      pos: -5.5,-23.5
+      rot: 1.5707963267948966 rad
+      pos: 7.5,-19.5
       parent: 2
-  - uid: 668
+  - uid: 493
     components:
     - type: Transform
       pos: -7.5,-23.5
       parent: 2
-  - uid: 695
+  - uid: 586
     components:
     - type: Transform
-      pos: -9.5,-21.5
+      pos: -5.5,-23.5
       parent: 2
-  - uid: 726
+  - uid: 587
     components:
     - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -9.5,-19.5
       parent: 2
-  - uid: 831
+  - uid: 621
     components:
     - type: Transform
-      pos: 7.5,-19.5
+      rot: -1.5707963267948966 rad
+      pos: -9.5,-21.5
       parent: 2
 - proto: AtmosFixBlockerMarker
   entities:
@@ -1102,67 +1117,67 @@ entities:
       parent: 2
 - proto: AtmosFixFreezerMarker
   entities:
-  - uid: 803
+  - uid: 805
     components:
     - type: Transform
       pos: 5.5,-22.5
       parent: 2
-  - uid: 805
+  - uid: 818
     components:
     - type: Transform
       pos: 5.5,-21.5
       parent: 2
-  - uid: 818
+  - uid: 821
     components:
     - type: Transform
       pos: 6.5,-22.5
       parent: 2
-  - uid: 821
+  - uid: 822
     components:
     - type: Transform
       pos: 6.5,-21.5
       parent: 2
-  - uid: 822
+  - uid: 823
     components:
     - type: Transform
       pos: 7.5,-22.5
       parent: 2
-  - uid: 823
+  - uid: 824
     components:
     - type: Transform
       pos: 7.5,-21.5
       parent: 2
-  - uid: 824
+  - uid: 825
     components:
     - type: Transform
       pos: 8.5,-22.5
       parent: 2
-  - uid: 825
+  - uid: 826
     components:
     - type: Transform
       pos: 8.5,-21.5
       parent: 2
-  - uid: 826
+  - uid: 827
     components:
     - type: Transform
       pos: 9.5,-21.5
       parent: 2
-  - uid: 827
+  - uid: 828
     components:
     - type: Transform
       pos: 9.5,-20.5
       parent: 2
-  - uid: 828
+  - uid: 829
     components:
     - type: Transform
       pos: 8.5,-20.5
       parent: 2
-  - uid: 829
+  - uid: 830
     components:
     - type: Transform
       pos: 8.5,-19.5
       parent: 2
-  - uid: 830
+  - uid: 831
     components:
     - type: Transform
       pos: 9.5,-19.5
@@ -2231,22 +2246,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-13.5
-      parent: 2
-- proto: DisposalUnit
-  entities:
-  - uid: 621
-    components:
-    - type: MetaData
-      name: transport to botany
-    - type: Transform
-      pos: 4.5,-13.5
-      parent: 2
-  - uid: 622
-    components:
-    - type: MetaData
-      name: transport to kitchen
-    - type: Transform
-      pos: 1.5,-6.5
       parent: 2
 - proto: DrinkShaker
   entities:
@@ -3823,6 +3822,39 @@ entities:
     - type: Transform
       pos: 9.5,-19.5
       parent: 2
+- proto: LockerWallEVAColorServiceWorkerFilled
+  entities:
+  - uid: 750
+    components:
+    - type: Transform
+      pos: 2.5,-9.5
+      parent: 2
+- proto: LockerWallMaterialsBasicFilled
+  entities:
+  - uid: 803
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-12.5
+      parent: 2
+- proto: MailingUnit
+  entities:
+  - uid: 668
+    components:
+    - type: Transform
+      pos: 1.5,-6.5
+      parent: 2
+    - type: MailingUnit
+      tag: botany
+      target: kitchen
+  - uid: 694
+    components:
+    - type: Transform
+      pos: 4.5,-13.5
+      parent: 2
+    - type: MailingUnit
+      tag: kitchen
+      target: botany
 - proto: MopBucket
   entities:
   - uid: 185
@@ -4176,27 +4208,6 @@ entities:
     - type: Transform
       pos: 7.5,-12.5
       parent: 2
-- proto: SheetGlass
-  entities:
-  - uid: 820
-    components:
-    - type: Transform
-      pos: 7.63264,-13.474377
-      parent: 2
-- proto: SheetPlastic
-  entities:
-  - uid: 817
-    components:
-    - type: Transform
-      pos: 7.3556504,-13.585793
-      parent: 2
-- proto: SheetSteel
-  entities:
-  - uid: 819
-    components:
-    - type: Transform
-      pos: 7.38264,-13.422256
-      parent: 2
 - proto: SheetUranium
   entities:
   - uid: 205
@@ -4219,270 +4230,174 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -3.5,-3.5
       parent: 2
-    - type: DeviceLinkSink
-      links:
-      - 814
   - uid: 294
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-4.5
       parent: 2
-    - type: DeviceLinkSink
-      links:
-      - 814
   - uid: 295
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-4.5
       parent: 2
-    - type: DeviceLinkSink
-      links:
-      - 814
   - uid: 296
     components:
     - type: Transform
       pos: 1.5,0.5
       parent: 2
-    - type: DeviceLinkSink
-      links:
-      - 814
   - uid: 311
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-2.5
       parent: 2
-    - type: DeviceLinkSink
-      links:
-      - 814
   - uid: 312
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-3.5
       parent: 2
-    - type: DeviceLinkSink
-      links:
-      - 814
   - uid: 360
     components:
     - type: Transform
       pos: -0.5,0.5
       parent: 2
-    - type: DeviceLinkSink
-      links:
-      - 814
   - uid: 361
     components:
     - type: Transform
       pos: 0.5,0.5
       parent: 2
-    - type: DeviceLinkSink
-      links:
-      - 814
   - uid: 413
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-2.5
       parent: 2
-    - type: DeviceLinkSink
-      links:
-      - 814
   - uid: 540
     components:
     - type: Transform
       pos: 7.5,-23.5
       parent: 2
-    - type: DeviceLinkSink
-      links:
-      - 812
   - uid: 639
     components:
     - type: Transform
       pos: 6.5,-23.5
       parent: 2
-    - type: DeviceLinkSink
-      links:
-      - 812
   - uid: 652
     components:
     - type: Transform
       pos: -6.5,-23.5
       parent: 2
-    - type: DeviceLinkSink
-      links:
-      - 816
   - uid: 653
     components:
     - type: Transform
       pos: 8.5,-23.5
       parent: 2
-    - type: DeviceLinkSink
-      links:
-      - 812
   - uid: 659
     components:
     - type: Transform
       pos: -8.5,-18.5
       parent: 2
-    - type: DeviceLinkSink
-      links:
-      - 816
   - uid: 663
     components:
     - type: Transform
       pos: -7.5,-23.5
       parent: 2
-    - type: DeviceLinkSink
-      links:
-      - 816
   - uid: 690
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 10.5,-20.5
       parent: 2
-    - type: DeviceLinkSink
-      links:
-      - 812
   - uid: 720
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,-8.5
       parent: 2
-    - type: DeviceLinkSink
-      links:
-      - 811
   - uid: 721
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,-9.5
       parent: 2
-    - type: DeviceLinkSink
-      links:
-      - 811
   - uid: 722
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,-10.5
       parent: 2
-    - type: DeviceLinkSink
-      links:
-      - 811
   - uid: 723
     components:
     - type: Transform
       pos: -7.5,-6.5
       parent: 2
-    - type: DeviceLinkSink
-      links:
-      - 811
   - uid: 724
     components:
     - type: Transform
       pos: -6.5,-6.5
       parent: 2
-    - type: DeviceLinkSink
-      links:
-      - 811
   - uid: 731
     components:
     - type: Transform
       pos: 7.5,-6.5
       parent: 2
-    - type: DeviceLinkSink
-      links:
-      - 815
   - uid: 732
     components:
     - type: Transform
       pos: 8.5,-6.5
       parent: 2
-    - type: DeviceLinkSink
-      links:
-      - 815
   - uid: 733
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,-7.5
       parent: 2
-    - type: DeviceLinkSink
-      links:
-      - 815
   - uid: 734
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,-8.5
       parent: 2
-    - type: DeviceLinkSink
-      links:
-      - 815
   - uid: 735
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,-9.5
       parent: 2
-    - type: DeviceLinkSink
-      links:
-      - 815
   - uid: 737
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 10.5,-21.5
       parent: 2
-    - type: DeviceLinkSink
-      links:
-      - 812
   - uid: 753
     components:
     - type: Transform
       pos: -9.5,-20.5
       parent: 2
-    - type: DeviceLinkSink
-      links:
-      - 816
   - uid: 758
     components:
     - type: Transform
       pos: -5.5,-23.5
       parent: 2
-    - type: DeviceLinkSink
-      links:
-      - 816
   - uid: 759
     components:
     - type: Transform
       pos: -9.5,-21.5
       parent: 2
-    - type: DeviceLinkSink
-      links:
-      - 816
   - uid: 760
     components:
     - type: Transform
       pos: -9.5,-19.5
       parent: 2
-    - type: DeviceLinkSink
-      links:
-      - 816
   - uid: 762
     components:
     - type: Transform
       pos: -3.5,-22.5
       parent: 2
-    - type: DeviceLinkSink
-      links:
-      - 816
 - proto: ShuttersRadiationOpen
   entities:
   - uid: 460
@@ -4490,17 +4405,11 @@ entities:
     - type: Transform
       pos: -2.5,-11.5
       parent: 2
-    - type: DeviceLinkSink
-      links:
-      - 245
   - uid: 513
     components:
     - type: Transform
       pos: -2.5,-10.5
       parent: 2
-    - type: DeviceLinkSink
-      links:
-      - 245
 - proto: ShuttersWindowOpen
   entities:
   - uid: 313
@@ -4509,34 +4418,22 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 1.5,-16.5
       parent: 2
-    - type: DeviceLinkSink
-      links:
-      - 655
   - uid: 385
     components:
     - type: Transform
       pos: -0.5,-15.5
       parent: 2
-    - type: DeviceLinkSink
-      links:
-      - 810
   - uid: 386
     components:
     - type: Transform
       pos: 0.5,-15.5
       parent: 2
-    - type: DeviceLinkSink
-      links:
-      - 810
   - uid: 472
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-17.5
       parent: 2
-    - type: DeviceLinkSink
-      links:
-      - 655
 - proto: ShuttleWindow
   entities:
   - uid: 85
@@ -4911,35 +4808,13 @@ entities:
         - Pressed: Toggle
 - proto: SignBar
   entities:
-  - uid: 387
-    components:
-    - type: Transform
-      pos: -3.5,-21.5
-      parent: 2
   - uid: 546
     components:
     - type: Transform
       pos: -1.5,-13.5
       parent: 2
-  - uid: 804
-    components:
-    - type: Transform
-      pos: -7.5,-18.5
-      parent: 2
 - proto: SignDirectionalFood
   entities:
-  - uid: 88
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -8.5,-22.5
-      parent: 2
-  - uid: 94
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -4.5,-23.5
-      parent: 2
   - uid: 607
     components:
     - type: Transform
@@ -4959,6 +4834,18 @@ entities:
     components:
     - type: Transform
       pos: -0.5,-11.5
+      parent: 2
+- proto: SignKitchen
+  entities:
+  - uid: 695
+    components:
+    - type: Transform
+      pos: -4.5,-23.5
+      parent: 2
+  - uid: 726
+    components:
+    - type: Transform
+      pos: -8.5,-22.5
       parent: 2
 - proto: SignRadiationMed
   entities:
@@ -5024,15 +4911,6 @@ entities:
     - type: Transform
       pos: -3.5,-9.5
       parent: 2
-- proto: SuitStorageWallmountEVA
-  entities:
-  - uid: 493
-    components:
-    - type: Transform
-      pos: 2.5,-9.5
-      parent: 2
-    - type: Physics
-      canCollide: False
 - proto: Table
   entities:
   - uid: 169

--- a/Resources/ServerInfo/_NF/Guidebook/Shipyard/Ceres.xml
+++ b/Resources/ServerInfo/_NF/Guidebook/Shipyard/Ceres.xml
@@ -40,7 +40,7 @@
   ## 1.2. S.U.P.E.R.P.A.C.M.A.N. generator unit
   <Box>
   <GuideEntityEmbed Entity="PortableGeneratorSuperPacmanShuttle"/>
-  <GuideEntityEmbed Entity="SheetPlasma"/>
+  <GuideEntityEmbed Entity="SheetUranium"/>
   </Box>
 
   - Check that S.U.P.E.R.P.A.C.M.A.N. generator unit is anchored to the floor.
@@ -56,7 +56,7 @@
   <GuideEntityEmbed Entity="OxygenCanister"/>
   <GuideEntityEmbed Entity="NitrogenCanister"/>
   <GuideEntityEmbed Entity="GasPort"/>
-  <GuideEntityEmbed Entity="GasPressurePump"/>
+  <GuideEntityEmbed Entity="GasMixer"/>
   </Box>
 
   - Check that the oxygen and nitrogen canisters are anchored to the connector port.
@@ -65,7 +65,6 @@
 
   ## 2.2. Waste Loop
   <Box>
-  <GuideEntityEmbed Entity="GasPressurePump"/>
   <GuideEntityEmbed Entity="AirAlarm"/>
   </Box>
 
@@ -85,7 +84,7 @@
   # GETTING THE MOST OUT OF THE CERES
 
   - The Ceres is designed for multi-person crews. Consider having a dedicated botanist to grow quality produce.
-  - Though unorthodox, the disposal units are designed to safely and efficiently transport produce from botany to kitchen. Make use of them!
+  - Though unorthodox, the mailing units are designed to safely and efficiently transport produce from botany to kitchen. Make use of them!
   - Don't be afraid to adjust the table and seating layout to suit your needs.
   - For serving food to a larger party, the food carts in the freezer may simplify transportation.
 </Document>


### PR DESCRIPTION
## About the PR
Slightly updated the Ceres to fit new guidelines:
* Directional fans instead of tiny fans
* Fancy new kitchen sign instead of the directional "food" sign
* Service worker EVA suit instead of wallstorage suit locker
* Replace the dumbwaiter disposal units with mailing units
* Materials locker by the service techfab instead of loose materials on the ground (ew)

## Why / Balance
Make good ship gooder. :)

## How to test
1. Buy Ceres.
2. Enjoy.

## Media
No changes to the subfloor, so subfloor is hidden in all the screenies.

New entrance area with "KTCHN" signs:
![image](https://github.com/user-attachments/assets/9b9b8e5c-fe1c-4e49-be98-1517d0bb1656)

Dumbwaiter mailing units + materials locker + EVA locker:
![image](https://github.com/user-attachments/assets/49fee6b2-05c8-4819-b890-21c1ef93e8d4)

Whole ship, preinit:
![image](https://github.com/user-attachments/assets/eecd09b0-47b5-4b20-a85d-eb6ac05ba366)

## Requirements
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None.

**Changelog**
:cl:
- tweak: The SBB Ceres has received some minor updates.