### PR TITLE
Personal Transport Shuttle Directional Fan Compliance Update

### DIFF
--- a/Resources/Maps/_NF/Shuttles/pts.yml
+++ b/Resources/Maps/_NF/Shuttles/pts.yml
@@ -331,17 +331,19 @@ entities:
     - type: Transform
       pos: 0.5,-1.5
       parent: 2
-- proto: AtmosDeviceFanTiny
+- proto: AtmosDeviceFanDirectional
   entities:
+  - uid: 1
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-0.5
+      parent: 2
   - uid: 53
     components:
     - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -3.5,1.5
-      parent: 2
-  - uid: 188
-    components:
-    - type: Transform
-      pos: -3.5,-0.5
       parent: 2
 - proto: AtmosFixBlockerMarker
   entities:
@@ -395,7 +397,6 @@ entities:
       parent: 2
     - type: Physics
       canCollide: False
-      bodyType: Static
     - type: Fixtures
       fixtures: {}
 - proto: BenchSofaCorpLeft
@@ -406,8 +407,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 2.5,-0.5
       parent: 2
-    - type: Physics
-      bodyType: Static
 - proto: BenchSofaCorpMiddle
   entities:
   - uid: 56
@@ -416,8 +415,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 3.5,0.5
       parent: 2
-    - type: Physics
-      bodyType: Static
 - proto: BenchSofaCorpRight
   entities:
   - uid: 54
@@ -426,8 +423,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 3.5,1.5
       parent: 2
-    - type: Physics
-      bodyType: Static
 - proto: CableApcExtension
   entities:
   - uid: 132

--- a/Resources/Maps/_NF/Shuttles/pts.yml
+++ b/Resources/Maps/_NF/Shuttles/pts.yml
@@ -1107,6 +1107,14 @@ entities:
     - type: Transform
       pos: 1.5,3.5
       parent: 2
+- proto: LockerWallMaterialsFuelPlasmaFilled
+  entities:
+  - uid: 184
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-4.5
+      parent: 2
 - proto: NitrogenCanister
   entities:
   - uid: 80
@@ -1206,13 +1214,6 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,3.5
-      parent: 2
-- proto: SheetPlasma
-  entities:
-  - uid: 184
-    components:
-    - type: Transform
-      pos: -0.5,-4.5
       parent: 2
 - proto: ShuttleWindow
   entities:


### PR DESCRIPTION
## About the PR
The PTSDFCU updates the Personal Transport Shuttle to be compliant with directional fan guidelines. Is there a reason this title has to be comically long? Not really. Is it truly comical? I mean, I find it so.

## Why / Balance
Directional fan good. Also, since the PTS is shared by the Chauffeur, this rounds off every ship on the Frontier Staff Shipyard Console.

## How to test
- Purchase a Personal Transport Shuttle or Chauffeur from the Shipyard Console or Frontier Staff Shipyard Console respectively.
- Open doors.
- Directional fans.

## Media
![image](https://github.com/user-attachments/assets/340f8102-915e-4caa-9011-dfbb950a5259)

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.