### PR TITLE
DeadDropSystem: check lifecycle and null refs on compromise.

### DIFF
--- a/Content.Server/_NF/Smuggling/DeadDropSystem.cs
+++ b/Content.Server/_NF/Smuggling/DeadDropSystem.cs
@@ -195,11 +195,18 @@ public sealed class DeadDropSystem : EntitySystem
 
     public void CompromiseDeadDrop(EntityUid uid, DeadDropComponent _)
     {
-        //Get our station: FIXME - check lifecycle on entities before adding another drop.
-        var station = _station.GetOwningStation(uid);
-
-        //Remove the dead drop.
+        // Remove the dead drop.
         RemComp<DeadDropComponent>(uid);
+
+        var station = _station.GetOwningStation(uid);
+        // If station is terminating, or if we aren't on one, nothing to do here.
+        if (station == null ||
+            !station.Value.Valid ||
+            MetaData(station.Value).EntityLifeStage >= EntityLifeStage.Terminating)
+        {
+            return;
+        }
+
         //Find a new potential dead drop to spawn.
         var deadDropQuery = EntityManager.EntityQueryEnumerator<PotentialDeadDropComponent>();
         List<(EntityUid ent, PotentialDeadDropComponent comp)> potentialDeadDrops = new();

--- a/Content.Server/_NF/Smuggling/DeadDropSystem.cs
+++ b/Content.Server/_NF/Smuggling/DeadDropSystem.cs
@@ -227,6 +227,12 @@ public sealed class DeadDropSystem : EntitySystem
         if (potentialDeadDrops.Count > 0)
         {
             var item = _random.Pick(potentialDeadDrops);
+
+            // If the item is tearing down, do nothing for now.
+            // FIXME: separate sector-wide scheduler?
+            if (MetaData(item.ent).EntityLifeStage >= EntityLifeStage.Terminating)
+                return;
+
             AddDeadDrop(item.ent);
             _sawmill.Debug($"Dead drop at {uid} compromised, new drop at {item.ent}!");
         }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

When reassigning dead drops on compromise (i.e. unanchored), we need to check if the station is actually tearing down, and check if the entity we've selected is terminating before adding another reference.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

#2209, and mistakes on my side.

## How to test
<!-- Describe the way it can be tested -->

Destroy a station with dead drops on it, no debug assertions or errors.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
None.