### PR TITLE
Display GPS coordinates on their own line

### DIFF
--- a/Resources/Locale/en-US/GPS/handheld-gps.ftl
+++ b/Resources/Locale/en-US/GPS/handheld-gps.ftl
@@ -1,1 +1,4 @@
-handheld-gps-coordinates-title = Coords: {$coordinates}
+# Frontier: Coords on their own line, make it easier to read
+handheld-gps-coordinates-title =
+    Coords:
+    {$coordinates}


### PR DESCRIPTION
## About the PR
Moves GPS coordinates to their own line, after the text "Coords:".

## Why / Balance
With the newish action bar, the previous single-line approach frequently resulted in hard-to-read coordinates. In particular, if the Y-coordinate is negative, the minus sign has a tendency to stay on the first line while the rest migrates to the second. It's much too easy to miss it and send people on a wild goose chase. Especially problematic considering Frontiersmen usually read their coordinates when they're lost and time is of the essence.

## How to test
1. Hold GPS or PDA with the AstroNav app.
2. Behold coordinates.

## Media
**Before:**
![image](https://github.com/user-attachments/assets/9b1ec10c-cd97-4273-aaa3-d3a9bd0beab4)

**After:**
![image](https://github.com/user-attachments/assets/de0e569d-5ca8-4e6b-b636-57b10f618d8f)

The label can easily support ridiculous, unrealistically large offsets even within the limited space afforded to it:
![image](https://github.com/user-attachments/assets/e1b1e688-b8b0-4473-ad08-a35da75691cb)

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
No.

**Changelog**
:cl:
- tweak: GPS coordinates are now more readable.