### PR TITLE
Сontainer grid sizes and footprints

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
@@ -5,7 +5,7 @@
   description: A cardboard box for storing things.
   components:
   - type: Item
-    size: Large
+    size: Normal # Frontier Large<Normal
     shape:
     - 0,0,2,2
   - type: Storage
@@ -17,6 +17,7 @@
   - type: Tag
     tags:
     - BoxCardboard
+    - Trash # Frontier
 
 - type: entity
   name: mousetrap box

--- a/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
@@ -33,7 +33,7 @@
   - type: AllowsSleepInside # Frontier
 
 - type: entity
-  parent: ClothingBackpack
+  parent: NFClothingBackpack # Frontier: ClothingBackpack<NFClothingBackpack
   id: ClothingBackpackClown
   name: giggles von honkerton
   description: It's a backpack made by Honk! Co.
@@ -45,7 +45,7 @@
       collection: BikeHorn
 
 - type: entity
-  parent: ClothingBackpack
+  parent: NFClothingBackpack # Frontier: ClothingBackpack<NFClothingBackpack
   id: ClothingBackpackIan
   name: Ian's backpack
   description: Sometimes he wears it.
@@ -57,7 +57,7 @@
       collection: IanBark
 
 - type: entity
-  parent: [ClothingBackpack, BaseC2Contraband ] # Frontier: BaseRestrictedContraband<BaseC2Contraband
+  parent: [NFClothingBackpack, BaseC2Contraband ] # Frontier: BaseRestrictedContraband<BaseC2Contraband, ClothingBackpack<NFClothingBackpack
   id: ClothingBackpackSecurity
   name: security backpack
   description: It's a very robust backpack.
@@ -66,7 +66,7 @@
     sprite: Clothing/Back/Backpacks/security.rsi
 
 - type: entity
-  parent: [ClothingBackpack, BaseC2Contraband ] # Frontier: BaseRestrictedContraband<BaseC2Contraband
+  parent: [NFClothingBackpack, BaseC2Contraband ] # Frontier: BaseRestrictedContraband<BaseC2Contraband, ClothingBackpack<NFClothingBackpack
   id: ClothingBackpackBrigmedic
   name: brigmedic backpack
   description: It's a very sterile backpack.
@@ -75,7 +75,7 @@
     sprite: Clothing/Back/Backpacks/brigmedic.rsi
 
 - type: entity
-  parent: ClothingBackpack
+  parent: NFClothingBackpack # Frontier: ClothingBackpack<NFClothingBackpack
   id: ClothingBackpackEngineering
   name: engineering backpack
   description: It's a tough backpack for the daily grind of station life.
@@ -84,7 +84,7 @@
     sprite: Clothing/Back/Backpacks/engineering.rsi
 
 - type: entity
-  parent: ClothingBackpack
+  parent: NFClothingBackpack # Frontier: ClothingBackpack<NFClothingBackpack
   id: ClothingBackpackAtmospherics
   name: atmospherics backpack
   description: It's a backpack made of fire resistant fibers. Smells like plasma.
@@ -93,7 +93,7 @@
     sprite: Clothing/Back/Backpacks/atmospherics.rsi
 
 - type: entity
-  parent: ClothingBackpack
+  parent: NFClothingBackpack # Frontier: ClothingBackpack<NFClothingBackpack
   id: ClothingBackpackMedical
   name: medical backpack
   description: It's a backpack especially designed for use in a sterile environment.
@@ -102,7 +102,7 @@
     sprite: Clothing/Back/Backpacks/medical.rsi
 
 - type: entity
-  parent: ClothingBackpack # Frontier: removed BaseCommandContraband
+  parent: NFClothingBackpack # Frontier: ClothingBackpack<NFClothingBackpack # Frontier: removed BaseCommandContraband
   id: ClothingBackpackCaptain
   name: captain's backpack
   description: It's a special backpack made exclusively for Nanotrasen officers.
@@ -111,7 +111,7 @@
     sprite: Clothing/Back/Backpacks/captain.rsi
 
 - type: entity
-  parent: ClothingBackpack
+  parent: NFClothingBackpack # Frontier: ClothingBackpack<NFClothingBackpack
   id: ClothingBackpackMime
   name: mime backpack
   description: A silent backpack made for those silent workers. Silence Co.
@@ -120,7 +120,7 @@
     sprite: Clothing/Back/Backpacks/mime.rsi
 
 - type: entity
-  parent: ClothingBackpack
+  parent: NFClothingBackpack # Frontier: ClothingBackpack<NFClothingBackpack
   id: ClothingBackpackChemistry
   name: chemistry backpack
   description: A backpack specially designed to repel stains and hazardous liquids.
@@ -129,7 +129,7 @@
     sprite: Clothing/Back/Backpacks/chemistry.rsi
 
 - type: entity
-  parent: ClothingBackpack
+  parent: NFClothingBackpack # Frontier: ClothingBackpack<NFClothingBackpack
   id: ClothingBackpackHydroponics
   name: hydroponics backpack
   description: It's a backpack made of all-natural fibers.
@@ -138,7 +138,7 @@
     sprite: Clothing/Back/Backpacks/hydroponics.rsi
 
 - type: entity
-  parent: ClothingBackpack
+  parent: NFClothingBackpack # Frontier: ClothingBackpack<NFClothingBackpack
   id: ClothingBackpackScience
   name: science backpack
   description: A backpack specially designed to repel stains and hazardous liquids.
@@ -147,7 +147,7 @@
     sprite: Clothing/Back/Backpacks/science.rsi
 
 - type: entity
