### PR TITLE
Events pass

### DIFF
--- a/Resources/Prototypes/_NF/Events/events.yml
+++ b/Resources/Prototypes/_NF/Events/events.yml
@@ -310,6 +310,7 @@
   - type: StationEvent
     weight: 8
     earliestStart: 15 # Frontier
+    reoccurrenceDelay: 30 # Frontier
     startAnnouncement: station-event-solar-flare-start-announcement
     endAnnouncement: station-event-solar-flare-end-announcement
     startAudio:

--- a/Resources/Prototypes/_NF/Events/nf_events_bluespace.yml
+++ b/Resources/Prototypes/_NF/Events/nf_events_bluespace.yml
@@ -8,7 +8,6 @@
       path: /Audio/Announcements/attention.ogg
     endAnnouncement: station-event-bluespace-cache-end-announcement
     earliestStart: 100
-    minimumPlayers: 30
     weight: 5
     duration: 1350
     maxDuration: 1560
@@ -30,7 +29,6 @@
       path: /Audio/Announcements/attention.ogg
     endAnnouncement: station-event-bluespace-vault-end-announcement
     earliestStart: 100
-    minimumPlayers: 30
     weight: 5
     duration: 1020
     maxDuration: 1350
@@ -52,7 +50,6 @@
       path: /Audio/Announcements/attention.ogg
     endAnnouncement: station-event-bluespace-vault-end-announcement
     earliestStart: 100
-    minimumPlayers: 30
     maximumPlayers: 45
     weight: 5
     duration: 590
@@ -75,7 +72,7 @@
       path: /Audio/Misc/notice1.ogg
     endAnnouncement: station-event-bluespace-generic-ftl-end-announcement
     earliestStart: 80
-    minimumPlayers: 45
+    minimumPlayers: 20
     weight: 1
     duration: 1800
     maxDuration: 2400
@@ -94,7 +91,7 @@
       path: /Audio/Misc/notice1.ogg
     endAnnouncement: station-event-bluespace-generic-ftl-end-announcement
     earliestStart: 100
-    minimumPlayers: 45
+    minimumPlayers: 20
     weight: 1
     duration: 900
     maxDuration: 1200
@@ -113,7 +110,7 @@
       path: /Audio/Misc/notice1.ogg
     endAnnouncement: station-event-bluespace-generic-ftl-end-announcement
     earliestStart: 80
-    minimumPlayers: 45
+    minimumPlayers: 20
     weight: 1
     duration: 1800
     maxDuration: 2400

--- a/Resources/Prototypes/_NF/Events/nf_events_bluespace.yml
+++ b/Resources/Prototypes/_NF/Events/nf_events_bluespace.yml
@@ -50,7 +50,7 @@
       path: /Audio/Announcements/attention.ogg
     endAnnouncement: station-event-bluespace-vault-end-announcement
     earliestStart: 100
-    maximumPlayers: 45
+    maximumPlayers: 30
     weight: 5
     duration: 590
     maxDuration: 780


### PR DESCRIPTION
## About the PR
Allow more bluespace events for low pop

## Why / Balance
With sheriff change vaults should be around without the need for min players anymore
Allow more events for 20 players online.

## How to test
N/A

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
:cl:
- tweak: Bluespace events require less players overall to show up.
