### PR TITLE
Kimonos

### DIFF
--- a/Resources/Prototypes/_NF/Loadouts/Jobs/Contractor/jumpsuit.yml
+++ b/Resources/Prototypes/_NF/Loadouts/Jobs/Contractor/jumpsuit.yml
@@ -231,7 +231,7 @@
   price: 200
   equipment:
     jumpsuit: ClothingUniformJumpskirtColorOrange
-    
+
 - type: loadout
   id: ContractorClothingUniformJumpsuitColorRed
   hideEffects:
@@ -240,13 +240,13 @@
   price: 200
   equipment:
     jumpsuit: ClothingUniformJumpsuitColorRed
-    
+
 - type: loadout
   id: ContractorClothingUniformJumpskirtColorRed
   price: 200
   equipment:
     jumpsuit: ClothingUniformJumpskirtColorRed
-    
+
 - type: loadout
   id: ContractorClothingUniformJumpsuitColorPurple
   hideEffects:
@@ -255,13 +255,13 @@
   price: 200
   equipment:
     jumpsuit: ClothingUniformJumpsuitColorPurple
-    
+
 - type: loadout
   id: ContractorClothingUniformJumpskirtColorPurple
   price: 200
   equipment:
     jumpsuit: ClothingUniformJumpskirtColorPurple
-    
+
 - type: loadout
   id: ContractorClothingUniformJumpsuitColorPink
   hideEffects:
@@ -270,14 +270,14 @@
   price: 200
   equipment:
     jumpsuit: ClothingUniformJumpsuitColorPink
-    
+
 - type: loadout
   id: ContractorClothingUniformJumpskirtColorPink
   price: 200
   equipment:
     jumpsuit: ClothingUniformJumpskirtColorPink
 
-#T1  
+#T1
 - type: loadout
   id: ContractorClothingUniformJumpsuitColorDarkBlue
   effects:
@@ -289,7 +289,7 @@
   price: 500
   equipment:
     jumpsuit: ClothingUniformJumpsuitColorDarkBlue
-    
+
 - type: loadout
   id: ContractorClothingUniformJumpskirtColorDarkBlue
   effects:
@@ -310,7 +310,7 @@
   price: 500
   equipment:
     jumpsuit: ClothingUniformJumpsuitColorDarkGreen
-  
+
 - type: loadout
   id: ContractorClothingUniformJumpskirtColorDarkGreen
   effects:
@@ -319,7 +319,7 @@
   price: 500
   equipment:
     jumpsuit: ClothingUniformJumpskirtColorDarkGreen
-  
+
 - type: loadout
   id: ContractorClothingUniformJumpsuitColorTeal
   effects:
@@ -331,7 +331,7 @@
   price: 500
   equipment:
     jumpsuit: ClothingUniformJumpsuitColorTeal
-  
+
 - type: loadout
   id: ContractorClothingUniformJumpskirtColorTeal
   effects:
@@ -340,7 +340,7 @@
   price: 500
   equipment:
     jumpsuit: ClothingUniformJumpskirtColorTeal
-  
+
 - type: loadout
   id: ContractorClothingUniformJumpsuitHawaiBlack
   effects:
@@ -352,7 +352,7 @@
   price: 500
   equipment:
     jumpsuit: ClothingUniformJumpsuitHawaiBlack
-  
+
 - type: loadout
   id: ContractorClothingUniformJumpsuitHawaiBlue
   effects:
@@ -364,7 +364,7 @@
   price: 500
   equipment:
     jumpsuit: ClothingUniformJumpsuitHawaiBlue
-  
+
 - type: loadout
   id: ContractorClothingUniformJumpsuitHawaiRed
   effects:
@@ -376,7 +376,7 @@
   price: 500
   equipment:
     jumpsuit: ClothingUniformJumpsuitHawaiRed
-  
+
 - type: loadout
   id: ContractorClothingUniformJumpsuitHawaiYellow
   effects:
@@ -388,7 +388,7 @@
   price: 500
   equipment:
     jumpsuit: ClothingUniformJumpsuitHawaiYellow
-  
+
 - type: loadout
   id: ContractorClothingUniformJumpsuitFlannel
   effects:
@@ -400,7 +400,7 @@
   price: 500
   equipment:
     jumpsuit: ClothingUniformJumpsuitFlannel
-  
+
 - type: loadout
   id: ContractorClothingUniformJumpsuitCasualBlue
   effects:
@@ -412,7 +412,7 @@
   price: 500
   equipment:
     jumpsuit: ClothingUniformJumpsuitCasualBlue
-  
+
 - type: loadout
   id: ContractorClothingUniformJumpskirtCasualBlue
   effects:
@@ -421,7 +421,7 @@
   price: 500
   equipment:
     jumpsuit: ClothingUniformJumpskirtCasualBlue
-  
+
 - type: loadout
   id: ContractorClothingUniformJumpsuitCasualPurple
   effects:
@@ -433,7 +433,7 @@
   price: 500
   equipment:
     jumpsuit: ClothingUniformJumpsuitCasualPurple
-  
+
 - type: loadout
   id: ContractorClothingUniformJumpskirtCasualPurple
   effects:
@@ -442,7 +442,7 @@
   price: 500
   equipment:
     jumpsuit: ClothingUniformJumpskirtCasualPurple
-  
+
 - type: loadout
   id: ContractorClothingUniformJumpsuitCasualRed
   effects:
@@ -454,7 +454,7 @@
   price: 500
   equipment:
     jumpsuit: ClothingUniformJumpsuitCasualRed
-  
+
 - type: loadout
   id: ContractorClothingUniformJumpskirtCasualRed
   effects:
@@ -463,7 +463,7 @@
   price: 500
   equipment:
     jumpsuit: ClothingUniformJumpskirtCasualRed
-  
+
 - type: loadout
   id: ContractorClothingUniformJumpsuitBartenderPurple
   effects:
@@ -475,7 +475,7 @@
   price: 500
   equipment:
     jumpsuit: ClothingUniformJumpsuitBartenderPurple
-  
+
 - type: loadout
   id: ContractorClothingUniformJumpsuitEngineeringHazard
   effects:
@@ -487,7 +487,7 @@
   price: 500
   equipment:
     jumpsuit: ClothingUniformJumpsuitEngineeringHazard
-  
+
 - type: loadout
   id: ContractorClothingUniformJumpsuitAtmosCasual
   effects:
@@ -499,7 +499,7 @@
   price: 500
   equipment:
     jumpsuit: ClothingUniformJumpsuitAtmosCasual
-  
+
 - type: loadout
   id: ContractorClothingUniformOveralls
   effects:
@@ -511,7 +511,7 @@
   price: 500
   equipment:
     jumpsuit: ClothingUniformOveralls
-  
+
 - type: loadout
   id: ContractorClothingUniformJumpsuitChaplain
   effects:
@@ -523,7 +523,7 @@
   price: 500
   equipment:
     jumpsuit: ClothingUniformJumpsuitChaplain
-  
+
 - type: loadout
   id: ContractorClothingUniformJumpskirtChaplain
   effects:
@@ -532,7 +532,7 @@
   price: 500
   equipment:
     jumpsuit: ClothingUniformJumpskirtChaplain
-  
+
 - type: loadout
   id: ContractorClothingUniformJumpsuitCurator
   effects:
@@ -544,7 +544,7 @@
   price: 500
   equipment:
     jumpsuit: ClothingUniformJumpsuitCurator
-  
+
 - type: loadout
   id: ContractorClothingUniformJumpskirtCurator
   effects:
@@ -553,7 +553,7 @@
   price: 500
   equipment:
     jumpsuit: ClothingUniformJumpskirtCurator
-  
+
 - type: loadout
   id: ContractorClothingUniformJumpsuitLibrarian
   effects:
@@ -565,7 +565,7 @@
   price: 500
   equipment:
     jumpsuit: ClothingUniformJumpsuitLibrarian
-  
+
 - type: loadout
   id: ContractorClothingUniformJumpskirtLibrarian
   effects:
@@ -574,7 +574,7 @@
   price: 500
   equipment:
     jumpsuit: ClothingUniformJumpskirtLibrarian
-  
+
 - type: loadout
   id: ContractorClothingUniformJumpsuitReporter
   effects:
@@ -586,7 +586,7 @@
   price: 500
   equipment:
     jumpsuit: ClothingUniformJumpsuitReporter
-  
+
 - type: loadout
   id: ContractorClothingUniformJumpsuitBH
   effects:
@@ -598,7 +598,7 @@
   price: 500
   equipment:
     jumpsuit: ClothingUniformJumpsuitBH
-  
+
 - type: loadout
   id: ContractorClothingUniformJumpskirtBH
   effects:
@@ -607,7 +607,7 @@
   price: 500
   equipment:
     jumpsuit: ClothingUniformJumpskirtBH
-  
+
 - type: loadout
   id: ContractorClothingUniformJumpsuitBHGrey
   effects:
@@ -619,7 +619,7 @@
   price: 500
   equipment:
     jumpsuit: ClothingUniformJumpsuitBHGrey
-  
+
 - type: loadout
   id: ContractorClothingUniformJumpskirtBHGrey
   effects:
@@ -628,7 +628,7 @@
   price: 500
   equipment:
     jumpsuit: ClothingUniformJumpskirtBHGrey
-  
+
 - type: loadout
   id: ContractorUniformScrubsColorGreen
   effects:
@@ -640,7 +640,7 @@
   price: 500
   equipment:
     jumpsuit: UniformScrubsColorGreen
-  
+
 - type: loadout
   id: ContractorUniformScrubsColorBlue
   effects:
@@ -652,7 +652,7 @@
   price: 500
   equipment:
     jumpsuit: UniformScrubsColorBlue
-  
+
 - type: loadout
   id: ContractorUniformScrubsColorPurple
   effects:
@@ -664,7 +664,7 @@
   price: 500
   equipment:
     jumpsuit: UniformScrubsColorPurple
-  
+
 - type: loadout
   id: ContractorClothingUniformJumpsuitParamedic
   effects:
@@ -676,7 +676,7 @@
   price: 500
   equipment:
     jumpsuit: ClothingUniformJumpsuitParamedic
-  
+
 - type: loadout
   id: ContractorClothingUniformJumpskirtParamedic
   effects:
@@ -685,7 +685,7 @@
   price: 500
   equipment:
     jumpsuit: ClothingUniformJumpskirtParamedic
-  
+
 - type: loadout
   id: ContractorClothingUniformJumpsuitVirology
   effects:
@@ -697,7 +697,7 @@
   price: 500
   equipment:
     jumpsuit: ClothingUniformJumpsuitVirology
-  
+
 - type: loadout
   id: ContractorClothingUniformJumpskirtVirology
   effects:
@@ -706,7 +706,7 @@
   price: 500
   equipment:
     jumpsuit: ClothingUniformJumpskirtVirology
-  
+
 - type: loadout
   id: ContractorClothingUniformJumpsuitChemistry
   effects:
@@ -718,7 +718,7 @@
   price: 500
   equipment:
     jumpsuit: ClothingUniformJumpsuitChemistry
-  
+
 - type: loadout
   id: ContractorClothingUniformJumpskirtChemistry
   effects:
@@ -727,7 +727,7 @@
   price: 500
   equipment:
     jumpsuit: ClothingUniformJumpskirtChemistry
-  
+
 - type: loadout
   id: ContractorClothingUniformJumpsuitGenetics
   effects:
@@ -739,7 +739,7 @@
   price: 500
   equipment:
     jumpsuit: ClothingUniformJumpsuitGenetics
-  
+
 - type: loadout
   id: ContractorClothingUniformJumpskirtGenetics
   effects:
@@ -748,7 +748,7 @@
   price: 500
   equipment:
     jumpsuit: ClothingUniformJumpskirtGenetics
-  
+
 - type: loadout
   id: ContractorClothingUniformJumpsuitPsychologist
   effects:
@@ -781,7 +781,7 @@
   price: 500
   equipment:
     jumpsuit: ClothingUniformJumpsuitScientistFormal
-  
+
 - type: loadout
   id: ContractorClothingUniformJumpsuitRoboticist
   effects:
@@ -1271,6 +1271,24 @@
   price: 1000
   equipment:
     jumpsuit: ClothingUniformJumpsuitKimono
+
+- type: loadout
+  id: ContractorClothingKimonoPink
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: ContractorT2
+  price: 1000
+  equipment:
+    jumpsuit: ClothingKimonoPink
+
+- type: loadout
+  id: ContractorClothingKimonoBlue
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: ContractorT2
+  price: 1000
+  equipment:
+    jumpsuit: ClothingKimonoBlue
 
 - type: loadout
   id: ContractorClothingUniformJumpsuitGladiator

--- a/Resources/Prototypes/_NF/Loadouts/contractor_loadout_groups.yml
+++ b/Resources/Prototypes/_NF/Loadouts/contractor_loadout_groups.yml
@@ -174,6 +174,8 @@
   - ContractorClothingUniformJumpsuitMilitaryColorPurple
   - ContractorClothingUniformJumpsuitMilitaryColorLightBrown
   - ContractorClothingUniformJumpsuitMilitaryColorBrown
+  - ContractorClothingKimonoBlue
+  - ContractorClothingKimonoPink
   fallbacks:
   - ContractorClothingUniformJumpsuitColorGrey
   - ContractorClothingUniformJumpskirtColorGrey

--- a/Resources/Prototypes/_NF/Loadouts/contractor_loadout_groups.yml
+++ b/Resources/Prototypes/_NF/Loadouts/contractor_loadout_groups.yml
@@ -131,6 +131,8 @@
   - ContractorClothingUniformJumpsuitKilt
   - ContractorClothingUniformJumpsuitDameDane
   - ContractorClothingUniformJumpsuitKimono
+  - ContractorClothingKimonoBlue
+  - ContractorClothingKimonoPink
   - ContractorClothingUniformJumpsuitGladiator
   - ContractorClothingUniformJumpskirtPerformer
   - ContractorClothingUniformJumpskirtJanimaid
@@ -174,8 +176,7 @@
   - ContractorClothingUniformJumpsuitMilitaryColorPurple
   - ContractorClothingUniformJumpsuitMilitaryColorLightBrown
   - ContractorClothingUniformJumpsuitMilitaryColorBrown
-  - ContractorClothingKimonoBlue
-  - ContractorClothingKimonoPink
+
   fallbacks:
   - ContractorClothingUniformJumpsuitColorGrey
   - ContractorClothingUniformJumpskirtColorGrey

--- a/Resources/Prototypes/_NF/Loadouts/contractor_loadout_groups.yml
+++ b/Resources/Prototypes/_NF/Loadouts/contractor_loadout_groups.yml
@@ -176,7 +176,6 @@
   - ContractorClothingUniformJumpsuitMilitaryColorPurple
   - ContractorClothingUniformJumpsuitMilitaryColorLightBrown
   - ContractorClothingUniformJumpsuitMilitaryColorBrown
-
   fallbacks:
   - ContractorClothingUniformJumpsuitColorGrey
   - ContractorClothingUniformJumpskirtColorGrey


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds blue and pink kimonos to load out selection

## Why / Balance
We should be able to wear other variants of the kimono

## How to test
Open server select either kimono in load outs
## Media
![image](https://github.com/user-attachments/assets/0501c81b-5632-4a07-acee-835869a1f8dc)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**

:cl:
- add: Added blue and pink kimonos to civilian loadouts.