### PR TITLE
Sprinter shuttle update

### DIFF
--- a/Resources/Maps/_NF/Shuttles/Expedition/sprinter.yml
+++ b/Resources/Maps/_NF/Shuttles/Expedition/sprinter.yml
@@ -2322,13 +2322,6 @@ entities:
     - type: Transform
       pos: -2.4529943,1.6674619
       parent: 1
-- proto: ClothingOuterWinterPara
-  entities:
-  - uid: 395
-    components:
-    - type: Transform
-      pos: 2.53125,-6.401108
-      parent: 1
 - proto: ComputerPowerMonitoring
   entities:
   - uid: 224
@@ -3346,8 +3339,6 @@ entities:
   entities:
   - uid: 152
     components:
-    - type: MetaData
-      name: O2 connector port
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-11.5
@@ -3356,8 +3347,6 @@ entities:
       color: '#0055CCFF'
   - uid: 180
     components:
-    - type: MetaData
-      name: N2 connector port
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-11.5

--- a/Resources/Maps/_NF/Shuttles/Expedition/sprinter.yml
+++ b/Resources/Maps/_NF/Shuttles/Expedition/sprinter.yml
@@ -111,6 +111,16 @@ entities:
           decals:
             1: 11,-4
         - node:
+            color: '#3AB3DAFF'
+            id: DeliveryGreyscale
+          decals:
+            503: -2,-12
+        - node:
+            color: '#F9801DFF'
+            id: DeliveryGreyscale
+          decals:
+            502: -1,-12
+        - node:
             cleanable: True
             color: '#C7621F47'
             id: Dirt
@@ -458,6 +468,8 @@ entities:
             486: -8,-5
             488: 6,-4
             489: 7,-4
+            512: 2,-8
+            513: 2,-8
         - node:
             cleanable: True
             color: '#FF0000FF'
@@ -988,9 +1000,9 @@ entities:
     - type: Transform
       pos: -3.5,-2.5
       parent: 1
-    - type: DeviceLinkSink
-      links:
-      - 412
+                          
+            
+           
 - proto: AirlockMercenaryLocked
   entities:
   - uid: 21
@@ -1103,52 +1115,59 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -2.5,-0.5
       parent: 1
-- proto: AtmosDeviceFanTiny
+- proto: AtmosDeviceFanDirectional
   entities:
-  - uid: 40
-    components:
-    - type: Transform
-      pos: 12.5,-5.5
-      parent: 1
+           
+               
+                     
+                    
+               
   - uid: 41
     components:
     - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -12.5,-5.5
       parent: 1
   - uid: 42
     components:
     - type: Transform
-      pos: -12.5,-3.5
+      rot: 1.5707963267948966 rad
+      pos: 12.5,-5.5
       parent: 1
   - uid: 43
     components:
     - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 12.5,-3.5
       parent: 1
   - uid: 44
     components:
     - type: Transform
-      pos: -5.5,-7.5
+      rot: -1.5707963267948966 rad
+      pos: -12.5,-3.5
       parent: 1
   - uid: 45
     components:
     - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -5.5,-9.5
       parent: 1
   - uid: 46
     components:
     - type: Transform
-      pos: -5.5,-8.5
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-7.5
       parent: 1
   - uid: 47
     components:
     - type: Transform
-      pos: -10.5,-1.5
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-8.5
       parent: 1
   - uid: 48
     components:
     - type: Transform
-      pos: -10.5,-6.5
+      pos: 10.5,-1.5
       parent: 1
   - uid: 49
     components:
@@ -1158,7 +1177,12 @@ entities:
   - uid: 50
     components:
     - type: Transform
-      pos: 10.5,-1.5
+      pos: -10.5,-6.5
+      parent: 1
+  - uid: 101
+    components:
+    - type: Transform
+      pos: -10.5,-1.5
       parent: 1
 - proto: AtmosFixBlockerMarker
   entities:
@@ -1610,25 +1634,25 @@ entities:
     - type: Transform
       pos: -5.5,-9.5
       parent: 1
-    - type: DeviceLinkSink
-      links:
-      - 36
+                          
+            
+          
   - uid: 65
     components:
     - type: Transform
       pos: -5.5,-7.5
       parent: 1
