### PR TITLE
Use correct sprite for sauna atmos fix marker

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Markers/atmos_blocker.yml
+++ b/Resources/Prototypes/_NF/Entities/Markers/atmos_blocker.yml
@@ -65,6 +65,6 @@
           shader: unshaded
         - sprite: Markers/atmos.rsi
           shader: unshaded # }
-          state: oxygen
+          state: watervapour
     - type: AtmosFixMarker
       mode: 11


### PR DESCRIPTION
## About the PR
Changed sauna atmos fix marker to use the `watervapour` sprite instead of `oxygen`.

## Why / Balance
Correctness. Fixing Darin's _laziness_.

## How to test
1. Spawn an Atmos Fix Sauna Marker.
2. Enjoy the barely legible text. 
3. Get annoyed at how it looks more like "H²O" than the more reasonable "H₂O".

## Media
![image](https://github.com/user-attachments/assets/9b0c80f8-8998-4d59-a25a-8d66bef63bb6)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
No.

**Changelog**
No.