### PR TITLE
Lower the price of shuttle wall

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/walls.yml
@@ -902,7 +902,7 @@
       - !type:DoActsBehavior
         acts: ["Destruction"]
   - type: StaticPrice
-    price: 250
+    price: 150 # Frontier: 250<150 - makes some shuttles way more expensive otherwise
   - type: RadiationBlocker
     resistance: 5
   - type: Sprite


### PR DESCRIPTION
## About the PR
Lower the price of reinforced, exterior shuttle wall back to 150, as it was before upstream merge.

## Why / Balance
Upstream increased the price to 250 because the materials that the wall is made of are now more expensive.  With my change, theoretically someone could disassemble the shuttle wall and get ~20 spesos more value, but shuttle walls are a gargantuan pain to deconstruct, so this seems like an acceptable tradeoff.

## How to test
1. Appraise a shuttle wall.
2. 150 spesos.

## Media
N/A

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
This is not a breaking change. This is a fixing change.

**Changelog**
No.