-    - type: DeviceLinkSink
-      links:
-      - 36
+                          
+            
+          
   - uid: 66
     components:
     - type: Transform
       pos: -5.5,-8.5
       parent: 1
-    - type: DeviceLinkSink
-      links:
-      - 36
+                          
+            
+          
 - proto: BookRandomStory
   entities:
   - uid: 590
@@ -3350,6 +3374,8 @@ entities:
   entities:
   - uid: 152
     components:
+    - type: MetaData
+      name: O2 connector port
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-11.5
@@ -3358,6 +3384,8 @@ entities:
       color: '#0055CCFF'
   - uid: 180
     components:
+    - type: MetaData
+      name: N2 connector port
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-11.5
@@ -3789,13 +3817,13 @@ entities:
     - type: Transform
       pos: -1.5,-1.5
       parent: 1
-- proto: LockerMedicalFilled
-  entities:
-  - uid: 176
-    components:
-    - type: Transform
-      pos: 2.5,-7.5
-      parent: 1
+                            
+           
+            
+               
+                     
+                   
+               
 - proto: LockerMercenaryFilled
   entities:
   - uid: 147
@@ -3809,6 +3837,13 @@ entities:
     components:
     - type: Transform
       pos: -3.5,-6.5
+      parent: 1
+- proto: LockerWallMedicalDoctorFilled
+  entities:
+  - uid: 176
+    components:
+    - type: Transform
+      pos: 2.5,-5.5
       parent: 1
 - proto: Mirror
   entities:
@@ -4177,49 +4212,49 @@ entities:
     - type: Transform
       pos: -1.5,12.5
       parent: 1
-    - type: DeviceLinkSink
-      links:
-      - 693
+                          
+            
+           
   - uid: 217
     components:
     - type: Transform
       pos: -2.5,11.5
       parent: 1
-    - type: DeviceLinkSink
-      links:
-      - 693
+                          
+            
+           
   - uid: 687
     components:
     - type: Transform
       pos: 0.5,12.5
       parent: 1
-    - type: DeviceLinkSink
-      links:
-      - 693
+                          
+            
+           
   - uid: 688
     components:
     - type: Transform
       pos: -0.5,12.5
       parent: 1
-    - type: DeviceLinkSink
-      links:
-      - 693
+                          
+            
+           
   - uid: 691
     components:
     - type: Transform
       pos: 1.5,12.5
       parent: 1
-    - type: DeviceLinkSink
-      links:
-      - 693
+                          
+            
+           
   - uid: 692
     components:
     - type: Transform
       pos: 2.5,11.5
       parent: 1
-    - type: DeviceLinkSink
-      links:
-      - 693
+                          
+            
+           
 - proto: SignalButton
   entities:
   - uid: 412
@@ -4461,8 +4496,8 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -5.5,-0.5
       parent: 1
-    - type: Physics
-      canCollide: False
+                   
+                       
 - proto: TableCarpet
   entities:
   - uid: 58

--- a/Resources/Maps/_NF/Shuttles/Expedition/sprinter.yml
+++ b/Resources/Maps/_NF/Shuttles/Expedition/sprinter.yml
@@ -1117,71 +1117,68 @@ entities:
       parent: 1
 - proto: AtmosDeviceFanDirectional
   entities:
-           
-               
-                     
-                    
-               
-  - uid: 41
+  - uid: 40
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -12.5,-5.5
       parent: 1
-  - uid: 42
+  - uid: 41
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 12.5,-5.5
       parent: 1
-  - uid: 43
+  - uid: 42
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 12.5,-3.5
       parent: 1
-  - uid: 44
+  - uid: 43
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -12.5,-3.5
       parent: 1
-  - uid: 45
+  - uid: 44
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,-9.5
       parent: 1
-  - uid: 46
+  - uid: 45
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,-7.5
       parent: 1
-  - uid: 47
+  - uid: 46
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,-8.5
       parent: 1
-  - uid: 48
+  - uid: 47
     components:
     - type: Transform
+      rot: 3.141592653589793 rad
       pos: 10.5,-1.5
       parent: 1
-  - uid: 49
+  - uid: 48
     components:
     - type: Transform
       pos: 10.5,-6.5
       parent: 1
-  - uid: 50
+  - uid: 49
     components:
     - type: Transform
       pos: -10.5,-6.5
       parent: 1
