### PR TITLE
Add Bosses to VGroids

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Markers/Spawners/Conditional/mobs_hostile_argocyte.yml
+++ b/Resources/Prototypes/_NF/Entities/Markers/Spawners/Conditional/mobs_hostile_argocyte.yml
@@ -1,0 +1,17 @@
+- type: entity
+  name: leviathing spawner
+  id: SpawnMobArgocyteLeviathingExpeditions
+  parent: MarkerBase
+  suffix: AI, Hostile
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+    - sprite: Mobs/Aliens/Argocyte/argocyte_large.rsi
+      state: leviathing
+    - sprite: _NF/Markers/general.rsi
+      state: questionmark
+      color: red
+  - type: ConditionalSpawner
+    prototypes:
+    - MobArgocyteLeviathingExpeditions

--- a/Resources/Prototypes/_NF/Entities/Markers/Spawners/Conditional/mobs_hostile_explorers.yml
+++ b/Resources/Prototypes/_NF/Entities/Markers/Spawners/Conditional/mobs_hostile_explorers.yml
@@ -1,0 +1,24 @@
+
+- type: entity
+  name: explorer boss spawner
+  id: SpawnMobExplorerBoss
+  parent: MarkerBase
+  suffix: AI, Hostile, Boss
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+    - state: ai
+    - sprite: _NF/Mobs/Species/Templates/human.rsi
+      state: human
+    - sprite: _NF/Clothing/OuterClothing/Hardsuits/maxim_prototype.rsi
+      state: equipped-OUTERCLOTHING
+    - sprite: _NF/Clothing/Head/Hardsuits/maxim_prototype.rsi
+      state: off-equipped-HELMET
+    - sprite: _NF/Objects/Weapons/Melee/energy_pickaxe.rsi
+      state: inhand-left
+    - sprite: _NF/Objects/Weapons/Melee/energy_pickaxe.rsi
+      state: inhand-left-blade
+  - type: ConditionalSpawner
+    prototypes:
+    - MobExplorerBoss

--- a/Resources/Prototypes/_NF/Entities/Markers/Spawners/Conditional/mobs_hostile_mercenaries.yml
+++ b/Resources/Prototypes/_NF/Entities/Markers/Spawners/Conditional/mobs_hostile_mercenaries.yml
@@ -1,0 +1,34 @@
+- type: entity
+  name: mercenary boss spawner
+  id: SpawnMobMercenaryCaptain
+  parent: MarkerBase
+  suffix: AI, Hostile
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+    - state: ai
+    - sprite: _NF/Mobs/Species/Templates/human.rsi
+      state: human
+    - sprite: Clothing/Uniforms/Jumpsuit/color.rsi
+      state: equipped-INNERCLOTHING
+      color: "#d3bf86"
+    - sprite: Clothing/OuterClothing/Armor/bulletproof.rsi
+      state: equipped-OUTERCLOTHING
+    - sprite: Clothing/Mask/gassecurity.rsi
+      state: equipped-MASK
+    - sprite: Clothing/Head/Helmets/security.rsi
+      state: equipped-HELMET
+    - sprite: Clothing/Belt/militarywebbing.rsi
+      state: equipped-BELT
+    - sprite: Clothing/Neck/mantles/qmmantle.rsi
+      state: equipped-NECK
+    - sprite: _NF/Clothing/Neck/Misc/mercenary_iff.rsi
+      state: equipped-NECK-off
+    - sprite: _NF/Clothing/Neck/Misc/mercenary_iff.rsi
+      state: equipped-NECK-on
+      color: "#a9b6bd"
+      shader: unshaded
+  - type: ConditionalSpawner
+    prototypes:
+    - MobMercenaryCaptain

--- a/Resources/Prototypes/_NF/Entities/Markers/Spawners/Conditional/mobs_hostile_rogue_ai.yml
+++ b/Resources/Prototypes/_NF/Entities/Markers/Spawners/Conditional/mobs_hostile_rogue_ai.yml
@@ -15,3 +15,37 @@
   - type: ConditionalSpawner
     prototypes:
     - MobRogueSiliconViscerator
+
+- type: entity
+  name: one star unit spawner
+  suffix: AI, Hostile
+  id: SpawnMobRogueSiliconBoss
+  parent: MarkerBase
+  components:
+  - type: Sprite
+    layers:
+      - state: red
+      - state: ai
+      - sprite: Mobs/Silicon/onestar.rsi
+        state: onestar_boss
+      - sprite: Mobs/Silicon/onestar.rsi
+        state: onestar_boss_screen
+  - type: ConditionalSpawner
+    prototypes:
+    - MobRogueSiliconBoss
+
+- type: entity
+  name: guardian unit spawner
+  suffix: AI, Hostile
+  id: SpawnMobRogueSiliconGuardian
+  parent: MarkerBase
+  components:
+  - type: Sprite
+    layers:
+      - state: red
+      - state: ai
+      - sprite: _NF/Mobs/RogueSilicons/netguardian.rsi
+        state: netguardian
+  - type: ConditionalSpawner
+    prototypes:
+    - MobRogueSiliconGuardian

--- a/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/mobs_hostile_silicons.yml
+++ b/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/mobs_hostile_silicons.yml
@@ -135,3 +135,22 @@
     rarePrototypes:
     - MobRogueSiliconGuardian
     rareChance: 0.05
+
+- type: entity
+  name: rogue silicon boss spawner
+  id: SpawnMobRogueSiliconBossRandom
+  parent: MarkerBase
+  suffix: AI, Hostile, Random
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+    - state: ai
+    - sprite: _NF/Mobs/RogueSilicons/netguardian.rsi
+      state: netguardian
+  - type: RandomSpawner
+    prototypes:
+    - MobRogueSiliconBoss
+    - MobRogueSiliconGuardian
+    chance: 1
+    offset: 0.0

