### PR TITLE
Remove curse from the golden mask.

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Masks/specific.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/specific.yml
@@ -67,7 +67,7 @@
   parent: ClothingMaskBase
   id: ClothingMaskGoldenCursed
   name: golden mask
-  description: Previously used in strange pantomimes, after one of the actors went mad on stage these masks have avoided use. You swear its face contorts when you're not looking.
+  description: An ancient-looking mask bearing the visage of some simian monarch. You swear it looks cursed. # Frontier: doesn't contort, not really cursed
   components:
   - type: Sprite
     sprite: Clothing/Mask/goldenmask.rsi
@@ -77,26 +77,39 @@
   - type: Clothing
     sprite: Clothing/Mask/goldenmask.rsi
   - type: Appearance
-  - type: GenericVisualizer
-    visuals:
-      enum.CursedMaskVisuals.State:
-        mask:
-          Neutral: { state: icon }
-          Despair: { state: icon-despair }
-          Joy: { state: icon-joy }
-          Anger: { state: icon-anger }
+  # Frontier: replace visualizer with random state
+  # - type: GenericVisualizer
+  #   visuals:
+  #     enum.CursedMaskVisuals.State:
+  #       mask:
+  #         Neutral: { state: icon }
+  #         Despair: { state: icon-despair }
+  #         Joy: { state: icon-joy }
+  #         Anger: { state: icon-anger }
+  # End Frontier
   - type: Tag
     tags: [] # ignore "WhitelistChameleon" tag
-  - type: SelfEquipOnly
-  - type: CursedMask # Frontier change, too much trouble for something that can insta-ghost you for wearing it.
-    despairDamageModifier:
-      coefficients:
-        Blunt: 0.6
-        Slash: 0.6
-        Piercing: 0.4
+  # Frontier: too much trouble for something that can insta-ghost you for wearing it.
+  # - type: SelfEquipOnly
+  # - type: CursedMask
+  #   despairDamageModifier: # Frontier
+  #     coefficients: # Frontier
+  #       Blunt: 0.6 # Frontier
+  #       Slash: 0.6 # Frontier
+  #       Piercing: 0.4 # Frontier
+  # End Frontier
   - type: HideLayerClothing
     slots:
     - Snout
   - type: IngestionBlocker
   - type: StaticPrice
     price: 5000
+  # Frontier: pick random sprite on spawn
+  - type: RandomSprite
+    available:
+      - mask:
+          icon: ""
+          icon-despair: ""
+          icon-joy: ""
+          icon-anger: ""
+  # End Frontier: random sprite on spawn

--- a/Resources/Prototypes/Entities/Clothing/Masks/specific.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/specific.yml
@@ -88,12 +88,12 @@
   - type: Tag
     tags: [] # ignore "WhitelistChameleon" tag
   - type: SelfEquipOnly
-  - type: CursedMask
-    despairDamageModifier:
-      coefficients:
-        Blunt: 0.6
-        Slash: 0.6
-        Piercing: 0.4
+  #- type: CursedMask # Frontier change, too much trouble for something that can insta-ghost you for wearing it.
+  #  despairDamageModifier:
+  #    coefficients:
+  #      Blunt: 0.6
+  #      Slash: 0.6
+  #      Piercing: 0.4
   - type: HideLayerClothing
     slots:
     - Snout

--- a/Resources/Prototypes/Entities/Clothing/Masks/specific.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/specific.yml
@@ -88,12 +88,12 @@
   - type: Tag
     tags: [] # ignore "WhitelistChameleon" tag
   - type: SelfEquipOnly
-  #- type: CursedMask # Frontier change, too much trouble for something that can insta-ghost you for wearing it.
-  #  despairDamageModifier:
-  #    coefficients:
-  #      Blunt: 0.6
-  #      Slash: 0.6
-  #      Piercing: 0.4
+  - type: CursedMask # Frontier change, too much trouble for something that can insta-ghost you for wearing it.
+    despairDamageModifier:
+      coefficients:
+        Blunt: 0.6
+        Slash: 0.6
+        Piercing: 0.4
   - type: HideLayerClothing
     slots:
     - Snout

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/tables_loot.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/tables_loot.yml
@@ -154,7 +154,7 @@
   id: SalvageTreasureLegendary
   table: !type:GroupSelector
     children:
-    - id: ClothingMaskGoldenCursed
+    # - id: ClothingMaskGoldenCursed # Frontier
     - id: ClothingHeadHatFancyCrown
     - id: GoldenBikeHorn
     - id: ClothingHeadHatCatEars

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/tables_loot.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/tables_loot.yml
@@ -154,7 +154,7 @@
   id: SalvageTreasureLegendary
   table: !type:GroupSelector
     children:
-    # - id: ClothingMaskGoldenCursed # Frontier
+    - id: ClothingMaskGoldenCursed
     - id: ClothingHeadHatFancyCrown
     - id: GoldenBikeHorn
     - id: ClothingHeadHatCatEars


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Title, removed cursed component from the golden mask, too much of a random RNG insta-ghost and dead over an item found in expeditions over 6+ hour rounds.



**Changelog**
:cl:
- tweak: The golden mask is no longer cursed.
