### PR TITLE
Artifacts no longer gain points on spray, just skip nodes.

### DIFF
--- a/Content.Server/Xenoarchaeology/XenoArtifacts/ArtifactComponent.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/ArtifactComponent.cs
@@ -93,6 +93,12 @@ public sealed partial class ArtifactComponent : Component
     };
 
     [DataField("activateActionEntity")] public EntityUid? ActivateActionEntity;
+
+    /// <summary>
+    /// Frontier: When set to true, any newly visited nodes contribute no new points.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite)]
+    public bool ConsumeGainedPoints = false;
 }
 
 /// <summary>

--- a/Content.Server/Xenoarchaeology/XenoArtifacts/ArtifactComponent.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/ArtifactComponent.cs
@@ -98,7 +98,13 @@ public sealed partial class ArtifactComponent : Component
     /// Frontier: When set to true, any newly visited nodes contribute no new points.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
-    public bool ConsumeGainedPoints = false;
+    public bool RemoveGainedPoints = false;
+
+    /// <summary>
+    /// Frontier: Points being skipped (e.g. by triggering a node through spraying an artifact).
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite)]
+    public int SkippedPoints;
 }
 
 /// <summary>

--- a/Content.Server/Xenoarchaeology/XenoArtifacts/ArtifactSystem.Nodes.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/ArtifactSystem.Nodes.cs
@@ -190,9 +190,6 @@ public sealed partial class ArtifactSystem
             EntityManager.AddComponent(uid, (Component)temp!);
         }
 
-        if (!node.Discovered && component.ConsumeGainedPoints) // Frontier: consume node value on spray
-            component.ConsumedPoints += component.PointsPerNode; // Frontier
-
         node.Discovered = true;
         RaiseLocalEvent(uid, new ArtifactNodeEnteredEvent(component.CurrentNodeId.Value));
     }
@@ -230,6 +227,7 @@ public sealed partial class ArtifactSystem
 
             EntityManager.RemoveComponentDeferred(uid, _componentFactory.GetRegistration(name).Type);
         }
+
         component.CurrentNodeId = null;
     }
 

--- a/Content.Server/Xenoarchaeology/XenoArtifacts/ArtifactSystem.Nodes.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/ArtifactSystem.Nodes.cs
@@ -190,6 +190,9 @@ public sealed partial class ArtifactSystem
             EntityManager.AddComponent(uid, (Component)temp!);
         }
 
+        if (!node.Discovered && component.ConsumeGainedPoints) // Frontier: consume node value on spray
+            component.ConsumedPoints += component.PointsPerNode; // Frontier
+
         node.Discovered = true;
         RaiseLocalEvent(uid, new ArtifactNodeEnteredEvent(component.CurrentNodeId.Value));
     }

--- a/Content.Server/Xenoarchaeology/XenoArtifacts/ArtifactSystem.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/ArtifactSystem.cs
@@ -173,11 +173,11 @@ public sealed partial class ArtifactSystem : EntitySystem
         }
         else
         {
-            int pointsPerNode = artifactComp.PointsPerNode;
-
-            artifactComp.PointsPerNode = 0;
+            // Activate the artifact, but consume any points from newly visited nodes.
+            bool oldConsume = artifactComp.ConsumeGainedPoints;
+            artifactComp.ConsumeGainedPoints = true;
             TryActivateArtifact(uid, uid, artifactComp);
-            artifactComp.PointsPerNode = pointsPerNode;
+            artifactComp.ConsumeGainedPoints = oldConsume;
         }
     }
     // End Frontier

--- a/Content.Server/_NF/EntityEffects/Effects/NFActivateArtifact.cs
+++ b/Content.Server/_NF/EntityEffects/Effects/NFActivateArtifact.cs
@@ -10,7 +10,7 @@ public sealed partial class NFActivateArtifact : EntityEffect
     /// Disintegrate chance
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite)]
-    public float ProbabilityBase = 0.5f;
+    public float ProbabilityBase = 0.05f;
 
     /// <summary>
     /// The range around the artifact that it will spawn the entity