-  parent: ClothingBackpack
+  parent: NFClothingBackpack # Frontier: ClothingBackpack<NFClothingBackpack
   id: ClothingBackpackVirology
   name: virology backpack
   description: A backpack made of hypo-allergenic fibers. It's designed to help prevent the spread of disease. Smells like monkey.
@@ -156,7 +156,7 @@
     sprite: Clothing/Back/Backpacks/virology.rsi
 
 - type: entity
-  parent: ClothingBackpack
+  parent: NFClothingBackpack # Frontier: ClothingBackpack<NFClothingBackpack
   id: ClothingBackpackGenetics
   name: genetics backpack
   description: A backpack designed to be super tough, just in case someone hulks out on you.
@@ -165,7 +165,7 @@
     sprite: Clothing/Back/Backpacks/genetics.rsi
 
 - type: entity
-  parent: ClothingBackpack
+  parent: NFClothingBackpack # Frontier: ClothingBackpack<NFClothingBackpack
   id: ClothingBackpackCargo
   name: cargo backpack
   description: A robust backpack for stealing cargo's loot.
@@ -174,7 +174,7 @@
       sprite: Clothing/Back/Backpacks/cargo.rsi
 
 - type: entity
-  parent: ClothingBackpack
+  parent: NFClothingBackpack # Frontier: ClothingBackpack<NFClothingBackpack
   id: ClothingBackpackSalvage
   name: salvage bag
   description: A robust backpack for stashing your loot.
@@ -183,7 +183,7 @@
       sprite: Clothing/Back/Backpacks/salvage.rsi
 
 - type: entity
-  parent: ClothingBackpack
+  parent: NFClothingBackpack # Frontier: ClothingBackpack<NFClothingBackpack
   id: ClothingBackpackMercenary # Frontier - Merc to Mercenary
   name: mercenary backpack
   description: A backpack that has been in many dangerous places, a reliable combat backpack.
@@ -205,7 +205,7 @@
     - 0,0,10,3
 
 - type: entity
-  parent: ClothingBackpackERTLeader
+  parent: NFClothingBackpack # Frontier: ClothingBackpack<NFClothingBackpackERTLeader
   id: ClothingBackpackERTSecurity
   name: ERT security backpack
   description: A spacious backpack with lots of pockets, worn by Security Officers of an Emergency Response Team.
@@ -214,7 +214,7 @@
     sprite: Clothing/Back/Backpacks/ertsec.rsi
 
 - type: entity
-  parent: ClothingBackpackERTLeader
+  parent: NFClothingBackpack # Frontier: ClothingBackpack<NFClothingBackpackERTLeader
   id: ClothingBackpackERTMedical
   name: ERT medical backpack
   description: A spacious backpack with lots of pockets, worn by Medical Officers of an Emergency Response Team.
@@ -223,7 +223,7 @@
     sprite: Clothing/Back/Backpacks/ertmed.rsi
 
 - type: entity
-  parent: ClothingBackpackERTLeader
+  parent: NFClothingBackpack # Frontier: ClothingBackpack<NFClothingBackpackERTLeader
   id: ClothingBackpackERTEngineer
   name: ERT engineer backpack
   description: A spacious backpack with lots of pockets, worn by Engineers of an Emergency Response Team.
@@ -232,7 +232,7 @@
     sprite: Clothing/Back/Backpacks/erteng.rsi
 
 - type: entity
-  parent: ClothingBackpackERTLeader
+  parent: NFClothingBackpack # Frontier: ClothingBackpack<NFClothingBackpackERTLeader
   id: ClothingBackpackERTJanitor
   name: ERT janitor backpack
   description: A spacious backpack with lots of pockets, worn by Janitors of an Emergency Response Team.
@@ -241,7 +241,7 @@
     sprite: Clothing/Back/Backpacks/ertjanitor.rsi
 
 - type: entity
-  parent: ClothingBackpackERTLeader
+  parent: NFClothingBackpack # Frontier: ClothingBackpack<NFClothingBackpackERTLeader
   id: ClothingBackpackERTClown
   name: ERT clown backpack
   description: A spacious backpack with lots of pockets, worn by Clowns of an Emergency Response Team.
@@ -250,7 +250,7 @@
     sprite: Clothing/Back/Backpacks/ertclown.rsi
 
 - type: entity
-  parent: ClothingBackpackERTLeader
+  parent: NFClothingBackpack # Frontier: ClothingBackpack<NFClothingBackpackERTLeader
   id: ClothingBackpackERTChaplain
   name: ERT chaplain backpack
   description: A spacious backpack with lots of pockets, worn by Chaplains of an Emergency Response Team.
@@ -259,7 +259,7 @@
     sprite: Clothing/Back/Backpacks/ertchaplain.rsi
 
 - type: entity
-  parent: ClothingBackpackERTSecurity
+  parent: NFClothingBackpack # Frontier: ClothingBackpack<NFClothingBackpackERTSecurity
   id: ClothingBackpackDeathSquad
   name: death squad backpack
   description: Holds the kit of CentComm's most feared agents.
@@ -282,7 +282,7 @@
 
 #Special
 - type: entity
-  parent: ClothingBackpack
+  parent: NFClothingBackpack # Frontier: ClothingBackpack<NFClothingBackpack
   id: ClothingBackpackHolding
   name: bag of holding
   description: A backpack that opens into a localized pocket of bluespace.
@@ -319,7 +319,7 @@
     - 0,0,11,4
 
 - type: entity
-  parent: ClothingBackpackClown
+  parent: NFClothingBackpack # Frontier: ClothingBackpack<NFClothingBackpackClown
   id: ClothingBackpackCluwne
   name: jiggles von jonkerton
   suffix: Unremoveable
@@ -331,7 +331,7 @@
     deleteOnDrop: false
 
 - type: entity