-  - uid: 101
+  - uid: 50
     components:
     - type: Transform
+      rot: 3.141592653589793 rad
       pos: -10.5,-1.5
       parent: 1
 - proto: AtmosFixBlockerMarker

--- a/Resources/Maps/_NF/Shuttles/Expedition/sprinter.yml
+++ b/Resources/Maps/_NF/Shuttles/Expedition/sprinter.yml
@@ -1000,9 +1000,6 @@ entities:
     - type: Transform
       pos: -3.5,-2.5
       parent: 1
-                          
-            
-           
 - proto: AirlockMercenaryLocked
   entities:
   - uid: 21
@@ -1631,25 +1628,16 @@ entities:
     - type: Transform
       pos: -5.5,-9.5
       parent: 1
-                          
-            
-          
   - uid: 65
     components:
     - type: Transform
       pos: -5.5,-7.5
       parent: 1
-                          
-            
-          
   - uid: 66
     components:
     - type: Transform
       pos: -5.5,-8.5
       parent: 1
-                          
-            
-          
 - proto: BookRandomStory
   entities:
   - uid: 590
@@ -3814,13 +3802,6 @@ entities:
     - type: Transform
       pos: -1.5,-1.5
       parent: 1
-                            
-           
-            
-               
-                     
-                   
-               
 - proto: LockerMercenaryFilled
   entities:
   - uid: 147
@@ -4209,49 +4190,31 @@ entities:
     - type: Transform
       pos: -1.5,12.5
       parent: 1
-                          
-            
-           
   - uid: 217
     components:
     - type: Transform
       pos: -2.5,11.5
       parent: 1
-                          
-            
-           
   - uid: 687
     components:
     - type: Transform
       pos: 0.5,12.5
       parent: 1
-                          
-            
-           
   - uid: 688
     components:
     - type: Transform
       pos: -0.5,12.5
       parent: 1
-                          
-            
-           
   - uid: 691
     components:
     - type: Transform
       pos: 1.5,12.5
       parent: 1
-                          
-            
-           
   - uid: 692
     components:
     - type: Transform
       pos: 2.5,11.5
       parent: 1
-                          
-            
-           
 - proto: SignalButton
   entities:
   - uid: 412
@@ -4493,8 +4456,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -5.5,-0.5
       parent: 1
-                   
-                       
 - proto: TableCarpet
   entities:
   - uid: 58

--- a/Resources/Maps/_NF/Shuttles/Expedition/sprinter.yml
+++ b/Resources/Maps/_NF/Shuttles/Expedition/sprinter.yml
@@ -1024,22 +1024,12 @@ entities:
           ent: 33
 - proto: AmeJar
   entities:
-  - uid: 25
-    components:
-    - type: Transform
-      pos: 0.6948629,7.6918755
-      parent: 1
   - uid: 33
     components:
     - type: Transform
       parent: 32
     - type: Physics
       canCollide: False
-  - uid: 415
-    components:
-    - type: Transform
-      pos: 0.3256532,7.6657753
-      parent: 1
 - proto: AmeShielding
   entities:
   - uid: 24
@@ -1749,45 +1739,10 @@ entities:
     - type: Transform
       pos: -10.5,-0.5
       parent: 1
-  - uid: 126
-    components:
-    - type: Transform
-      pos: 10.5,-7.5
-      parent: 1
-  - uid: 127
-    components:
-    - type: Transform
-      pos: 10.5,-6.5
-      parent: 1
-  - uid: 128
-    components:
-    - type: Transform
-      pos: 10.5,-5.5
-      parent: 1
   - uid: 129
     components:
     - type: Transform
       pos: 10.5,-4.5
-      parent: 1
-  - uid: 130
-    components:
-    - type: Transform
-      pos: 10.5,-3.5
-      parent: 1
-  - uid: 131
-    components:
-    - type: Transform
-      pos: 10.5,-2.5
-      parent: 1
-  - uid: 132
-    components:
-    - type: Transform
-      pos: 10.5,-1.5
-      parent: 1
-  - uid: 133
-    components:
-    - type: Transform
-      pos: 10.5,-0.5
       parent: 1
   - uid: 134
     components:
@@ -3734,7 +3689,7 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 9.5,-0.5
+      pos: 0.5,7.5
       parent: 1
 - proto: HospitalCurtainsOpen
   entities:
