### PR TITLE
Debuggable dungen output, wallmount typo

### DIFF
--- a/Content.Server/Gateway/Systems/GatewayGeneratorSystem.cs
+++ b/Content.Server/Gateway/Systems/GatewayGeneratorSystem.cs
@@ -184,7 +184,7 @@ public sealed class GatewayGeneratorSystem : EntitySystem
         var dungeonRotation = _dungeon.GetDungeonRotation(seed);
         var dungeonPosition = (origin + dungeonRotation.RotateVec(new Vector2i(0, dungeonDistance))).Floored();
 
-        _dungeon.GenerateDungeon(_protoManager.Index<DungeonConfigPrototype>("Experiment"), args.MapUid, grid, dungeonPosition, seed);
+        _dungeon.GenerateDungeon(_protoManager.Index<DungeonConfigPrototype>("Experiment"), "Experiment", args.MapUid, grid, dungeonPosition, seed); // Frontier: added "Experiment"
 
         // TODO: Dungeon mobs + loot.
 

--- a/Content.Server/Procedural/DungeonJob/DungeonJob.cs
+++ b/Content.Server/Procedural/DungeonJob/DungeonJob.cs
@@ -55,6 +55,7 @@ public sealed partial class DungeonJob : Job<List<Dungeon>>
     private readonly EntityCoordinates? _targetCoordinates;
 
     private readonly ISawmill _sawmill;
+    private readonly string _genId; // Frontier: add ID
 
     public DungeonJob(
         ISawmill sawmill,
@@ -73,6 +74,7 @@ public sealed partial class DungeonJob : Job<List<Dungeon>>
         EntityUid gridUid,
         int seed,
         Vector2i position,
+        string genID, // Frontier
         EntityCoordinates? targetCoordinates = null,
         CancellationToken cancellation = default) : base(maxTime, cancellation)
     {
@@ -99,6 +101,7 @@ public sealed partial class DungeonJob : Job<List<Dungeon>>
         _seed = seed;
         _position = position;
         _targetCoordinates = targetCoordinates;
+        _genId = genID; // Frontier
     }
 
     /// <summary>
@@ -144,7 +147,7 @@ public sealed partial class DungeonJob : Job<List<Dungeon>>
 
     protected override async Task<List<Dungeon>?> Process()
     {
-        _sawmill.Info($"Generating dungeon {_gen} with seed {_seed} on {_entManager.ToPrettyString(_gridUid)}");
+        _sawmill.Info($"Generating dungeon {_genId} with seed {_seed} on {_entManager.ToPrettyString(_gridUid)}"); // Frontier: _gen<_genId
         _grid.CanSplit = false;
         var random = new Random(_seed);
         var position = (_position + random.NextPolarVector2(_gen.MinOffset, _gen.MaxOffset)).Floored();

--- a/Content.Server/Procedural/DungeonSystem.Commands.cs
+++ b/Content.Server/Procedural/DungeonSystem.Commands.cs
@@ -71,7 +71,7 @@ public sealed partial class DungeonSystem
         }
 
         shell.WriteLine(Loc.GetString("cmd-dungen-start", ("seed", seed)));
-        GenerateDungeon(dungeon, dungeonUid, dungeonGrid, position, seed);
+        GenerateDungeon(dungeon, dungeon.ID, dungeonUid, dungeonGrid, position, seed); // Frontier: add dungeon.ID
     }
 
     private CompletionResult CompletionCallback(IConsoleShell shell, string[] args)

--- a/Content.Server/Procedural/DungeonSystem.cs
+++ b/Content.Server/Procedural/DungeonSystem.cs
@@ -188,6 +188,7 @@ public sealed partial class DungeonSystem : SharedDungeonSystem
     /// </summary>
     /// <param name="coordinates">Coordinates to move the dungeon to afterwards. Will delete the original map</param>
     public void GenerateDungeon(DungeonConfig gen,
+        string genID, // Frontier
         EntityUid gridUid,
         MapGridComponent grid,
         Vector2i position,
@@ -212,6 +213,7 @@ public sealed partial class DungeonSystem : SharedDungeonSystem
             gridUid,
             seed,
             position,
+            genID, // Frontier
             coordinates,
             cancelToken.Token);
 
