### PR TITLE
whitelisted equal opportunities goblinbane

### DIFF
--- a/Resources/Locale/en-US/_NF/ghost/roles/ghost-role-component.ftl
+++ b/Resources/Locale/en-US/_NF/ghost/roles/ghost-role-component.ftl
@@ -58,9 +58,9 @@ ghost-role-information-dungeon-boss-rules = You are a [color=red][bold]Team Anta
 
 ghost-role-information-goblinbane-name = The Goblinbane
 ghost-role-information-goblinbane-ghost-name = The Ghost of Goblinbane
-ghost-role-information-goblinbane-description = Hunt down those pesky-little-dirty-smelly goblins. And felinids. And also chaplains.
+ghost-role-information-goblinbane-description = Look for people who lack personal hygiene and either convince them to change their ways or make them face the consequences.
 ghost-role-information-goblinbane-rules = You are a [color=red][bold]Solo Antagonist[/bold][/color] capable of summoning minions. [color=yellow]Do note[/color], your minions will be hostile to everyone, except you.
-                                        Search and destroy goblins/felinids/chaplains. [color=yellow]Consider[/color] ignoring players dressed as janitors regardless of their species.
+                                        Search and destroy people with poor personal hygiene. [color=yellow]Consider[/color] ignoring players dressed as janitors.
                                         Please note that [color=yellow]all server rules still apply.[/color]. Additionally:
                                         - [color=yellow]Reminder[/color] that Frontier Outpost (the station and 200m area around it) is a safe zone.
                                         - [color=red]DO NOT[/color] attack players on the Outpost.

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_meme_goblinbane.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_meme_goblinbane.yml
@@ -112,10 +112,12 @@
     color: "#ff0000"
   # Ghost role stuff
   - type: GhostRole
+    prob: 1
     allowMovement: true
     name: ghost-role-information-goblinbane-name
     description: ghost-role-information-goblinbane-description
     rules: ghost-role-information-goblinbane-rules
+    prototype: GhostMemeGoblinbane
     raffle:
       settings: default
   - type: GhostTakeoverAvailable

--- a/Resources/Prototypes/_NF/Roles/Ghostroles/whitelisted.yml
+++ b/Resources/Prototypes/_NF/Roles/Ghostroles/whitelisted.yml
@@ -71,3 +71,12 @@
   rules: ghost-role-information-nonantagonist-rules
   entityPrototype: MobKoboldYipyip
   whitelisted: true
+
+# Other others
+- type: ghostRole
+  id: GhostMemeGoblinbane
+  name: ghost-role-information-goblinbane-name
+  description: ghost-role-information-goblinbane-description
+  rules: ghost-role-information-goblinbane-rules
+  entityPrototype: BaseMobMemeGoblinbane
+  whitelisted: true

--- a/Resources/Prototypes/_NF/ai_factions.yml
+++ b/Resources/Prototypes/_NF/ai_factions.yml
@@ -538,10 +538,10 @@
   - Mouse
   - Zombie
   ## Frontier Factions
-  - Felinid
+  #- Felinid
   - Monkey
-  - Goblin
-  - ChaplainClothes
+  #- Goblin
+  #- ChaplainClothes
 
 - type: npcFaction
   id: GoblinbaneProvokedFaction


### PR DESCRIPTION
## About the PR
Non-speciesist update! Wow!
- Made Goblinbane ghost role whitelisted.
- Altered ghost role rules and description so Goblinbane wouldn't have to target exclusively goblins/felinids or chaplains. Every one at risk now.
- The mob is now neutral to everyone by default, but still will retaliate if attacked.

## Why / Balance


## How to test
<!-- Describe the way it can be tested -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl: erhardsteinhauer
- tweak: Made Goblinbane ghost role whitelisted, altered ghost role rules and description so Goblinbane wouldn't have to target exclusively goblins/felinids or chaplains. Every one is at risk now. When not controlled by a ghost, Goblinbane is neutral towards players.
