### PR TITLE
Bookworm (Update): Directional fans + mixer + more

### DIFF
--- a/Resources/Maps/_NF/Shuttles/bookworm.yml
+++ b/Resources/Maps/_NF/Shuttles/bookworm.yml
@@ -67,12 +67,19 @@ entities:
             color: '#FFFFFFFF'
             id: Bot
           decals:
-            135: -2,-4
+            142: -4,-3
+            143: -4,-4
+            144: -3,-4
         - node:
-            color: '#FFFFFFFF'
-            id: Box
+            color: '#0096FFFF'
+            id: BoxGreyscale
           decals:
-            87: -4,-4
+            141: -1,-3
+        - node:
+            color: '#FF0000FF'
+            id: BoxGreyscale
+          decals:
+            140: -1,-4
         - node:
             color: '#FFFFFFFF'
             id: BrickTileDarkCornerNe
@@ -223,12 +230,6 @@ entities:
             96: -6,-8
             97: -6,-6
         - node:
-            color: '#FFFFFFFF'
-            id: Delivery
-          decals:
-            88: -1,-3
-            89: -1,-4
-        - node:
             color: '#EFB34196'
             id: DeliveryGreyscale
           decals:
@@ -366,6 +367,12 @@ entities:
           decals:
             98: -6,-8
             99: -6,-6
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnLineS
+          decals:
+            145: -7,-6
+            146: -7,-8
         - node:
             color: '#FFFFFFFF'
             id: WoodTrimThinCornerNe
@@ -563,16 +570,6 @@ entities:
       - 512
       - 193
       - 197
-- proto: AirCanister
-  entities:
-  - uid: 299
-    components:
-    - type: Transform
-      anchored: True
-      pos: -3.5,-3.5
-      parent: 2
-    - type: Physics
-      bodyType: Static
 - proto: Airlock
   entities:
   - uid: 3
@@ -622,17 +619,17 @@ entities:
       parent: 2
 - proto: AirlockGlassShuttle
   entities:
-  - uid: 410
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -6.5,-5.5
-      parent: 2
-  - uid: 412
+  - uid: 76
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -6.5,-7.5
+      parent: 2
+  - uid: 77
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-5.5
       parent: 2
 - proto: AirSensor
   entities:
@@ -648,27 +645,30 @@ entities:
       - 480
 - proto: APCBasic
   entities:
+  - uid: 166
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-0.5
+      parent: 2
   - uid: 288
     components:
     - type: Transform
       rot: 4.71238898038469 rad
       pos: 2.5,-2.5
       parent: 2
-  - uid: 323
-    components:
-    - type: Transform
-      pos: -3.5,-1.5
-      parent: 2
-- proto: AtmosDeviceFanTiny
+- proto: AtmosDeviceFanDirectional
   entities:
   - uid: 25
     components:
     - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -6.5,-7.5
       parent: 2
   - uid: 26
     components:
     - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -6.5,-5.5
       parent: 2
 - proto: AtmosFixBlockerMarker
@@ -857,6 +857,16 @@ entities:
     - type: Transform
       pos: 5.5,-5.5
       parent: 2
+  - uid: 126
+    components:
+    - type: Transform
+      pos: -3.5,-0.5
+      parent: 2
+  - uid: 132
+    components:
+    - type: Transform
+      pos: -2.5,-2.5
+      parent: 2
   - uid: 146
     components:
     - type: Transform
@@ -877,25 +887,10 @@ entities:
     - type: Transform
       pos: -4.5,5.5
       parent: 2
-  - uid: 312
-    components:
-    - type: Transform
-      pos: -3.5,-1.5
-      parent: 2
-  - uid: 313
-    components:
-    - type: Transform
-      pos: -3.5,-2.5
-      parent: 2
-  - uid: 314
-    components:
-    - type: Transform
-      pos: -3.5,-3.5
-      parent: 2
   - uid: 315
     components:
     - type: Transform