-  parent: ClothingBackpack
+  parent: NFClothingBackpack # Frontier: ClothingBackpack<NFClothingBackpack
   id: ClothingBackpackElectropack
   name: electropack
   suffix: SelfUnremovable
@@ -355,7 +355,7 @@
 
 # Debug
 - type: entity
-  parent: ClothingBackpack
+  parent: NFClothingBackpack # Frontier: ClothingBackpack<NFClothingBackpack
   id: ClothingBackpackDebug
   name: wackpack
   description: What the fuck is this?
@@ -371,7 +371,7 @@
     - 9,5,9,5
 
 - type: entity
-  parent: ClothingBackpack
+  parent: NFClothingBackpack # Frontier: ClothingBackpack<NFClothingBackpack
   id: ClothingBackpackDebug2
   name: big wackpack
   description: What the fuck is this?
@@ -382,7 +382,7 @@
     - 0,0,39,24
 
 - type: entity
-  parent: ClothingBackpack
+  parent: NFClothingBackpack # Frontier: ClothingBackpack<NFClothingBackpack
   id: ClothingBackpackDebug3
   name: gay wackpack
   description: What the fuck is this?
@@ -403,7 +403,7 @@
     - 10,2,10,3
 
 - type: entity
-  parent: ClothingBackpack
+  parent: NFClothingBackpack # Frontier: ClothingBackpack<NFClothingBackpack
   id: ClothingBackpackDebug4
   name: offset wackpack
   description: What the fuck is this?

--- a/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
@@ -16,7 +16,7 @@
   - type: HeldSpeedModifier
 
 - type: entity
-  parent: ClothingBackpackDuffel
+  parent: NFClothingDuffel # Frontier: ClothingBackpackDuffelNFClothingDuffel
   id: ClothingBackpackDuffelEngineering
   name: engineering duffel bag
   description: A large duffel bag for holding extra tools and supplies.
@@ -25,7 +25,7 @@
       sprite: Clothing/Back/Duffels/engineering.rsi
 
 - type: entity
-  parent: ClothingBackpackDuffel
+  parent: NFClothingDuffel # Frontier: ClothingBackpackDuffelNFClothingDuffel
   id: ClothingBackpackDuffelAtmospherics
   name: atmospherics duffel bag
   description: A large duffel bag made of fire resistant fibers. Smells like plasma.
@@ -34,7 +34,7 @@
       sprite: Clothing/Back/Duffels/atmospherics.rsi
 
 - type: entity
-  parent: ClothingBackpackDuffel
+  parent: NFClothingDuffel # Frontier: ClothingBackpackDuffelNFClothingDuffel
   id: ClothingBackpackDuffelMedical
   name: medical duffel bag
   description: A large duffel bag for holding extra medical supplies.
@@ -43,7 +43,7 @@
       sprite: Clothing/Back/Duffels/medical.rsi
 
 - type: entity
-  parent: ClothingBackpackDuffel # Frontier: removed BaseCommandContraband
+  parent: NFClothingDuffel # Frontier: ClothingBackpackDuffelNFClothingDuffel # Frontier: removed BaseCommandContraband
   id: ClothingBackpackDuffelCaptain
   name: captain's duffel bag
   description: A large duffel bag for holding extra captainly goods.
@@ -52,7 +52,7 @@
       sprite: Clothing/Back/Duffels/captain.rsi
 
 - type: entity
-  parent: ClothingBackpackDuffel
+  parent: NFClothingDuffel # Frontier: ClothingBackpackDuffelNFClothingDuffel
   id: ClothingBackpackDuffelClown
   name: clown duffel bag
   description: A large duffel bag for holding extra honk goods.
@@ -64,7 +64,7 @@
         collection: BikeHorn
 
 - type: entity
-  parent: [ClothingBackpackDuffel, BaseC2Contraband ] # Frontier: BaseRestrictedContraband<BaseC2Contraband
+  parent: [NFClothingDuffel, BaseC2Contraband ] # Frontier: BaseRestrictedContraband<BaseC2Contraband, ClothingBackpackDuffel<NFClothingDuffel
   id: ClothingBackpackDuffelSecurity
   name: security duffel bag
   description: A large duffel bag for holding extra security related goods.
@@ -73,7 +73,7 @@
       sprite: Clothing/Back/Duffels/security.rsi
 
 - type: entity
-  parent: [ClothingBackpackDuffel, BaseC2Contraband ] # Frontier: BaseRestrictedContraband<BaseC2Contraband
+  parent: [NFClothingDuffel, BaseC2Contraband ] # Frontier: BaseRestrictedContraband<BaseC2Contraband, ClothingBackpackDuffel<NFClothingDuffel
   id: ClothingBackpackDuffelBrigmedic
   name: brigmedic duffel bag
   description: A large duffel bag for holding extra medical related goods.
@@ -82,7 +82,7 @@
       sprite: Clothing/Back/Duffels/brigmedic.rsi
 
 - type: entity
-  parent: ClothingBackpackDuffel
+  parent: NFClothingDuffel # Frontier: ClothingBackpackDuffelNFClothingDuffel
   id: ClothingBackpackDuffelChemistry
   name: chemistry duffel bag
   description: A large duffel bag for holding extra beakers and test tubes.
@@ -91,7 +91,7 @@
       sprite: Clothing/Back/Duffels/chemistry.rsi
 
 - type: entity
-  parent: ClothingBackpackDuffel
+  parent: NFClothingDuffel # Frontier: ClothingBackpackDuffelNFClothingDuffel
   id: ClothingBackpackDuffelVirology
   name: virology duffel bag
   description: A large duffel bag made of hypo-allergenic fibers. It's designed to help prevent the spread of disease. Smells like monkey.
