### PR TITLE
Replaced Misplaced BasePenAdvanced in the Spectre's Bridge With a Captain's Pen.

### DIFF
--- a/Resources/Maps/_NF/Shuttles/spectre.yml
+++ b/Resources/Maps/_NF/Shuttles/spectre.yml
@@ -2106,14 +2106,6 @@ entities:
     - type: Transform
       pos: -9.5,0.5
       parent: 3
-- proto: BaseAdvancedPen
-  entities:
-  - uid: 1032
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.2843938,24.057287
-      parent: 3
 - proto: Bed
   entities:
   - uid: 876
@@ -6035,6 +6027,14 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.7531438,23.885412
+      parent: 3
+- proto: PenCap
+  entities:
+  - uid: 1032
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.2843938,24.057287
       parent: 3
 - proto: PortableScrubber
   entities:

--- a/Resources/Prototypes/_NF/Shipyard/spectre.yml
+++ b/Resources/Prototypes/_NF/Shipyard/spectre.yml
@@ -12,7 +12,7 @@
   id: Spectre
   name: NR Spectre
   description: A large, attractive but dated vessel with a pure focus on research and development. It is capable of generating anomalies.
-  price: 113,500 # ~98700 + 15%
+  price: 113500 # ~98700 + 15%
   category: Large
   group: Shipyard
   shuttlePath: /Maps/_NF/Shuttles/spectre.yml

--- a/Resources/Prototypes/_NF/Shipyard/spectre.yml
+++ b/Resources/Prototypes/_NF/Shipyard/spectre.yml
@@ -12,7 +12,7 @@
   id: Spectre
   name: NR Spectre
   description: A large, attractive but dated vessel with a pure focus on research and development. It is capable of generating anomalies.
-  price: 113500 # ~98700 + 15%
+  price: 185000 # Anomaly spawner
   category: Large
   group: Shipyard
   shuttlePath: /Maps/_NF/Shuttles/spectre.yml

--- a/Resources/Prototypes/_NF/Shipyard/spectre.yml
+++ b/Resources/Prototypes/_NF/Shipyard/spectre.yml
@@ -12,7 +12,7 @@
   id: Spectre
   name: NR Spectre
   description: A large, attractive but dated vessel with a pure focus on research and development. It is capable of generating anomalies.
-  price: 185000
+  price: 113,500 # ~98700 + 15%
   category: Large
   group: Shipyard
   shuttlePath: /Maps/_NF/Shuttles/spectre.yml


### PR DESCRIPTION
## About the PR
Spectre tweak.
Replaced the BasePenAdvanced in the bridge with the captain's pen.
Adjusted price to current price plus around 15%.

## Why / Balance
The BasePenAdvanced prototype should not be mapped. Quite aside from being T3 contraband, it should also probably be an abstract prototype, being a cybersun pen without the accompanying appearance, name, and description. A captain's pen is relatively normal for a bridge pen on a medium or large ship.
An 85-90% markup is entirely out of line with existing standards, and is likely the result of the ship's price falling significantly since its last evaluation. 15% appears to be a normal ship markup for non-expedition ships. I took the median of five price checks and rounded the result, then rounded the marked-up price.

## How to test
Purchase the ship, compare the purchase price to the sell value. Walk into the bridge, check the pen's description, try to rewrite a stamped page.

## Media
### Before
![before](https://github.com/user-attachments/assets/29dfdea0-6548-4f16-8d74-3bd6f232b8f5)
### After
![after](https://github.com/user-attachments/assets/01c3a91d-2ed4-47be-826b-be4ecd23d850)


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
NA
