### PR TITLE
Fix SBB Tyne Shipyard Price

### DIFF
--- a/Resources/Prototypes/_NF/Shipyard/tyne.yml
+++ b/Resources/Prototypes/_NF/Shipyard/tyne.yml
@@ -12,7 +12,7 @@
   id: Tyne
   name: SBB Tyne
   description: A small, agile lifeboat with an exterior deck and survivor cabin for search and rescue operations. 
-  price: 18500 #~5% markup as it's a med ship. Grid values at 17372.
+  price: 19000 #~5-6% markup as it's a med ship. Grid values at 17372.
   category: Small
   group: Shipyard
   shuttlePath: /Maps/_NF/Shuttles/tyne.yml


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Increased the price of the SBB Tyne to 19000 spesos. This is still around 5-7% markup.

## Why / Balance
You could sell it for a profit. A whopping 19 spesos. 
(More importantly it was causing test failures).

## How to test
Check the .yml, checkout the branch, load the game and buy it for 19k. 

## Media
No.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Nuh uh.

**Changelog**
:cl:
- fix: Corrected price of the SBB Tyne.