@@ -100,7 +100,7 @@
       sprite: Clothing/Back/Duffels/virology.rsi
 
 - type: entity
-  parent: ClothingBackpackDuffel
+  parent: NFClothingDuffel # Frontier: ClothingBackpackDuffelNFClothingDuffel
   id: ClothingBackpackDuffelGenetics
   name: genetics duffel bag
   description: A large duffel bag for holding extra genetic mutations.
@@ -109,7 +109,7 @@
       sprite: Clothing/Back/Duffels/genetics.rsi
 
 - type: entity
-  parent: ClothingBackpackDuffel
+  parent: NFClothingDuffel # Frontier: ClothingBackpackDuffelNFClothingDuffel
   id: ClothingBackpackDuffelMime
   name: mime duffel bag
   description: A large duffel bag for holding... mime... stuff.
@@ -122,7 +122,7 @@
         collection: null
 
 - type: entity
-  parent: ClothingBackpackDuffel
+  parent: NFClothingDuffel # Frontier: ClothingBackpackDuffelNFClothingDuffel
   id: ClothingBackpackDuffelScience
   name: science duffel bag
   description: A large duffel bag for holding extra science related goods.
@@ -131,7 +131,7 @@
       sprite: Clothing/Back/Duffels/science.rsi
 
 - type: entity
-  parent: ClothingBackpackDuffel
+  parent: NFClothingDuffel # Frontier: ClothingBackpackDuffelNFClothingDuffel
   id: ClothingBackpackDuffelHydroponics
   name: hydroponics duffel bag
   description: A large duffel bag for holding extra gardening tools.
@@ -140,7 +140,7 @@
       sprite: Clothing/Back/Duffels/hydroponics.rsi
 
 - type: entity
-  parent: ClothingBackpackDuffel
+  parent: NFClothingDuffel # Frontier: ClothingBackpackDuffelNFClothingDuffel
   id: ClothingBackpackDuffelCargo
   name: cargo duffel bag
   description: A large duffel bag for stealing cargo's precious loot.
@@ -149,7 +149,7 @@
       sprite: Clothing/Back/Duffels/cargo.rsi
 
 - type: entity
-  parent: ClothingBackpackDuffel
+  parent: NFClothingDuffel # Frontier: ClothingBackpackDuffelNFClothingDuffel
   id: ClothingBackpackDuffelSalvage
   name: salvage duffel bag
   description: A large duffel bag for holding extra exotic treasures.
@@ -158,7 +158,7 @@
       sprite: Clothing/Back/Duffels/salvage.rsi
 
 - type: entity
-  parent: [ClothingBackpackDuffel, BaseC3Contraband, ContrabandClothing] # Frontier: BaseSyndicateContraband<BaseC3Contraband, added ContrabandClothing as parent
+  parent: [NFClothingDuffel, BaseC3Contraband, ContrabandClothing] # Frontier: BaseSyndicateContraband<BaseC3Contraband, added ContrabandClothing as parent
   id: ClothingBackpackDuffelSyndicate
   name: syndicate duffel bag
   description: A large duffel bag for holding various traitor goods.
@@ -172,7 +172,7 @@
     - 0,0,8,4
 
 - type: entity
-  parent: ClothingBackpackDuffelSyndicate
+  parent: NFClothingDuffel # Frontier: ClothingBackpackDuffelNFClothingDuffelSyndicate
   id: ClothingBackpackDuffelSyndicateBundle
   abstract: true
   components:
@@ -180,7 +180,7 @@
       tags: [] # ignore "WhitelistChameleon" tag
 
 - type: entity
-  parent: ClothingBackpackDuffelSyndicate
+  parent: NFClothingDuffel # Frontier: ClothingBackpackDuffelNFClothingDuffelSyndicate
   id: ClothingBackpackDuffelSyndicateAmmo
   name: syndicate duffel bag
   components:
@@ -193,7 +193,7 @@
       equippedPrefix: ammo
 
 - type: entity
-  parent: ClothingBackpackDuffelSyndicateAmmo
+  parent: NFClothingDuffel # Frontier: ClothingBackpackDuffelNFClothingDuffelSyndicateAmmo
   id: ClothingBackpackDuffelSyndicateAmmoBundle
   abstract: true
   components:
@@ -201,7 +201,7 @@
       tags: [] # ignore "WhitelistChameleon" tag
 
 - type: entity
-  parent: ClothingBackpackDuffelSyndicate
+  parent: NFClothingDuffel # Frontier: ClothingBackpackDuffelNFClothingDuffelSyndicate
   id: ClothingBackpackDuffelSyndicateMedical
   name: syndicate duffel bag
   components:
@@ -214,7 +214,7 @@
       equippedPrefix: med
 
 - type: entity
-  parent: ClothingBackpackDuffelSyndicateMedical
+  parent: NFClothingDuffel # Frontier: ClothingBackpackDuffelNFClothingDuffelSyndicateMedical
   id: ClothingBackpackDuffelSyndicateMedicalBundle
   abstract: true
   components:
@@ -222,7 +222,7 @@
       tags: [] # ignore "WhitelistChameleon" tag
 
 - type: entity
-  parent: ClothingBackpackDuffel
+  parent: NFClothingDuffel # Frontier: ClothingBackpackDuffelNFClothingDuffel
   id: ClothingBackpackDuffelHolding
   name: duffelbag of holding
   description: A duffelbag that opens into a localized pocket of bluespace.
@@ -261,7 +261,7 @@
         shader: unshaded # Frontier
 
 - type: entity
