### PR TITLE
Fix "Allow Goblins to ride cats"

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -2938,31 +2938,6 @@
   - type: NpcFactionMember # Frontier
     factions:
     - Cat
-# Frontier Start: Allow goblins to ride cats
-  - type: Strap
-    buckleOffset: "0.025, 0.2"
-    whitelist:
-      components:
-      - Goblin
-    unbuckleDistanceSquared: 0.09 # Frontier: (30 cm)^2 - seems unnecessary, but for consistency with vehicles
-  - type: Vehicle
-    southOver: true
-    westOver: true
-    eastOver: true
-    northOver: true
-    northOverride: 0.0
-    southOverride: 0.0
-    autoAnimate: false
-  - type: ItemSlots
-    slots:
-      key_slot:
-        disableEject: true
-        locked: true
-  - type: ContainerFill
-    containers:
-      key_slot:
-      - VehicleKeyATV
-# Frontier End: Allow goblins to ride cats
 
 - type: entity
   name: calico cat


### PR DESCRIPTION
Fixing new-frontiers-14/frontier-station-14#2312

:cl:
- remove: Goblins can no longer ride cats.