-      pos: -3.5,-0.5
+      pos: -1.5,-0.5
       parent: 2
   - uid: 316
     components:
@@ -1077,6 +1072,11 @@ entities:
     - type: Transform
       pos: 4.5,-4.5
       parent: 2
+  - uid: 398
+    components:
+    - type: Transform
+      pos: -2.5,-1.5
+      parent: 2
   - uid: 434
     components:
     - type: Transform
@@ -1122,64 +1122,59 @@ entities:
     - type: Transform
       pos: 7.5,1.5
       parent: 2
+  - uid: 534
+    components:
+    - type: Transform
+      pos: -2.5,-0.5
+      parent: 2
 - proto: CableHV
   entities:
+  - uid: 174
+    components:
+    - type: Transform
+      pos: -3.5,-3.5
+      parent: 2
+  - uid: 182
+    components:
+    - type: Transform
+      pos: -2.5,-3.5
+      parent: 2
   - uid: 285
     components:
     - type: Transform
-      pos: -1.5,-2.5
+      pos: -2.5,-4.5
       parent: 2
-  - uid: 304
-    components:
-    - type: Transform
-      pos: -0.5,-2.5
-      parent: 2
-  - uid: 305
-    components:
-    - type: Transform
-      pos: -0.5,-3.5
-      parent: 2
-  - uid: 539
-    components:
-    - type: Transform
-      pos: -2.5,-2.5
-      parent: 2
-  - uid: 540
+  - uid: 306
     components:
     - type: Transform
       pos: -3.5,-2.5
       parent: 2
 - proto: CableMV
   entities:
-  - uid: 150
+  - uid: 274
     components:
     - type: Transform
-      pos: -3.5,-0.5
+      pos: -2.5,-4.5
       parent: 2
-  - uid: 306
+  - uid: 299
     components:
     - type: Transform
-      pos: -0.5,-3.5
+      pos: -1.5,-0.5
       parent: 2
-  - uid: 307
-    components:
-    - type: Transform
-      pos: -1.5,-3.5
-      parent: 2
-  - uid: 308
+  - uid: 304
     components:
     - type: Transform
       pos: -2.5,-3.5
       parent: 2
-  - uid: 309
+  - uid: 308
+    components:
+    - type: Transform
+      pos: -2.5,-0.5
+      parent: 2
+  - uid: 314
     components:
     - type: Transform
       pos: -2.5,-2.5
-      parent: 2
-  - uid: 311
-    components:
-    - type: Transform
-      pos: -3.5,0.5
       parent: 2
   - uid: 324
     components:
@@ -1226,12 +1221,14 @@ entities:
     - type: Transform
       pos: 2.5,-2.5
       parent: 2
-  - uid: 537
+  - uid: 412
     components:
     - type: Transform
-      pos: -3.5,-1.5
+      pos: -2.5,-1.5
       parent: 2
-  - uid: 538
+- proto: CableTerminal
+  entities:
+  - uid: 177
     components:
     - type: Transform
       pos: -3.5,-2.5
@@ -1301,6 +1298,11 @@ entities:
       parent: 2
 - proto: CarpetPurple
   entities:
+  - uid: 183
+    components:
+    - type: Transform
+      pos: -4.5,0.5
+      parent: 2
   - uid: 528
     components:
     - type: Transform
@@ -1325,11 +1327,6 @@ entities:
     components:
     - type: Transform
       pos: -4.5,1.5
-      parent: 2
-  - uid: 533
-    components:
-    - type: Transform
-      pos: -4.5,0.5
       parent: 2
 - proto: ChairOfficeLight
   entities:
@@ -1452,14 +1449,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 5.5,5.5
       parent: 2
-- proto: ComputerPowerMonitoring
-  entities:
-  - uid: 541
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.5,-2.5
-      parent: 2
 - proto: ComputerTabletopShuttle
   entities:
   - uid: 186