-  parent: [ ClothingBackpackDuffel, BaseCentcommContraband ]
+  parent: [ NFClothingDuffel, BaseCentcommContraband ] # Frontier: ClothingBackpackDuffel<NFClothingDuffel
   id: ClothingBackpackDuffelCBURN
   name: CBURN duffel bag
   description: A duffel bag containing a variety of biological containment equipment.

--- a/Resources/Prototypes/Entities/Clothing/Back/satchel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/satchel.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: ClothingBackpack
+  parent: NFClothingBackpack # Frontier: ClothingBackpack<NFClothingBackpack
   id: ClothingBackpackSatchel
   name: satchel
   description: A trendy looking satchel.

--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -1,7 +1,7 @@
 # Belts that need/have visualizers
 
 - type: entity
-  parent: ClothingBeltStorageBase
+  parent: NFClothingBeltStorageBase # Frontier: ClothingBeltStorageBase<NFClothingBeltStorageBase
   id: ClothingBeltUtility
   name: utility belt
   description: Can hold various things.
@@ -11,7 +11,7 @@
   - type: Clothing
     sprite: Clothing/Belt/utility.rsi
   - type: Storage
-    maxItemSize: Normal
+    #maxItemSize: Normal# Frontier
     # TODO: Fill this out more.
     # whitelist: # Frontier: commented out whitelist
       # tags:
@@ -81,7 +81,7 @@
   - type: Appearance
 
 - type: entity
-  parent: ClothingBeltStorageBase
+  parent: NFClothingBeltStorageBase # Frontier: ClothingBeltStorageBase<NFClothingBeltStorageBase
   id: ClothingBeltChiefEngineer
   name: chief engineer's toolbelt
   description: Holds tools, looks snazzy.
@@ -161,7 +161,7 @@
   - type: Appearance
 
 - type: entity
-  parent: ClothingBeltStorageBase
+  parent: NFClothingBeltStorageBase # Frontier: ClothingBeltStorageBase<NFClothingBeltStorageBase
   id: ClothingBeltAssault
   name: assault belt
   description: A tactical assault belt.
@@ -201,7 +201,7 @@
   - type: Appearance
 
 - type: entity
-  parent: ClothingBeltStorageBase
+  parent: NFClothingBeltStorageBase # Frontier: ClothingBeltStorageBase<NFClothingBeltStorageBase
   id: ClothingBeltJanitor
   name: janibelt
   description: A belt used to hold most janitorial supplies.
@@ -210,7 +210,7 @@
     sprite: Clothing/Belt/janitor.rsi
   - type: Clothing
     sprite: Clothing/Belt/janitor.rsi
-  - type: Storage
+  #- type: Storage # Frontier
     # whitelist: # Frontier: commented out whitelist
       # tags:
         # - Wrench
@@ -228,7 +228,7 @@
       # components:
         # - LightReplacer
         # - SmokeOnTrigger
-    maxItemSize: Large
+    #maxItemSize: Large # Frontier
   - type: ItemMapper
     mapLayers:
       bottle:
@@ -247,7 +247,7 @@
   - type: Appearance
 
 - type: entity
-  parent: ClothingBeltStorageBase
+  parent: NFClothingBeltStorageBase # Frontier: ClothingBeltStorageBase<NFClothingBeltStorageBase
   id: ClothingBeltMedical
   name: medical belt
   description: Can hold various medical equipment.
@@ -324,7 +324,7 @@
     sprite: Clothing/Belt/emt.rsi
 
 - type: entity
-  parent: ClothingBeltStorageBase
+  parent: NFClothingBeltStorageBase # Frontier: ClothingBeltStorageBase<NFClothingBeltStorageBase
   id: ClothingBeltPlant
   name: botanical belt
   description: A belt used to hold most hydroponics supplies. Suprisingly, not green.
@@ -381,7 +381,7 @@
   - type: Appearance
 
 - type: entity
-  parent: ClothingBeltStorageBase
+  parent: NFClothingBeltStorageBase # Frontier: ClothingBeltStorageBase<NFClothingBeltStorageBase
   id: ClothingBeltChef
   name: chef belt
   description: A belt used to hold kitchen knives and condiments for quick access.
@@ -520,8 +520,8 @@
     state: sheath
   - type: Clothing
     sprite: Clothing/Belt/sheath.rsi
-  - type: Item
-    size: Ginormous
+  #- type: Item # Frontier
+    #size: Ginormous # Frontier
   - type: ItemSlots
     slots:
       item:
@@ -553,8 +553,8 @@
     sprite: Clothing/Belt/bandolier.rsi
   - type: Clothing
     sprite: Clothing/Belt/bandolier.rsi
-  - type: Item
-    size: Huge
+  #- type: Item # Frontier
+    #size: Huge # Frontier
   - type: BallisticAmmoProvider
     whitelist:
       tags:
@@ -577,7 +577,7 @@
     - Kangaroo
 
 - type: entity
-  parent: ClothingBeltStorageBase
+  parent: NFClothingBeltStorageBase # Frontier: ClothingBeltStorageBase<NFClothingBeltStorageBase
   id: ClothingBeltHolster
   name: shoulder holster
   description: 'A holster to carry a handgun and ammo. WARNING: Badasses only.'
@@ -591,7 +591,7 @@
     # - 0,0,3,1 # Frontier: commented out
 
 - type: entity
-  parent: [ClothingBeltStorageBase, BaseC3SyndicateContraband, ContrabandClothing] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband, added ContrabandClothing as parent
+  parent: [NFClothingBeltStorageBase, BaseC3SyndicateContraband, ContrabandClothing] # Frontier: ClothingBeltStorageBase<NFClothingBeltStorageBase, BaseSyndicateContraband<BaseC3SyndicateContraband, added ContrabandClothing as parent
   id: ClothingBeltSyndieHolster
   name: syndicate shoulder holster
   description: A deep shoulder holster capable of holding many types of ballistics.