--- a/Content.Server/_NF/EntityEffects/Effects/NFActivateArtifact.cs
+++ b/Content.Server/_NF/EntityEffects/Effects/NFActivateArtifact.cs
@@ -1,28 +1,21 @@
-﻿using Content.Server.Xenoarchaeology.XenoArtifacts;
+using Content.Server.Xenoarchaeology.XenoArtifacts;
 using Content.Shared.EntityEffects;
 using Robust.Shared.Prototypes;
 
 namespace Content.Server.Chemistry.EntityEffects;
 
-public sealed partial class DisintegrateArtifact : EntityEffect
+public sealed partial class NFActivateArtifact : EntityEffect
 {
-
     /// <summary>
     /// Disintegrate chance
     /// </summary>
-    [DataField("probabilityMin"), ViewVariables(VVAccess.ReadWrite)]
-    public float ProbabilityMax = 0.05f;
-
-    /// <summary>
-    /// Disintegrate chance
-    /// </summary>
-    [DataField("probabilityMax"), ViewVariables(VVAccess.ReadWrite)]
-    public float ProbabilityMin = 0.15f;
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public float ProbabilityBase = 0.5f;
 
     /// <summary>
     /// The range around the artifact that it will spawn the entity
     /// </summary>
-    [DataField("range")]
+    [DataField]
     public float Range = 0.5f;
 
     public override void Effect(EntityEffectBaseArgs args)
@@ -30,7 +23,7 @@ public sealed partial class DisintegrateArtifact : EntityEffect
         if (args is not EntityEffectReagentArgs reagentArgs)
             return;
         var artifact = args.EntityManager.EntitySysManager.GetEntitySystem<ArtifactSystem>();
-        artifact.DisintegrateArtifact(reagentArgs.TargetEntity, ProbabilityMin, ProbabilityMax, Range);
+        artifact.NFActivateArtifact(reagentArgs.TargetEntity, ProbabilityBase, Range);
     }
 
     protected override string? ReagentEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys) =>

--- a/Resources/Prototypes/Guidebook/science.yml
+++ b/Resources/Prototypes/Guidebook/science.yml
@@ -36,7 +36,7 @@
 - type: guideEntry
   id: Xenoarchaeology
   name: guide-entry-xenoarchaeology
-  text: "/ServerInfo/Guidebook/Science/Xenoarchaeology.xml"
+  text: "/ServerInfo/_NF/Guidebook/Science/Xenoarchaeology.xml" # Frontier: added _NF folder
   children:
   - ArtifactReports
 

--- a/Resources/Prototypes/Reagents/chemicals.yml
+++ b/Resources/Prototypes/Reagents/chemicals.yml
@@ -76,11 +76,7 @@
     Acidic:
       methods: [ Touch ]
       effects:
-      - !type:ActivateArtifact
-        conditions:
-        - !type:ReagentThreshold
-          min: 5
-      - !type:DisintegrateArtifact
+      - !type:NFActivateArtifact # Frontier: ActivateArtifact<NFActivateArtifact
         conditions:
         - !type:ReagentThreshold
           min: 5

