### PR TITLE
Science Rebalance: The Point of Points

### DIFF
--- a/Content.Server/Anomaly/AnomalySystem.Scanner.cs
+++ b/Content.Server/Anomaly/AnomalySystem.Scanner.cs
@@ -175,6 +175,11 @@ public sealed partial class AnomalySystem
             msg.AddMarkupOrThrow(Loc.GetString("anomaly-scanner-point-output-unknown"));
         else
             msg.AddMarkupOrThrow(Loc.GetString("anomaly-scanner-point-output", ("point", GetAnomalyPointValue(anomaly, anomalyComp))));
+        //Frontier: Point earned
+        if (secret != null && secret.Secret.Contains(AnomalySecretData.PointsEarned))
+            msg.AddMarkupOrThrow(Loc.GetString("anomaly-scanner-point-earned-unknown"));
+        else
+            msg.AddMarkupOrThrow(Loc.GetString("anomaly-scanner-point-earned", ("point", anomalyComp.PointsEarned)));
         msg.PushNewline();
         msg.PushNewline();
 

--- a/Content.Server/Anomaly/AnomalySystem.Scanner.cs
+++ b/Content.Server/Anomaly/AnomalySystem.Scanner.cs
@@ -180,6 +180,7 @@ public sealed partial class AnomalySystem
             msg.AddMarkupOrThrow(Loc.GetString("anomaly-scanner-point-earned-unknown"));
         else
             msg.AddMarkupOrThrow(Loc.GetString("anomaly-scanner-point-earned", ("point", anomalyComp.PointsEarned)));
+        // End Frontier
         msg.PushNewline();
         msg.PushNewline();
 

--- a/Content.Server/Anomaly/AnomalySystem.Vessel.cs
+++ b/Content.Server/Anomaly/AnomalySystem.Vessel.cs
@@ -95,7 +95,16 @@ public sealed partial class AnomalySystem
         if (!this.IsPowered(uid, EntityManager) || component.Anomaly is not {} anomaly)
             return;
 
-        args.Points += (int) (GetAnomalyPointValue(anomaly) * component.PointMultiplier);
+        var rawPointValue = GetAnomalyPointValue(anomaly); // Frontier: cache value
+        args.Points += (int)(rawPointValue * component.PointMultiplier); // Frontier: GetAnomalyPointValue() < rawPointValue
+        // Frontier: increase anomaly points
+        if (TryComp<AnomalyComponent>(anomaly, out var anomalyComp)
+            && anomalyComp.LastTickPointsEarned != Timing.CurTick)
+        {
+            anomalyComp.LastTickPointsEarned = Timing.CurTick;
+            anomalyComp.PointsEarned += rawPointValue;
+        }
+        // End Frontier
     }
 
     private void OnVesselAnomalyShutdown(ref AnomalyShutdownEvent args)

--- a/Content.Server/Anomaly/Components/SecretDataAnomalyComponent.cs
+++ b/Content.Server/Anomaly/Components/SecretDataAnomalyComponent.cs
@@ -36,6 +36,7 @@ public enum AnomalySecretData : byte
     Severity,
     Stability,
     OutputPoint,
+    PointsEarned, // Frontier
     ParticleDanger,
     ParticleUnstable,
     ParticleContainment,

