### PR TITLE
Add GitHub auto-label for database migrations

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -49,5 +49,5 @@
   - any: ["**/*.yml"]
     all: ["!Resources/Maps/_NF/**/*.yml", "!Resources/Prototypes/Maps/_NF/**/*.yml"]
 
-"DATABASE MIGRATIONS":
+"DB":
   - "Content.Server.Database/Migrations/**/*.cs"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -48,3 +48,6 @@
 "YML":
   - any: ["**/*.yml"]
     all: ["!Resources/Maps/_NF/**/*.yml", "!Resources/Prototypes/Maps/_NF/**/*.yml"]
+
+"DATABASE MIGRATIONS":
+  - "Content.Server.Database/Migrations/**/*.cs"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -49,5 +49,5 @@
   - any: ["**/*.yml"]
     all: ["!Resources/Maps/_NF/**/*.yml", "!Resources/Prototypes/Maps/_NF/**/*.yml"]
 
-"DB":
+"DB Migration":
   - "Content.Server.Database/Migrations/**/*.cs"


### PR DESCRIPTION
## About the PR
* Add a new entry to .github/labeler for database migrations

## Why / Balance
A botched database migration has the potential to completely wipe out our economy. Every single migration has to be vetted properly. By attaching a label to anything that touches migrations, it is my hope that we'll be able to catch them _early_ and perform the necessary testing.

## How to test
1. You can't, easily. :) Make a PR based on this branch that adds a dummy migration? I'm not sure.

## Media
N/A

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
No.

**Changelog**
N/A