### PR TITLE
Fix roundstart janitor access, no maid smite

### DIFF
--- a/Content.Server/Administration/Systems/AdminVerbSystem.Smites.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.Smites.cs
@@ -563,6 +563,8 @@ public sealed partial class AdminVerbSystem
             };
             args.Verbs.Add(cluwne);
 
+            // Frontier: remove maid smite due to weird ID perms
+            /*
             Verb maiden = new()
             {
                 Text = "admin-smite-remove-gravity-name",
@@ -581,6 +583,7 @@ public sealed partial class AdminVerbSystem
                 Message = Loc.GetString("admin-smite-maid-description")
             };
             args.Verbs.Add(maiden);
+            */
         }
 
         Verb angerPointingArrows = new()

--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -505,6 +505,7 @@
   id: JanitorPDA
   name: janitor PDA
   description: Smells like bleach.
+  categories: [ HideSpawnMenu ] # Frontier
   components:
   - type: Pda
     id: JanitorIDCard

--- a/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
@@ -285,6 +285,7 @@
   parent: IDCardStandard
   id: JanitorIDCard
   name: janitor ID card
+  categories: [ HideSpawnMenu ] # Frontier
   components:
   - type: Sprite
     layers:

--- a/Resources/Prototypes/Roles/Jobs/Civilian/janitor.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/janitor.yml
@@ -31,7 +31,7 @@
   id: JanitorMaidGear
   equipment:
     jumpsuit: ClothingUniformJumpskirtJanimaid
-    id: NFMaidJanitorPDA # Frontier: JanitorPDA<NFMaidJanitorPDA
+    id: JanitorPDA
     gloves: ClothingHandsGlovesJanitor
     head: ClothingHeadHatCatEars
     ears: ClothingHeadsetService

--- a/Resources/Prototypes/Roles/Jobs/Civilian/janitor.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/janitor.yml
@@ -31,7 +31,7 @@
   id: JanitorMaidGear
   equipment:
     jumpsuit: ClothingUniformJumpskirtJanimaid
-    id: JanitorPDA
+    id: NFMaidJanitorPDA # Frontier: JanitorPDA<NFMaidJanitorPDA
     gloves: ClothingHandsGlovesJanitor
     head: ClothingHeadHatCatEars
     ears: ClothingHeadsetService

--- a/Resources/Prototypes/_NF/Entities/Objects/Devices/Misc/identification_cards.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Devices/Misc/identification_cards.yml
@@ -198,6 +198,13 @@
     - state: idvalet
 
 - type: entity
+  parent: JanitorIDCard
+  id: NFJanitorIDCard
+  components:
+  - type: PresetIdCard
+    job: NFJanitor
+
+- type: entity
   parent: PassengerIDCard
   id: ContractorIDCard
   name: contractor ID card

--- a/Resources/Prototypes/_NF/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Devices/pda.yml
@@ -498,3 +498,11 @@
   - type: Pda
     id: ContractorIDCard
     state: pda-clear
+
+- type: entity
+  parent: JanitorPDA
+  id: NFJanitorPDA
+  components:
+  - type: Pda
+    id: NFJanitorIDCard
+    state: pda-janitor

--- a/Resources/Prototypes/_NF/Roles/Jobs/Civilian/janitor.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Civilian/janitor.yml
@@ -33,7 +33,7 @@
   id: NFJanitorGear
   equipment:
     shoes: ClothingShoesGaloshes
-    id: JanitorPDA
+    id: NFJanitorPDA
     belt: ClothingBeltJanitorFilled
   storage:
     back:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Adds a new Frontier-specific janitor set up to receive Frontier janitor access.

Removes the maid smite as it spawns a new PDA with a janitorial ID with old janitorial permissions.  If we want to keep this, I can make a version with contractor permissions.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

https://discord.com/channels/1123826877245694004/1305566159890026559

No access to the mail room or break room on roundstart.

## How to test
<!-- Describe the way it can be tested -->

1. Join as a roundstart Janitor, open the break room.  You should be able to, you have Frontier access.
2. Open the spawn menu, there should be one janitor ID card and janitor PDA, and they should be the frontier variant.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Fixed access for round start Janitors.