@@ -600,8 +600,8 @@
     sprite: Clothing/Belt/syndieholster.rsi
   - type: Clothing
     sprite: Clothing/Belt/syndieholster.rsi
-  - type: Item
-    size: Ginormous
+  #- type: Item # Frontier
+    #size: Ginormous # Frontier
   # - type: Storage # Frontier: commented out
     # maxItemSize: Huge # Frontier: commented out
     # grid: # Frontier: commented out
@@ -613,7 +613,7 @@
         # - CartridgeAmmo
 
 - type: entity
-  parent: ClothingBeltStorageBase #Frontier - ClothingBeltSecurity<ClothingBeltStorageBase
+  parent: NFClothingBeltStorageBase # Frontier: ClothingBeltStorageBase<NFClothingBeltStorageBase
   id: ClothingBeltSecurityWebbing
   name: security carrier
   description: Unique and versatile chest rig, can hold security gear.
@@ -624,7 +624,7 @@
     sprite: Clothing/Belt/securitywebbing.rsi
 
 - type: entity
-  parent: ClothingBeltStorageBase # Frontier: remove BaseSecurityCargoContraband
+  parent: NFClothingBeltStorageBase # Frontier: ClothingBeltStorageBase<NFClothingBeltStorageBase, remove BaseSecurityCargoContraband
   id: ClothingBeltMercenaryWebbing # Frontier: Merc to Mercenary
   name: mercenary webbing
   description: Ideal for storing everything from ammo to weapons and combat essentials.
@@ -635,7 +635,7 @@
     sprite: Clothing/Belt/mercwebbing.rsi
 
 - type: entity
-  parent: ClothingBeltStorageBase
+  parent: NFClothingBeltStorageBase # Frontier: ClothingBeltStorageBase<NFClothingBeltStorageBase
   id: ClothingBeltSalvageWebbing
   name: salvage rig
   description: Universal unloading system for work in space.
@@ -646,7 +646,7 @@
     sprite: Clothing/Belt/salvagewebbing.rsi
 
 - type: entity
-  parent: [ClothingBeltStorageBase, ContentsExplosionResistanceBase, BaseC1Contraband] # Frontier: BaseSyndicateContraband<BaseC1Contraband
+  parent: [NFClothingBeltStorageBase, ContentsExplosionResistanceBase, BaseC1Contraband] # Frontier: ClothingBeltStorageBase<NFClothingBeltStorageBase, BaseSyndicateContraband<BaseC1Contraband
   id: ClothingBeltMilitaryWebbing
   name: chest rig
   description: A set of tactical webbing worn by boarding parties. # Frontier
@@ -668,13 +668,13 @@
     sprite: Clothing/Belt/militarywebbingmed.rsi
   - type: Clothing
     sprite: Clothing/Belt/militarywebbingmed.rsi
-  - type: Item
-    size: Huge
+  #- type: Item # Frontier
+    #size: Huge # Frontier
   - type: ExplosionResistance
     damageCoefficient: 0.1
 
 - type: entity
-  parent: ClothingBeltBase
+  parent: NFClothingBeltStorageBase # Frontier: ClothingBeltStorageBase<NFClothingBeltStorageBase
   id: ClothingBeltSuspendersRed
   name: red suspenders
   description: For holding your pants up.
@@ -700,7 +700,7 @@
     sprite: Clothing/Belt/suspenders_black.rsi
 
 - type: entity
-  parent: [ClothingBeltStorageBase, BaseC3WizardContraband, ContrabandClothing] # Frontier: added BaseC3WizardContraband, ContrabandClothing as parent
+  parent: [NFClothingBeltStorageBase, BaseC3WizardContraband, ContrabandClothing] # Frontier: ClothingBeltStorageBase<NFClothingBeltStorageBase, added BaseC3WizardContraband, ContrabandClothing as parent
   id: ClothingBeltWand
   name: wizard belt # Frontier: changed the name from 'wand belt' -> 'wizard belt'
   description: A belt designed to hold various rods of power. A veritable fanny pack of exotic magic.

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/medkits.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/medkits.yml
@@ -12,7 +12,9 @@
     grid:
     - 0,0,3,1
   - type: Item
-    size: Large
+    size: Normal # Frontier: Large<Normal
+    shape: # Frontier
+    - 0,0,3,1 # Frontier
     sprite: Objects/Specific/Medical/firstaidkits.rsi
     heldPrefix: firstaid
   - type: PhysicalComposition

--- a/Resources/Prototypes/Entities/Objects/Tools/toolbox.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/toolbox.yml
@@ -15,7 +15,9 @@
     grid:
     - 0,0,6,3
   - type: Item
-    size: Ginormous
+    size: Large # Frontier: Ginormous<Large
+    shape: # Frontier
+    - 0,0,6,3 # Frontier
   - type: MeleeWeapon
     damage:
       types:

--- a/Resources/Prototypes/_NF/Entities/Clothing/Back/base_clothing_backpack.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Back/base_clothing_backpack.yml
@@ -1,0 +1,30 @@
+
+- type: entity
+  abstract: true
+  parent: ClothingBackpack
+  id: NFClothingBackpack
+  components:
+  - type: Storage
+    maxItemSize: Large
+    defaultStorageOrientation: Vertical
+    grid:
+    - 0,0,6,3
+  - type: Item
+    size: Huge
+    shape:
+    - 0,0,6,3
+
+- type: entity
+  abstract: true
+  parent: ClothingBackpack
+  id: NFClothingDuffel
+  components:
+  - type: Storage
+    maxItemSize: Huge
+    defaultStorageOrientation: Vertical
+    grid:
+    - 0,0,7,4
+  - type: Item
+    size: Huge
+    shape:
+    - 0,0,7,5

