### PR TITLE
SalvageMobRestrictions: no warning/logging for safe mobs (e.g. Clugg)

### DIFF
--- a/Content.Server/_NF/Salvage/SalvageMobRestrictionsSystem.cs
+++ b/Content.Server/_NF/Salvage/SalvageMobRestrictionsSystem.cs
@@ -117,7 +117,8 @@ public sealed class SalvageMobRestrictionsSystem : EntitySystem
             if (actor.PlayerSession.AttachedEntity == null)
                 return;
 
-            _adminLogger.Add(LogType.AdminMessage, LogImpact.Low, $"{ToPrettyString(actor.PlayerSession.AttachedEntity.Value):player} returned to dungeon grid");
+            if (component.DespawnIfOffLinkedGrid)
+                _adminLogger.Add(LogType.AdminMessage, LogImpact.Low, $"{ToPrettyString(actor.PlayerSession.AttachedEntity.Value):player} returned to dungeon grid");
         }
         else
         {
@@ -130,8 +131,11 @@ public sealed class SalvageMobRestrictionsSystem : EntitySystem
             if (actor.PlayerSession.AttachedEntity == null)
                 return;
 
-            _adminLogger.Add(LogType.AdminMessage, LogImpact.Low, $"{ToPrettyString(actor.PlayerSession.AttachedEntity.Value):player} left the dungeon grid");
-            _popupSystem.PopupEntity(popupMessage, actor.PlayerSession.AttachedEntity.Value, actor.PlayerSession, PopupType.MediumCaution);
+            if (component.DespawnIfOffLinkedGrid)
+            {
+                _adminLogger.Add(LogType.AdminMessage, LogImpact.Low, $"{ToPrettyString(actor.PlayerSession.AttachedEntity.Value):player} left the dungeon grid");
+                _popupSystem.PopupEntity(popupMessage, actor.PlayerSession.AttachedEntity.Value, actor.PlayerSession, PopupType.MediumCaution);
+            }
         }
     }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

When a mob leaves its restricted grid, if the mob will not be destroyed when leaving (i.e. it's a safe mob that spawns in with a bluespace event), it will not be warned or leave an admin log if leaving the grid.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Oversight in #2449.

## How to test
<!-- Describe the way it can be tested -->

1. Run `addgamerule BluespaceCave`.
2. Become Clugg.
3. Leave the grid.  You shouldn't get a popup.
4. Return to the grid.
5. Spawn in and become a Xeno queen.
6. Leave the grid. You should get a popup and turn pacified.
7. Return to the grid.  No more pacifism.
8. Check the admin logs, you should have nothing from Clugg, and messages about the xeno queen leaving.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Step 6: the xeno queen leaves the grid it's attached to, and is prompted to return.
![image](https://github.com/user-attachments/assets/1c116046-66c7-4530-a65e-7d7f4ad4e161)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Clugg is no longer prompted to return to the cave if leaving.