### PR TITLE
Disable insane Christmas gifts

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Decoration/flora.yml
+++ b/Resources/Prototypes/Entities/Objects/Decoration/flora.yml
@@ -484,9 +484,9 @@
       - id: PresentRandomUnsafe
         prob: 0.5
         orGroup: present
-      - id: PresentRandomInsane
-        prob: 0.2
-        orGroup: present
+      # - id: PresentRandomInsane # Frontier: Disable insane gifts
+      #   prob: 0.2
+      #   orGroup: present
     receivedPopup: christmas-tree-got-gift
     deniedPopup: christmas-tree-no-gift
     requiredHoliday: FestiveSeason


### PR DESCRIPTION
## About the PR
Disables "insane" Christmas presents.

## Why / Balance
Insane presents can contain almost any conceivable entity. This includes a variety of hostile mobs, various consoles, chasms (hello, instant round removal!), tesla balls, singularities, and so much more. They are a little bit _too_ insane at times. In the interest of keeping Frontier just a little bit safe from _instant death_, insane gifts are disabled with this PR.

"Unsafe" gifts (any item) remain. I'm sure fun shenanigans will occur.

Unfortunately, yes, this means you can't get crates and lockers that fit in a pocket. :(

## How to test
1. Spawn a number of gift-giving Christmas tree
2. Don't receive a PresentRandomInsane.

Yeah, this one is annoying to test. :D

## Media
N/A

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
No.

**Changelog**
:cl:
- remove: Christmas gifts are now limited to things that are normally items. Don't worry, you can still get funny things.