--- a/Resources/Prototypes/_NF/Entities/Clothing/Back/base_clothing_backpack.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Back/base_clothing_backpack.yml
@@ -28,3 +28,26 @@
     size: Huge
     shape:
     - 0,0,7,5
+
+- type: entity
+  abstract: true
+  parent: NFClothingBackpack
+  id: NFClothingMessenger
+  components:  
+  ## One 4x4 pocket, four 2x2 pockets
+  - type: Storage
+    grid:
+    - 0,0,1,1
+    - 0,3,1,4
+    - 3,0,6,3
+    - 8,0,9,1
+    - 8,3,9,4
+
+  # Alternative layouts
+  ## Two 2x1 pockets, one 2x3 pocket and one 6x3 pocket
+  # - type: Storage
+    # grid:
+    # - 0,0,1,2
+    # - 3,0,8,2
+    # - 10,0,11,0
+    # - 10,2,11,2

--- a/Resources/Prototypes/_NF/Entities/Clothing/Back/duffel.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Back/duffel.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: ClothingBackpackDuffel
+  parent: NFClothingDuffel
   id: ClothingBackpackDuffelMercenary # Frontier - Merc to Mercenary
   name: mercenary duffel
   description: A duffel that has been in many dangerous places, a reliable combat duffel.
@@ -10,14 +10,14 @@
 - type: entity
   id: ClothingBackpackDuffelArcadia
   name: arcadia duffel
-  parent: [ ClothingBackpackDuffel, BaseC3ContrabandNoValue, ContrabandClothing ]
+  parent: [ NFClothingDuffel, BaseC3ContrabandNoValue, ContrabandClothing ]
   description: A duffelbag produced by Arcadia Industries
   components:
   - type: Sprite
     sprite: _NF/Clothing/Back/Duffels/arcadia.rsi
 
 - type: entity
-  parent: ClothingBackpackDuffel
+  parent: NFClothingDuffel
   id: ClothingBackpackDuffelPilot
   name: pilot duffel
   description: A duffelbag produced for a True Ace.

--- a/Resources/Prototypes/_NF/Entities/Clothing/Back/messenger.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Back/messenger.yml
@@ -1,6 +1,6 @@
 # BASE
 - type: entity
-  parent: ClothingBackpack
+  parent: NFClothingMessenger
   id: ClothingBackpackMessengerContractor
   name: contractor messenger bag
   description: A trendy looking messenger bag in tasteful colors.
@@ -38,7 +38,7 @@
         color: "#eeeeee"
 
 - type: entity
-  parent: ClothingBackpack
+  parent: NFClothingMessenger
   id: ClothingBackpackMessenger
   name: messenger bag
   description: A trendy looking messenger bag.

--- a/Resources/Prototypes/_NF/Entities/Clothing/Belt/base_clothing_belt.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Belt/base_clothing_belt.yml
@@ -12,7 +12,7 @@
   - type: Item
     size: Large
     shape:
-    - 0,0,4,3
+    - 0,0,3,3
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/_NF/Entities/Clothing/Belt/base_clothing_belt.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Belt/base_clothing_belt.yml
@@ -5,14 +5,14 @@
   id: NFClothingBeltStorageBase
   components:
   - type: Storage
-    maxItemSize: Small
+    maxItemSize: Normal
     defaultStorageOrientation: Vertical
     grid:
     - 0,0,7,1
   - type: Item
-    size: Normal
+    size: Large
     shape:
-    - 0,0,3,3
+    - 0,0,4,3
 
 - type: entity
   abstract: true
@@ -22,7 +22,7 @@
   - type: BallisticAmmoProvider
     mayTransfer: true
   - type: Item
-    size: Normal
+    size: Large
     shape:
     - 0,0,3,3
   - type: ContainerContainer

--- a/Resources/Prototypes/_NF/Entities/Clothing/Belt/base_clothing_belt.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Belt/base_clothing_belt.yml
@@ -1,0 +1,30 @@
+
+- type: entity
+  abstract: true
+  parent: ClothingBeltStorageBase
+  id: NFClothingBeltStorageBase
+  components:
+  - type: Storage
+    maxItemSize: Small
+    defaultStorageOrientation: Vertical
+    grid:
+    - 0,0,7,1
+  - type: Item
+    size: Normal
+    shape:
+    - 0,0,3,3
+
+- type: entity
+  abstract: true
+  parent: ClothingBeltAmmoProviderBase
+  id: NFClothingBeltAmmoProviderBase
+  components:
+  - type: BallisticAmmoProvider
+    mayTransfer: true
+  - type: Item
+    size: Normal
+    shape:
+    - 0,0,3,3
+  - type: ContainerContainer
+    containers:
+      ballistic-ammo: !type:Container

--- a/Resources/Prototypes/_NF/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Belt/belts.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: ClothingBeltArcadia
   name: arcadia webbing
-  parent: [ ClothingBeltStorageBase, BaseC3ContrabandNoValue, ContrabandClothing ]
+  parent: [ NFClothingBeltStorageBase, BaseC3ContrabandNoValue, ContrabandClothing ]
   description: A webbing created by Arcadia Industries. Seems very capable of fitting many items.
   components:
   - type: Sprite
@@ -10,7 +10,7 @@
     sprite: _NF/Clothing/Belt/arcadia.rsi
 
 - type: entity
-  parent: ClothingBeltStorageBase
+  parent: NFClothingBeltStorageBase
   id: ClothingBeltChaplainSash
   name: chaplain sash
   description: Who knew that scarves can be also tied around your waist?