--- a/Content.Server/Anomaly/Effects/AnomalyCoreSystem.cs
+++ b/Content.Server/Anomaly/Effects/AnomalyCoreSystem.cs
@@ -18,6 +18,14 @@ public sealed class AnomalyCoreSystem : EntitySystem
 
     private void OnGetPrice(Entity<AnomalyCoreComponent> core, ref PriceCalculationEvent args)
     {
+        // Frontier: quick path
+        if (core.Comp.EndPrice == core.Comp.StartPrice)
+        {
+            args.Price = core.Comp.EndPrice;
+            return;
+        }
+        // End Frontier
+
         var timeLeft = core.Comp.DecayMoment - _gameTiming.CurTime;
         var lerp = timeLeft.TotalSeconds / core.Comp.TimeToDecay;
         lerp = Math.Clamp(lerp, 0, 1);

--- a/Content.Server/Anomaly/Effects/InnerBodyAnomalySystem.cs
+++ b/Content.Server/Anomaly/Effects/InnerBodyAnomalySystem.cs
@@ -17,6 +17,7 @@ using Content.Shared.Whitelist;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Physics.Events;
 using Robust.Shared.Prototypes;
+using Robust.Server.GameObjects; // Frontier
 
 namespace Content.Server.Anomaly.Effects;
 
@@ -35,6 +36,8 @@ public sealed class InnerBodyAnomalySystem : SharedInnerBodyAnomalySystem
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly IPrototypeManager _proto = default!;
     [Dependency] private readonly StunSystem _stun = default!;
+    [Dependency] private readonly TransformSystem _transform = default!; // Frontier
+    [Dependency] private readonly SharedAnomalyCoreSystem _anomalyCore = default!; // Frontier
 
     private readonly Color _messageColor = Color.FromSrgb(new Color(201, 22, 94));
 

--- a/Content.Server/Xenoarchaeology/XenoArtifacts/ArtifactComponent.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/ArtifactComponent.cs
@@ -58,7 +58,7 @@ public sealed partial class ArtifactComponent : Component
     /// to determine the monetary value of the artifact
     /// </summary>
     [DataField("priceMultiplier"), ViewVariables(VVAccess.ReadWrite)]
-    public float PriceMultiplier = 0.175f;
+    public float PriceMultiplier = 0.4f; // Frontier: 0.175 < 0.4
 
     /// <summary>
     /// The base amount of research points for each artifact node.

--- a/Content.Shared/Anomaly/Components/AnomalyComponent.cs
+++ b/Content.Shared/Anomaly/Components/AnomalyComponent.cs
@@ -5,6 +5,7 @@ using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+using Robust.Shared.Timing; // Frontier
 
 namespace Content.Shared.Anomaly.Components;
 
@@ -259,6 +260,18 @@ public sealed partial class AnomalyComponent : Component
 
     [DataField]
     public bool DeleteEntity = true;
+
+    /// <summary>
+    ///     Frontier: the number of points earned by this anomaly.
+    /// </summary>
+    [ViewVariables]
+    public int PointsEarned = 0;
+
+    /// <summary>
+    ///     Frontier: the last time this anomaly earned points.  Prevents double counting.
+    /// </summary>
+    [ViewVariables]
+    public GameTick LastTickPointsEarned = GameTick.Zero;
 }
 
 /// <summary>

--- a/Content.Shared/Anomaly/Components/AnomalyComponent.cs
+++ b/Content.Shared/Anomaly/Components/AnomalyComponent.cs
@@ -268,7 +268,7 @@ public sealed partial class AnomalyComponent : Component
     public int PointsEarned = 0;
 
     /// <summary>
-    ///     Frontier: the last time this anomaly earned points.  Prevents double counting.
+    ///     Frontier: the last time this anomaly earned points. Prevents double counting.
     /// </summary>
     [ViewVariables]
     public GameTick LastTickPointsEarned = GameTick.Zero;

--- a/Content.Shared/Anomaly/Components/AnomalyCoreComponent.cs
+++ b/Content.Shared/Anomaly/Components/AnomalyCoreComponent.cs
@@ -49,4 +49,22 @@ public sealed partial class AnomalyCoreComponent : Component
     [DataField, ViewVariables(VVAccess.ReadWrite)]
     [AutoNetworkedField]
     public int Charge = 5;
+
+    /// <summary>
+    /// Frontier: the fraction of the price to be taken from the researched points
+    /// </summary>
+    [DataField]
+    public double PointPriceCoefficient = 0.4;
+
+    /// <summary>
+    /// Frontier: the maximum price for the core to be worth
+    /// </summary>
+    [DataField]
+    public double MaximumPrice = 30000;
+
+    /// <summary>
+    /// Frontier: the maximum price for the core to be worth
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public double MinimumPrice = 200;
 }

--- a/Content.Shared/Anomaly/SharedAnomalyCoreSystem.cs
+++ b/Content.Shared/Anomaly/SharedAnomalyCoreSystem.cs
@@ -126,7 +126,7 @@ public sealed class SharedAnomalyCoreSystem : EntitySystem
         if (!_net.IsServer)
             return;
 
-        int price = int.Clamp((int)(pointsEarned * 0.4f), 100, 30000);
+        int price = (int)double.Clamp((pointsEarned * component.PointPriceCoefficient), component.MinimumPrice, component.MaximumPrice);
 
         component.StartPrice = price;
         component.EndPrice = price;

--- a/Content.Shared/Anomaly/SharedAnomalyCoreSystem.cs
+++ b/Content.Shared/Anomaly/SharedAnomalyCoreSystem.cs
@@ -6,7 +6,8 @@ using Content.Shared.Weapons.Melee.Components;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Timing;
-using Robust.Shared.Network; // Frontier
+using Robust.Shared.Network;
+using Content.Shared.Anomaly.Effects; // Frontier
 
 namespace Content.Shared.Anomaly;
 
@@ -112,14 +113,23 @@ public sealed class SharedAnomalyCoreSystem : EntitySystem
         Dirty(uid, component);
     }
 
