### PR TITLE
New Ship: NT Meteor

### DIFF
--- a/Resources/Maps/_NF/Shuttles/Expedition/meteor.yml
+++ b/Resources/Maps/_NF/Shuttles/Expedition/meteor.yml
@@ -1,0 +1,2582 @@
+meta:
+  format: 6
+  postmapinit: false
+tilemap:
+  0: Space
+  3: FloorDark
+  4: FloorDarkMini
+  5: FloorDarkMono
+  1: FloorGlass
+  6: FloorHull
+  7: FloorHullReinforced
+  69: FloorMetalDiamond
+  2: FloorMining
+  85: FloorReinforcedHardened
+  98: FloorSteel
+  8: FloorSteelCheckerDark
+  108: FloorSteelMini
+  109: FloorSteelMono
+  113: FloorTechMaint
+  9: FloorTechMaint2
+  130: Lattice
+  131: Plating
+entities:
+- proto: ""
+  entities:
+  - uid: 1
+    components:
+    - type: MetaData
+      name: grid
+    - type: Transform
+      pos: -0.46875,-0.578125
+      parent: invalid
+    - type: MapGrid
+      chunks:
+        0,0:
+          ind: 0,0
+          tiles: bAAAAAADbQAAAAAAgwAAAAAACQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAbAAAAAADbAAAAAADgwAAAAAACQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAbAAAAAAAbAAAAAACCQAAAAAACQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAbAAAAAACCQAAAAAAAQAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACQAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          version: 6
+        -1,0:
+          ind: -1,0
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAACQAAAAAAgwAAAAAACAAAAAABCAAAAAADCAAAAAAAgwAAAAAAAwAAAAAAAwAAAAABAwAAAAACAwAAAAAAAwAAAAAAgwAAAAAAbAAAAAACAAAAAAAAAAAAAAAAAAAAAAAACQAAAAAACQAAAAAACAAAAAAACAAAAAACCAAAAAAAgwAAAAAAAwAAAAADAwAAAAAAgwAAAAAAAwAAAAABgwAAAAAAgwAAAAAAbAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACQAAAAAACQAAAAAACAAAAAAACAAAAAACCAAAAAACgwAAAAAAgwAAAAAAgwAAAAAAgwAAAAAAAwAAAAAAgwAAAAAAgwAAAAAAbAAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAABgwAAAAAACAAAAAADCAAAAAACgwAAAAAAgwAAAAAAgwAAAAAAgwAAAAAAAwAAAAACgwAAAAAAgwAAAAAAbAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAgwAAAAAACAAAAAADgwAAAAAAgwAAAAAAgwAAAAAAgwAAAAAAAwAAAAABgwAAAAAAgwAAAAAAgwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAACgwAAAAAAgwAAAAAAgwAAAAAAgwAAAAAAgwAAAAAAgwAAAAAAgwAAAAAAgwAAAAAAgwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          version: 6
+        -1,-1:
+          ind: -1,-1
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgwAAAAAAgwAAAAAARQAAAAAARQAAAAAARQAAAAAAgwAAAAAAgwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACQAAAAAACQAAAAAACQAAAAAAgwAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAAgwAAAAAACQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgwAAAAAAgwAAAAAAgwAAAAAAgwAAAAAAgwAAAAAAgwAAAAAAgwAAAAAACQAAAAAACQAAAAAACQAAAAAAgwAAAAAAgwAAAAAAgwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgwAAAAAAbQAAAAADbQAAAAAAbQAAAAAAbQAAAAADbQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAAbQAAAAABbQAAAAACAAAAAAAAAAAAAAAAAAAAAAAAgwAAAAAAbQAAAAABbQAAAAACbQAAAAABbQAAAAAAbQAAAAACCQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAAbQAAAAABbQAAAAABAAAAAAAAAAAAAAAAAAAAAAAARQAAAAAAYgAAAAAAYgAAAAAAYgAAAAABYgAAAAABYgAAAAADYgAAAAABYgAAAAADYgAAAAABYgAAAAADYgAAAAACYgAAAAABYgAAAAADAAAAAAAAAAAAAAAAAAAAAAAARQAAAAAAYgAAAAACYgAAAAABYgAAAAADYgAAAAAAYgAAAAADYgAAAAABYgAAAAABYgAAAAACYgAAAAAAYgAAAAABYgAAAAACYgAAAAACAAAAAAAAAAAAAAAAAAAAAAAAgwAAAAAAgwAAAAAAgwAAAAAACQAAAAAACQAAAAAAgwAAAAAAgwAAAAAAgwAAAAAACQAAAAAAgwAAAAAAgwAAAAAAgwAAAAAAgwAAAAAA
+          version: 6
+        0,-1:
+          ind: 0,-1
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACQAAAAAACQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgwAAAAAAgwAAAAAAgwAAAAAAgwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAbQAAAAADbQAAAAAAbQAAAAAAgwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAbQAAAAABbQAAAAABbQAAAAADgwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYgAAAAADYgAAAAADYgAAAAAARQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYgAAAAADYgAAAAACYgAAAAAARQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACQAAAAAAgwAAAAAAgwAAAAAAgwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          version: 6
+    - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      angularDamping: 0.05
+      linearDamping: 0.05
+      fixedRotation: False
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures: {}
+    - type: OccluderTree
+    - type: SpreaderGrid
+    - type: Shuttle
+    - type: GridPathfinding
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+    - type: DecalGrid
+      chunkCollection:
+        version: 2
+        nodes:
+        - node:
+            angle: -1.5707963267948966 rad
+            color: '#FFA647FF'
+            id: Arrows
+          decals:
+            1343: 2,-3
+        - node:
+            angle: 1.5707963267948966 rad
+            color: '#FFA647FF'
+            id: Arrows
+          decals:
+            1016: -12,-2
+            1017: -12,-2
+            1342: -12,-3
+        - node:
+            angle: 4.71238898038469 rad
+            color: '#FFA647FF'
+            id: Arrows
+          decals:
+            1064: 2,-2
+            1065: 2,-2
+        - node:
+            color: '#FF9821FF'
+            id: Bot
+          decals:
+            1326: -12,-4
+            1327: -11,-4
+            1328: -10,-4
+            1329: -9,-4
+            1330: -8,-4
+            1331: -2,-4
+            1332: -1,-4
+            1333: 0,-4
+            1334: 1,-4
+            1335: 2,-4
+        - node:
+            color: '#FFA647FF'
+            id: Bot
+          decals:
+            1157: -8,-5
+            1160: -9,-5
+            1163: -10,-5
+            1166: -11,-5
+            1167: -12,-5
+            1171: -2,-5
+            1172: -1,-5
+            1175: 0,-5
+            1176: 1,-5
+            1181: 2,-5
+        - node:
+            color: '#334E6DC8'
+            id: BrickLineOverlayN
+          decals:
+            1216: 0,-2
+            1217: 0,-2
+        - node:
+            color: '#9FED5896'
+            id: BrickLineOverlayN
+          decals:
+            885: -9,-2
+        - node:
+            color: '#EFB34196'
+            id: BrickLineOverlayN
+          decals:
+            884: -5,-2
+        - node:
+            color: '#FF9821FF'
+            id: BrickTileSteelCornerSe
+          decals:
+            1344: -3,-5
+        - node:
+            color: '#FF9821FF'
+            id: BrickTileSteelCornerSw
+          decals:
+            1345: -7,-5
+        - node:
+            color: '#FF9821FF'
+            id: BrickTileSteelLineE
+          decals:
+            1325: -3,-4
+        - node:
+            color: '#FF9821FF'
+            id: BrickTileSteelLineN
+          decals:
+            895: -12,-2
+            899: -4,-2
+            900: -3,-2
+            901: -2,-2
+            902: -1,-2
+            927: -10,-2
+            1018: -11,-2
+            1035: 1,-2
+            1036: 2,-2
+            1292: -8,-2
+            1295: -6,-2
+            1296: -7,-2
+        - node:
+            color: '#FF9821FF'
+            id: BrickTileSteelLineS
+          decals:
+            1307: 2,-3
+            1308: 1,-3
+            1309: 0,-3
+            1310: -1,-3
+            1311: -2,-3
+            1312: -3,-3
+            1313: -4,-3
+            1314: -6,-3
+            1315: -5,-3
+            1316: -7,-3
+            1317: -8,-3
+            1318: -9,-3
+            1319: -10,-3
+            1320: -11,-3
+            1321: -12,-3
+            1346: -6,-5
+            1347: -5,-5
+            1348: -4,-5
+        - node:
+            color: '#FF9821FF'
+            id: BrickTileSteelLineW
+          decals:
+            1324: -7,-4
+        - node:
+            color: '#EFB34196'
+            id: BrickTileWhiteCornerSe
+          decals:
+            1350: -3,0
+        - node:
+            color: '#EFB34196'
+            id: BrickTileWhiteCornerSw
+          decals:
+            594: -7,0
+        - node:
+            color: '#EFB34196'
+            id: BrickTileWhiteLineN
+          decals:
+            1360: -4,4
+        - node:
+            color: '#EFB34196'
+            id: BrickTileWhiteLineS
+          decals:
+            1367: -6,0
+            1368: -5,0
+            1369: -4,0
+        - node:
+            color: '#EFB34196'
+            id: BrickTileWhiteLineW
+          decals:
+            1370: -7,1
+        - node:
+            color: '#9FED5896'
+            id: CheckerNESW
+          decals:
+            518: -9,2
+            519: -10,2
+            520: -11,2
+            525: -9,3
+            526: -10,3
+            552: -11,0
+            553: -11,1
+            554: -10,1
+            555: -10,0
+            556: -9,0
+            557: -9,1
+            963: -9,4
+        - node:
+            color: '#334E6DC8'
+            id: MiniTileCornerOverlayNE
+          decals:
+            1186: 1,2
+            1187: 0,3
+            1190: 0,3
+            1191: 1,2
+        - node:
+            color: '#334E6DC8'
+            id: MiniTileCornerOverlayNW
+          decals:
+            1188: -1,3
+            1189: -1,3
+        - node:
+            color: '#334E6DC8'
+            id: MiniTileCornerOverlaySE
+          decals:
+            1297: 0,0
+            1298: 0,0
+            1305: 1,1
+            1306: 1,1
+        - node:
+            color: '#334E6DC8'
+            id: MiniTileCornerOverlaySW
+          decals:
+            1192: -1,0
+            1193: -1,0
+        - node:
+            color: '#334E6DC8'
+            id: MiniTileInnerOverlayNE
+          decals:
+            1201: 0,2
+            1202: 0,2
+        - node:
+            color: '#334E6DC8'
+            id: MiniTileInnerOverlaySE
+          decals:
+            1303: 0,1
+            1304: 0,1
+        - node:
+            color: '#334E6DC8'
+            id: MiniTileLineOverlayW
+          decals:
+            1184: -1,1
+            1185: -1,2
+            1197: -1,1
+            1198: -1,2
+        - node:
+            color: '#FFA647FF'
+            id: WarnCornerNE
+          decals:
+            1082: 3,2
+        - node:
+            cleanable: True
+            color: '#FFA647FF'
+            id: WarnCornerNE
+          decals:
+            1380: -6,1
+        - node:
+            color: '#FFA647FF'
+            id: WarnCornerNW
+          decals:
+            620: -13,2
+        - node:
+            color: '#FFA647FF'
+            id: WarnCornerSE
+          decals:
+            1337: 1,-7
+        - node:
+            color: '#FFA647FF'
+            id: WarnCornerSW
+          decals:
+            1336: -11,-7
+        - node:
+            color: '#FFA647FF'
+            id: WarnCornerSmallNE
+          decals:
+            1371: -4,0
+        - node:
+            cleanable: True
+            color: '#FFA647FF'
+            id: WarnCornerSmallNE
+          decals:
+            1378: -6,0
+        - node:
+            cleanable: True
+            color: '#FFA647FF'
+            id: WarnCornerSmallNW
+          decals:
+            1377: -4,0
+        - node:
+            color: '#FFA647FF'
+            id: WarnLineE
+          decals:
+            1070: 2,-2
+            1079: 3,0
+            1081: 3,1
+            1323: 2,-3
+            1357: -4,1
+            1358: -4,2
+            1359: -4,3
+            1361: -4,4
+        - node:
+            color: '#FFA647FF'
+            id: WarnLineN
+          decals:
+            1338: -1,-7
+            1339: 0,-7
+            1340: -10,-7
+            1341: -9,-7
+        - node:
+            color: '#FFA647FF'
+            id: WarnLineS
+          decals:
+            569: -13,0
+            619: -13,1
+            924: -12,-2
+            1322: -12,-3
+        - node:
+            cleanable: True
+            color: '#FFA647FF'
+            id: WarnLineS
+          decals:
+            1373: -4,4
+            1374: -4,3
+            1375: -4,2
+            1376: -4,1
+        - node:
+            color: '#FFA647FF'
+            id: WarnLineW
+          decals:
+            1352: -3,0
+        - node:
+            cleanable: True
+            color: '#FFA647FF'
+            id: WarnLineW
+          decals:
+            1372: -7,1
+            1379: -5,0
+        - node:
+            cleanable: True
+            angle: 0.6283185307179586 rad
+            color: '#DE3A3AFF'
+            id: cyka
+          decals:
+            1269: -6,3
+    - type: GridAtmosphere
+      version: 2
+      data:
+        tiles:
+          0,0:
+            0: 23483
+          0,-1:
+            0: 6007
+          -1,0:
+            0: 48059
+          0,1:
+            0: 18
+          -4,0:
+            0: 2184
+          -3,0:
+            0: 57070
+          -3,1:
+            0: 74
+          -3,-1:
+            0: 36863
+          -2,0:
+            0: 61166
+          -2,1:
+            0: 14
+          -2,-1:
+            0: 36863
+          -1,1:
+            0: 3
+          -3,-2:
+            0: 61664
+          -2,-2:
+            0: 64748
+          -1,-2:
+            0: 61873
+          -1,-1:
+            0: 4095
+          0,-2:
+            0: 28720
+        uniqueMixes:
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 21.824879
+          - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        chunkSize: 4
+    - type: GasTileOverlay
+    - type: RadiationGridResistance
+    - type: BecomesStation
+      id: Blob
+- proto: AirAlarm
+  entities:
+  - uid: 2
+    components:
+    - type: Transform
+      pos: -1.5,-0.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 162
+      - 161
+      - 163
+      - 165
+      - 167
+      - 168
+      - 166
+      - 108
+      - 110
+      - 109
+- proto: AirlockCommand
+  entities:
+  - uid: 3
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 1
+- proto: AirlockEngineering
+  entities:
+  - uid: 4
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-0.5
+      parent: 1
+- proto: AirlockExternal
+  entities:
+  - uid: 5
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-5.5
+      parent: 1
+    - type: Door
+      secondsUntilStateChange: -879.76666
+      state: Opening
+    - type: DeviceLinkSource
+      lastSignals:
+        DoorStatus: True
+  - uid: 6
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-5.5
+      parent: 1
+  - uid: 7
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-5.5
+      parent: 1
+- proto: AirlockGlass
+  entities:
+  - uid: 8
+    components:
+    - type: Transform
+      pos: -8.5,-0.5
+      parent: 1
+    - type: Door
+      secondsUntilStateChange: -8272.857
+      state: Opening
+    - type: DeviceLinkSource
+      lastSignals:
+        DoorStatus: True
+- proto: AirlockShuttle
+  entities:
+  - uid: 9
+    components:
+    - type: Transform
+      pos: -4.5,-7.5
+      parent: 1
+  - uid: 10
+    components:
+    - type: Transform
+      pos: -5.5,-7.5
+      parent: 1
+  - uid: 11
+    components:
+    - type: Transform
+      pos: -3.5,-7.5
+      parent: 1
+- proto: AmeController
+  entities:
+  - uid: 12
+    components:
+    - type: Transform
+      pos: -4.5,1.5
+      parent: 1
+    - type: ContainerContainer
+      containers:
+        fuelSlot: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: 13
+- proto: AmeJar
+  entities:
+  - uid: 13
+    components:
+    - type: Transform
+      parent: 12
+    - type: Physics
+      canCollide: False
+- proto: AmeShielding
+  entities:
+  - uid: 14
+    components:
+    - type: Transform
+      pos: -4.5,3.5
+      parent: 1
+  - uid: 15
+    components:
+    - type: Transform
+      pos: -5.5,4.5
+      parent: 1
+  - uid: 16
+    components:
+    - type: Transform
+      pos: -6.5,4.5
+      parent: 1
+  - uid: 17
+    components:
+    - type: Transform
+      pos: -4.5,4.5
+      parent: 1
+  - uid: 18
+    components:
+    - type: Transform
+      pos: -6.5,3.5
+      parent: 1
+  - uid: 19
+    components:
+    - type: Transform
+      pos: -5.5,3.5
+      parent: 1
+  - uid: 20
+    components:
+    - type: Transform
+      pos: -5.5,2.5
+      parent: 1
+  - uid: 21
+    components:
+    - type: Transform
+      pos: -6.5,2.5
+      parent: 1
+  - uid: 22
+    components:
+    - type: Transform
+      pos: -4.5,2.5
+      parent: 1
+- proto: APCBasic
+  entities:
+  - uid: 23
+    components:
+    - type: Transform
+      pos: -2.5,-0.5
+      parent: 1
+    - type: Apc
+      hasAccess: True
+- proto: AtmosDeviceFanDirectional
+  entities:
+  - uid: 24
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -12.5,-2.5
+      parent: 1
+  - uid: 25
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -12.5,-1.5
+      parent: 1
+  - uid: 26
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-2.5
+      parent: 1
+  - uid: 27
+    components:
+    - type: Transform
+      pos: -5.5,-7.5
+      parent: 1
+  - uid: 28
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-1.5
+      parent: 1
+  - uid: 29
+    components:
+    - type: Transform
+      pos: -4.5,-7.5
+      parent: 1
+  - uid: 30
+    components:
+    - type: Transform
+      pos: -3.5,-7.5
+      parent: 1
+- proto: BlastDoorExterior1
+  entities:
+  - uid: 31
+    components:
+    - type: Transform
+      pos: -12.5,-1.5
+      parent: 1
+  - uid: 32
+    components:
+    - type: Transform
+      pos: -12.5,-2.5
+      parent: 1
+- proto: BlastDoorExterior2
+  entities:
+  - uid: 33
+    components:
+    - type: Transform
+      pos: 3.5,-1.5
+      parent: 1
+  - uid: 34
+    components:
+    - type: Transform
+      pos: 3.5,-2.5
+      parent: 1
+- proto: CableApcExtension
+  entities:
+  - uid: 35
+    components:
+    - type: Transform
+      pos: -9.5,-0.5
+      parent: 1
+  - uid: 36
+    components:
+    - type: Transform
+      pos: -9.5,2.5
+      parent: 1
+  - uid: 37
+    components:
+    - type: Transform
+      pos: -6.5,0.5
+      parent: 1
+  - uid: 38
+    components:
+    - type: Transform
+      pos: -9.5,1.5
+      parent: 1
+  - uid: 39
+    components:
+    - type: Transform
+      pos: -9.5,-1.5
+      parent: 1
+  - uid: 40
+    components:
+    - type: Transform
+      pos: -9.5,-2.5
+      parent: 1
+  - uid: 41
+    components:
+    - type: Transform
+      pos: -0.5,0.5
+      parent: 1
+  - uid: 42
+    components:
+    - type: Transform
+      pos: -7.5,0.5
+      parent: 1
+  - uid: 43
+    components:
+    - type: Transform
+      pos: -8.5,0.5
+      parent: 1
+  - uid: 44
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 1
+  - uid: 45
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 1
+  - uid: 46
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 1
+  - uid: 47
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+  - uid: 48
+    components:
+    - type: Transform
+      pos: -4.5,0.5
+      parent: 1
+  - uid: 49
+    components:
+    - type: Transform
+      pos: -9.5,-4.5
+      parent: 1
+  - uid: 50
+    components:
+    - type: Transform
+      pos: -9.5,-3.5
+      parent: 1
+  - uid: 51
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 1
+  - uid: 52
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 1
+  - uid: 53
+    components:
+    - type: Transform
+      pos: -11.5,2.5
+      parent: 1
+  - uid: 54
+    components:
+    - type: Transform
+      pos: -2.5,-0.5
+      parent: 1
+  - uid: 55
+    components:
+    - type: Transform
+      pos: -5.5,0.5
+      parent: 1
+  - uid: 56
+    components:
+    - type: Transform
+      pos: -3.5,0.5
+      parent: 1
+  - uid: 57
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 1
+  - uid: 58
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 1
+  - uid: 59
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 1
+  - uid: 60
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+  - uid: 61
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 62
+    components:
+    - type: Transform
+      pos: -4.5,-5.5
+      parent: 1
+  - uid: 63
+    components:
+    - type: Transform
+      pos: -2.5,2.5
+      parent: 1
+  - uid: 64
+    components:
+    - type: Transform
+      pos: -2.5,1.5
+      parent: 1
+  - uid: 65
+    components:
+    - type: Transform
+      pos: -9.5,0.5
+      parent: 1
+  - uid: 66
+    components:
+    - type: Transform
+      pos: -6.5,-4.5
+      parent: 1
+  - uid: 67
+    components:
+    - type: Transform
+      pos: -2.5,-4.5
+      parent: 1
+  - uid: 68
+    components:
+    - type: Transform
+      pos: -7.5,-4.5
+      parent: 1
+  - uid: 69
+    components:
+    - type: Transform
+      pos: -5.5,-4.5
+      parent: 1
+  - uid: 70
+    components:
+    - type: Transform
+      pos: -4.5,-4.5
+      parent: 1
+  - uid: 71
+    components:
+    - type: Transform
+      pos: -0.5,-4.5
+      parent: 1
+  - uid: 72
+    components:
+    - type: Transform
+      pos: -8.5,-4.5
+      parent: 1
+  - uid: 73
+    components:
+    - type: Transform
+      pos: -1.5,-4.5
+      parent: 1
+  - uid: 74
+    components:
+    - type: Transform
+      pos: -3.5,-4.5
+      parent: 1
+- proto: CableHV
+  entities:
+  - uid: 75
+    components:
+    - type: Transform
+      pos: -4.5,2.5
+      parent: 1
+  - uid: 76
+    components:
+    - type: Transform
+      pos: -4.5,1.5
+      parent: 1
+  - uid: 77
+    components:
+    - type: Transform
+      pos: -3.5,2.5
+      parent: 1
+  - uid: 78
+    components:
+    - type: Transform
+      pos: -2.5,1.5
+      parent: 1
+  - uid: 79
+    components:
+    - type: Transform
+      pos: -2.5,2.5
+      parent: 1
+- proto: CableMV
+  entities:
+  - uid: 80
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 1
+  - uid: 81
+    components:
+    - type: Transform
+      pos: -2.5,-0.5
+      parent: 1
+  - uid: 82
+    components:
+    - type: Transform
+      pos: -2.5,1.5
+      parent: 1
+- proto: CableTerminal
+  entities:
+  - uid: 83
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,2.5
+      parent: 1
+- proto: CargoPallet
+  entities:
+  - uid: 84
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,0.5
+      parent: 1
+- proto: ChairOfficeLight
+  entities:
+  - uid: 85
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,1.5
+      parent: 1
+  - uid: 86
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,0.5
+      parent: 1
+  - uid: 87
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,2.5
+      parent: 1
+- proto: ChairPilotSeat
+  entities:
+  - uid: 88
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 89
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,-4.5
+      parent: 1
+  - uid: 90
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,-3.5
+      parent: 1
+  - uid: 91
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-4.5
+      parent: 1
+  - uid: 92
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-3.5
+      parent: 1
+  - uid: 193
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -11.5,-3.5
+      parent: 1
+  - uid: 324
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -11.5,-4.5
+      parent: 1
+  - uid: 325
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-3.5
+      parent: 1
+  - uid: 326
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-4.5
+      parent: 1
+- proto: ClothingHeadHatCapcap
+  entities:
+  - uid: 93
+    components:
+    - type: Transform
+      pos: -0.33339095,2.951693
+      parent: 1
+- proto: ComputerTabletopSalvageExpedition
+  entities:
+  - uid: 94
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,2.5
+      parent: 1
+- proto: ComputerTabletopShuttle
+  entities:
+  - uid: 95
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 1
+- proto: ComputerTabletopStationRecords
+  entities:
+  - uid: 96
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,1.5
+      parent: 1
+- proto: CrateFreezer
+  entities:
+  - uid: 97
+    components:
+    - type: Transform
+      pos: -8.5,4.5
+      parent: 1
+- proto: DefibrillatorCabinetFilled
+  entities:
+  - uid: 98
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,0.5
+      parent: 1
+- proto: EmergencyLight
+  entities:
+  - uid: 99
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-6.5
+      parent: 1
+  - uid: 100
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-4.5
+      parent: 1
+  - uid: 101
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,-4.5
+      parent: 1
+  - uid: 102
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 1
+  - uid: 103
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -8.5,1.5
+      parent: 1
+  - uid: 104
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,1.5
+      parent: 1
+  - uid: 105
+    components:
+    - type: Transform
+      pos: -3.5,-1.5
+      parent: 1
+- proto: ExtinguisherCabinetFilled
+  entities:
+  - uid: 106
+    components:
+    - type: Transform
+      pos: -10.5,-0.5
+      parent: 1
+- proto: FaxMachineShip
+  entities:
+  - uid: 107
+    components:
+    - type: Transform
+      pos: -0.5,3.5
+      parent: 1
+- proto: FirelockEdge
+  entities:
+  - uid: 108
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-1.5
+      parent: 1
+    - type: DeviceNetwork
+      configurators:
+      - invalid
+      deviceLists:
+      - 2
+  - uid: 109
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-1.5
+      parent: 1
+    - type: DeviceNetwork
+      configurators:
+      - invalid
+      deviceLists:
+      - 2
+  - uid: 110
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -8.5,-1.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 2
+- proto: FoodBoxPizzaFilled
+  entities:
+  - uid: 111
+    components:
+    - type: Transform
+      pos: -10.535391,1.9365752
+      parent: 1
+- proto: GasMixerOnFlipped
+  entities:
+  - uid: 112
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,0.5
+      parent: 1
+    - type: GasMixer
+      inletTwoConcentration: 0.78
+      inletOneConcentration: 0.22
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasPassiveVent
+  entities:
+  - uid: 113
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -12.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 114
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPipeBend
+  entities:
+  - uid: 115
+    components:
+    - type: Transform
+      pos: -5.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 116
+    components:
+    - type: Transform
+      pos: -9.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 117
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 118
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 119
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -10.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 120
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 121
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasPipeStraight
+  entities:
+  - uid: 122
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 123
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 124
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 125
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 126
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 127
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 128
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 129
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 130
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 131
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 132
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 133
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 134
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 135
+    components:
+    - type: Transform
+      pos: -10.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 136
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 137
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 138
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 139
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 140
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -11.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 141
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 142
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 143
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 144
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 145
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 146
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 147
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 148
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 149
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPipeTJunction
+  entities:
+  - uid: 150
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 151
+    components:
+    - type: Transform
+      pos: -1.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 152
+    components:
+    - type: Transform
+      pos: -8.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 153
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 154
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 155
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 156
+    components:
+    - type: Transform
+      pos: -4.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 157
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -10.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPort
+  entities:
+  - uid: 158
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 159
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasVentPump
+  entities:
+  - uid: 160
+    components:
+    - type: Transform
+      pos: -5.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 161
+    components:
+    - type: Transform
+      pos: -2.5,1.5
+      parent: 1
+    - type: DeviceNetwork
+      configurators:
+      - invalid
+      deviceLists:
+      - 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 162
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,2.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 163
+    components:
+    - type: Transform
+      pos: -0.5,3.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasVentScrubber
+  entities:
+  - uid: 164
+    components:
+    - type: Transform
+      pos: -3.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 165
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 166
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -8.5,-2.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 167
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-2.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 168
+    components:
+    - type: Transform
+      pos: -10.5,1.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GravityGeneratorMini
+  entities:
+  - uid: 169
+    components:
+    - type: Transform
+      pos: -2.5,3.5
+      parent: 1
+- proto: Grille
+  entities:
+  - uid: 170
+    components:
+    - type: Transform
+      pos: -11.5,1.5
+      parent: 1
+  - uid: 171
+    components:
+    - type: Transform
+      pos: 2.5,2.5
+      parent: 1
+  - uid: 172
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,3.5
+      parent: 1
+  - uid: 173
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+  - uid: 174
+    components:
+    - type: Transform
+      pos: -11.5,2.5
+      parent: 1
+  - uid: 175
+    components:
+    - type: Transform
+      pos: -9.5,-0.5
+      parent: 1
+- proto: GrilleDiagonal
+  entities:
+  - uid: 176
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,4.5
+      parent: 1
+  - uid: 177
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 178
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,5.5
+      parent: 1
+- proto: Gyroscope
+  entities:
+  - uid: 179
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,4.5
+      parent: 1
+- proto: LockerCaptainFilledNoLaser
+  entities:
+  - uid: 180
+    components:
+    - type: Transform
+      anchored: True
+      pos: -0.5,0.5
+      parent: 1
+    - type: Physics
+      bodyType: Static
+- proto: LockerSalvageSpecialistFilled
+  entities:
+  - uid: 181
+    components:
+    - type: Transform
+      anchored: True
+      pos: -2.5,-3.5
+      parent: 1
+    - type: Physics
+      bodyType: Static
+  - uid: 182
+    components:
+    - type: Transform
+      anchored: True
+      pos: -6.5,-3.5
+      parent: 1
+    - type: Physics
+      bodyType: Static
+- proto: LockerWallMaterialsFuelAmeJarFilled
+  entities:
+  - uid: 183
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-0.5
+      parent: 1
+- proto: Multitool
+  entities:
+  - uid: 184
+    components:
+    - type: Transform
+      pos: -8.009964,-4.4579997
+      parent: 1
+    - type: NetworkConfigurator
+      linkModeActive: False
+- proto: NitrogenCanister
+  entities:
+  - uid: 185
+    components:
+    - type: Transform
+      anchored: True
+      pos: -6.5,1.5
+      parent: 1
+    - type: Physics
+      bodyType: Static
+- proto: OxygenCanister
+  entities:
+  - uid: 186
+    components:
+    - type: Transform
+      anchored: True
+      pos: -6.5,0.5
+      parent: 1
+    - type: Physics
+      bodyType: Static
+- proto: PaperBin20
+  entities:
+  - uid: 187
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,2.5
+      parent: 1
+- proto: PlushieHampter
+  entities:
+  - uid: 188
+    components:
+    - type: Transform
+      pos: -0.26394653,3.1322486
+      parent: 1
+- proto: Poweredlight
+  entities:
+  - uid: 189
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -8.5,2.5
+      parent: 1
+  - uid: 190
+    components:
+    - type: Transform
+      pos: -7.5,-1.5
+      parent: 1
+  - uid: 191
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,1.5
+      parent: 1
+  - uid: 194
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,0.5
+      parent: 1
+  - uid: 195
+    components:
+    - type: Transform
+      pos: -0.5,-1.5
+      parent: 1
+  - uid: 196
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-6.5
+      parent: 1
+  - uid: 218
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -11.5,-3.5
+      parent: 1
+  - uid: 323
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-3.5
+      parent: 1
+- proto: Railing
+  entities:
+  - uid: 197
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-4.5
+      parent: 1
+  - uid: 198
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-3.5
+      parent: 1
+  - uid: 199
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-4.5
+      parent: 1
+  - uid: 200
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-3.5
+      parent: 1
+- proto: RailingCorner
+  entities:
+  - uid: 201
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -12.5,0.5
+      parent: 1
+  - uid: 202
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,0.5
+      parent: 1
+- proto: RailingCornerSmall
+  entities:
+  - uid: 203
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-2.5
+      parent: 1
+  - uid: 204
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-2.5
+      parent: 1
+- proto: RandomPosterLegit
+  entities:
+  - uid: 205
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -10.5,-5.5
+      parent: 1
+  - uid: 206
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,3.5
+      parent: 1
+  - uid: 207
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,2.5
+      parent: 1
+  - uid: 208
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-4.5
+      parent: 1
+- proto: ReinforcedWindow
+  entities:
+  - uid: 209
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,4.5
+      parent: 1
+  - uid: 210
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,2.5
+      parent: 1
+  - uid: 211
+    components:
+    - type: Transform
+      pos: -11.5,2.5
+      parent: 1
+  - uid: 212
+    components:
+    - type: Transform
+      pos: -11.5,1.5
+      parent: 1
+  - uid: 213
+    components:
+    - type: Transform
+      pos: -9.5,-0.5
+      parent: 1
+  - uid: 214
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,3.5
+      parent: 1
+- proto: ReinforcedWindowDiagonal
+  entities:
+  - uid: 215
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 216
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 217
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,4.5
+      parent: 1
+- proto: RipleyChassis
+  entities:
+  - uid: 192
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.662157,-4.062092
+      parent: 1
+- proto: SalvageTechfabNF
+  entities:
+  - uid: 219
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 1
+- proto: SignalButtonExt1
+  entities:
+  - uid: 220
+    components:
+    - type: Transform
+      pos: -11.5,-0.5
+      parent: 1
+- proto: SignalButtonExt2
+  entities:
+  - uid: 221
+    components:
+    - type: Transform
+      pos: 2.5,-0.5
+      parent: 1
+- proto: SignBridge
+  entities:
+  - uid: 222
+    components:
+    - type: Transform
+      pos: -0.5,-0.5
+      parent: 1
+- proto: SignEngineering
+  entities:
+  - uid: 223
+    components:
+    - type: Transform
+      pos: -3.5,-0.5
+      parent: 1
+- proto: SignKitchen
+  entities:
+  - uid: 224
+    components:
+    - type: Transform
+      pos: -7.5,-0.5
+      parent: 1
+- proto: SMESBasic
+  entities:
+  - uid: 225
+    components:
+    - type: Transform
+      pos: -2.5,2.5
+      parent: 1
+- proto: SpawnPointLatejoin
+  entities:
+  - uid: 226
+    components:
+    - type: Transform
+      pos: -8.5,1.5
+      parent: 1
+- proto: SubstationBasic
+  entities:
+  - uid: 227
+    components:
+    - type: Transform
+      pos: -2.5,1.5
+      parent: 1
+- proto: SuitStorageQuartermaster
+  entities:
+  - uid: 228
+    components:
+    - type: Transform
+      pos: -0.5,1.5
+      parent: 1
+- proto: SuitStorageSalv
+  entities:
+  - uid: 229
+    components:
+    - type: Transform
+      pos: -2.5,-4.5
+      parent: 1
+  - uid: 230
+    components:
+    - type: Transform
+      pos: -6.5,-4.5
+      parent: 1
+- proto: TableReinforced
+  entities:
+  - uid: 231
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 1
+  - uid: 232
+    components:
+    - type: Transform
+      pos: -10.5,0.5
+      parent: 1
+  - uid: 233
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,2.5
+      parent: 1
+  - uid: 234
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,1.5
+      parent: 1
+  - uid: 235
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,3.5
+      parent: 1
+  - uid: 236
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,2.5
+      parent: 1
+  - uid: 237
+    components:
+    - type: Transform
+      pos: 1.5,2.5
+      parent: 1
+  - uid: 238
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,3.5
+      parent: 1
+- proto: Thruster
+  entities:
+  - uid: 239
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-6.5
+      parent: 1
+  - uid: 240
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-6.5
+      parent: 1
+  - uid: 241
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-6.5
+      parent: 1
+  - uid: 242
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -12.5,1.5
+      parent: 1
+  - uid: 243
+    components:
+    - type: Transform
+      pos: -12.5,2.5
+      parent: 1
+  - uid: 244
+    components:
+    - type: Transform
+      pos: 3.5,2.5
+      parent: 1
+  - uid: 245
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,1.5
+      parent: 1
+  - uid: 246
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,-6.5
+      parent: 1
+  - uid: 247
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,-6.5
+      parent: 1
+  - uid: 248
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -8.5,-6.5
+      parent: 1
+- proto: ToolboxElectricalFilled
+  entities:
+  - uid: 249
+    components:
+    - type: Transform
+      pos: -8.306839,-4.0361247
+      parent: 1
+- proto: VendingMachineAtmosDrobe
+  entities:
+  - uid: 250
+    components:
+    - type: Transform
+      pos: -3.5,4.5
+      parent: 1
+- proto: VendingMachineCargoDrobe
+  entities:
+  - uid: 251
+    components:
+    - type: Transform
+      pos: -2.5,-6.5
+      parent: 1
+- proto: VendingMachineTankDispenserEVA
+  entities:
+  - uid: 252
+    components:
+    - type: Transform
+      pos: -6.5,-6.5
+      parent: 1
+- proto: WallReinforced
+  entities:
+  - uid: 253
+    components:
+    - type: Transform
+      pos: -9.5,-5.5
+      parent: 1
+  - uid: 254
+    components:
+    - type: Transform
+      pos: -8.5,-5.5
+      parent: 1
+  - uid: 255
+    components:
+    - type: Transform
+      pos: 2.5,-5.5
+      parent: 1
+  - uid: 256
+    components:
+    - type: Transform
+      pos: 0.5,-5.5
+      parent: 1
+  - uid: 257
+    components:
+    - type: Transform
+      pos: -7.5,-5.5
+      parent: 1
+  - uid: 258
+    components:
+    - type: Transform
+      pos: -0.5,-5.5
+      parent: 1
+  - uid: 259
+    components:
+    - type: Transform
+      pos: -1.5,-5.5
+      parent: 1
+  - uid: 260
+    components:
+    - type: Transform
+      pos: -10.5,-5.5
+      parent: 1
+  - uid: 261
+    components:
+    - type: Transform
+      pos: -2.5,-5.5
+      parent: 1
+  - uid: 262
+    components:
+    - type: Transform
+      pos: -6.5,-5.5
+      parent: 1
+  - uid: 263
+    components:
+    - type: Transform
+      pos: -11.5,-5.5
+      parent: 1
+  - uid: 264
+    components:
+    - type: Transform
+      pos: 1.5,-5.5
+      parent: 1
+  - uid: 265
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-7.5
+      parent: 1
+  - uid: 266
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-7.5
+      parent: 1
+  - uid: 267
+    components:
+    - type: Transform
+      pos: -12.5,-3.5
+      parent: 1
+  - uid: 268
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 1
+  - uid: 269
+    components:
+    - type: Transform
+      pos: -1.5,-7.5
+      parent: 1
+  - uid: 270
+    components:
+    - type: Transform
+      pos: -7.5,-7.5
+      parent: 1
+  - uid: 271
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-5.5
+      parent: 1
+  - uid: 272
+    components:
+    - type: Transform
+      pos: -0.5,5.5
+      parent: 1
+  - uid: 273
+    components:
+    - type: Transform
+      pos: -10.5,3.5
+      parent: 1
+  - uid: 274
+    components:
+    - type: Transform
+      pos: -8.5,5.5
+      parent: 1
+  - uid: 275
+    components:
+    - type: Transform
+      pos: -9.5,4.5
+      parent: 1
+  - uid: 276
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-3.5
+      parent: 1
+  - uid: 277
+    components:
+    - type: Transform
+      pos: -11.5,0.5
+      parent: 1
+  - uid: 278
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,-6.5
+      parent: 1
+  - uid: 279
+    components:
+    - type: Transform
+      pos: -11.5,-0.5
+      parent: 1
+  - uid: 280
+    components:
+    - type: Transform
+      pos: 2.5,-0.5
+      parent: 1
+  - uid: 281
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 1
+  - uid: 282
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-4.5
+      parent: 1
+  - uid: 283
+    components:
+    - type: Transform
+      pos: -12.5,-0.5
+      parent: 1
+  - uid: 284
+    components:
+    - type: Transform
+      pos: -12.5,-4.5
+      parent: 1
+  - uid: 285
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-6.5
+      parent: 1
+  - uid: 286
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -12.5,-5.5
+      parent: 1
+  - uid: 287
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-0.5
+      parent: 1
+  - uid: 288
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,5.5
+      parent: 1
+  - uid: 289
+    components:
+    - type: Transform
+      pos: -7.5,5.5
+      parent: 1
+  - uid: 290
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,5.5
+      parent: 1
+  - uid: 291
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,5.5
+      parent: 1
+  - uid: 292
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,5.5
+      parent: 1
+  - uid: 293
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,5.5
+      parent: 1
+  - uid: 294
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,5.5
+      parent: 1
+- proto: WallReinforcedDiagonal
+  entities:
+  - uid: 295
+    components:
+    - type: Transform
+      pos: -10.5,4.5
+      parent: 1
+  - uid: 296
+    components:
+    - type: Transform
+      pos: -9.5,5.5
+      parent: 1
+  - uid: 297
+    components:
+    - type: Transform
+      pos: -11.5,3.5
+      parent: 1
+- proto: WallSolid
+  entities:
+  - uid: 298
+    components:
+    - type: Transform
+      pos: -10.5,-0.5
+      parent: 1
+  - uid: 299
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,4.5
+      parent: 1
+  - uid: 300
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,4.5
+      parent: 1
+  - uid: 301
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 1
+  - uid: 302
+    components:
+    - type: Transform
+      pos: -2.5,-0.5
+      parent: 1
+  - uid: 303
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,1.5
+      parent: 1
+  - uid: 304
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,4.5
+      parent: 1
+  - uid: 305
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,0.5
+      parent: 1
+  - uid: 306
+    components:
+    - type: Transform
+      pos: -7.5,-0.5
+      parent: 1
+  - uid: 307
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,3.5
+      parent: 1
+  - uid: 308
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,2.5
+      parent: 1
+  - uid: 309
+    components:
+    - type: Transform
+      pos: -6.5,-0.5
+      parent: 1
+  - uid: 310
+    components:
+    - type: Transform
+      pos: -3.5,-0.5
+      parent: 1
+  - uid: 311
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 1
+  - uid: 312
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 1
+  - uid: 313
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 1
+  - uid: 314
+    components:
+    - type: Transform
+      pos: -1.5,-0.5
+      parent: 1
+  - uid: 315
+    components:
+    - type: Transform
+      pos: -0.5,-0.5
+      parent: 1
+  - uid: 316
+    components:
+    - type: Transform
+      pos: 1.5,-0.5
+      parent: 1
+  - uid: 317
+    components:
+    - type: Transform
+      pos: -5.5,-0.5
+      parent: 1
+- proto: WallWeaponCapacitorRecharger
+  entities:
+  - uid: 318
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-0.5
+      parent: 1
+- proto: WarpPointShip
+  entities:
+  - uid: 319
+    components:
+    - type: Transform
+      pos: -5.5,-2.5
+      parent: 1
+- proto: WaterCooler
+  entities:
+  - uid: 320
+    components:
+    - type: Transform
+      pos: -9.5,3.5
+      parent: 1
+- proto: WeaponCapacitorRecharger
+  entities:
+  - uid: 321
+    components:
+    - type: Transform
+      pos: -10.5,0.5
+      parent: 1
+- proto: Wrench
+  entities:
+  - uid: 322
+    components:
+    - type: Transform
+      pos: -8.728714,-4.2548747
+      parent: 1
+...