@@ -52,7 +52,7 @@
   - type: Appearance
 
 - type: entity
-  parent: ClothingBeltStorageBase
+  parent: NFClothingBeltStorageBase
   id: ClothingBeltPilot
   name: pilot webbing
   description: A webbing designed for someone seating a lot.

--- a/Resources/Prototypes/_NF/Entities/Clothing/Belt/belts_blood_cult.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Belt/belts_blood_cult.yml
@@ -18,7 +18,7 @@
 - type: entity
   parent:
   - BaseC3CultContrabandUnredeemable
-  - ClothingBeltStorageBase
+  - NFClothingBeltStorageBase
   - ContrabandClothing
   id: ClothingBeltCultWebbing
   name: cult webbing

--- a/Resources/Prototypes/_NF/Entities/Clothing/Belt/belts_crossbow_quiver.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Belt/belts_crossbow_quiver.yml
@@ -1,5 +1,5 @@
 ﻿- type: entity
-  parent: ClothingBeltStorageBase
+  parent: NFClothingBeltStorageBase
   id: ClothingBeltQuiverCrossbow
   name: quiver (bolts)
   description: Can hold up to 25 bolts, and fits snug around your waist.

--- a/Resources/Prototypes/_NF/Entities/Clothing/Belt/belts_punk.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Belt/belts_punk.yml
@@ -1,7 +1,7 @@
 
 - type: entity
   id: ClothingBeltPunkRandomized
-  parent: [ ClothingBeltStorageBase, RecyclableItemClothBasic ]
+  parent: [ NFClothingBeltStorageBase, RecyclableItemClothBasic ]
   name: punk belt
   description: A webbing with functional pockets.
   suffix: Random visuals

--- a/Resources/Prototypes/_NF/Entities/Objects/Storage/weapon_cases.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Storage/weapon_cases.yml
@@ -12,18 +12,22 @@
       state: icon
     - state: unshaded
       shader: unshaded
-  - type: Item
-    sprite: _NF/Objects/Storage/Cases/guncaselong.rsi
   - type: GenericVisualizer
     visuals:
       enum.StorageVisuals.Open:
         base:
           True: { state: icon-open }
           False: { state: icon }
+  - type: Item
+    sprite: _NF/Objects/Storage/Cases/guncaselong.rsi
+    size: Large
+    shape:
+    - 0,0,4,3
   - type: Storage
     maxItemSize: Huge
     grid:
-    - 0,0,4,3
+    - 0,0,3,3
+    - 5,0,6,3
     whitelist:
       components:
       - Gun
@@ -47,8 +51,10 @@
   - type: Sprite
     sprite: _NF/Objects/Storage/Cases/guncaseshort.rsi
   - type: Item
-    size: Large
     sprite: _NF/Objects/Storage/Cases/guncaseshort.rsi
+    size: Normal
+    shape:
+    - 0,0,3,1
   - type: Storage
     maxItemSize: Normal
     grid:
@@ -124,8 +130,10 @@
   - type: Sprite
     sprite: _NF/Objects/Storage/Cases/guncaseheavy.rsi
   - type: Item
-    size: Ginormous
     sprite: _NF/Objects/Storage/Cases/guncaseheavy.rsi
+    size: Ginormous
+    shape:
+    - 0,0,8,3
   - type: Storage
     maxItemSize: Ginormous
     grid:


### PR DESCRIPTION
## About the PR
Right now, for example, a utility belt has a 2x8 inventory space, but its current footprint is 6x6, and it can't be stored in duffels or backpacks. In this PR I'm adjusting its footprint to match its actual inventory size, such as 2x8 or 4x4, and removing the restriction on placing them in larger containers like backpacks. This could similarly apply to other belt slot storage accessories or containers like toolboxes. This change should not significantly impact game balance, but it could enhance the quality of life for players in certain edge cases.

Slightly more context [in this post](https://discord.com/channels/1123826877245694004/1294667861876277341/1294667861876277341). Here is the table of new values. 

<html>

<body>

Container | Container size | Max stored size | Grid | Footprint
-- | -- | -- | -- | --
duffel | Huge | Huge | 8x5 | 8x5
backpack | Huge | Large | 7x4 | 7x4
satchel | Huge | Large | two 2x4, 4x4 | 8x4
messenger bag | Huge | Large | four 2x2, 4x4 | 8x4
toolbox | Large | Medium/Normal | 7x4 | 7x4
belt | Large | Medium/Normal | 4x4 | 4x4
webbing | Medium/Normal | Small | 4x4 | 4x4
cardboard box | Medium/Normal | Small | 3x3 | 3x3
medkit | Medium/Normal | Small | 4x2 | 4x2
weapon case (short) | Medium/Normal | Small | 4x2 | 4x2
weapon case (long) | Huge | Huge | 4x4, 2x4 | 6x4
weapon case (heavy) | Ginoromous | Ginoromous | 8x6 | 9x6


</body>

</html>

## Why / Balance
I thought that something like this should be a reasonable change:
belt -> duffel/backpack/toolbox
toolbox -/-> toolbox
toolbox -> duffel/backpack
duffel/backpack -/-> duffel/backpack

## How to test
Spawn various bags, try to put one in another.

## Media
New messenger bag inventory grid
![image](https://github.com/user-attachments/assets/b4e9cd05-6f36-497a-ac64-c7731bd8577e)

New long weapon case grid
![image](https://github.com/user-attachments/assets/13fd0b0b-47ef-4b55-8f74-562c41cf8331)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl: erhardsteinhauer
- tweak: Slightly changed how wearable containers (like backpacks etc) work: now it's possible (but rather pointless) to put a belt in backpack, a backpack in duffel, a toolbox fits in a backpack.