### PR TITLE
Unhide shuttle computer in entity spawn menu

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -122,7 +122,6 @@
   id: ComputerShuttle
   name: shuttle console
   description: Used to pilot a shuttle.
-  categories: [ HideSpawnMenu ] # Frontier
   components:
   - type: Sprite
     layers:


### PR DESCRIPTION
## About the PR
The regular shuttle console was hidden in the entity spawn menu. I unhid it.

## Why / Balance
Allows it to be spawned again. Don't just want to use tabletops.

## How to test
Play hide and seek with the shuttle console by opening the entity spawn menu, look for it, find it. Congratulations, you win!

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
- fix: Made the shuttle console spawnable again.

