### PR TITLE
Sawn-off PKA Nerf

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Basic/sawn_pka.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Basic/sawn_pka.yml
@@ -12,6 +12,8 @@
     size: Small
     shape:
     - 0,0,1,0
+  - type: UseDelay
+    delay: 1
   - type: RechargeBasicEntityAmmo
     rechargeCooldown: 1
   - type: Gun

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Basic/sawn_pka.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Basic/sawn_pka.yml
@@ -12,8 +12,10 @@
     size: Small
     shape:
     - 0,0,1,0
+  - type: RechargeBasicEntityAmmo
+    rechargeCooldown: 1
   - type: Gun
-    fireRate: 8
+    fireRate: 0.9
     selectedMode: FullAuto
     availableModes:
     - FullAuto


### PR DESCRIPTION
## About the PR
Nerfed sawn-off PKA, gone are the days when one could turbo blast walls with 2 of those. Swapping hands resets cooldowns so it is faster to use one. Reduced fire rate from 8 to 0.9, decreased ammo regeneration from 0.75 to 1, added usedelay of 1.

## Why / Balance
Balance: double sawn-off PKA were significantly better than specialized wall busting equipment.

## How to test
1. Get a sawn-off PKA, start blasting
2. Get two sawn-off PKAs, start blasting rapidly swapping hands, expect worse performance.

## Media

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

**Changelog**
:cl: erhardsteinhauer
- tweak: Nerfed sawn-off PKA dual wielding: firing more than 1 shot per second shouldn't be possible now.
