### PR TITLE
Capfruit: fake cap guns are contraband, grown ones have standard ammo.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -2010,7 +2010,7 @@
     seedId: fakeCapfruit
   - type: Food
     trash:
-    - RevolverCapGunFake
+    - RevolverCapGunFakeGrown # Frontier: add Grown
 
 - type: entity
   name: rice bushel

--- a/Resources/Prototypes/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/toys.yml
@@ -1006,7 +1006,7 @@
       revolver-ammo: !type:Container
 
 - type: entity
-  parent: RevolverCapGun
+  parent: [RevolverCapGun, BaseC3SyndicateContraband] # Frontier: added BaseC3SyndicateContraband
   id: RevolverCapGunFake
   name: cap gun
   suffix: Fake
@@ -1020,6 +1020,8 @@
         - CartridgeMagnum
         - SpeedLoaderMagnum
     proto: CartridgeMagnumAP
+  - type: Contraband # Frontier
+    hideValues: true # Frontier
 
 - type: entity
   parent: BaseItem

--- a/Resources/Prototypes/_NF/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Fun/toys.yml
@@ -509,3 +509,13 @@
     steps: 2
     zeroVisible: false
   - type: Appearance
+
+# Grown cap gun, in toys.yml for consistency with fake parent
+- type: entity
+  parent: [BaseC3SyndicateContrabandNoValue, RevolverCapGunFake] # Frontier: added BaseC3SyndicateContraband
+  id: RevolverCapGunFakeGrown
+  suffix: Fake, Grown
+  noSpawn: true
+  components:
+  - type: RevolverAmmoProvider
+    proto: CartridgeMagnum # Base has AP rounds


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Adds contraband status to fake cap guns.  Both found and grown fake cap guns do not display their contraband status on examine, but found fake cap guns will redeem for one FUC.
Grown fake cap guns have normal magnum rounds and sell for no FUCs.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Oversight.  Both should be contraband (if not immediately visible) and the grown ones shouldn't be a farmable source of armor-piercing rounds or FUCs.

## How to test
<!-- Describe the way it can be tested -->

1. Farm some fake capfruit, it should output a grown fake cap gun.
2. Eject the rounds from the cap gun, they should be regular magnum ammunition.
3. Redeem the gun at the contraband pallet, it should redeem for no FUCs.
4. Spawn a fake cap gun (two objects should show in the spawn menu - the found fake capgun and the real cap gun)
5. Eject the rounds from the fake cap gun, they should be AP magnum rounds.
6. Redeem the gun at the contraband pallet, it should redeem for one FUC.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->

All three of the cap guns (real, found fake and grown fake) are put on the contraband console.  The two fake capguns are identified as contraband (and redeemable), but the total FUCs received is 1 (for the found fake gun).  Regular magnum ammo ejected from a grown fake capgun is shown in the top right.
![image](https://github.com/user-attachments/assets/b827811e-eee8-4a13-85b8-e16bd9ee7692)

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Fake cap guns are now properly qualified as C3 contraband.
- tweak: Grown fake cap guns no longer spawn armor piercing ammunition.