### PR TITLE
Make borgs able to fly in space (DeltaV #2339)

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -240,6 +240,7 @@
     damageProtection:
       flatReductions:
         Heat: 10 # capable of touching light bulbs and stoves without feeling pain!
+  - type: JetpackUser # DeltaV: Lets cyborgs fly in space
 
 - type: entity
   abstract: true


### PR DESCRIPTION
## About the PR
Based on https://github.com/DeltaV-Station/Delta-v/pull/2339

## Why / Balance
Allow all borgs basic flight in space

## How to test
Spawn as borg, jump into space

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
:cl: Emily9031
- add: Cyborgs are now able to slowly fly through space.