### PR TITLE
Fix shipyard causing SpawnAndDeleteEntityCountTest to fail

### DIFF
--- a/Content.Server/Shipyard/Systems/ShipyardSystem.cs
+++ b/Content.Server/Shipyard/Systems/ShipyardSystem.cs
@@ -84,7 +84,6 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
         if (!_enabled)
             return;
         InitializeConsole();
-        SetupShipyard();
     }
 
     private void OnRoundRestart(RoundRestartCleanupEvent ev)
@@ -101,7 +100,7 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
 
         if (value)
         {
-            SetupShipyard();
+            SetupShipyardIfNeeded();
         }
         else
         {
@@ -148,6 +147,7 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
     private bool TryAddShuttle(string shuttlePath, [NotNullWhen(true)] out EntityUid? shuttleGrid)
     {
         shuttleGrid = null;
+        SetupShipyardIfNeeded();
         if (ShipyardMap == null)
             return false;
 
@@ -276,7 +276,7 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
         _mapManager.DeleteMap(ShipyardMap.Value);
     }
 
-    private void SetupShipyard()
+    private void SetupShipyardIfNeeded()
     {
         if (ShipyardMap != null && _mapManager.MapExists(ShipyardMap.Value))
             return;


### PR DESCRIPTION
If some computer with the shipyard component is spawned the system makes a new map automatically
with this pr the map is only created before spawning a shuttle.