### PR TITLE
Fix certain machine boards not accepting modular components when placed into a machine frame

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -208,7 +208,7 @@
     state: service
   - type: MachineBoard
     prototype: Biogenerator
-    stackRequirements:
+    requirements:
       MatterBin: 2
     tagRequirements:
       GlassBeaker:
@@ -1329,8 +1329,9 @@
   components:
   - type: MachineBoard
     prototype: CutterMachine
-    stackRequirements:
-      Steel: 2
+    requirements:
       Capacitor: 1
       Manipulator: 1
+    stackRequirements:
+      Steel: 2
       Cable: 1


### PR DESCRIPTION
…nents when placed into a machine frame

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
As of the recent update, certain machine boards have been unable to be crafted via the machine frame method. Initially, I had thought something was absolutely wrong until I checked the code and found the culprits being out of sync with the rest of the boards, so I've updated them.

It's worth noting that the station anchor machine board also doesn't accept modular components but I've left it untouched for now because I'm unsure about its purpose in the grand scheme of things when it comes to Frontier.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Because being unable to craft a biogenerator or cutter makes me sadface.

## How to test
<!-- Describe the way it can be tested -->
* Step 1: Spawn a machine frame construction ghost and do the steps as normal up until you apply a machine board. Spawn in a biogenerator machine board or a cutter machine board.
* Step 2: Follow the component guide for the machine board, inserting the requisite materials and components.
* Step 3: Use a screwdriver to complete the construction
* Step 4: Type *claps! in chat for a job well done!

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed an issue where certain machine boards (biogenerator, cutter) refused to accept capacitors, matter bins, or manipulators when attempting to build them via machine frame.
