### PR TITLE
Destroy lingering shuttle grids on sale.

### DIFF
--- a/Content.Server/Shipyard/Systems/ShipyardSystem.Consoles.cs
+++ b/Content.Server/Shipyard/Systems/ShipyardSystem.Consoles.cs
@@ -44,6 +44,7 @@ using Content.Shared.Access;
 using Content.Shared.Tiles;
 using Content.Server._NF.Smuggling.Components;
 using Content.Shared._NF.ShuttleRecords;
+using Content.Server.StationEvents.Components;
 
 namespace Content.Server.Shipyard.Systems;
 
@@ -289,6 +290,9 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
             if (vessel.GridProtection.HasFlag(GridProtectionFlags.ArtifactTriggers))
                 prot.PreventArtifactTriggers = true;
         }
+
+        // Ensure cleanup on ship sale
+        EnsureComp<LinkedLifecycleGridParentComponent>(shuttleUid);
 
         var sellValue = 0;
         if (!voucherUsed)

--- a/Content.Server/_NF/StationEvents/Events/BluespaceErrorRule.cs
+++ b/Content.Server/_NF/StationEvents/Events/BluespaceErrorRule.cs
@@ -32,8 +32,6 @@ public sealed class BluespaceErrorRule : StationEventSystem<BluespaceErrorRuleCo
     [Dependency] private readonly PricingSystem _pricing = default!;
     [Dependency] private readonly CargoSystem _cargo = default!;
 
-    private List<(Entity<TransformComponent> Entity, EntityUid MapUid, Vector2 LocalPosition)> _playerMobs = new();
-
     public override void Initialize()
     {
         base.Initialize();
@@ -217,7 +215,7 @@ public sealed class BluespaceErrorRule : StationEventSystem<BluespaceErrorRuleCo
                 }
 
                 var mobQuery = AllEntityQuery<HumanoidAppearanceComponent, MobStateComponent, TransformComponent>();
-                _playerMobs.Clear();
+                List<(Entity<TransformComponent> Entity, EntityUid MapUid, Vector2 LocalPosition)> playerMobs = new();
 
                 while (mobQuery.MoveNext(out var mobUid, out _, out _, out var xform))
                 {
@@ -225,7 +223,7 @@ public sealed class BluespaceErrorRule : StationEventSystem<BluespaceErrorRuleCo
                         continue;
 
                     // Can't parent directly to map as it runs grid traversal.
-                    _playerMobs.Add(((mobUid, xform), xform.MapUid.Value, _transform.GetWorldPosition(xform)));
+                    playerMobs.Add(((mobUid, xform), xform.MapUid.Value, _transform.GetWorldPosition(xform)));
                     _transform.DetachEntity(mobUid, xform);
                 }
 
@@ -234,7 +232,7 @@ public sealed class BluespaceErrorRule : StationEventSystem<BluespaceErrorRuleCo
                 // Deletion has to happen before grid traversal re-parents players.
                 Del(gridUid);
 
-                foreach (var mob in _playerMobs)
+                foreach (var mob in playerMobs)
                 {
                     _transform.SetCoordinates(mob.Entity.Owner, new EntityCoordinates(mob.MapUid, mob.LocalPosition));
                 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Adds LinkedLifecycleGridParentComponent to shuttle grids purchased from shipyards.

When grids split off from this grid, they will be linked to the original, and when this is sold, they will be deleted.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Garbage collection.

Expectations for players: grids that are not attached to ships may be destroyed, along with anything on them save people.

Note: the "don't delete this" condition between this and the BluespaceErrorRule could use some work.  Things like Pun Pun and borgs will be deleted off both.

## How to test
<!-- Describe the way it can be tested -->
1. Purchase a Crescent.
2. Cut the two arms off the Crescent (delete entities, crowbar up floors, maintenance jack the plating, and wirecutter the lattice).
3. Put a few Urists down on the arms.
4. Sell the Crescent.  All three grids will be destroyed.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
Think this one's fine without a changelog entry.