### PR TITLE
Add xeno spawn markers

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
@@ -4,6 +4,7 @@
   id: MobXeno
   parent: [NFMobRestrictions, SimpleSpaceMobBase] # Frontier: add NFMobRestrictions
   description: They mostly come at night. Mostly.
+  categories: [ HideSpawnMenu ] # Frontier
   components:
   - type: Insulated
   - type: CombatMode
@@ -127,6 +128,7 @@
   name: praetorian
   parent: MobXeno
   id: MobXenoPraetorian
+  categories: [ HideSpawnMenu ] # Frontier
   components:
   - type: Sprite
     drawdepth: Mobs
@@ -160,6 +162,7 @@
   name: drone
   parent: MobXeno
   id: MobXenoDrone
+  categories: [ HideSpawnMenu ] # Frontier
   components:
   - type: Sprite
     drawdepth: Mobs
@@ -197,6 +200,7 @@
   name: queen
   parent: MobXeno
   id: MobXenoQueen
+  categories: [ HideSpawnMenu ] # Frontier
   components:
   - type: Sprite
     drawdepth: Mobs
@@ -236,6 +240,7 @@
   name: ravager
   parent: MobXeno
   id: MobXenoRavager
+  categories: [ HideSpawnMenu ] # Frontier
   components:
   - type: Sprite
     drawdepth: Mobs
@@ -273,6 +278,7 @@
   name: runner
   parent: MobXeno
   id: MobXenoRunner
+  categories: [ HideSpawnMenu ] # Frontier
   components:
   - type: Sprite
     drawdepth: Mobs
@@ -303,6 +309,7 @@
   name: rouny
   parent: MobXenoRunner
   id: MobXenoRouny
+  categories: [ HideSpawnMenu ] # Frontier
   components:
   - type: Sprite
     drawdepth: Mobs
@@ -318,6 +325,7 @@
   name: spitter
   parent: MobXeno
   id: MobXenoSpitter
+  categories: [ HideSpawnMenu ] # Frontier
   components:
   - type: Sprite
     drawdepth: Mobs
@@ -366,6 +374,7 @@
   parent: [NFMobRestrictions, SimpleSpaceMobBase] # Frontier: add NFMobRestrictions
   id: MobPurpleSnake
   description: A menacing purple snake from Kepler-283c.
+  categories: [ HideSpawnMenu ] # Frontier
   components:
   - type: Sprite
     drawdepth: Mobs

--- a/Resources/Prototypes/_NF/Entities/Markers/Spawners/Conditional/mobs_hostile_xeno.yml
+++ b/Resources/Prototypes/_NF/Entities/Markers/Spawners/Conditional/mobs_hostile_xeno.yml
@@ -1,0 +1,111 @@
+- type: entity
+  id: SpawnMobXenoBurrowerExpeditions
+  name: xeno burrower spawner
+  parent: MarkerBase
+  suffix: AI, Hostile
+  components:
+  - type: Sprite
+    layers:
+      - state: red
+      - state: ai
+      - sprite: Mobs/Aliens/Xenos/burrower.rsi
+        state: running
+  - type: ConditionalSpawner
+    prototypes:
+    - MobXenoBurrowerExpeditions
+
+- type: entity
+  id: SpawnMobXenoDroneExpeditions
+  name: xeno drone spawner
+  parent: MarkerBase
+  suffix: AI, Hostile
+  components:
+  - type: Sprite
+    layers:
+      - state: red
+      - state: ai
+      - sprite: Mobs/Aliens/Xenos/drone.rsi
+        state: running
+  - type: ConditionalSpawner
+    prototypes:
+    - MobXenoDroneExpeditions
+
+- type: entity
+  id: SpawnMobXenoPraetorianExpeditions
+  name: xeno praetorian spawner
+  parent: MarkerBase
+  suffix: AI, Hostile
+  components:
+  - type: Sprite
+    layers:
+      - state: red
+      - state: ai
+      - sprite: Mobs/Aliens/Xenos/praetorian.rsi
+        state: running
+  - type: ConditionalSpawner
+    prototypes:
+    - MobXenoPraetorianExpeditions
+
+- type: entity
+  id: SpawnMobXenoRavagerExpeditions
+  name: xeno ravager spawner
+  parent: MarkerBase
+  suffix: AI, Hostile
+  components:
+  - type: Sprite
+    layers:
+      - state: red
+      - state: ai
+      - sprite: Mobs/Aliens/Xenos/ravager.rsi
+        state: running
+  - type: ConditionalSpawner
+    prototypes:
+    - MobXenoRavagerExpeditions
+
+- type: entity
+  id: SpawnMobXenoRunnerExpeditions
+  name: xeno runner spawner
+  parent: MarkerBase
+  suffix: AI, Hostile
+  components:
+  - type: Sprite
+    layers:
+      - state: red
+      - state: ai
+      - sprite: Mobs/Aliens/Xenos/runner.rsi
+        state: running
+  - type: ConditionalSpawner
+    prototypes:
+    - MobXenoRunnerExpeditions
+
+- type: entity
+  id: SpawnMobXenoSpitterExpeditions
+  name: xeno spitter spawner
+  parent: MarkerBase
+  suffix: AI, Hostile
+  components:
+  - type: Sprite
+    layers:
+      - state: red
+      - state: ai
+      - sprite: Mobs/Aliens/Xenos/spitter.rsi
+        state: running
+  - type: ConditionalSpawner
+    prototypes:
+    - MobXenoSpitterExpeditions
+
+- type: entity
+  id: SpawnMobXenoQueenDungeon
+  name: xeno queen spawner
+  parent: MarkerBase
+  suffix: AI, Hostile
+  components:
+  - type: Sprite
+    layers:
+      - state: red
+      - state: ai
+      - sprite: Mobs/Aliens/Xenos/queen.rsi
+        state: running
+  - type: ConditionalSpawner
+    prototypes:
+    - MobXenoQueenDungeon


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- Made conditional spawn markers for xeno.
- Hid base game mobs from spawn menu, only frontier versions is visible.

## Why / Balance
Was missing those, redused menu bloat (kind of)

## How to test
Search for `xeno` in spawn menu

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
Don't think CL is needed for this one
