### PR TITLE
Unpacify NFSD and Lodge

### DIFF
--- a/Resources/Maps/_NF/POI/lodge.yml
+++ b/Resources/Maps/_NF/POI/lodge.yml
@@ -14407,13 +14407,6 @@ entities:
     - type: Transform
       pos: 7.5,17.5
       parent: 1
-- proto: PacifiedZonePanicBunker100
-  entities:
-  - uid: 2555
-    components:
-    - type: Transform
-      pos: -1.5,10.5
-      parent: 1
 - proto: PaperBin20
   entities:
   - uid: 1044

--- a/Resources/Maps/_NF/POI/nfsd.yml
+++ b/Resources/Maps/_NF/POI/nfsd.yml
@@ -13227,13 +13227,6 @@ entities:
     - type: Transform
       pos: -9.5,16.5
       parent: 1
-- proto: PacifiedZonePanicBunker100
-  entities:
-  - uid: 2686
-    components:
-    - type: Transform
-      pos: 0.5,5.5
-      parent: 1
 - proto: PaperBin10
   entities:
   - uid: 1267


### PR DESCRIPTION
## About the PR
Removes the pacified zone from the NFSD Outpost and the Exped Lodge.

## Why / Balance
These POIs are both outside the safe zone. The pacified zone also made it hard for new players to use the gun ranges in each POI, even with the provided practice rounds.

## How to test
1. Warp to the NFSDO or Lodge with less than 10 hours of playtime.
2. Go ham. There's nothing there to stop you. Shoot and destroy. There are no admins to stop you in your private world.

## Media
N/A

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
No.

**Changelog**
N/A