### PR TITLE
Space Dungeon generation: explicit list of prototypes, name dungeon grids.

### DIFF
--- a/Content.Server/_NF/GameRule/Components/AdventureRuleComponent.cs
+++ b/Content.Server/_NF/GameRule/Components/AdventureRuleComponent.cs
@@ -1,3 +1,6 @@
+using Content.Shared.Procedural;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.List;
+
 namespace Content.Server._NF.GameRule.Components;
 
 [RegisterComponent, Access(typeof(NfAdventureRuleSystem))]
@@ -9,4 +12,7 @@ public sealed partial class AdventureRuleComponent : Component
     public List<EntityUid> RequiredPois = new();
     public List<EntityUid> OptionalPois = new();
     public List<EntityUid> UniquePois = new();
+
+    [DataField(customTypeSerializer: typeof(PrototypeIdListSerializer<DungeonConfigPrototype>))]
+    public List<string> SpaceDungeons = new();
 }

--- a/Content.Server/_NF/GameRule/NfAdventureRuleSystem.cs
+++ b/Content.Server/_NF/GameRule/NfAdventureRuleSystem.cs
@@ -257,11 +257,9 @@ public sealed class NfAdventureRuleSystem : GameRuleSystem<AdventureRuleComponen
         // Using invalid entity, we don't have a relevant entity to reference here.
         RaiseLocalEvent(EntityUid.Invalid, new StationsGeneratedEvent(), broadcast: true); // TODO: attach this to a meaningful entity.
 
-        var dungenTypes = _prototypeManager.EnumeratePrototypes<DungeonConfigPrototype>();
-
-        foreach (var dunGen in dungenTypes)
+        foreach (var dungeonProto in component.SpaceDungeons)
         {
-            if (dunGen.SkipDungeonGen)
+            if (!_prototypeManager.TryIndex<DungeonConfigPrototype>(dungeonProto, out var dunGen))
                 continue;
 
             var seed = _random.Next();
@@ -278,6 +276,9 @@ public sealed class NfAdventureRuleSystem : GameRuleSystem<AdventureRuleComponen
             var mapGrid = EnsureComp<MapGridComponent>(grids[0]);
             _shuttle.AddIFFFlag(grids[0], IFFFlags.HideLabel);
             _console.WriteLine(null, $"dungeon spawned at {offset}");
+
+            string dungeonName = Loc.GetString("adventure-space-dungeon-name", ("dungeonPrototype", dungeonProto));
+            _meta.SetEntityName(grids[0], dungeonName);
 
             //pls fit the grid I beg, this is so hacky
             //its better now but i think i need to do a normalization pass on the dungeon configs

--- a/Content.Shared/Procedural/DungeonConfig.cs
+++ b/Content.Shared/Procedural/DungeonConfig.cs
@@ -53,9 +53,4 @@ public sealed class DungeonConfigPrototype : DungeonConfig, IPrototype
 {
     [IdDataField]
     public string ID { get; private set; } = default!;
-
-    // Frontier: skip dungeon generation
-    [DataField]
-    public bool SkipDungeonGen = false;
-    // End Frontier
 }

--- a/Resources/Locale/en-US/_NF/adventure/adventure.ftl
+++ b/Resources/Locale/en-US/_NF/adventure/adventure.ftl
@@ -28,3 +28,5 @@ multiauth-already-connected = Already connected to Frontier Official servers.
 
 public-transit-departure = Now departing for {$destination}. Estimated travel time: {$flytime} seconds.
 public-transit-arrival = Thank you for choosing NT Public Transit. Next transfer to {$destination} departs in {$waittime} seconds.
+
+adventure-space-dungeon-name = Space Dungeon: {$dungeonPrototype}

--- a/Resources/Prototypes/Procedural/dungeon_configs.yml
+++ b/Resources/Prototypes/Procedural/dungeon_configs.yml
@@ -1,7 +1,6 @@
 # Base configs
 - type: dungeonConfig
   id: PlanetBase
-  skipDungeonGen: true # Frontier
   layers:
   - !type:PrefabDunGen
     presets:

--- a/Resources/Prototypes/_NF/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_NF/GameRules/roundstart.yml
@@ -4,6 +4,17 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: AdventureRule
+    spaceDungeons:
+    - CaveFactory
+    - MedSci
+    - FactoryDorms
+    - LavaMercenary
+    - VirologyLab
+    - SalvageOutpost
+    # Upstream definitions
+    - Experiment
+    - SnowyLabs
+    - LavaBrig # Skipping Mineshaft, Haunted; they're in caves
 
 - type: entity
   id: BluespaceEventScheduler

--- a/Resources/Prototypes/_NF/Procedural/dungeon_configs.yml
+++ b/Resources/Prototypes/_NF/Procedural/dungeon_configs.yml
@@ -1,7 +1,6 @@
 # Base dungeon prototypes
 - type: dungeonConfig
   id: Everything
-  skipDungeonGen: true # Frontier
   layers:
   - !type:PrefabDunGen
     presets:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Dungeon generation is currently done by enumerating all dungeon configs and removing ones we don't care about.  This turns it into an explicitly whitelisted process, with the AdventureGameRule itself defining the set of space dungeons it generates.

All generated space dungeon grids will be given a name (e.g. "Space Dungeon: VirologyLab").

Haunted and Mineshaft, as they generate using rock walls, were removed from this whitelisted pool - they look odd having rock walls on a giant steel sheet in space.

Note: unsure if the dungeons generate well in Debug configs, but Release seems to work fine.  The space platform itself should probably be removed in favour of having a crappy lattice that the dungeon sits on in space.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Missed a dungeon config added upstream containing fultons.

## How to test
<!-- Describe the way it can be tested -->

1. Start a round, check the admin grid list.
2. Note: the 9 blank entries are still related to this dungeon generation, but I couldn't find where they were created.
3. Warp to one as a ghost, fly outside of it and check the radar, it should not have an IFF name.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

To the right, the admin menu with the space dungeons listed.  To the left, the CaveFactory dungeon.
![image](https://github.com/user-attachments/assets/6df8a729-0f9b-4921-ab5b-1bab9533c26b)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
No changelog, negligible in-game effect.