### PR TITLE
remove glaive from salvage weapons rack

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Structures/Furniture/Armory/weapon_racks_filled.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Furniture/Armory/weapon_racks_filled.yml
@@ -20,10 +20,8 @@
   - type: ContainerFill
     containers:
       weapon1:
-      - WeaponCrusherGlaive
-      weapon2:
       - WeaponCrusher
-      weapon3:
+      weapon2:
       - Pickaxe
 
 ## Pirates/Freelancers


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Removes crusher glaives from the salvage weapon rack
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Crusher glaives were recently buffed and removed from vendors, however one can still be found on the prospector via the filled salvage melee weapons rack.
## How to test
<!-- Describe the way it can be tested -->

1. Spawn filled salvage melee weapons rack
2. Check contents

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
N/A
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- remove: The salvage weapons rack (Found on the prospector) no longer contains a crusher glaive.

