### PR TITLE
Removing Goblinbane complex interactions

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_meme_goblinbane.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_meme_goblinbane.yml
@@ -134,7 +134,7 @@
     followEntity: true
     maxIffRange: 256
     hideCoords: true
-  - type: ComplexInteraction
+  # - type: ComplexInteraction
   # Abilities
   - type: Devourer
     foodPreference: Humanoid


### PR DESCRIPTION
Removed ability for goblinbanes to pilot shuttles and take over the galaxy

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Removed ComplexInteractions from Goblinbane to prevent interaction with shuttle consoles and other actions

Resolves #2322

## Why / Balance
While sentient a goblinbane would not be able to operate a console by bashing it with a toiletbrush

## How to test
Buy shuttle
Spawn Goblinbane
Become Goblinbane
Try to use shuttle
Cry

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Before
<img width="911" alt="Goblinbane Shuttle - Before" src="https://github.com/user-attachments/assets/2be03880-0f3c-402c-b9b1-48c3e42d74c9">
After
<img width="832" alt="Goblinbane Shuttle - After" src="https://github.com/user-attachments/assets/d9e31f71-327e-465c-906b-77110a0c78dc">

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Goblinebanes can no longer pilot ships
