### PR TITLE
Remove paracusia and changes solar flare event

### DIFF
--- a/Resources/Prototypes/_NF/Events/events.yml
+++ b/Resources/Prototypes/_NF/Events/events.yml
@@ -525,22 +525,22 @@
 #       - type: TraitorRole
 #         prototype: TraitorSleeper
 
-#- type: entity
-#  id: MassHallucinations
-#  parent: BaseGameRule
-#  components:
-#  - type: StationEvent
-#    earliestStart: 15 # Frontier
-#    weight: 7
-#    duration: 150
-#    maxDuration: 300
-#    reoccurrenceDelay: 30
-#  - type: MassHallucinationsRule
-#    minTimeBetweenIncidents: 0.1
-#    maxTimeBetweenIncidents: 300
-#    maxSoundDistance: 7
-#    sounds:
-#      collection: Paracusia
+- type: entity
+  id: MassHallucinations
+  parent: BaseGameRule
+  components:
+  - type: StationEvent
+    earliestStart: 15 # Frontier
+    weight: 7
+    duration: 150
+    maxDuration: 300
+    reoccurrenceDelay: 30
+  - type: MassHallucinationsRule
+    minTimeBetweenIncidents: 0.1
+    maxTimeBetweenIncidents: 300
+    maxSoundDistance: 7
+    sounds:
+      collection: Paracusia
 
 - type: entity
   parent: BaseGameRule

--- a/Resources/Prototypes/_NF/Events/events.yml
+++ b/Resources/Prototypes/_NF/Events/events.yml
@@ -310,13 +310,13 @@
   - type: StationEvent
     weight: 4
     earliestStart: 15 # Frontier
-    reoccurrenceDelay: 30 # Frontier
+    reoccurrenceDelay: 45 # Frontier
     startAnnouncement: station-event-solar-flare-start-announcement
     endAnnouncement: station-event-solar-flare-end-announcement
     startAudio:
       path: /Audio/Announcements/attention.ogg
-    duration: 240 # 120 > 240 frontier
-    maxDuration: 480 # 240 > 480 frontier
+    duration: 120
+    maxDuration: 240
   - type: SolarFlareRule
     onlyJamHeadsets: true
     affectedChannels:
@@ -332,8 +332,8 @@
     - Traffic # Frontier
     - Nfsd # Frontier
     extraCount: 2
-    lightBreakChancePerSecond: 0.00003 # 0.0003 > 0.00003 frontier
-    doorToggleChancePerSecond: 0.0001 #0.001 > 0.0001 frontier
+    lightBreakChancePerSecond: 0.0003
+    doorToggleChancePerSecond: 0.001
 
 - type: entity
   id: VentClog

--- a/Resources/Prototypes/_NF/Events/events.yml
+++ b/Resources/Prototypes/_NF/Events/events.yml
@@ -12,7 +12,7 @@
     - id: GasLeak
     - id: IonStorm # its calm like 90% of the time smh
     # - id: KudzuGrowth
-    - id: MassHallucinations
+    # - id: MassHallucinations # Frontier
     # - id: MimicVendorRule
     - id: MouseMigration
     - id: PowerGridCheck
@@ -308,15 +308,15 @@
   id: SolarFlare
   components:
   - type: StationEvent
-    weight: 8
+    weight: 4
     earliestStart: 15 # Frontier
     reoccurrenceDelay: 30 # Frontier
     startAnnouncement: station-event-solar-flare-start-announcement
     endAnnouncement: station-event-solar-flare-end-announcement
     startAudio:
       path: /Audio/Announcements/attention.ogg
-    duration: 120
-    maxDuration: 240
+    duration: 240 # 120 > 240 frontier
+    maxDuration: 480 # 240 > 480 frontier
   - type: SolarFlareRule
     onlyJamHeadsets: true
     affectedChannels:
@@ -332,8 +332,8 @@
     - Traffic # Frontier
     - Nfsd # Frontier
     extraCount: 2
-    lightBreakChancePerSecond: 0.0003
-    doorToggleChancePerSecond: 0.001
+    lightBreakChancePerSecond: 0.00003 # 0.0003 > 0.00003 frontier
+    doorToggleChancePerSecond: 0.0001 #0.001 > 0.0001 frontier
 
 - type: entity
   id: VentClog
@@ -525,22 +525,22 @@
 #       - type: TraitorRole
 #         prototype: TraitorSleeper
 
-- type: entity
-  id: MassHallucinations
-  parent: BaseGameRule
-  components:
-  - type: StationEvent
-    earliestStart: 15 # Frontier
-    weight: 7
-    duration: 150
-    maxDuration: 300
-    reoccurrenceDelay: 30
-  - type: MassHallucinationsRule
-    minTimeBetweenIncidents: 0.1
-    maxTimeBetweenIncidents: 300
-    maxSoundDistance: 7
-    sounds:
-      collection: Paracusia
+#- type: entity
+#  id: MassHallucinations
+#  parent: BaseGameRule
+#  components:
+#  - type: StationEvent
+#    earliestStart: 15 # Frontier
+#    weight: 7
+#    duration: 150
+#    maxDuration: 300
+#    reoccurrenceDelay: 30
+#  - type: MassHallucinationsRule
+#    minTimeBetweenIncidents: 0.1
+#    maxTimeBetweenIncidents: 300
+#    maxSoundDistance: 7
+#    sounds:
+#      collection: Paracusia
 
 - type: entity
   parent: BaseGameRule

--- a/Resources/Prototypes/_NF/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_NF/GameRules/roundstart.yml
@@ -33,6 +33,7 @@
   table: !type:AllSelector # we need to pass a list of rules, since rules have further restrictions to consider via StationEventComp
     children:
     - id: BluespaceCacheError
+    - id: BluespaceCave
     - id: BluespaceVaultError
     - id: BluespaceVaultSmallError
     - id: BluespaceSyndicateFTLInterception


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Title, Paracusia AKA MassHallucination event is removed, i have always hated the event and does not fit the frontier at all as an event.

Solar flare even has been getting way too annoying recently so i lowered its weight and made it last the double of time in average, doors opening and it breaking lights chances have also been reduced too.

**Changelog**

:cl: Leander
- remove: Paracusia event removed, now all things you hear will be real.
- tweak: Solar flares are more rare but will last longer but less light bulbs will break from it.