@@ -3815,6 +3770,14 @@ entities:
     components:
     - type: Transform
       pos: -3.5,-6.5
+      parent: 1
+- proto: LockerWallMaterialsFuelAmeJarFilled
+  entities:
+  - uid: 126
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,6.5
       parent: 1
 - proto: LockerWallMedicalDoctorFilled
   entities:
@@ -3984,11 +3947,6 @@ entities:
     components:
     - type: Transform
       pos: 3.5,4.5
-      parent: 1
-  - uid: 627
-    components:
-    - type: Transform
-      pos: 0.5,7.5
       parent: 1
 - proto: RagItem
   entities:

--- a/Resources/Maps/_NF/Shuttles/Expedition/sprinter.yml
+++ b/Resources/Maps/_NF/Shuttles/Expedition/sprinter.yml
@@ -20,9 +20,6 @@ entities:
     components:
     - type: MetaData
       name: Sprinter
-    - type: Transform
-      pos: -1.3749695,4.533844
-      parent: invalid
     - type: MapGrid
       chunks:
         0,0:
@@ -1739,10 +1736,45 @@ entities:
     - type: Transform
       pos: -10.5,-0.5
       parent: 1
+  - uid: 126
+    components:
+    - type: Transform
+      pos: 10.5,-7.5
+      parent: 1
+  - uid: 127
+    components:
+    - type: Transform
+      pos: 10.5,-6.5
+      parent: 1
+  - uid: 128
+    components:
+    - type: Transform
+      pos: 10.5,-5.5
+      parent: 1
   - uid: 129
     components:
     - type: Transform
       pos: 10.5,-4.5
+      parent: 1
+  - uid: 130
+    components:
+    - type: Transform
+      pos: 10.5,-3.5
+      parent: 1
+  - uid: 131
+    components:
+    - type: Transform
+      pos: 10.5,-2.5
+      parent: 1
+  - uid: 132
+    components:
+    - type: Transform
+      pos: 10.5,-1.5
+      parent: 1
+  - uid: 133
+    components:
+    - type: Transform
+      pos: 10.5,-0.5
       parent: 1
   - uid: 134
     components:
@@ -3544,7 +3576,7 @@ entities:
   - uid: 437
     components:
     - type: Transform
-      pos: 0.5,6.5
+      pos: 0.5,7.5
       parent: 1
 - proto: Grille
   entities:
@@ -3689,7 +3721,7 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 0.5,7.5
+      pos: 9.5,-0.5
       parent: 1
 - proto: HospitalCurtainsOpen
   entities:
@@ -3773,7 +3805,7 @@ entities:
       parent: 1
 - proto: LockerWallMaterialsFuelAmeJarFilled
   entities:
-  - uid: 126
+  - uid: 238
     components:
     - type: Transform
       rot: -1.5707963267948966 rad


### PR DESCRIPTION
## About the PR
Replaced tiny fans with directional fans.
Named O2 and N2 ports and added decals.
Replaced medical doctor's locker with wallmount.
Added dirt where the locker used to be.
Replaced AME fuel rack with wall locker.

## Why / Balance
Tiny fans create an enclosed atmosphere box that will quickly become unbreathable. Directional fans fix this problem.
Connector port changes bring the shuttle in line with other shuttles such as the Gasbender.
Wall lockers are preferred, especially for AME fuel.

## How to test
Load the Sprinter and walk around. Open all the airlocks while watching the atmosphere for any sudden drops or other changes. check that two AME fuel bottles are supplied in the wall locker.

## Media
### Directional fans
![starboarddockfans](https://github.com/user-attachments/assets/0c7b53a4-5726-4325-bcb7-385867fdf975)
![portdockfans](https://github.com/user-attachments/assets/c8f8b844-5209-4b82-bd5d-190922484e9b)
![evafans](https://github.com/user-attachments/assets/d905207a-1067-455c-9c9d-460652b5321e)
### Medical locker
![medicallocker](https://github.com/user-attachments/assets/e3adced3-bdc2-4a94-a711-67066222641d)
### Engineering
![engineering](https://github.com/user-attachments/assets/b0180bf1-4692-4a0e-a1bc-5e23c0876838)

## Requirements
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Retrofitted the Sprinter with directional fans and tweaked storage.