### PR TITLE
Fix CrateTrashCart contents exceeding maximum contents

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Crates/service.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/service.yml
@@ -277,7 +277,7 @@
 #          prob: 0.03 # Frontier
 #        - id: MobMouse # Frontier
 #          prob: 0.05 # Frontier
-          # Food Packaging # Frontier
+          # Food Packaging
         - id: FoodPacketBoritosTrash
           prob: 0.1
         - id: FoodPacketCheesieTrash

--- a/Resources/Prototypes/Catalog/Fills/Crates/service.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/service.yml
@@ -271,15 +271,13 @@
     - type: StorageFill
       contents:
           # Creatures
-        - id: MobCockroach
-          prob: 0.05
-        - id: MobMothroach
-          prob: 0.03
-        - id: MobRosyMothroach # Frontier
-          prob: 0.005 # Frontier
-        - id: MobMouse
-          prob: 0.05
-          # Food Packaging
+#        - id: MobCockroach # Frontier
+#          prob: 0.05 # Frontier
+#        - id: MobMothroach # Frontier
+#          prob: 0.03 # Frontier
+#        - id: MobMouse # Frontier
+#          prob: 0.05 # Frontier
+          # Food Packaging # Frontier
         - id: FoodPacketBoritosTrash
           prob: 0.1
         - id: FoodPacketCheesieTrash
@@ -315,24 +313,26 @@
         - id: CigaretteSpent
           prob: 0.15
           # Bacteria
-        - id: FoodBreadMoldySlice
-          prob: 0.15
-        - id: FoodPizzaMoldySlice
-          prob: 0.15
+#        - id: FoodBreadMoldySlice # Frontier
+#          prob: 0.15 # Frontier
+#        - id: FoodPizzaMoldySlice # Frontier
+#          prob: 0.15 # Frontier
           # Botanical Waste
         - id: TrashBananaPeel
           prob: 0.15
         - id: FoodCornTrash
           prob: 0.15
           # Misc
+        - id: DrinkGlass
+          prob: 0.15
         - id: BrokenBottle
           prob: 0.15
         - id: LightTubeBroken
           prob: 0.15
         - id: LightBulbBroken
           prob: 0.15
-        - id: MobMouseDead
-          prob: 0.1
+#        - id: MobMouseDead # Frontier
+#          prob: 0.1 # Frontier
         - id: Syringe
           prob: 0.1
         - id: ShardGlassPlasma

--- a/Resources/Prototypes/Catalog/Fills/Crates/service.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/service.yml
@@ -325,8 +325,6 @@
         - id: FoodCornTrash
           prob: 0.15
           # Misc
-        - id: DrinkGlass
-          prob: 0.15
         - id: BrokenBottle
           prob: 0.15
         - id: LightTubeBroken


### PR DESCRIPTION

This fixes a integration test that tests if there is sufficient space for entities with StorageFillComponent.
![image](https://github.com/user-attachments/assets/0fcaa2ba-4ef5-4c19-a86f-eefda78f63f3)

I removed one item from it to make the test pass.
