### PR TITLE
Raise DroppedEvent on items in pockets/suit storage.

### DIFF
--- a/Content.Shared/Inventory/InventorySystem.Equip.cs
+++ b/Content.Shared/Inventory/InventorySystem.Equip.cs
@@ -321,7 +321,7 @@ public abstract partial class InventorySystem
         ClothingComponent? clothing = null,
         bool reparent = true,
         bool checkDoafter = false,
-        bool child = false)
+        bool child = false) // Frontier: raise DroppedEvent on all children
     {
         return TryUnequip(uid, uid, slot, silent, force, predicted, inventory, clothing, reparent, checkDoafter, child); // Frontier: add child
     }
@@ -337,7 +337,7 @@ public abstract partial class InventorySystem
         ClothingComponent? clothing = null,
         bool reparent = true,
         bool checkDoafter = false,
-        bool child = false) // Frontier: spawn DroppedEvent on all children
+        bool child = false) // Frontier: raise DroppedEvent on all children
     {
         return TryUnequip(actor, target, slot, out _, silent, force, predicted, inventory, clothing, reparent, checkDoafter, child); // Frontier: add child
     }
@@ -353,7 +353,7 @@ public abstract partial class InventorySystem
         ClothingComponent? clothing = null,
         bool reparent = true,
         bool checkDoafter = false,
-        bool child = false) // Frontier: spawn DroppedEvent on all children
+        bool child = false) // Frontier: raise DroppedEvent on all children
     {
         return TryUnequip(uid, uid, slot, out removedItem, silent, force, predicted, inventory, clothing, reparent, checkDoafter, child); // Frontier: add child
     }
@@ -370,7 +370,7 @@ public abstract partial class InventorySystem
         ClothingComponent? clothing = null,
         bool reparent = true,
         bool checkDoafter = false,
-        bool child = false) // Frontier: spawn DroppedEvent on all children
+        bool child = false) // Frontier: raise DroppedEvent on all children
     {
         removedItem = null;
 
@@ -443,7 +443,8 @@ public abstract partial class InventorySystem
 
         // Frontier: spawn dropped events for children
         if (child)
-            RaiseLocalEvent(removedItem.Value, new DroppedEvent(actor), true); // Gas tank internals etc.
+            RaiseLocalEvent(removedItem.Value, new DroppedEvent(actor), true);
+        // End Frontier
 
         // TODO: Inventory needs a hot cleanup hoo boy
         // Check if something else (AKA toggleable) dumped it into a container.

--- a/Content.Shared/Inventory/InventorySystem.Equip.cs
+++ b/Content.Shared/Inventory/InventorySystem.Equip.cs
@@ -6,6 +6,7 @@ using Content.Shared.Hands;
 using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction;
+using Content.Shared.Interaction.Events;
 using Content.Shared.Inventory.Events;
 using Content.Shared.Item;
 using Content.Shared.Movement.Systems;
@@ -319,9 +320,10 @@ public abstract partial class InventorySystem
         InventoryComponent? inventory = null,
         ClothingComponent? clothing = null,
         bool reparent = true,
-        bool checkDoafter = false)
+        bool checkDoafter = false,
+        bool child = false)
     {
-        return TryUnequip(uid, uid, slot, silent, force, predicted, inventory, clothing, reparent, checkDoafter);
+        return TryUnequip(uid, uid, slot, silent, force, predicted, inventory, clothing, reparent, checkDoafter, child); // Frontier: add child
     }
 
     public bool TryUnequip(
@@ -334,9 +336,10 @@ public abstract partial class InventorySystem
         InventoryComponent? inventory = null,
         ClothingComponent? clothing = null,
         bool reparent = true,
-        bool checkDoafter = false)
+        bool checkDoafter = false,
+        bool child = false) // Frontier: spawn DroppedEvent on all children
     {
-        return TryUnequip(actor, target, slot, out _, silent, force, predicted, inventory, clothing, reparent, checkDoafter);
+        return TryUnequip(actor, target, slot, out _, silent, force, predicted, inventory, clothing, reparent, checkDoafter, child); // Frontier: add child
     }
 
     public bool TryUnequip(
@@ -349,9 +352,10 @@ public abstract partial class InventorySystem
         InventoryComponent? inventory = null,
         ClothingComponent? clothing = null,
         bool reparent = true,
-        bool checkDoafter = false)
+        bool checkDoafter = false,
+        bool child = false) // Frontier: spawn DroppedEvent on all children
     {
-        return TryUnequip(uid, uid, slot, out removedItem, silent, force, predicted, inventory, clothing, reparent, checkDoafter);
+        return TryUnequip(uid, uid, slot, out removedItem, silent, force, predicted, inventory, clothing, reparent, checkDoafter, child); // Frontier: add child
     }
 
     public bool TryUnequip(
@@ -365,7 +369,8 @@ public abstract partial class InventorySystem
         InventoryComponent? inventory = null,
         ClothingComponent? clothing = null,
         bool reparent = true,
-        bool checkDoafter = false)
+        bool checkDoafter = false,
+        bool child = false) // Frontier: spawn DroppedEvent on all children
     {
         removedItem = null;
 
@@ -429,12 +434,16 @@ public abstract partial class InventorySystem
             if (slotDef != slotDefinition && slotDef.DependsOn == slotDefinition.Name)
             {
                 //this recursive call might be risky
-                TryUnequip(actor, target, slotDef.Name, true, true, predicted, inventory, reparent: reparent);
+                TryUnequip(actor, target, slotDef.Name, true, true, predicted, inventory, reparent: reparent, child: true); // Frontier: add child
             }
         }
 
         if (!_containerSystem.Remove(removedItem.Value, slotContainer, force: force, reparent: reparent))
             return false;
+
+        // Frontier: spawn dropped events for children
+        if (child)
+            RaiseLocalEvent(removedItem.Value, new DroppedEvent(actor), true); // Gas tank internals etc.
 
         // TODO: Inventory needs a hot cleanup hoo boy
         // Check if something else (AKA toggleable) dumped it into a container.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Raises a DroppedEvent on all items in dependent inventory slot when unequipping its parent.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

When removing a piece of clothing in an outer slot, the dependent slots' contents (e.g. pockets, suit storage, belt) would not raise a DroppedEvent.  Some items (jetpacks, health scanners, etc.) rely on this event to cut down on bookkeeping or maintain state.

Fixes https://discord.com/channels/1123826877245694004/1305455935216549940.

## Issues

This fix depends on some existing behaviour - all existing code that raises DroppedEvent removing items from slots through interaction or the like only interacts with the item being dropped directly, ignoring any children (which it doesn't know about from the call).  The contents of dependent slots are only removed and relocated without any event.

## How to test
<!-- Describe the way it can be tested -->
1. Wear an EVA suit (any will work), have a mini jetpack in your suit storage.
2. Waddle into space, turn your jetpack on.
3. Spawn another suit, pick it up and wear it.
4. Jetpack will fall into space.
5. Try to move, your character will impotently wiggle, the jetpack will remain stationary.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
Minor fix, difficult to describe to players, no changelog.