### PR TITLE
Fix TryIndex used with null param

### DIFF
--- a/Content.Client/Nyanotrasen/Mail/MailSystem.cs
+++ b/Content.Client/Nyanotrasen/Mail/MailSystem.cs
@@ -38,7 +38,7 @@ namespace Content.Client.Mail
             if (args.Sprite == null)
                 return;
 
-            if (_appearance.TryGetData(uid, MailVisuals.JobIcon, out string job) ||
+            if (!_appearance.TryGetData(uid, MailVisuals.JobIcon, out string job) ||
                 !_prototypeManager.TryIndex<JobIconPrototype>(job, out var icon))
                 return;
 


### PR DESCRIPTION
```
Caught exception in "entsys" Exception: System.ArgumentNullException: Value cannot be null. (Parameter 'key')
```

in this if-statement the `job` is null, causing the TryIndex to become null

Happens during SpawnAndDeleteEntityCountTest