### PR TITLE
Diagonal grille fix

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Walls/grille.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/grille.yml
@@ -194,7 +194,7 @@
           mask:
           - FullTileMask
           layer:
-          - WallLayer
+          - GlassLayer
     - type: Construction
       graph: GrilleDiagonal
       node: grilleDiagonal
@@ -229,7 +229,7 @@
           mask:
           - FullTileMask
           layer:
-          - WallLayer
+          - GlassLayer
     - type: Construction
       graph: GrilleDiagonal
       node: clockworkGrilleDiagonal

--- a/Resources/Prototypes/Entities/Structures/Walls/grille.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/grille.yml
@@ -191,10 +191,10 @@
               - "-0.5,-0.5"
               - "0.5,0.5"
               - "0.5,-0.5"
-          mask:
-          - FullTileMask
+          # mask: # Frontier
+          # - FullTileMask # Frontier
           layer:
-          - GlassLayer
+          - GlassLayer # Frontier: WallLayer<GlassLayer
     - type: Construction
       graph: GrilleDiagonal
       node: grilleDiagonal
@@ -226,10 +226,10 @@
               - "-0.5,-0.5"
               - "0.5,0.5"
               - "0.5,-0.5"
-          mask:
-          - FullTileMask
+          # mask: # Frontier
+          # - FullTileMask # Frontier
           layer:
-          - GlassLayer
+          - GlassLayer # Frontier: WallLayer<GlassLayer
     - type: Construction
       graph: GrilleDiagonal
       node: clockworkGrilleDiagonal


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Changed WallLayer (Blocks laser shots) to GlassLayer (does not) for Diagonal Clockwork and Diagonal Grilles
## Why / Balance

Bug report on the discord mentioned it and I did not think there was really a reason for specifically corner windows to block shots.
## How to test
Load up a server
Spawn a diagonal grille
Spawn a laser weapon
Fire at the grille, witness the laser pass through

## Media
Forgot to take a picture, of it, apologies.
## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
Hopefully none?

**Changelog**
:cl:
-fix: Diagonal grilles and diagonal clockwork grilles no longer block lasers from passing through them.