--- a/Resources/Prototypes/_NF/Procedural/basalt_vgroid.yml
+++ b/Resources/Prototypes/_NF/Procedural/basalt_vgroid.yml
@@ -242,6 +242,18 @@
     groups:
     - id: SpawnMobMercenaryT2
       amount: 1
+  - !type:MobsDunGen
+    minCount: 1
+    maxCount: 3
+    groups:
+    - id: SpawnMobMercenaryT3
+      amount: 1
+  - !type:MobsDunGen
+    minCount: 1
+    maxCount: 3
+    groups:
+    - id: SpawnMobMercenaryCaptain
+      amount: 1
 
 #- type: dungeonConfig
 #  id: NFVGRoidInteriorDungeonsBasalt

--- a/Resources/Prototypes/_NF/Procedural/basalt_vgroid.yml
+++ b/Resources/Prototypes/_NF/Procedural/basalt_vgroid.yml
@@ -250,7 +250,7 @@
       amount: 1
   - !type:MobsDunGen
     minCount: 1
-    maxCount: 3
+    maxCount: 1
     groups:
     - id: SpawnMobMercenaryCaptain
       amount: 1

--- a/Resources/Prototypes/_NF/Procedural/cave_vgroid.yml
+++ b/Resources/Prototypes/_NF/Procedural/cave_vgroid.yml
@@ -242,6 +242,12 @@
     groups:
     - id: SpawnMobExplorerT2
       amount: 1
+  - !type:MobsDunGen
+    minCount: 1
+    maxCount: 1
+    groups:
+    - id: SpawnMobExplorerBoss # Boss
+      amount: 1
 
 #- type: dungeonConfig
 #  id: NFVGRoidInteriorDungeonsCave

--- a/Resources/Prototypes/_NF/Procedural/chromite_vgroid.yml
+++ b/Resources/Prototypes/_NF/Procedural/chromite_vgroid.yml
@@ -266,6 +266,12 @@
     groups:
     - id: SpawnMobBloodCultistCaster
       amount: 1
+  - !type:MobsDunGen
+    minCount: 1
+    maxCount: 1
+    groups:
+    - id: SpawnMobBloodCultistAscended # Boss
+      amount: 1
 
 #- type: dungeonConfig
 #  id: NFVGRoidInteriorDungeonsChromite

--- a/Resources/Prototypes/_NF/Procedural/scrap_vgroid.yml
+++ b/Resources/Prototypes/_NF/Procedural/scrap_vgroid.yml
@@ -144,6 +144,13 @@
       entity: SpawnMobRogueScapT1
       count: 25
       minGroupSize: 1
+      maxGroupSize: 2
+    - !type:OreDunGen
+      tileMask:
+      - Plating
+      entity: SpawnMobRogueDronesT1
+      count: 15
+      minGroupSize: 1
       maxGroupSize: 1
 
 # Configs
@@ -244,6 +251,12 @@
     maxCount: 2
     groups:
     - id: SpawnMobRogueSiliconsT2
+      amount: 1
+  - !type:MobsDunGen
+    minCount: 1
+    maxCount: 1
+    groups:
+    - id: SpawnMobRogueSiliconBossRandom
       amount: 1
 
 #- type: dungeonConfig

--- a/Resources/Prototypes/_NF/Procedural/scrap_vgroid.yml
+++ b/Resources/Prototypes/_NF/Procedural/scrap_vgroid.yml
@@ -142,14 +142,14 @@
       tileMask:
       - Plating
       entity: SpawnMobRogueScapT1
-      count: 25
+      count: 15
       minGroupSize: 1
       maxGroupSize: 2
     - !type:OreDunGen
       tileMask:
       - Plating
       entity: SpawnMobRogueDronesT1
-      count: 15
+      count: 10
       minGroupSize: 1
       maxGroupSize: 1
 

--- a/Resources/Prototypes/_NF/Procedural/snow_vgroid.yml
+++ b/Resources/Prototypes/_NF/Procedural/snow_vgroid.yml
@@ -161,6 +161,13 @@
       count: 5
       minGroupSize: 1
       maxGroupSize: 1
+    - !type:OreDunGen
+      tileMask:
+      - FloorSnow
+      entity: SpawnMobArgocyteLeviathingExpeditions
+      count: 1
+      minGroupSize: 0
+      maxGroupSize: 1
 
 # Configs
 - type: dungeonConfig
@@ -255,6 +262,12 @@
     maxCount: 15
     groups:
     - id: SpawnMobXenoT2
+      amount: 1
+  - !type:MobsDunGen
+    minCount: 1
+    maxCount: 1
+    groups:
+    - id: SpawnMobXenoQueenDungeon
       amount: 1
 
 #- type: dungeonConfig


### PR DESCRIPTION
## About the PR
Added the following bosses:
- Basalt VGroid: Mercenary Captain.
- Cave VGroid: Explorer Captain (ghost role). Added T3 spawns to the interior.
- Chromite VGroid: Ascended Cultist.
- Scrap VGroid: One Star Unit or Guardian Unit (random). Added drone spawns to the exterior.
- Snow VGroid: Xeno Queen (ghost role) and Leviathing.

## Why / Balance
Danger!

## How to test
1. Use addgamerule command to spawn VGroid, eg: `addgamerule BluespaceDungeonCave `
2. Take control over a boss and leave the grid, mob should become pacified and despawned after ~15 sec off-grid.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl: erhardsteinhauer
- tweak: Hostile faction bosses can now be encountered on VGroids.
