### PR TITLE
Allow Goblins to ride cats

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -2931,6 +2931,31 @@
   - type: NpcFactionMember # Frontier
     factions:
     - Cat
+# Frontier Start: Allow goblins to ride cats
+  - type: Strap
+    buckleOffset: "0.025, 0.2"
+    whitelist:
+      components:
+      - Goblin
+    unbuckleDistanceSquared: 0.09 # Frontier: (30 cm)^2 - seems unnecessary, but for consistency with vehicles
+  - type: Vehicle
+    southOver: true
+    westOver: true
+    eastOver: true
+    northOver: true
+    northOverride: 0.0
+    southOverride: 0.0
+    autoAnimate: false
+  - type: ItemSlots
+    slots:
+      key_slot:
+        disableEject: true
+        locked: true
+  - type: ContainerFill
+    containers:
+      key_slot:
+      - VehicleKeyATV
+# Frontier End: Allow goblins to ride cats
 
 - type: entity
   name: calico cat


### PR DESCRIPTION
## About the PR
They said it cannot be done, I proved it can.

## Why / Balance
Funny

## How to test
Spawn as goblin, spawn a cat

## Media
![image](https://github.com/user-attachments/assets/4802f7a5-41eb-4368-a434-3b8a33cc884b)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Not sure, I didnt manage to find any issues with the cats but this is very weird way to add it.

**Changelog**
:cl:
- add: Goblins can now ride cats, to some extent.