@@ -1476,18 +1465,23 @@ entities:
       parent: 2
 - proto: ComputerWallmountWithdrawBankATM
   entities:
-  - uid: 523
+  - uid: 62
     components:
     - type: Transform
-      pos: -2.5,-4.5
+      pos: -4.5,-4.5
       parent: 2
-    - type: Physics
-      canCollide: False
     - type: ContainerContainer
       containers:
         board: !type:Container
+          showEnts: False
+          occludes: True
           ents: []
-        bank-ATM-cashSlot: !type:ContainerSlot {}
+        bank-ATM-cashSlot: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+    - type: Physics
+      canCollide: False
     - type: ItemSlots
 - proto: CrateServiceGuidebooks
   entities:
@@ -1596,7 +1590,7 @@ entities:
   - uid: 296
     components:
     - type: Transform
-      pos: -3.5,5.5
+      pos: -5.5,4.5
       parent: 2
 - proto: Firelock
   entities:
@@ -1666,6 +1660,16 @@ entities:
     - type: Transform
       pos: -4.3900414,2.6233003
       parent: 2
+- proto: GasMixerOnFlipped
+  entities:
+  - uid: 311
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
 - proto: GasPassiveVent
   entities:
   - uid: 134
@@ -1678,37 +1682,6 @@ entities:
       color: '#990000FF'
 - proto: GasPipeBend
   entities:
-  - uid: 77
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -4.5,-0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 78
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -3.5,-0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 80
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -0.5,1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 181
-    components:
-    - type: Transform
-      pos: -3.5,-0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
   - uid: 208
     components:
     - type: Transform
@@ -1755,6 +1728,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
+  - uid: 307
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 319
     components:
     - type: Transform
@@ -1770,15 +1751,23 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-- proto: GasPipeFourway
-  entities:
-  - uid: 128
+  - uid: 451
     components:
     - type: Transform
-      pos: -4.5,0.5
+      rot: 3.141592653589793 rad
+      pos: -1.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
+      color: '#0055CCFF'
+- proto: GasPipeFourway
+  entities:
+  - uid: 418
+    components:
+    - type: Transform
+      pos: -2.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
 - proto: GasPipeStraight
   entities:
   - uid: 54
@@ -1811,61 +1800,44 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 76
+  - uid: 128
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.5,0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 122
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -1.5,-0.5
+      pos: -2.5,0.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 135
+  - uid: 131
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 150
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 163
+    components:
+    - type: Transform
+      pos: -2.5,-4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 168
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -4.5,-2.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 165
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -3.5,-1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 171
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -0.5,-2.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 172
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -0.5,-1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 177
-    components:
-    - type: Transform
-      pos: -3.5,0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 178
     components:
     - type: Transform
@@ -1880,11 +1852,10 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 182
+  - uid: 181
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -2.5,-0.5
+      pos: -2.5,-1.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
@@ -1904,14 +1875,6 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 192
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -0.5,0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 194
     components:
     - type: Transform
@@ -1999,10 +1962,10 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -0.5,-4.5
+      pos: -3.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0055CCFF'
+      color: '#990000FF'
   - uid: 216
     components:
     - type: Transform
@@ -2072,6 +2035,22 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
+  - uid: 305
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 312
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 360
     components:
     - type: Transform
@@ -2079,6 +2058,21 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
+  - uid: 394
+    components:
+    - type: Transform
+      pos: -2.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 410
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 416
     components:
     - type: Transform
@@ -2087,22 +2081,6 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 417
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -1.5,-5.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 418
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,-5.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 419
     components:
     - type: Transform
@@ -2116,51 +2094,34 @@ entities:
   - uid: 83
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -0.5,-0.5
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-2.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 126
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -0.5,-5.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 163
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -3.5,-2.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 170
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -1.5,-3.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 174
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -0.5,-3.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 183
+  - uid: 165
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -3.5,1.5
+      pos: -2.5,-3.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
+  - uid: 171
+    components:
+    - type: Transform
+      pos: -3.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 192
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 196
     components:
     - type: Transform
