### PR TITLE
Add suffix to damaged RTG generator flatpack

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Objects/Devices/flatpacks.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Devices/flatpacks.yml
@@ -137,6 +137,7 @@
   id: GeneratorRTGDamagedFlatpack
   name: RTG generator flatpack
   description: A flatpack used for constructing a Radioisotope Thermoelectric Generator. The packaging seems to be somewhat damaged.
+  suffix: Damaged
   components:
   - type: Flatpack
     entity: GeneratorRTGDamaged


### PR DESCRIPTION
## About the PR
Add the `Damaged` suffix to the damaged RTG generator flatpack.

## Why / Balance
Makes it easier to distinguish them.

## How to test
1. Search the entity spawn panel for "RTG".
2. Be able to distinguish the damaged RTG generator flatpack from the intact one.
3. :)

## Media
![image](https://github.com/user-attachments/assets/0c2f6c17-4708-40ad-9b5f-ee3697dd9708)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
Negatory.

**Changelog**
N/A