### PR TITLE
Bahama Mama's: Fix power issues + some tiny changes

### DIFF
--- a/Resources/Maps/_NF/POI/bahama.yml
+++ b/Resources/Maps/_NF/POI/bahama.yml
@@ -104,6 +104,20 @@ entities:
         version: 2
         nodes:
         - node:
+            color: '#0096FFFF'
+            id: BotGreyscale
+          decals:
+            321: -6,16
+            322: -5,16
+        - node:
+            color: '#FF0000FF'
+            id: BotGreyscale
+          decals:
+            317: -4,16
+            318: -3,16
+            319: -2,16
+            320: -1,16
+        - node:
             color: '#FFFFFFFF'
             id: BrickTileDarkCornerNe
           decals:
@@ -7233,6 +7247,16 @@ entities:
     components:
     - type: Transform
       pos: 2.5,16.5
+      parent: 2
+  - uid: 2101
+    components:
+    - type: Transform
+      pos: 3.5,13.5
+      parent: 2
+  - uid: 2102
+    components:
+    - type: Transform
+      pos: 4.5,13.5
       parent: 2
 - proto: CableMV
   entities:
@@ -19236,6 +19260,13 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 12.5,10.5
+      parent: 2
+- proto: ToolboxMechanicalFilled
+  entities:
+  - uid: 2159
+    components:
+    - type: Transform
+      pos: 4.4002657,16.811377
       parent: 2
 - proto: TwoWayLever
   entities:


### PR DESCRIPTION
## About the PR
Bahama Mama's had a tiny HV wiring issue which meant the second SMES wasn't connected to the powernet. This has now been resolved so the POI doesn't power down within 5 mins of roundstart when the solars aren't aligned. 

Added decals to the gas ports for greater visibility there.

Added a toolbox so there are some available if you need to anchor the JRPACMAN.

## Why / Balance
Noticed these issues while observing during a round. 

## How to test
Checkout the branch, load the POI.

## Media
Not required.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None.

**Changelog**
:cl:
- fix: Fixed power issues on Bahama Mama's. 

