### PR TITLE
Frontier Weapon Mags Visual Fix

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -27,17 +27,17 @@
 # Frontier
 - type: entity
   name: Gestio
-  parent: [ BaseC1Contraband, BaseWeaponRifle ]
+  parent: [ BaseWeaponRifle, BaseC1Contraband ]
   id: WeaponRifleGestio
   description: An old prototype burst-fire NanoTrasen marksman rifle. Manufactured by Silver Industries. It never left the trials. Given its antiquity it is considered a civilian grade weapon.  Uses .30 rifle ammo.
   components:
   - type: Sprite
     sprite: _NF/Objects/Weapons/Guns/Rifles/gestio.rsi
     layers:
-      - state: base
-        map: ["enum.GunVisualLayers.Base"]
       - state: mag-0
         map: ["enum.GunVisualLayers.Mag"]
+      - state: base
+        map: ["enum.GunVisualLayers.Base"]
   - type: Clothing
     sprite: _NF/Objects/Weapons/Guns/Rifles/gestio.rsi
   - type: Gun
@@ -86,6 +86,7 @@
     magState: mag
     steps: 1
     zeroVisible: true
+  - type: Appearance
 
 - type: entity
   parent: WeaponRifleGestio
@@ -112,7 +113,7 @@
             - CartridgeLightRifle
 
 - type: entity
-  parent: [ BaseC1Contraband, BaseWeaponRifle ]
+  parent: [ BaseWeaponRifle, BaseC1Contraband ]
   id: WeaponRifleNovaliteC1
   name: Novalite C1
   description: A modification to the Lecter from SW LLC, a civilian grade semi-automatic rifle with an internal magazine. Nanotrasen Representatives can not stress how compliant this rifle is. Uses .20 rifle ammo.
@@ -120,10 +121,10 @@
   - type: Sprite
     sprite: _NF/Objects/Weapons/Guns/Rifles/novalitec1.rsi
     layers:
-      - state: base
-        map: ["enum.GunVisualLayers.Base"]
       - state: mag-0
         map: ["enum.GunVisualLayers.Mag"]
+      - state: base
+        map: ["enum.GunVisualLayers.Base"]
   - type: Clothing
     sprite: _NF/Objects/Weapons/Guns/Rifles/novalitec1.rsi
   - type: Gun
@@ -161,6 +162,7 @@
     magState: mag
     steps: 1
     zeroVisible: true
+  - type: Appearance
 
 - type: entity
   parent: WeaponRifleNovaliteC1
@@ -189,17 +191,17 @@
 - type: entity
   id: WeaponRifleSVT
   name: SVT-40
-  parent: [ BaseC1Contraband, BaseWeaponRifle ]
+  parent: [ BaseWeaponRifle, BaseC1Contraband ]
   description: |-
    Once a weapon used in war, now a civilian hunting rifle brought to you by S.E.S.W.C., "Retreating is Considered Treason" is etched on one side.
   components:
   - type: Sprite
     sprite: _NF/Objects/Weapons/Guns/Rifles/svt40.rsi
     layers:
-      - state: base
-        map: ["enum.GunVisualLayers.Base"]
       - state: mag-0
         map: ["enum.GunVisualLayers.Mag"]
+      - state: base
+        map: ["enum.GunVisualLayers.Base"]
   - type: Clothing
     sprite: _NF/Objects/Weapons/Guns/Rifles/svt40.rsi
     quickEquip: false
@@ -242,3 +244,4 @@
     magState: mag
     steps: 1
     zeroVisible: true
+  - type: Appearance


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Mags on gestio and svt are once again visible.

## Why / Balance
Fixes

## How to test
Get Frontier specific magfed rifles (Gestio and SVT), insert mags in the, rack the bolts.

## Media
![image](https://github.com/user-attachments/assets/36c85470-46b6-4460-8160-0947905d62d3)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl: erhardsteinhauer
- fix: Fixed Gestio and SVT mags visial bug.