@@ -2190,21 +2151,37 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
+  - uid: 417
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 510
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
 - proto: GasPort
   entities:
-  - uid: 168
+  - uid: 309
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.5,-3.5
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-2.5
       parent: 2
-- proto: GasPressurePumpOn
-  entities:
-  - uid: 62
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 313
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -2.5,-3.5
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-3.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
@@ -2217,18 +2194,19 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
+  - uid: 78
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 90
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,-3.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 167
-    components:
-    - type: Transform
-      pos: -1.5,-2.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
@@ -2253,11 +2231,10 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 320
+  - uid: 323
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,1.5
+      pos: -2.5,2.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
@@ -2271,7 +2248,7 @@ entities:
       color: '#0055CCFF'
 - proto: GasVentScrubber
   entities:
-  - uid: 166
+  - uid: 170
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2341,10 +2318,10 @@ entities:
       parent: 2
 - proto: GravityGeneratorMini
   entities:
-  - uid: 394
+  - uid: 122
     components:
     - type: Transform
-      pos: -1.5,-3.5
+      pos: -2.5,-3.5
       parent: 2
 - proto: Grille
   entities:
@@ -2508,8 +2485,6 @@ entities:
     - type: Transform
       pos: -0.5,3.5
       parent: 2
-    - type: Thruster
-      originalPowerLoad: 1500
 - proto: LampGold
   entities:
   - uid: 84
@@ -2529,6 +2504,20 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.68543017,1.7031286
+      parent: 2
+- proto: LockerWallEVAColorServiceWorkerFilled
+  entities:
+  - uid: 523
+    components:
+    - type: Transform
+      pos: -2.5,3.5
+      parent: 2
+- proto: LockerWallMaterialsFuelPlasmaFilled
+  entities:
+  - uid: 433
+    components:
+    - type: Transform
+      pos: -3.5,-1.5
       parent: 2
 - proto: LuxuryPen
   entities:
@@ -2556,6 +2545,26 @@ entities:
     - type: Transform
       pos: 6.2763557,-3.4680002
       parent: 2
+- proto: NitrogenCanister
+  entities:
+  - uid: 80
+    components:
+    - type: Transform
+      anchored: True
+      pos: -0.5,-3.5
+      parent: 2
+    - type: Physics
+      bodyType: Static
+- proto: OxygenCanister
+  entities:
+  - uid: 135
+    components:
+    - type: Transform
+      anchored: True
+      pos: -0.5,-2.5
+      parent: 2
+    - type: Physics
+      bodyType: Static
 - proto: PaintingCafeTerraceAtNight
   entities:
   - uid: 428
@@ -2654,10 +2663,10 @@ entities:
       parent: 2
 - proto: PortableGeneratorPacmanShuttle
   entities:
-  - uid: 131
+  - uid: 1
     components:
     - type: Transform
-      pos: -0.5,-2.5
+      pos: -3.5,-2.5
       parent: 2
     - type: FuelGenerator
       on: False
@@ -3000,19 +3009,12 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -2.5,7.5
       parent: 2
-- proto: SheetPlasma
-  entities:
-  - uid: 274
-    components:
-    - type: Transform
-      pos: -1.5,-2.5
-      parent: 2
 - proto: ShipyardBookwormInfo
   entities:
-  - uid: 1
+  - uid: 167
     components:
     - type: Transform
-      pos: -1.4975295,-2.5484562
+      pos: -2.2856998,-2.5196183
       parent: 2
 - proto: ShuttersNormalOpen
   entities:
@@ -3021,155 +3023,101 @@ entities:
     - type: Transform
       pos: 7.5,6.5
       parent: 2
-    - type: DeviceLinkSink
-      links:
-      - 214
   - uid: 68
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,1.5
       parent: 2
-    - type: DeviceLinkSink
-      links:
-      - 63
   - uid: 123
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,2.5
       parent: 2
