### PR TITLE
PTK-800 But only for mining

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -423,12 +423,12 @@
     impactEffect: BulletImpactEffectKinetic
     damage:
       types:
-        Blunt: 30
-        Structural: 35
+        Blunt: 0.5 # Frontier 30<0.5
+        Structural: 1 # Frontier 35<1
   - type: Ammo
     muzzleFlash: HitscanEffect
   - type: TimedDespawn
-    lifetime: 1.5
+    lifetime: 1 # Frontier 1.5<1
   - type: PointLight
     radius: 2.5
     color: white


### PR DESCRIPTION
## About the PR
Editing the damage out of the PTK-800 projectiles

## Why / Balance
Did you know the PTK-800 is used for mining?
Almost didn't know that with how its getting used now.

Overall the damage nerf also means it wont self destroy itself when you mine + lifetime might make it more easy to avoid reflects.

## How to test
Place one, place some ore in front, mine with it normally 

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A If you used it for mining nothing changed.

**Changelog**
:cl:
- tweak: The PTK-800 Range and damage lowered, mining ability stay the same with the PTK-800 able to mine without self destructing itself on reflects.
