### PR TITLE
Remove world loader from outpost STC terminals, bus shuttle console.

### DIFF
--- a/Content.Server/Worldgen/Components/WorldLoaderComponent.cs
+++ b/Content.Server/Worldgen/Components/WorldLoaderComponent.cs
@@ -14,5 +14,11 @@ public sealed partial class WorldLoaderComponent : Component
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)] [DataField("radius")]
     public int Radius = 128;
+
+    /// <summary>
+    ///     Frontier: if true, this loader is disabled, and will not be used
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite)] [DataField]
+    public bool Disabled;
 }
 

--- a/Content.Server/Worldgen/Systems/WorldControllerSystem.cs
+++ b/Content.Server/Worldgen/Systems/WorldControllerSystem.cs
@@ -100,6 +100,9 @@ public sealed class WorldControllerSystem : EntitySystem
 
         while (loaderEnum.MoveNext(out var uid, out var worldLoader, out var xform))
         {
+            if (worldLoader.Disabled) // Frontier: disable world loading
+                continue; // Frontier
+
             var mapOrNull = xform.MapUid;
             if (mapOrNull is null)
                 continue;

--- a/Resources/Maps/_NF/Shuttles/Bus/publicts.yml
+++ b/Resources/Maps/_NF/Shuttles/Bus/publicts.yml
@@ -447,6 +447,8 @@ entities:
     - type: Transform
       pos: 0.5,1.5
       parent: 8756
+    - type: WorldLoader
+      disabled: true
 - proto: DefibrillatorCabinetFilled
   entities:
   - uid: 27

--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers.yml
@@ -381,6 +381,9 @@
   - type: AccessReader
     access: [["StationTrafficController"]]
   - type: ActivatableUIRequiresAccess
+  - type: WorldLoader
+    disabled: true
+    radius: 0 # Just in case.
 
 - type: entity
   parent: [BaseStructureDisableToolUse, BaseStructureIndestructible, BaseStructureAccessReaderImmuneToEmag, BaseComputerShuttle, BaseComputerTraffic]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Adds a disable flag to WorldLoaderComponent, disables the world loader attached to station traffic consoles on Frontier Outpost and Trade Outpost.  Disables world loader on the bus.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Unnecessary overhead.

## How to test
<!-- Describe the way it can be tested -->

Spawn on Frontier Outpost, check the remote feed around Trade Outpost.  There should be no asteroids loaded.

Wait until the bus jumps to Trade Outpost, there should be no asteroids loaded.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

The Trade Outpost, as viewed through the remote console on Frontier Outpost.
![image](https://github.com/user-attachments/assets/31f90439-b36f-4f64-8517-3cfe2b7fa5c6)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
No real in-game impact, slight performance gain.