### PR TITLE
NFSD Access Shelves

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Structures/Wallmounts/shelfs.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Wallmounts/shelfs.yml
@@ -78,3 +78,19 @@
   - type: Construction
     graph: WallFreezer
     node: ShelfWallFreezerDark
+
+- type: entity
+  parent: ShelfRMetal
+  id: ShelfRMetalSecurity
+  suffix: Security, Locked
+  components:
+  - type: AccessReader
+    access: [["Security"]]
+
+- type: entity
+  parent: ShelfRWood
+  id: ShelfRWoodSecurity
+  suffix: Security, Locked
+  components:
+  - type: AccessReader
+    access: [["Security"]]


### PR DESCRIPTION
## About the PR
Added NFSD access-locked variants of the wood and metal sturdy shelves.

## Why / Balance
Useful for mapping. Some NFSD ships have shelves already but anybody can open them. 

## How to test
Checkout the branch, spawn the shelves, try to open with and without an NFSD or guard ID.

## Media
No changed visuals.

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None.

**Changelog**
:cl:
- add: Added access-locked shelves for the NFSD.