-    - type: DeviceLinkSink
-      links:
-      - 63
   - uid: 144
     components:
     - type: Transform
       pos: 3.5,6.5
       parent: 2
-    - type: DeviceLinkSink
-      links:
-      - 214
   - uid: 158
     components:
     - type: Transform
       pos: 6.5,-7.5
       parent: 2
-    - type: DeviceLinkSink
-      links:
-      - 475
   - uid: 162
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,-4.5
       parent: 2
-    - type: DeviceLinkSink
-      links:
-      - 475
   - uid: 240
     components:
     - type: Transform
       pos: 5.5,6.5
       parent: 2
-    - type: DeviceLinkSink
-      links:
-      - 214
   - uid: 275
     components:
     - type: Transform
       pos: 4.5,6.5
       parent: 2
-    - type: DeviceLinkSink
-      links:
-      - 214
   - uid: 276
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,2.5
       parent: 2
-    - type: DeviceLinkSink
-      links:
-      - 283
   - uid: 277
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,3.5
       parent: 2
-    - type: DeviceLinkSink
-      links:
-      - 283
   - uid: 278
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,4.5
       parent: 2
-    - type: DeviceLinkSink
-      links:
-      - 283
   - uid: 279
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,5.5
       parent: 2
-    - type: DeviceLinkSink
-      links:
-      - 283
   - uid: 282
     components:
     - type: Transform
       pos: 8.5,6.5
       parent: 2
-    - type: DeviceLinkSink
-      links:
-      - 214
   - uid: 294
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,1.5
       parent: 2
-    - type: DeviceLinkSink
-      links:
-      - 283
   - uid: 301
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,-5.5
       parent: 2
-    - type: DeviceLinkSink
-      links:
-      - 475
   - uid: 373
     components:
     - type: Transform
       pos: 5.5,-7.5
       parent: 2
-    - type: DeviceLinkSink
-      links:
-      - 475
   - uid: 380
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-2.5
       parent: 2
-    - type: DeviceLinkSink
-      links:
-      - 381
   - uid: 432
     components:
     - type: Transform
       pos: 6.5,6.5
       parent: 2
-    - type: DeviceLinkSink
-      links:
-      - 214
 - proto: SignalButtonDirectional
   entities:
   - uid: 63
@@ -3286,23 +3234,24 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 1.5,6.5
       parent: 2
-    - type: Thruster
-      originalPowerLoad: 500
   - uid: 375
     components:
     - type: Transform
       pos: -0.5,4.5
       parent: 2
-    - type: Thruster
-      originalPowerLoad: 500
   - uid: 387
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-8.5
       parent: 2
-    - type: Thruster
-      originalPowerLoad: 500
+- proto: SMESBasic
+  entities:
+  - uid: 533
+    components:
+    - type: Transform
+      pos: -3.5,-3.5
+      parent: 2
 - proto: SolidSecretDoor
   entities:
   - uid: 169
@@ -3326,22 +3275,14 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 2.5,-6.5
       parent: 2
-- proto: SubstationBasic
+- proto: SubstationWallBasic
   entities:
-  - uid: 132
+  - uid: 172
     components:
     - type: Transform
-      pos: -0.5,-3.5
+      rot: 3.141592653589793 rad
+      pos: -2.5,-4.5
       parent: 2
-- proto: SuitStorageWallmountEVA
-  entities:
-  - uid: 433
-    components:
-    - type: Transform
-      pos: -2.5,3.5
-      parent: 2
-    - type: Physics
-      canCollide: False
 - proto: Table
   entities:
   - uid: 130
@@ -3462,39 +3403,29 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 9.5,-1.5
       parent: 2
-    - type: Thruster
-      originalPowerLoad: 1500
   - uid: 38
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-3.5
       parent: 2
-    - type: Thruster
-      originalPowerLoad: 1500
   - uid: 49
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-8.5
       parent: 2