--- a/Resources/Prototypes/_NF/Shipyard/Expedition/meteor.yml
+++ b/Resources/Prototypes/_NF/Shipyard/Expedition/meteor.yml
@@ -1,0 +1,41 @@
+# Author Info
+# GitHub: The048
+# Discord: @sh1nycrab
+
+# Maintainer Info
+# GitHub: someone from the future
+# Discord: that same person from the future
+
+# Shuttle Notes: the core concept is to be a capital S Small expeditionary ship, with basically everything being sacrificed for that large cargo bay while trying to fit within the 256 tile guideline that the ship submisssion guidelines point to.
+#
+- type: vessel
+  id: meteor
+  name: NT Meteor
+  description: The civilian version of a NanoTrasen dropship meant to move mechanized strike teams, now used for its large cargo bay and small overall size.
+  price: 51525 #the base sell value is ~29,687 spesos
+  category: Small
+  group: Expedition
+  shuttlePath: /Maps/_NF/Shuttles/Expedition/meteor.yml
+  guidebookPage: Null
+  class:
+  - Expedition
+  
+- type: gameMap
+  id: meteor
+  mapName: 'NT Meteor'
+  mapPath: /Maps/_NF/Shuttles/Expedition/meteor.yml
+  minPlayers: 0
+  stations: 
+    meteor:
+      stationProto: StandardFrontierExpeditionVessel
+      components:
+        - type: StationNameSetup
+          mapNameTemplate: 'Meteor {1}'
+          nameGenerator:
+            !type:NanotrasenNameGenerator
+            prefixCreator: '14'
+        - type: StationJobs
+          availableJobs:
+            Contractor: [ 0, 0 ]
+            Pilot: [ 0, 0 ]
+            Mercenary: [ 0, 0 ]


