### PR TITLE
Respawn timer fix: show correct time on reconnect

### DIFF
--- a/Content.Server/Corvax/Respawn/RespawnSystem.cs
+++ b/Content.Server/Corvax/Respawn/RespawnSystem.cs
@@ -45,13 +45,14 @@ public sealed class RespawnSystem : EntitySystem
         SubscribeLocalEvent<MindContainerComponent, CryosleepBeforeMindRemovedEvent>(OnCryoBeforeMindRemoved);
         SubscribeLocalEvent<MindContainerComponent, CryosleepWakeUpEvent>(OnCryoWakeUp);
 
-        _admin.OnPermsChanged += OnAdminPermsChanged;
-        _player.PlayerStatusChanged += PlayerStatusChanged;
+        _admin.OnPermsChanged += OnAdminPermsChanged; // Frontier
+        _player.PlayerStatusChanged += PlayerStatusChanged; // Frontier
 
-        Subs.CVar(_cfg, NFCCVars.RespawnCryoFirstTime, OnRespawnCryoFirstTimeChanged, true);
-        Subs.CVar(_cfg, NFCCVars.RespawnTime, OnRespawnCryoTimeChanged, true);
+        Subs.CVar(_cfg, NFCCVars.RespawnCryoFirstTime, OnRespawnCryoFirstTimeChanged, true); // Frontier
+        Subs.CVar(_cfg, NFCCVars.RespawnTime, OnRespawnCryoTimeChanged, true); // Frontier
     }
 
+    // Frontier: CVar setters
     private void OnRespawnCryoFirstTimeChanged(float value)
     {
         _respawnTimeOnFirstCryo = value;
@@ -61,6 +62,7 @@ public sealed class RespawnSystem : EntitySystem
     {
         _respawnTime = value;
     }
+    // End Frontier
 
     private void OnMobStateChanged(EntityUid entity, MindContainerComponent component, MobStateChangedEvent e)
     {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

When players reconnect, this fixes the timer shown on the respawn button.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Bug.  Players that have a respawn timer currently have the ghost button show that they can respawn without issue when they are on a cooldown.

## How to test
<!-- Describe the way it can be tested -->

1. Deadmin, spawn.
2. Ghost.
3. Disconnect, reconnect.
4. The button should show the amount of time you have left to wait.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

None.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Respawn timers are now properly shown on reconnect.