### PR TITLE
Pathfinder directional fans update

### DIFF
--- a/Resources/Maps/_NF/Shuttles/Expedition/pathfinder.yml
+++ b/Resources/Maps/_NF/Shuttles/Expedition/pathfinder.yml
@@ -1409,8 +1409,8 @@ entities:
       pos: 1.5,1.5
       parent: 1
     - type: GasMixer
-      inletTwoConcentration: 0.78
-      inletOneConcentration: 0.22
+      inletTwoConcentration: 0.79
+      inletOneConcentration: 0.21
     - type: AtmosPipeColor
       color: '#0055CCFF'
 - proto: GasPassiveVent
@@ -1954,8 +1954,6 @@ entities:
   entities:
   - uid: 268
     components:
-    - type: MetaData
-      name: N2 connector port
     - type: Transform
       pos: 2.5,2.5
       parent: 1
@@ -1963,8 +1961,6 @@ entities:
       color: '#0055CCFF'
   - uid: 269
     components:
-    - type: MetaData
-      name: O2 connector port
     - type: Transform
       pos: 1.5,2.5
       parent: 1

--- a/Resources/Maps/_NF/Shuttles/Expedition/pathfinder.yml
+++ b/Resources/Maps/_NF/Shuttles/Expedition/pathfinder.yml
@@ -517,7 +517,6 @@ entities:
   - uid: 9
     components:
     - type: Transform
-                                
       pos: 0.5,-10.5
       parent: 1
   - uid: 25

--- a/Resources/Maps/_NF/Shuttles/Expedition/pathfinder.yml
+++ b/Resources/Maps/_NF/Shuttles/Expedition/pathfinder.yml
@@ -94,6 +94,16 @@ entities:
             133: -2,-5
             134: -4,0
         - node:
+            color: '#3AB3DAFF'
+            id: DeliveryGreyscale
+          decals:
+            136: 1,2
+        - node:
+            color: '#F9801DFF'
+            id: DeliveryGreyscale
+          decals:
+            135: 2,2
+        - node:
             cleanable: True
             color: '#FFFFFFFF'
             id: Dirt
@@ -502,38 +512,41 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 0.5,-3.5
       parent: 1
-- proto: AtmosDeviceFanTiny
+- proto: AtmosDeviceFanDirectional
   entities:
   - uid: 9
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
+                                
       pos: 0.5,-10.5
       parent: 1
   - uid: 25
     components:
     - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -10.5,-4.5
       parent: 1
   - uid: 26
     components:
     - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -10.5,-6.5
       parent: 1
   - uid: 27
     components:
     - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -10.5,-5.5
       parent: 1
   - uid: 28
     components:
     - type: Transform
-      pos: -0.5,-10.5
+      pos: 1.5,-10.5
       parent: 1
   - uid: 29
     components:
     - type: Transform
-      pos: 1.5,-10.5
+      pos: -0.5,-10.5
       parent: 1
 - proto: AtmosFixBlockerMarker
   entities:
@@ -1941,6 +1954,8 @@ entities:
   entities:
   - uid: 268
     components:
+    - type: MetaData
+      name: N2 connector port
     - type: Transform
       pos: 2.5,2.5
       parent: 1
@@ -1948,6 +1963,8 @@ entities:
       color: '#0055CCFF'
   - uid: 269
     components:
+    - type: MetaData
+      name: O2 connector port
     - type: Transform
       pos: 1.5,2.5
       parent: 1


### PR DESCRIPTION
Replaced all tiny fans with directional fans
Also added coloured decals for the O2 and N2 connector ports and gave them names.

## About the PR
Each tiny fan has been replaced with a directional fan aligned to the outer edge of the shuttle.
The O2 and N2 connector ports have been named, and each has been given a colour-coded decal.

## Why / Balance
Tiny fans trap bad air inside their bounding box and are difficult or impossible to clean up. Directional fans merely create a single bounding box around the outside edge of the ship, allowing the entire ship to be one air box with a linked atmosphere (when all airlocks are opened), and allowing the scrubbers and vents to do their job.

Adding indicators for which connector port is intended for which gas brings it into line with other shuttles (see the Gasbender).

## How to test
Purchase a Pathfinder and walk around for a bit. Look at the atmospherics connectors. Cut a hole in the wall and patch it, and use a gas analyser to watch the shuttle's atmospherics fix the problem.

## Media
EVA fans:
![evafans](https://github.com/user-attachments/assets/9aba62b8-8bf9-4334-b29a-dbcfa3aeccf1)
Docking fans:
![dockingfans](https://github.com/user-attachments/assets/84dfeb7d-f18d-436d-9d55-6b4e7cdd0757)
Gas ports:
![gasportdecals](https://github.com/user-attachments/assets/66f737f9-14b5-49f7-ab96-d808067c1092)

## Requirements
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Updated the Pathfinder with directional fans, replacing the existing tiny fans.