### PR DESCRIPTION
## About the PR
This PR adds a new small expeditionary ship in the salvage category named the NT Meteor. It’s packed with salvage equipment, cargo space, and tightly built rooms, enabling it to function very well as a ship for players who like to salvage, mine, and go on expeditions.

## Why / Balance
This ship provides a solid alternative to the Pathfinder, which currently is the only small expeditionary ship in the game. I primarily found myself frustrated with the extra work required to operate/improve the Pathfinder, as well as its unwieldy size, poor layout, and single blast door setup. The Meteor, in contrast, sets itself up to be more sectioned off per department than the Pathfinder, with fewer total rooms, but each room fulfilling its purpose much more single-mindedly. In total, it provides an alternative for small crews that desire a more segmented setup of departments and efficient layout.

Otherwise, the NT Meteor takes up a 17x14 space and consumes around 16,925 Watts at rest. As well, it has a purchasing price of 51,525 spesos due to its small size, and a base sell price of 28,478 spesos.

## How to test
Start a local instance, warp to/spawn at the Expeditionary Lodge, purchase the NT Meteor at the expeditionary shipyard console, and see what you think of it.

## Media
These images display how the ship will be seen by players, how it appears with fullbright enabled, and with both fullbright and viewsubfloor enabled respectively.

Normal Lighting
![meteor final](https://github.com/user-attachments/assets/b061ec31-85af-41bb-9aea-f1e57f7d6837)

Fullbright
![meteor final fullbright](https://github.com/user-attachments/assets/93812195-2415-462a-bea0-4c7f8a8393e2)

Fullbright and Viewsubfloor
![meteor final fullbright subfloor](https://github.com/user-attachments/assets/0800f45a-46cb-49c6-95f9-c185be0a7085)

**Changelog**
The048
-add: Added the NT Meteor