-    // Frontier: set value
-    public void SetValue(EntityUid uid, AnomalyCoreComponent component, int startPrice, int endPrice)
+    // Frontier: settable value
+    /// <summary>
+    ///  Sets the value of an anomaly core based on the number of points it earned.
+    /// </summary>
+    /// <param name="uid">The anomaly core entity</param>
+    /// <param name="component">The anomaly core component to set.</param>
+    /// <param name="pointsEarned">The number of points earned by the anomaly during its lifetime.</param>
+    [Access(typeof(SharedAnomalySystem), typeof(SharedInnerBodyAnomalySystem))]
+    public void SetValueFromPointsEarned(EntityUid uid, AnomalyCoreComponent component, int pointsEarned)
     {
         if (!_net.IsServer)
             return;
 
-        component.StartPrice = startPrice;
-        component.EndPrice = endPrice;
+        int price = int.Clamp((int)(pointsEarned * 0.4f), 100, 30000);
+
+        component.StartPrice = price;
+        component.EndPrice = price;
     }
-    // End Frontier
+    // End Frontier: settable anomaly value
 }

--- a/Content.Shared/Anomaly/SharedAnomalyCoreSystem.cs
+++ b/Content.Shared/Anomaly/SharedAnomalyCoreSystem.cs
@@ -6,7 +6,7 @@ using Content.Shared.Weapons.Melee.Components;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Timing;
-using Robust.Shared.Network;
+using Robust.Shared.Network; // Frontier
 using Content.Shared.Anomaly.Effects; // Frontier
 
 namespace Content.Shared.Anomaly;
@@ -113,7 +113,7 @@ public sealed class SharedAnomalyCoreSystem : EntitySystem
         Dirty(uid, component);
     }
 
-    // Frontier: settable value
+    // Frontier: settable anomaly price
     /// <summary>
     ///  Sets the value of an anomaly core based on the number of points it earned.
     /// </summary>
@@ -131,5 +131,5 @@ public sealed class SharedAnomalyCoreSystem : EntitySystem
         component.StartPrice = price;
         component.EndPrice = price;
     }
-    // End Frontier: settable anomaly value
+    // End Frontier: settable anomaly price
 }

--- a/Content.Shared/Anomaly/SharedAnomalyCoreSystem.cs
+++ b/Content.Shared/Anomaly/SharedAnomalyCoreSystem.cs
@@ -6,6 +6,7 @@ using Content.Shared.Weapons.Melee.Components;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Timing;
+using Robust.Shared.Network; // Frontier
 
 namespace Content.Shared.Anomaly;
 
@@ -17,6 +18,7 @@ public sealed class SharedAnomalyCoreSystem : EntitySystem
     [Dependency] private readonly IGameTiming _gameTiming = default!;
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
     [Dependency] private readonly ItemSlotsSystem _itemSlots = default!;
+    [Dependency] private readonly INetManager _net = default!; // Frontier
 
     public override void Initialize()
     {
@@ -109,4 +111,15 @@ public sealed class SharedAnomalyCoreSystem : EntitySystem
         component.IsDecayed = true;
         Dirty(uid, component);
     }
+
+    // Frontier: set value
+    public void SetValue(EntityUid uid, AnomalyCoreComponent component, int startPrice, int endPrice)
+    {
+        if (!_net.IsServer)
+            return;
+
+        component.StartPrice = startPrice;
+        component.EndPrice = endPrice;
+    }
+    // End Frontier
 }

--- a/Content.Shared/Anomaly/SharedAnomalySystem.cs
+++ b/Content.Shared/Anomaly/SharedAnomalySystem.cs
@@ -194,8 +194,7 @@ public abstract class SharedAnomalySystem : EntitySystem
             // Frontier: set value to points retrieved
             if (TryComp<AnomalyCoreComponent>(core, out var coreComp))
             {
-                var anomalyPrice = int.Clamp(component.PointsEarned, 0, 30000);
-                _anomalyCore.SetValue(core, coreComp, anomalyPrice, anomalyPrice);
+                _anomalyCore.SetValueFromPointsEarned(core, coreComp, component.PointsEarned);
             }
             // End Frontier
         }

--- a/Content.Shared/Anomaly/SharedAnomalySystem.cs
+++ b/Content.Shared/Anomaly/SharedAnomalySystem.cs
@@ -48,6 +48,8 @@ public abstract class SharedAnomalySystem : EntitySystem
     {
         if (!TryComp<CorePoweredThrowerComponent>(args.Used, out var corePowered) || !TryComp<PhysicsComponent>(ent, out var body))
             return;
+        if (HasComp<InnerBodyAnomalyComponent>(ent.Owner)) // Frontier
+            return; // Frontier
         _physics.SetBodyType(ent, BodyType.Dynamic, body: body);
         ChangeAnomalyStability(ent, Random.NextFloat(corePowered.StabilityPerThrow.X, corePowered.StabilityPerThrow.Y), ent.Comp);
     }

