### PR TITLE
Add OnUiOpened function for RadarConsole

### DIFF
--- a/Content.Server/Shuttles/Systems/RadarConsoleSystem.cs
+++ b/Content.Server/Shuttles/Systems/RadarConsoleSystem.cs
@@ -21,6 +21,7 @@ public sealed class RadarConsoleSystem : SharedRadarConsoleSystem
     {
         base.Initialize();
         SubscribeLocalEvent<RadarConsoleComponent, ComponentStartup>(OnRadarStartup);
+        SubscribeLocalEvent<RadarConsoleComponent, BoundUIOpenedEvent>(OnUIOpened); // Frontier
     }
 
     private void OnRadarStartup(EntityUid uid, RadarConsoleComponent component, ComponentStartup args)
@@ -28,24 +29,23 @@ public sealed class RadarConsoleSystem : SharedRadarConsoleSystem
         UpdateState(uid, component);
     }
 
+    // Frontier
+    private void OnUIOpened(EntityUid uid, RadarConsoleComponent component, ref BoundUIOpenedEvent args)
+    {
+        UpdateState(uid, component);
+    }
+    // End Frontier
+
     protected override void UpdateState(EntityUid uid, RadarConsoleComponent component)
     {
         var xform = Transform(uid);
         var onGrid = xform.ParentUid == xform.GridUid;
         EntityCoordinates? coordinates = onGrid ? xform.Coordinates : null;
         Angle? angle = onGrid ? xform.LocalRotation : null;
-
-        // Frontier - For handheld mass scanner, PR 484
-        if (HasComp<PowerCellDrawComponent>(uid))
-        {
-            coordinates = new EntityCoordinates(uid, Vector2.Zero);
-            angle = Angle.Zero + MathHelper.DegreesToRadians(180);
-        }
-
         if (component.FollowEntity)
         {
             coordinates = new EntityCoordinates(uid, Vector2.Zero);
-            angle = Angle.Zero;
+            angle = Angle.FromDegrees(180); // Frontier: Angle.Zero<Angle.FromDegrees(180)
         }
 
         if (_uiSystem.HasUi(uid, RadarConsoleUiKey.Key))


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Updates the radar console state when opening the UI.

Consolidates changes from #484 with Ed's upstream handheld mass scanner changes w.r.t. angles.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

https://discord.com/channels/1123826877245694004/1307959730026713138

## How to test
<!-- Describe the way it can be tested -->

1. Open mass scanner console on Frontier.
2. Unwrench it, rotate it.
3. Open mass scanner console again.  It should be rotated.
4. Be a ghost, open your innate mass scanner, it should be properly rotated.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Rotato.
![image](https://github.com/user-attachments/assets/c4f5b5ad-d832-448e-b08c-b666f9aed006)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Mass scanner consoles should now reflect their current position.