### PR TITLE
Retire the Dart-X pending a rework

### DIFF
--- a/Resources/Prototypes/_NF/Shipyard/Expedition/dartx.yml
+++ b/Resources/Prototypes/_NF/Shipyard/Expedition/dartx.yml
@@ -7,35 +7,35 @@
 # Discord: ???
 
 # Shuttle Notes:
-# 
-- type: vessel
-  id: DartX
-  name: NT Dart-X
-  description: A light emergency response cruiser outfitted for extended rescue missions.
-  price: 83500 # ~64000$ on mapinit + ~19200$ from 30% markup
-  category: Medium
-  group: Expedition
-  shuttlePath: /Maps/_NF/Shuttles/Expedition/dartx.yml
-  guidebookPage: Null
-  class:
-  - Expedition
+#
+#- type: vessel
+#  id: DartX
+#  name: NT Dart-X
+#  description: A light emergency response cruiser outfitted for extended rescue missions.
+#  price: 83500 # ~64000$ on mapinit + ~19200$ from 30% markup
+#  category: Medium
+#  group: Expedition
+#  shuttlePath: /Maps/_NF/Shuttles/Expedition/dartx.yml
+#  guidebookPage: Null
+#  class:
+#  - Expedition
 
-- type: gameMap
-  id: DartX
-  mapName: 'NT Dart-X'
-  mapPath: /Maps/_NF/Shuttles/Expedition/dartx.yml
-  minPlayers: 0
-  stations:
-    DartX:
-      stationProto: StandardFrontierExpeditionVessel
-      components:
-        - type: StationNameSetup
-          mapNameTemplate: 'Dart-X {1}'
-          nameGenerator:
-            !type:NanotrasenNameGenerator
-            prefixCreator: '14'
-        - type: StationJobs
-          availableJobs:
-            Contractor: [ 0, 0 ]
-            Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+#- type: gameMap
+#  id: DartX
+#  mapName: 'NT Dart-X'
+#  mapPath: /Maps/_NF/Shuttles/Expedition/dartx.yml
+#  minPlayers: 0
+#  stations:
+#    DartX:
+#      stationProto: StandardFrontierExpeditionVessel
+#      components:
+#        - type: StationNameSetup
+#          mapNameTemplate: 'Dart-X {1}'
+#          nameGenerator:
+#            !type:NanotrasenNameGenerator
+#            prefixCreator: '14'
+#        - type: StationJobs
+#          availableJobs:
+#            Contractor: [ 0, 0 ]
+#            Pilot: [ 0, 0 ]
+#            Mercenary: [ 0, 0 ]


### PR DESCRIPTION
## About the PR
Retires the Dart-X pending a rework.

## Why / Balance
The Dart-X has a lot of problematic stuff, including, but not limited to:
* Custom filled lockers in many places, including a medal case.
* A random drain in the middle of the ship for no justifiable reason.
* Clown equipment?!
* THREE defibs, but no extinguisher.
* A bunch of seemingly random clothes vendors.
* Booze and soda dispensers (filled).
* Free medicine and a medical bed.
* Two AME cores on a ship that needs no more than one.
* ...

In attempting to fix these things quickly, it became clear that the ship would benefit from a more thorough rework. The Dart-X is an adaptation of the upstream admeme ship Dart, which has received several changes we could probably take inspiration from. Alternatively, we can leave it in the past and focus on giving ourselves nice ships that are unique to Frontier.

## How to test
1. Don't buy a Dart-X, because you can't.

## Media
N/A

## Requirements
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
Negatory.

**Changelog**
:cl:
- remove: The Dart-X is no longer available for purchase.