### PR TITLE
removed laser reflect on mobs

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_bloodcultist.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_bloodcultist.yml
@@ -35,7 +35,7 @@
   parent:
   - MobBloodCultistBase
   - MobHumanoidHostileAISimpleRanged
-  - MobLaserReflect # Added to prevent laser abuse from players
+  #- MobLaserReflect # Added to prevent laser abuse from players
   id: MobBloodCultistPriest
   description: Enlightened by the whispers of The Void That Is, these individuals are initiated into secret rituals. They lead the blood harvest and perform rites, bringing the day when Nar'Sie rises ever closer.
   categories: [ HideSpawnMenu ]
@@ -69,7 +69,7 @@
   parent:
   - MobBloodCultistBase
   - MobHumanoidHostileAISimpleRanged
-  - MobLaserReflect # Added to prevent laser abuse from players
+  #- MobLaserReflect # Added to prevent laser abuse from players
   id: MobBloodCultistJanitor
   description: The fate of blood cults on space stations hinges on the actions of a single individual - the station janitor. This humble worker serves as the primary line of defense against the presence of blood cults, but even the most resolute individuals can be swayed by corruption.
   categories: [ HideSpawnMenu ]
@@ -104,7 +104,7 @@
   parent:
   - MobBloodCultistBase
   - MobHumanoidHostileAISimpleMelee
-  - MobLaserReflect # Added to prevent laser abuse from players
+  #- MobLaserReflect # Added to prevent laser abuse from players
   id: MobBloodCultistAcolyte
   description: |-
    The acolyte - The most trusted cult follower and bodyguard of a priest, clad in the finest armor the cult has to offer and armed with the most vile weapons: eldrich blades and unholy halberds.
@@ -246,7 +246,7 @@
   parent:
   - MobNonHumanHostileBase
   - MobHumanoidHostileAIComplex
-  - MobLaserReflect # Added to prevent laser abuse from players
+  #- MobLaserReflect # Added to prevent laser abuse from players
   - NFMobRestrictions
   id: MobBloodCultistAscended
   components:

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_expeditions_aberrant_flesh.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_expeditions_aberrant_flesh.yml
@@ -148,7 +148,7 @@
 - type: entity
   parent:
   - BaseMobFleshExpeditions
-  - MobLaserReflect # Added to prevent laser abuse from players
+  #- MobLaserReflect # Added to prevent laser abuse from players
   id: MobFleshAssimilatedMiner
   description: An unfortunate miner that was infected upon contact with aberrant flesh and has been slowly assimilated.
   #categories: [ HideSpawnMenu ]

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_expeditions_explorers.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_expeditions_explorers.yml
@@ -359,7 +359,7 @@
   categories: [ HideSpawnMenu ]
   parent:
   - MobExplorerBase
-  - MobLaserReflect # Added to prevent laser abuse from players
+  #- MobLaserReflect # Added to prevent laser abuse from players
   id: MobExplorerHauler
   description: |- 
    Loaded with heavy equipment for industrial-scale looting. Pardon me, "asset recovery".

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_rogue_ai.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_rogue_ai.yml
@@ -47,7 +47,7 @@
   - MobNonHumanHostileBase
   - MobHumanoidInvetorySimplified
   - MobRogueSiliconAISimpleRanged
-  - MobLaserReflect # Added to prevent laser abuse from players
+  #- MobLaserReflect # Added to prevent laser abuse from players
   - NFMobRestrictions
   id: MobRogueSiliconBase
   components:

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_syndicate.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_syndicate.yml
@@ -507,7 +507,7 @@
   name: syndicate commander # Mega Fauna for Dungeons
   parent:
   - MobSyndicateNavalBase
-  - MobLaserReflect # Added to prevent laser abuse from players
+  #- MobLaserReflect # Added to prevent laser abuse from players
   id: MobSyndicateNavalCommanderA
   description: A regional commander of Syndicate operations, this officer holds ultimate local command and responsibility. Armed with an assault rifle and heavily armored.
   categories: [ HideSpawnMenu ]
@@ -725,7 +725,7 @@
   name: syndicate captain
   parent:
   - MobSyndicateNavalCaptainA
-  - MobLaserReflect # Added to prevent laser abuse from players
+  #- MobLaserReflect # Added to prevent laser abuse from players
   id: MobSyndicateNavalCaptainVoid
   categories: [ HideSpawnMenu ]
   components:
@@ -741,7 +741,7 @@
 - type: entity
   parent:
   - MobSyndicateNavalSecondOfficerA
-  - MobLaserReflect # Added to prevent laser abuse from players
+  #- MobLaserReflect # Added to prevent laser abuse from players
   id: MobSyndicateNavalSecondOfficerVoid
   categories: [ HideSpawnMenu ]
   components:
@@ -753,7 +753,7 @@
 - type: entity
   parent:
   - MobSyndicateNavalOperatorA
-  - MobLaserReflect # Added to prevent laser abuse from players
+  #- MobLaserReflect # Added to prevent laser abuse from players
   id: MobSyndicateNavalOperatorVoid
   categories: [ HideSpawnMenu ]
   components:
@@ -765,7 +765,7 @@
 - type: entity
   parent:
   - MobSyndicateNavalEngineerA
-  - MobLaserReflect # Added to prevent laser abuse from players
+  #- MobLaserReflect # Added to prevent laser abuse from players
   id: MobSyndicateNavalEngineerVoid
   categories: [ HideSpawnMenu ]
   components:
@@ -783,7 +783,7 @@
 - type: entity
   parent:
   - MobSyndicateNavalDeckhandA
-  - MobLaserReflect # Added to prevent laser abuse from players
+  #- MobLaserReflect # Added to prevent laser abuse from players
   id: MobSyndicateNavalDeckhandVoid
   categories: [ HideSpawnMenu ]
   components:
@@ -797,7 +797,7 @@
 - type: entity
   parent:
   - MobSyndicateNavalMedicA
-  - MobLaserReflect # Added to prevent laser abuse from players
+  #- MobLaserReflect # Added to prevent laser abuse from players
   id: MobSyndicateNavalMedicVoid
   categories: [ HideSpawnMenu ]
   components:

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_wizardfederation.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_wizardfederation.yml
@@ -7,7 +7,7 @@
   - MobPassiveRegen
   - MobHumanoidInvetory
   - MobHumanoidHostileAISimpleRanged
-  - MobLaserReflect # Added to prevent laser abuse from players
+  #- MobLaserReflect # Added to prevent laser abuse from players
   - NFMobRestrictions
   id: MobWizFedlBase
   components:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Laser reflect was initially added to limit player abuse of AI short comings during expeditions, however since then non-transparent windows and airlocks were added, so I guess there is no need to have both of those tweaks.

## Why / Balance
Small QoL for laser enjoyers

## How to test
<!-- Describe the way it can be tested -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl: erhardsteinhauer
- tweak: Removed laser reflect from mobs.