--- a/Resources/ServerInfo/_NF/Guidebook/Science/Xenoarchaeology.xml
+++ b/Resources/ServerInfo/_NF/Guidebook/Science/Xenoarchaeology.xml
@@ -1,0 +1,55 @@
+<Document>
+# Xenoarchaeology
+Xenoarchaeology is a field of science focused on researching and experimenting on alien artifacts.
+
+Artifacts can be found by mining asteroids found around the sector, or you can buy some from miners or salvagers.
+
+By researching the unique things each artifact can do, you gain Research Points, increase the artifact's sale value, and potentially discover a useful ability or two!
+
+## Artifact Nodes
+<Box>
+<GuideEntityEmbed Entity="ComplexXenoArtifact" Caption=""/>
+<GuideEntityEmbed Entity="SimpleXenoArtifactItem" Caption=""/>
+</Box>
+Artifacts consist of a randomly-generated tree of nodes. These nodes have a "[color=#a4885c]depth[/color]", representing how dangerous the node is, and the number of other nodes connected to it, called "[color=#a4885c]edges[/color]",
+
+Artifacts always start at depth zero, the root of the tree. Travelling the tree to find as many nodes as possible is the main goal of the scientists working on them. Knowledge is extracted from nodes to gain Research Points and increase the artifact's sale value.
+
+Each node has two components: its [color=#a4885c]stimulus[/color] and a [color=#a4885c]reaction[/color].
+
+A stimulus is the external behavior that triggers the reaction. There's a variety of these, and higher depth nodes have more difficult to accomplish stimuli. Some stimuli will need improvisation to trigger, and you may need special materials or resources to get everything you need.
+
+Some reactions are instantaneous effects while others are permanent changes. Once an artifact is triggered, the reaction causes the artifact to randomly move to another node it is linked to.
+
+With some experimental science, you can begin to grasp how the different nodes of an artifact are connected, and how to move between them by repeatedly activating nodes.
+
+All non-zero-depth nodes will have exactly one edge that leads up to its parent node. All other edges a node has lead down to the next depth.
+
+## Artifact Analyzer and Analysis Console
+<Box>
+<GuideEntityEmbed Entity="MachineArtifactAnalyzer"/>
+<GuideEntityEmbed Entity="ComputerAnalysisConsole"/>
+</Box>
+The main equipment that you'll be using for Xenoarchaeology is the [color=#a4885c]artifact analyzer[/color] and the [color=#a4885c]analysis console[/color]. You can use these to create reports that contain valuable information about an artifact.
+
+To set them up, simply link them with a network configurator and set an artifact on top of the analyzer. Every science vessel has at least one of these machines already set up.
+
+Use the console's [color=#a4885c]scan[/color] button to discover what stimulus the artifact needs and what its reaction will do. Scanning takes thirty seconds.
+
+Use the [color=#a4885c]print[/color] button to save the scan result, so you can refer to it later.
+
+Once you've discovered a new node, you can extract points from the artifact using the [color=#a4885c]Extract[/color] button.
+
+## Artifexium and You
+
+With difficult to trigger stimuli, one risky alternative is the use of [color=#a4885c]artifexium[/color]. In order to get artifexium, artifact fragments can be [color=#a4885c]ground[/color] in a [color=#a4885c]reagent grinder[/color]. This artifexium can then be [color=#a4885c]sprayed[/color] or [color=#a4885c]splashed[/color] on an artifact to cause a trigger.
+
+It is worth note that artifexium can cause unwanted reactions and reduced yield when interacting with alien artifacts. Use it sparingly, and it can be a useful tool.
+
+For reasons yet understood by science, use of artifexium is more stable when performed in laboratories than on rocks in the void. Our xenoarchaeologists suggest that these artifacts may exhibit sentient properties and be more stable in social settings.
+
+## Assembling Artifacts
+<GuideEntityEmbed Entity="ArtifactFragment" Caption="Artifact Fragment"/>
+
+It is possible to gather multiple artifact fragments and assemble them into a working artifact. You can ask for these from mining ships, who usually find these while mining asteroids or on Expeditions.
+</Document>


### PR DESCRIPTION
## About the PR
Can we actually use the spray to what its intended?

## Why / Balance
Restore arti to what it used to be.

## How to test
Spawn arti on a ship, spray it, scan.

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
:cl:
- tweak: Using artifexium to trigger artifacts now results in gaining no points for any triggered nodes.
- add: The Xenoarchaeology guidebook now has a section on using artifexium.