--- a/Content.Shared/Anomaly/SharedAnomalySystem.cs
+++ b/Content.Shared/Anomaly/SharedAnomalySystem.cs
@@ -34,6 +34,7 @@ public abstract class SharedAnomalySystem : EntitySystem
     [Dependency] protected readonly SharedPopupSystem Popup = default!;
     [Dependency] private readonly IPrototypeManager _prototype = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
+    [Dependency] private readonly SharedAnomalyCoreSystem _anomalyCore = default!; // Frontier
 
     public override void Initialize()
     {
@@ -189,6 +190,14 @@ public abstract class SharedAnomalySystem : EntitySystem
         {
             var core = Spawn(supercritical ? component.CorePrototype : component.CoreInertPrototype, Transform(uid).Coordinates);
             _transform.PlaceNextTo(core, uid);
+
+            // Frontier: set value to points retrieved
+            if (TryComp<AnomalyCoreComponent>(core, out var coreComp))
+            {
+                var anomalyPrice = int.Clamp(component.PointsEarned, 0, 30000);
+                _anomalyCore.SetValue(core, coreComp, anomalyPrice, anomalyPrice);
+            }
+            // End Frontier
         }
 
         if (component.DeleteEntity)

--- a/Resources/Locale/en-US/_NF/anomaly/anomaly.ftl
+++ b/Resources/Locale/en-US/_NF/anomaly/anomaly.ftl
@@ -1,0 +1,2 @@
+anomaly-scanner-point-earned = Point earned: [color=gray]{$point}[/color]
+anomaly-scanner-point-earned-unknown = Point earned: [color=red]ERROR[/color]

--- a/Resources/Locale/en-US/_NF/anomaly/anomaly.ftl
+++ b/Resources/Locale/en-US/_NF/anomaly/anomaly.ftl
@@ -1,2 +1,2 @@
-anomaly-scanner-point-earned = Point earned: [color=gray]{$point}[/color]
-anomaly-scanner-point-earned-unknown = Point earned: [color=red]ERROR[/color]
+anomaly-scanner-point-earned = Points earned: [color=gray]{$point}[/color]
+anomaly-scanner-point-earned-unknown = Points earned: [color=red]ERROR[/color]

--- a/Resources/Locale/en-US/_NF/cargo/pirate-bounties.ftl
+++ b/Resources/Locale/en-US/_NF/cargo/pirate-bounties.ftl
@@ -4,7 +4,6 @@ pirate-bounty-item-extinguisher = Fire Extinguisher
 pirate-bounty-item-captainGloves = Captain Gloves
 pirate-bounty-item-gyro = Gyroscope (any)
 pirate-bounty-item-defib = Defibrillator
-pirate-bounty-item-researchDisk = Technology Disk
 pirate-bounty-item-alcohol = Booze Dispenser
 pirate-bounty-item-thruster = Thruster
 pirate-bounty-item-gravGen = Gravity Generator

--- a/Resources/Maps/_NF/Dungeon/mineshaft.yml
+++ b/Resources/Maps/_NF/Dungeon/mineshaft.yml
@@ -3019,13 +3019,6 @@ entities:
     - type: Transform
       pos: 43.312515,23.740736
       parent: 2
-- proto: MachineAnomalySynchronizer
-  entities:
-  - uid: 591
-    components:
-    - type: Transform
-      pos: 36.5,22.5
-      parent: 2
 - proto: MachineArtifactCrusher
   entities:
   - uid: 680

--- a/Resources/Maps/_NF/POI/anomalousgeode.yml
+++ b/Resources/Maps/_NF/POI/anomalousgeode.yml
@@ -3566,13 +3566,6 @@ entities:
     - type: Transform
       pos: 3.5,3.5
       parent: 1
-- proto: MachineAnomalySynchronizer
-  entities:
-  - uid: 665
-    components:
-    - type: Transform
-      pos: 3.5,0.5
-      parent: 1
 - proto: MachineAnomalyVessel
   entities:
   - uid: 662

--- a/Resources/Maps/_NF/Test/dev_map.yml
+++ b/Resources/Maps/_NF/Test/dev_map.yml
@@ -3777,13 +3777,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: -8.5,1.5
       parent: 179
-- proto: ComputerTechnologyDiskTerminal
-  entities:
-  - uid: 1088
-    components:
-    - type: Transform
-      pos: 13.5,16.5
-      parent: 179
 - proto: ComputerWallmountBankATM
   entities:
   - uid: 1228

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/tables_loot.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/tables_loot.yml
@@ -123,8 +123,8 @@
     children:
     - id: MaterialDiamond1
     - id: TreasureCPUSupercharged
-    - id: TechnologyDiskRare
-      weight: 0.5
+    # - id: TechnologyDiskRare # Frontier
+    #   weight: 0.5 # Frontier
     - id: ResearchDisk10000
       weight: 0.5
     - id: ArabianLamp

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/maintenance.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/maintenance.yml
@@ -285,7 +285,7 @@
       - id: WelderIndustrial
       - id: SheetPlasteel10
       - id: ClothingMaskGasExplorer
-      - id: TechnologyDisk
+      # - id: TechnologyDisk # Frontier
       - id: ResearchDisk5000
       - id: PetCarrier
       - id: DrinkMopwataBottleRandom

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -334,22 +334,22 @@
       PlasmaGlass: 15
       MetalRod: 4
 
-# - type: entity
-#   parent: BaseMachineCircuitboard
-#   id: AnomalySynchronizerCircuitboard
-#   name: anomaly synchronizer machine board
-#   description: A machine printed circuit board for an anomaly synchronizer.
-#   components:
-#     - type: Sprite
-#       state: science
-#     - type: MachineBoard
-#       prototype: MachineAnomalySynchronizer
-#       requirements: # Frontier
-#         Manipulator: 2 # Frontier stackRequirements<requirements
-#         Capacitor: 5 # Frontier stackRequirements<requirements
-#       stackRequirements:
-#         PlasmaGlass: 5
-#         Cable: 5
+- type: entity
+  parent: BaseMachineCircuitboard
+  id: AnomalySynchronizerCircuitboard
+  name: anomaly synchronizer machine board
+  description: A machine printed circuit board for an anomaly synchronizer.
+  components:
+    - type: Sprite
+      state: science
+    - type: MachineBoard
+      prototype: MachineAnomalySynchronizer
+      requirements: # Frontier
+        Manipulator: 2 # Frontier stackRequirements<requirements
+        Capacitor: 5 # Frontier stackRequirements<requirements
+      stackRequirements:
+        PlasmaGlass: 5
+        Cable: 5
 
 - type: entity
   parent: BaseMachineCircuitboard

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -334,22 +334,22 @@
       PlasmaGlass: 15
       MetalRod: 4
 
-- type: entity
-  parent: BaseMachineCircuitboard
-  id: AnomalySynchronizerCircuitboard
-  name: anomaly synchronizer machine board
-  description: A machine printed circuit board for an anomaly synchronizer.
-  components:
-    - type: Sprite
-      state: science
-    - type: MachineBoard
-      prototype: MachineAnomalySynchronizer
-      requirements: # Frontier
-        Manipulator: 2 # Frontier stackRequirements<requirements
-        Capacitor: 5 # Frontier stackRequirements<requirements
-      stackRequirements:
-        PlasmaGlass: 5
-        Cable: 5
+# - type: entity
+#   parent: BaseMachineCircuitboard
+#   id: AnomalySynchronizerCircuitboard
+#   name: anomaly synchronizer machine board
+#   description: A machine printed circuit board for an anomaly synchronizer.
+#   components:
+#     - type: Sprite
+#       state: science
+#     - type: MachineBoard
+#       prototype: MachineAnomalySynchronizer
+#       requirements: # Frontier
+#         Manipulator: 2 # Frontier stackRequirements<requirements
+#         Capacitor: 5 # Frontier stackRequirements<requirements
+#       stackRequirements:
+#         PlasmaGlass: 5
+#         Cable: 5
 
 - type: entity
   parent: BaseMachineCircuitboard

--- a/Resources/Prototypes/Entities/Objects/Specific/Research/disk.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Research/disk.yml
@@ -63,7 +63,7 @@
   - type: TechnologyDisk
     tierWeightPrototype: TechDiskTierWeights # Frontier
   - type: StaticPrice
-    price: 5000 # Frontier - Rebalance
+    price: 0.01 # Frontier - research points are a means to an end, not an end of their own
   - type: PirateBountyItem # Frontier
     id: TechnologyDisk # Frontier
 

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/techdiskterminal.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/techdiskterminal.yml
@@ -1,6 +1,7 @@
 - type: entity
   parent: BaseComputer
   id: ComputerTechnologyDiskTerminal
+  categories: [ HideSpawnMenu ] # Frontier: no tech disks
   name: tech disk terminal
   description: A terminal used to print out technology disks.
   components:

--- a/Resources/Prototypes/Entities/Structures/Machines/anomaly_sync.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/anomaly_sync.yml
@@ -3,6 +3,7 @@
   parent: [ BaseMachinePowered, ConstructibleMachine ]
   name: anomaly synchronizer
   description: A sophisticated device that reads changes in anomalous waves, and converts them into energy signals.
+  categories: [ HideSpawnMenu ] # Frontier: doesn't make much sense for Frontier
   components:
   - type: AnomalySynchronizer
   - type: Machine

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -546,7 +546,7 @@
       - SheetifierMachineCircuitboard
       - ShuttleConsoleCircuitboard
       - RadarConsoleCircuitboard
-      - TechDiskComputerCircuitboard
+      # - TechDiskComputerCircuitboard # Frontier: no tech disks
       - DawInstrumentMachineCircuitboard
       - CloningConsoleComputerCircuitboard
       - StasisBedMachineCircuitboard
@@ -575,7 +575,7 @@
       - ExosuitFabricatorMachineCircuitboard
       - AnomalyVesselCircuitboard
       - AnomalyVesselExperimentalCircuitboard
-      - AnomalySynchronizerCircuitboard
+      # - AnomalySynchronizerCircuitboard # Frontier: doesn't make sense for Frontier gameplay
       - APECircuitboard
       - ArtifactAnalyzerMachineCircuitboard
       - ArtifactCrusherMachineCircuitboard

--- a/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomaly_injectors.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomaly_injectors.yml
@@ -46,6 +46,7 @@
         deleteEntity: false
         maxPointsPerSecond: 100
         corePrototype: AnomalyCorePyroclastic
+        coreInertPrototype: AnomalyCorePyroclasticInert # Frontier
       - type: InnerBodyAnomaly
         injectionProto: AnomalyInjectionPyroclastic
         startMessage: inner-anomaly-start-message-pyro
@@ -75,6 +76,7 @@
         deleteEntity: false
         maxPointsPerSecond: 100
         corePrototype: AnomalyCoreElectricity
+        coreInertPrototype: AnomalyCoreElectricityInert # Frontier
       - type: InnerBodyAnomaly
         injectionProto: AnomalyInjectionElectric
         startMessage: inner-anomaly-start-message-shock
@@ -104,6 +106,7 @@
         deleteEntity: false
         maxPointsPerSecond: 100
         corePrototype: AnomalyCoreShadow
+        coreInertPrototype: AnomalyCoreShadowInert # Frontier
       - type: InnerBodyAnomaly
         injectionProto: AnomalyInjectionShadow
         startMessage: inner-anomaly-start-message-shadow
@@ -133,6 +136,7 @@
         deleteEntity: false
         maxPointsPerSecond: 100
         corePrototype: AnomalyCoreIce
+        coreInertPrototype: AnomalyCoreIceInert # Frontier
       - type: InnerBodyAnomaly
         injectionProto: AnomalyInjectionIce
         startMessage: inner-anomaly-start-message-frost
@@ -162,6 +166,7 @@
         deleteEntity: false
         maxPointsPerSecond: 100
         corePrototype: AnomalyCoreFlora
+        coreInertPrototype: AnomalyCoreFloraInert # Frontier
       - type: InnerBodyAnomaly
         injectionProto: AnomalyInjectionFlora
         startMessage: inner-anomaly-start-message-flora
@@ -191,6 +196,7 @@
         deleteEntity: false
         maxPointsPerSecond: 100
         corePrototype: AnomalyCoreBluespace
+        coreInertPrototype: AnomalyCoreBluespaceInert # Frontier
       - type: InnerBodyAnomaly
         injectionProto: AnomalyInjectionBluespace
         startMessage: inner-anomaly-start-message-bluespace
@@ -220,6 +226,7 @@
         deleteEntity: false
         maxPointsPerSecond: 100
         corePrototype: AnomalyCoreFlesh
+        coreInertPrototype: AnomalyCoreFleshInert # Frontier
       - type: InnerBodyAnomaly
         injectionProto: AnomalyInjectionFlesh
         startMessage: inner-anomaly-start-message-flesh
@@ -249,6 +256,7 @@
         deleteEntity: false
         maxPointsPerSecond: 100
         corePrototype: AnomalyCoreGravity
+        coreInertPrototype: AnomalyCoreGravityInert # Frontier
       - type: InnerBodyAnomaly
         injectionProto: AnomalyInjectionGravity
         startMessage: inner-anomaly-start-message-grav
@@ -278,6 +286,7 @@
         deleteEntity: false
         maxPointsPerSecond: 100
         corePrototype: AnomalyCoreTech
+        coreInertPrototype: AnomalyCoreTechInert # Frontier
       - type: InnerBodyAnomaly
         injectionProto: AnomalyInjectionTech
         startMessage: inner-anomaly-start-message-tech
@@ -308,6 +317,7 @@
         deleteEntity: false
         maxPointsPerSecond: 100
         corePrototype: AnomalyCoreRock
+        coreInertPrototype: AnomalyCoreRockInert # Frontier
       - type: InnerBodyAnomaly
         injectionProto: AnomalyInjectionRock
         startMessage: inner-anomaly-start-message-rock

--- a/Resources/Prototypes/Recipes/Lathes/electronics.yml
+++ b/Resources/Prototypes/Recipes/Lathes/electronics.yml
@@ -268,10 +268,12 @@
   id: AnomalyVesselExperimentalCircuitboard
   result: AnomalyVesselExperimentalCircuitboard
 
-- type: latheRecipe
-  parent: BaseSilverCircuitboardRecipe
-  id: AnomalySynchronizerCircuitboard
-  result: AnomalySynchronizerCircuitboard
+# Frontier: no recipes for the anomaly synchronizer
+# - type: latheRecipe
+#   parent: BaseSilverCircuitboardRecipe
+#   id: AnomalySynchronizerCircuitboard
+#   result: AnomalySynchronizerCircuitboard
+# End Frontier
 
 - type: latheRecipe
   parent: BaseCircuitboardRecipe
@@ -293,10 +295,12 @@
   id: AnalysisComputerCircuitboard
   result: AnalysisComputerCircuitboard
 
-- type: latheRecipe
-  parent: BaseGoldCircuitboardRecipe
-  id: TechDiskComputerCircuitboard
-  result: TechDiskComputerCircuitboard
+# Frontier: no tech disk recipes
+# - type: latheRecipe
+#   parent: BaseGoldCircuitboardRecipe
+#   id: TechDiskComputerCircuitboard
+#   result: TechDiskComputerCircuitboard
+# End Frontier
 
 - type: latheRecipe
   parent: BaseGoldCircuitboardRecipe

--- a/Resources/Prototypes/Research/experimental.yml
+++ b/Resources/Prototypes/Research/experimental.yml
@@ -45,17 +45,19 @@
   - AnalysisComputerCircuitboard
   - ArtifactAnalyzerMachineCircuitboard
 
-- type: technology
-  id: AlternativeResearch
-  name: research-technology-alternative-research
-  icon:
-    sprite: Structures/Machines/tech_disk_printer.rsi
-    state: display
-  discipline: Experimental
-  tier: 1
-  cost: 5000
-  recipeUnlocks:
-  - TechDiskComputerCircuitboard
+# Frontier: no tech disks
+# - type: technology
+#   id: AlternativeResearch
+#   name: research-technology-alternative-research
+#   icon:
+#     sprite: Structures/Machines/tech_disk_printer.rsi
+#     state: display
+#   discipline: Experimental
+#   tier: 1
+#   cost: 5000
+#   recipeUnlocks:
+#   - TechDiskComputerCircuitboard
+# End Frontier: no tech disks
 
 - type: technology
   id: MagnetsTech
@@ -121,7 +123,7 @@
   cost: 10000
   recipeUnlocks:
   - WeaponPistolCHIMP
-  - AnomalySynchronizerCircuitboard
+  # - AnomalySynchronizerCircuitboard # Frontier: doesn't make sense for Frontier
   - AnomalyVesselExperimentalCircuitboard
   technologyPrerequisites:
   - BasicAnomalousResearch

--- a/Resources/Prototypes/XenoArch/Effects/utility_effects.yml
+++ b/Resources/Prototypes/XenoArch/Effects/utility_effects.yml
@@ -55,12 +55,14 @@
     grid:
     - 0,0,10,5
 
-- type: artifactEffect
-  id: EffectPhasing
-  targetDepth: 2
-  effectHint: artifact-effect-hint-phasing
-  permanentComponents:
-  - type: PhasingArtifact
+# Frontier: artifacts should always be sellable
+# - type: artifactEffect
+#   id: EffectPhasing
+#   targetDepth: 2
+#   effectHint: artifact-effect-hint-phasing
+#   permanentComponents:
+#   - type: PhasingArtifact
+# End Frontier
 
 - type: artifactEffect
   id: EffectWandering

--- a/Resources/Prototypes/_NF/Catalog/Bounties/pirate_bounties.yml
+++ b/Resources/Prototypes/_NF/Catalog/Bounties/pirate_bounties.yml
@@ -55,15 +55,6 @@
     id: Defibrillator
 
 - type: pirateBounty
-  id: PirateBountyResearchDisk
-  reward: 5
-  description: pirate-bounty-description-generic
-  entries:
-  - name: pirate-bounty-item-researchDisk
-    amount: 7
-    id: TechnologyDisk
-
-- type: pirateBounty
   id: PirateBountyAlcohol
   reward: 4
   description: pirate-bounty-description-generic

--- a/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/dungeon_items_research.yml
+++ b/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/dungeon_items_research.yml
@@ -217,11 +217,9 @@
     - ResearchDisk
     - ResearchDisk
     - ResearchDisk5000
-    - TechnologyDisk
     chance: 0.95
     offset: 0.0
     rarePrototypes:
-    - TechnologyDiskRare
     - ResearchDisk10000
     - WeaponCaseShortDocumentsFilled
     rareChance: 0.05

--- a/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/dungeon_items_research.yml
+++ b/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/dungeon_items_research.yml
@@ -246,7 +246,6 @@
     # Computers
     - ResearchComputerCircuitboard
     - AnalysisComputerCircuitboard
-    - TechDiskComputerCircuitboard
     # Lathes
     - CircuitImprinterMachineCircuitboard
     - ExosuitFabricatorMachineCircuitboard
@@ -259,7 +258,6 @@
     - APECircuitboard
     - ArtifactAnalyzerMachineCircuitboard
     - ArtifactCrusherMachineCircuitboard
-    - AnomalySynchronizerCircuitboard
     - AnomalyVesselCircuitboard
     - AnomalyVesselExperimentalCircuitboard
     chance: 0.9
@@ -296,7 +294,6 @@
     - MachineArtifactCrusherFlatpack
     - ComputerResearchAndDevelopmentFlatpack
     - ResearchAndDevelopmentServerFlatpack
-    - MachineAnomalySynchronizerFlatpack
     - MachineAnomalyVesselExperimentalFlatpack
     - MachineAnomalyVesselFlatpack
     chance: 0.95

--- a/Resources/Prototypes/_NF/Entities/Objects/Devices/flatpacks.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Devices/flatpacks.yml
@@ -270,15 +270,6 @@
 
 - type: entity
   parent: ExosuitFabricatorFlatpack
-  id: MachineAnomalySynchronizerFlatpack
-  name: anomaly synchronizer flatpack
-  description: A flatpack used for constructing an anomaly synchronizer.
-  components:
-  - type: Flatpack
-    entity: MachineAnomalySynchronizer
-
-- type: entity
-  parent: ExosuitFabricatorFlatpack
   id: MachineAnomalyVesselExperimentalFlatpack
   name: experimental anomaly vessel flatpack
   description: A flatpack used for constructing an experimental anomaly vessel.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

A proposal to rebalance science and incentivize researching technologies.

Anomaly cores (both inert and active) and artifacts receive value for the research points earned (0.4:1), with anomalies capping at a fixed value ($30k at time of writing).  This supplants technology disks as a source of income.  "PvE" income is to come from selling researched materials (anomaly cores and artifacts) for cash - the points themselves are yours, and can be spent on technology, which can be used to make fun things and/or sell to other players.

Recipes for the technology disk console and anomaly synchronizer circuitboards have been removed, and the anomaly synchronizer has been unmapped from the Anomalous Geode - science gameplay should be active and involve player input, and turning science into an idle game is not desirable; you should be keeping track of your anomalies.  Technology disks as-is do not make sense in a point-rich environment, and so their values have been nullified.  If there were rare, disk-only technologies that you could come across, this would make more sense.

TODO: need to incorporate Dvir's reversions to tech disks from #2418 where appropriate.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Science should primarily be about scientists actively doing things to learn how to make stuff, and then making said stuff.  The points are a means to make stuff, and having them sellable undermines that.

With this set of changes, artifacts seem to be the stronger of the two - anomalies generated need to be rotated out, and optimally, fairly regularly (~12 minutes at 100 pt/s).  If anomalies could work on a prestige-like system where you can extract a core once it's given you enough points, but doing this makes it more dangerous, that could be interesting, and give some choices to keeping anomalies beyond "babysit as many as you can before swapping them out".

## How to test
<!-- Describe the way it can be tested -->

1. Purchase a science ship, spawn an alien artifact, research it partially.
2. Check the number of points you've received.
3. Appraise the artifact, it should be equal to 40% of that value.
4. Spray the artifact when on an unresearched node.
5. Appraise the artifact, it should maintain its value.
6. Spawn an anomaly trap, step into it.
7. Hook yourself up to an anomaly vessel.
8. Generate some points.
9. Stabilize yourself and decay the anomaly.  It should spawn an anomaly core.
10. Appraise the anomaly core, it should be equal to 40% of the number of points it generated.  This value should not change over time.
11. Generate a normal anomaly.  Do not hook it up to an anomaly vessel.
12. Decay the anomaly.  Its core should be worth 100 spesos.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
Preliminary:
:cl:
- tweak: Artifacts and anomaly cores are valued at 40% of the points generated.
- remove: The technology printer and anomaly synchronizer are no longer printable.