### PR TITLE
Ice and Sandstone walls dont spawn girders

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/walls.yml
@@ -347,11 +347,11 @@
         !type:DamageTrigger
         damage: 300
       behaviors:
-      # - !type:SpawnEntitiesBehavior # Frontier
-      #   spawn: # Frontier
-      #     Girder: # Frontier
-      #       min: 1 # Frontier
-      #       max: 1 # Frontier
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          Girder:
+            min: 1
+            max: 1
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
   - type: IconSmooth
@@ -752,11 +752,11 @@
         !type:DamageTrigger
         damage: 300
       behaviors:
-      # - !type:SpawnEntitiesBehavior # Frontier
-      #   spawn: # Frontier
-      #     Girder: # Frontier
-      #       min: 1 # Frontier
-      #       max: 1 # Frontier
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          Girder:
+            min: 1
+            max: 1
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
   - type: IconSmooth

--- a/Resources/Prototypes/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/walls.yml
@@ -347,11 +347,11 @@
         !type:DamageTrigger
         damage: 300
       behaviors:
-      - !type:SpawnEntitiesBehavior
-        spawn:
-          Girder:
-            min: 1
-            max: 1
+      # - !type:SpawnEntitiesBehavior # Frontier
+      #   spawn: # Frontier
+      #     Girder: # Frontier
+      #       min: 1 # Frontier
+      #       max: 1 # Frontier
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
   - type: IconSmooth
@@ -752,11 +752,11 @@
         !type:DamageTrigger
         damage: 300
       behaviors:
-      - !type:SpawnEntitiesBehavior
-        spawn:
-          Girder:
-            min: 1
-            max: 1
+      # - !type:SpawnEntitiesBehavior # Frontier
+      #   spawn: # Frontier                     
+      #     Girder: # Frontier
+      #       min: 1 # Frontier
+      #       max: 1 # Frontier
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
   - type: IconSmooth

--- a/Resources/Prototypes/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/walls.yml
@@ -753,7 +753,7 @@
         damage: 300
       behaviors:
       # - !type:SpawnEntitiesBehavior # Frontier
-      #   spawn: # Frontier                     
+      #   spawn: # Frontier
       #     Girder: # Frontier
       #       min: 1 # Frontier
       #       max: 1 # Frontier

--- a/Resources/Prototypes/_NF/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Walls/walls.yml
@@ -13,7 +13,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 300
+        damage: 1000
       behaviors:
       - !type:DoActsBehavior
         acts: [ "Destruction" ]

--- a/Resources/Prototypes/_NF/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Walls/walls.yml
@@ -9,6 +9,14 @@
     spread: 10 # Narrow spread, need to balance vs. max projectile distance
     reflects:
     - ShuttleKinetic # Only reflects PTK (otherwise RIP miners)
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 300
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
 
 - type: entity
   parent: [AsteroidWallNF, WallIce]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Changes ice and sandstone walls to no longer spawn a girder on their destruction
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
![2024-10-09_11 04 47](https://github.com/user-attachments/assets/736973c3-c95b-498d-b507-dd257ab21126)

## How to test
<!-- Describe the way it can be tested -->

1. Spawn Ice Wall / Sandstone Wall
2. Destroy it

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/a343877b-af1c-47b8-bb59-00946d6b81f9

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Ice and sandstone walls no longer spawn a girder upon their destruction