@@ -221,6 +223,7 @@ public sealed partial class DungeonSystem : SharedDungeonSystem
 
     public async Task<List<Dungeon>> GenerateDungeonAsync(
         DungeonConfig gen,
+        string genID, // Frontier
         EntityUid gridUid,
         MapGridComponent grid,
         Vector2i position,
@@ -244,6 +247,7 @@ public sealed partial class DungeonSystem : SharedDungeonSystem
             gridUid,
             seed,
             position,
+            genID, // Frontier
             null,
             cancelToken.Token);
 

--- a/Content.Server/Salvage/SalvageSystem.Magnet.cs
+++ b/Content.Server/Salvage/SalvageSystem.Magnet.cs
@@ -268,12 +268,12 @@ public sealed partial class SalvageSystem
         {
             case AsteroidOffering asteroid:
                 var grid = _mapManager.CreateGridEntity(salvMap);
-                await _dungeon.GenerateDungeonAsync(asteroid.DungeonConfig, grid.Owner, grid.Comp, Vector2i.Zero, seed);
+                await _dungeon.GenerateDungeonAsync(asteroid.DungeonConfig, asteroid.Id, grid.Owner, grid.Comp, Vector2i.Zero, seed); // Frontier: added asteroid.Id - FIXME: value makes no sense.
                 break;
             case DebrisOffering debris:
                 var debrisProto = _prototypeManager.Index<DungeonConfigPrototype>(debris.Id);
                 var debrisGrid = _mapManager.CreateGridEntity(salvMap);
-                await _dungeon.GenerateDungeonAsync(debrisProto, debrisGrid.Owner, debrisGrid.Comp, Vector2i.Zero, seed);
+                await _dungeon.GenerateDungeonAsync(debrisProto, debrisProto.ID, debrisGrid.Owner, debrisGrid.Comp, Vector2i.Zero, seed); // Frontier: debrisProto.ID
                 break;
             case SalvageOffering wreck:
                 var salvageProto = wreck.SalvageMap;

--- a/Content.Server/Salvage/SpawnSalvageMissionJob.cs
+++ b/Content.Server/Salvage/SpawnSalvageMissionJob.cs
@@ -234,7 +234,7 @@ public sealed class SpawnSalvageMissionJob : Job<bool>
             dungeonOffset = dungeonRotation.RotateVec(dungeonOffset);
             var dungeonMod = _prototypeManager.Index<SalvageDungeonModPrototype>(mission.Dungeon);
             var dungeonConfig = _prototypeManager.Index(dungeonMod.Proto);
-            var dungeons = await WaitAsyncTask(_dungeon.GenerateDungeonAsync(dungeonConfig, mapUid, grid, (Vector2i) dungeonOffset,
+            var dungeons = await WaitAsyncTask(_dungeon.GenerateDungeonAsync(dungeonConfig, dungeonConfig.ID, mapUid, grid, (Vector2i) dungeonOffset, // Frontier: add dungeonConfig.ID
                     _missionParams.Seed));
 
             dungeon = dungeons.First();

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.GridFill.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.GridFill.cs
@@ -120,7 +120,7 @@ public sealed partial class ShuttleSystem
         var spawnedGrid = _mapManager.CreateGridEntity(mapId);
 
         _transform.SetMapCoordinates(spawnedGrid, new MapCoordinates(Vector2.Zero, mapId));
-        _dungeon.GenerateDungeon(dungeonProto, spawnedGrid.Owner, spawnedGrid.Comp, Vector2i.Zero, _random.Next(), spawnCoords);
+        _dungeon.GenerateDungeon(dungeonProto, dungeonProto.ID, spawnedGrid.Owner, spawnedGrid.Comp, Vector2i.Zero, _random.Next(), spawnCoords); // Frontier: add dungeonProto.ID
 
         spawned = spawnedGrid.Owner;
         return true;

--- a/Content.Server/_NF/GameRule/NfAdventureRuleSystem.cs
+++ b/Content.Server/_NF/GameRule/NfAdventureRuleSystem.cs
@@ -166,6 +166,9 @@ public sealed class NfAdventureRuleSystem : GameRuleSystem<AdventureRuleComponen
 
         foreach (var dunGen in dungenTypes)
         {
+            if (dunGen.SkipDungeonGen)
+                continue;
+
             var seed = _random.Next();
             var offset = GetRandomPOICoord(3000f, 8500f, true);
             if (!_map.TryLoad(_mapId, "/Maps/_NF/Dungeon/spaceplatform.yml", out var grids,
@@ -184,7 +187,7 @@ public sealed class NfAdventureRuleSystem : GameRuleSystem<AdventureRuleComponen
             //pls fit the grid I beg, this is so hacky
             //its better now but i think i need to do a normalization pass on the dungeon configs
             //because they are all offset. confirmed good size grid, just need to fix all the offsets.
-            _dunGen.GenerateDungeon(dunGen, grids[0], mapGrid, new Vector2i(0, 0), seed);
+            _dunGen.GenerateDungeon(dunGen, dunGen.ID, grids[0], mapGrid, new Vector2i(0, 0), seed);
             AddStationCoordsToSet(offset);
         }
     }

--- a/Content.Shared/Procedural/DungeonConfig.cs
+++ b/Content.Shared/Procedural/DungeonConfig.cs
@@ -53,4 +53,9 @@ public sealed class DungeonConfigPrototype : DungeonConfig, IPrototype
 {
     [IdDataField]
     public string ID { get; private set; } = default!;
+
+    // Frontier: skip dungeon generation
+    [DataField]
+    public bool SkipDungeonGen = false;
+    // End Frontier
 }

--- a/Resources/Prototypes/Procedural/dungeon_configs.yml
+++ b/Resources/Prototypes/Procedural/dungeon_configs.yml
@@ -1,6 +1,7 @@
 # Base configs
 - type: dungeonConfig
   id: PlanetBase
+  skipDungeonGen: true # Frontier
   layers:
   - !type:PrefabDunGen
     presets:
@@ -125,7 +126,7 @@
       Entrance: LavaBrigEntrance
       EntranceFlank: BaseWindow
       Junction: BaseAirlock
-      WallMounts: NanoTrasenFasilityWallmounts # Frontier: ScienceLabsWalls<NanoTrasenFasilityWallmounts
+      WallMounts: NanoTrasenFacilityWallmounts # Frontier: ScienceLabsWalls<NanoTrasenFacilityWallmounts
       Window: BaseWindow
     whitelists:
       Rooms:
@@ -147,7 +148,7 @@
       Entrance: BaseWoodWall
       EntranceFlank: BaseWoodWall
       Junction: BaseWoodSupport
-      WallMounts: NanoTrasenFasilityWallmounts # Frontier:added WallMounts: NanoTrasenFasilityWallmounts
+      WallMounts: NanoTrasenFacilityWallmounts # Frontier:added WallMounts: NanoTrasenFacilityWallmounts
       Window: BaseWoodWall
     tiles:
       FallbackTile: FloorCaveDrought

--- a/Resources/Prototypes/_NF/Procedural/dungeon_configs.yml
+++ b/Resources/Prototypes/_NF/Procedural/dungeon_configs.yml
@@ -1,6 +1,7 @@
 # Base dungeon prototypes
 - type: dungeonConfig
   id: Everything
+  skipDungeonGen: true # Frontier
   layers:
   - !type:PrefabDunGen
     presets:
@@ -334,7 +335,7 @@
 
 ## Wallmounts
 - type: entitySpawnEntry
-  id: NanoTrasenFasilityWallmounts
+  id: NanoTrasenFacilityWallmounts
   entries:
   - id: RandomPosterLegit
     orGroup: content


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Adds a skipDungeonGeneration to DungeonConfigPrototype to skip dungeon generation in NfAdventureSystem for base types (i.e. BasePlanet, Everything).
Add an ID field to DungeonJob for debugging - this will print the name of the prototype being generated - should help with error tracking.

## How to test
<!-- Describe the way it can be tested -->

Run game, no dungeon generation errors.  Go on expedition, should be fine.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