-    - type: Thruster
-      originalPowerLoad: 1500
   - uid: 215
     components:
     - type: Transform
       pos: -1.5,4.5
       parent: 2
-    - type: Thruster
-      originalPowerLoad: 1500
   - uid: 364
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-8.5
       parent: 2
-    - type: Thruster
-      originalPowerLoad: 1500
 - proto: ToyFigurineLibrarian
   entities:
   - uid: 31
@@ -3919,9 +3850,9 @@ entities:
       parent: 2
 - proto: Wrench
   entities:
-  - uid: 534
+  - uid: 320
     components:
     - type: Transform
-      pos: -3.5,-3.5
+      pos: -1.5,-3.5
       parent: 2
 ...

--- a/Resources/Prototypes/_NF/Shipyard/bookworm.yml
+++ b/Resources/Prototypes/_NF/Shipyard/bookworm.yml
@@ -12,7 +12,7 @@
   id: Bookworm
   name: SBB Bookworm
   description: A cozy medium-size library for travellers who wish to relax with a book or perhaps a board game.
-  price: 28000
+  price: 27000 # ~24660 after purchase + ~9% markup
   category: Medium
   group: Shipyard
   shuttlePath: /Maps/_NF/Shuttles/bookworm.yml

--- a/Resources/ServerInfo/_NF/Guidebook/Shipyard/Bookworm.xml
+++ b/Resources/ServerInfo/_NF/Guidebook/Shipyard/Bookworm.xml
@@ -27,6 +27,7 @@
 
   ## 1.1. Battery units
   <Box>
+  <GuideEntityEmbed Entity="SMESBasic"/>
   <GuideEntityEmbed Entity="SubstationBasic"/>
   <GuideEntityEmbed Entity="APCBasic"/>
   </Box>
@@ -51,14 +52,15 @@
 
   ## 2.1. Distribution Loop
   <Box>
-  <GuideEntityEmbed Entity="AirCanister"/>
+  <GuideEntityEmbed Entity="OxygenCanister"/>
+  <GuideEntityEmbed Entity="NitrogenCanister"/>
   <GuideEntityEmbed Entity="GasPort"/>
-  <GuideEntityEmbed Entity="GasPressurePump"/>
+  <GuideEntityEmbed Entity="GasMixer"/>
   </Box>
 
-  - Check that the air canister is anchored to connector port.
-  - Check that the distribution pump is set to 101kPa.
-  - Enable the distribution pump.
+  - Check that the oxygen and nitrogen canisters are anchored to the connector port.
+  - Check that the distribution mixer is set to 101kPa.
+  - Enable the distribution mixer.
 
   ## 3. Other checks
   <Box>


### PR DESCRIPTION
## About the PR
A few updates to the Bookworm to keep it up to date and stuff:
* Replace tiny fans with directional fans
* Oxygen + nitrogen mix instead of air canister
* Completely redid engineering with a SMES + wallmount substation and a plasma fuel wall locker
* Redid piping and wiring around engineering, to reduce the "oh my god what is this"
* Service worker EVA locker
* Reduced price by 1,000 spesos to fit new appraisal price

## Why / Balance
Make Bookworm great again.

The redone engineering no longer has a power monitor, as the ship hasn't started at a power deficit for some time now. The SMES provides further resilience against power loss in case you forget to refuel or choose to install more machines or whatever.

## How to test
1. Buy Boookworm.
2. Read a book. :)

## Media
Full ship with subfloor:
![image](https://github.com/user-attachments/assets/f2516966-1245-4853-8367-1bc235d82846)

Reworked engineering:
![image](https://github.com/user-attachments/assets/6b88f888-a14f-48bb-8a7d-adc83285a81e)

Service worker EVA locker:
![image](https://github.com/user-attachments/assets/4ce6d2d8-22ab-41f1-b233-b31b2029190b)

## Requirements
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
Only fixing changes.

**Changelog**
:cl:
- tweak: The SBB Bookworm has received a few smaller updates.