### PR TITLE
Fix FactionClothing tracking

### DIFF
--- a/Content.Shared/Clothing/EntitySystems/FactionClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/FactionClothingSystem.cs
@@ -3,6 +3,10 @@ using Content.Shared.Inventory.Events;
 using Content.Shared.NPC.Components;
 using Content.Shared.NPC.Systems;
 using Robust.Shared.Player; // Frontier - Dont edit AI factions
+using Content.Shared.Inventory; // Frontier
+using Content.Shared.NPC.Prototypes; // Frontier
+using Robust.Shared.Prototypes; // Frontier
+using Content.Shared.Mind.Components; // Frontier
 
 namespace Content.Shared.Clothing.EntitySystems;
 
@@ -12,6 +16,7 @@ namespace Content.Shared.Clothing.EntitySystems;
 public sealed class FactionClothingSystem : EntitySystem
 {
     [Dependency] private readonly NpcFactionSystem _faction = default!;
+    [Dependency] private readonly InventorySystem _inventory = default!; // Frontier
 
     public override void Initialize()
     {
@@ -19,31 +24,98 @@ public sealed class FactionClothingSystem : EntitySystem
 
         SubscribeLocalEvent<FactionClothingComponent, GotEquippedEvent>(OnEquipped);
         SubscribeLocalEvent<FactionClothingComponent, GotUnequippedEvent>(OnUnequipped);
+        SubscribeLocalEvent<NpcFactionMemberComponent, PlayerAttachedEvent>(OnPlayerAttached); // Frontier
+        SubscribeLocalEvent<NpcFactionMemberComponent, PlayerDetachedEvent>(OnPlayerDetached); // Frontier
     }
 
+    // Frontier: rewritten from scratch
     private void OnEquipped(Entity<FactionClothingComponent> ent, ref GotEquippedEvent args)
     {
-        if (!HasComp<ActorComponent>(args.Equipee)) // Frontier - Dont edit AI factions
-            return; // Frontier - Dont edit AI factions
+        var alreadyMember = CheckEntityEquipmentForFaction(args.Equipee, ent.Comp.Faction, args.Equipment);
+        if (alreadyMember is null)
+        {
+            TryComp<NpcFactionMemberComponent>(args.Equipee, out var factionComp);
+            var faction = (args.Equipee, factionComp);
+            ent.Comp.AlreadyMember = _faction.IsMember(faction, ent.Comp.Faction);
 
-        TryComp<NpcFactionMemberComponent>(args.Equipee, out var factionComp);
-        var faction = (args.Equipee, factionComp);
-        ent.Comp.AlreadyMember = _faction.IsMember(faction, ent.Comp.Faction);
+            // Do not edit factions on AI controlled mobs
+            if (!HasComp<ActorComponent>(args.Equipee))
+                return;
 
-        _faction.AddFaction(faction, ent.Comp.Faction);
+            if (!ent.Comp.AlreadyMember)
+                _faction.AddFaction(faction, ent.Comp.Faction);
+        }
+        else
+        {
+            ent.Comp.AlreadyMember = alreadyMember.Value;
+        }
     }
 
     private void OnUnequipped(Entity<FactionClothingComponent> ent, ref GotUnequippedEvent args)
     {
-        if (!HasComp<ActorComponent>(args.Equipee)) // Frontier - Dont edit AI factions
-            return; // Frontier - Dont edit AI factions
-
+        // Frontier: entity
         if (ent.Comp.AlreadyMember)
         {
             ent.Comp.AlreadyMember = false;
             return;
         }
 
-        _faction.RemoveFaction(args.Equipee, ent.Comp.Faction);
+        // Do not edit factions on AI controlled mobs
+        if (!HasComp<ActorComponent>(args.Equipee))
+            return;
+
+        var alreadyMember = CheckEntityEquipmentForFaction(args.Equipee, ent.Comp.Faction, args.Equipment);
+        if (alreadyMember is null)
+        {
+            _faction.RemoveFaction(args.Equipee, ent.Comp.Faction);
+        }
     }
+
+    public bool? CheckEntityEquipmentForFaction(EntityUid ent, ProtoId<NpcFactionPrototype> prototype, EntityUid? skipEnt = null)
+    {
+        var enumerator = _inventory.GetSlotEnumerator(ent);
+        while (enumerator.NextItem(out var item))
+        {
+            if (!TryComp<FactionClothingComponent>(item, out var faction))
+                continue;
+            if (faction.Faction == prototype && item != skipEnt)
+                return faction.AlreadyMember;
+        }
+        return null;
+    }
+
+    private void OnPlayerAttached(Entity<NpcFactionMemberComponent> ent, ref PlayerAttachedEvent args)
+    {
+        // Iterate through all items, add factions for any items found where AlreadyMember is false
+        List<ProtoId<NpcFactionPrototype>> factions = new();
+        var enumerator = _inventory.GetSlotEnumerator(ent.Owner);
+        while (enumerator.NextItem(out var item))
+        {
+            if (!TryComp<FactionClothingComponent>(item, out var faction))
+                continue;
+            if (!faction.AlreadyMember && !factions.Contains(faction.Faction))
+            {
+                _faction.AddFaction((ent.Owner, ent.Comp), faction.Faction);
+                factions.Add(faction.Faction);
+            }
+        }
+    }
+
+    private void OnPlayerDetached(Entity<NpcFactionMemberComponent> ent, ref PlayerDetachedEvent args)
+    {
+        // Iterate through all items, remove factions for any items found where AlreadyMember is true
+        List<ProtoId<NpcFactionPrototype>> factions = new();
+        var enumerator = _inventory.GetSlotEnumerator(ent.Owner);
+        while (enumerator.NextItem(out var item))
+        {
+            if (!TryComp<FactionClothingComponent>(item, out var faction))
+                continue;
+            if (!faction.AlreadyMember && !factions.Contains(faction.Faction))
+            {
+                _faction.RemoveFaction((ent.Owner, ent.Comp), faction.Faction);
+                factions.Add(faction.Faction);
+            }
+        }
+    }
+    // End Frontier
 }

--- a/Content.Shared/NPC/Components/NpcFactionMemberComponent.cs
+++ b/Content.Shared/NPC/Components/NpcFactionMemberComponent.cs
@@ -38,4 +38,10 @@ public sealed partial class NpcFactionMemberComponent : Component
     /// </summary>
     [DataField, ViewVariables]
     public HashSet<ProtoId<NpcFactionPrototype>>? AddHostileFactions;
+
+    /// <summary>
+    /// Frontier: used to track temporary factions (e.g. those gained from worn clothing)
+    /// </summary>
+    [DataField]
+    public HashSet<ProtoId<NpcFactionPrototype>> TemporaryFactions = new();
 }

--- a/Content.Shared/NPC/Components/NpcFactionMemberComponent.cs
+++ b/Content.Shared/NPC/Components/NpcFactionMemberComponent.cs
@@ -38,10 +38,4 @@ public sealed partial class NpcFactionMemberComponent : Component
     /// </summary>
     [DataField, ViewVariables]
     public HashSet<ProtoId<NpcFactionPrototype>>? AddHostileFactions;
-
-    /// <summary>
-    /// Frontier: used to track temporary factions (e.g. those gained from worn clothing)
-    /// </summary>
-    [DataField]
-    public HashSet<ProtoId<NpcFactionPrototype>> TemporaryFactions = new();
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Fixes FactionClothingComponent tracking.

Faction clothing tracking now checks all slots.
An "AlreadyMember" field being true implies that the wearer, for all the clothing knows, is not innately part of that faction, and is wearing one or more pieces of clothing in that faction.
All clothing is expected to agree - on equipping faction clothing, we check all existing slots to see the state of any other piece of clothing - we do not try to enforce consensus, we trust the first piece of clothing we see.

On disconnecting or reconnecting, we remove or restore temporary faction associations from worn items with FactionClothingComponent.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

More complaints about the CDET shooting or not shooting people than I can shake a stick at.

## How to test
<!-- Describe the way it can be tested -->

1. Connect two clients - neither of them should be pirates.
2. On Client 2, equip a syndicate pyjama hat on client 1's character - check the faction, it should have ContrabandClothing.
3. On Client 2, equip a syndicate pyjama jumpsuit on client 1's character - check the faction, it should still have ContrabandClothing.
4. On Client 2, unequip the pyjama hat - before, this would remove the ContrabandClothing faction - after, it should still be there.
5. On Client 2, unequip the pyjama jumpsuit.  Client 1's character should not have the ContrabandClothing faction.
7. On Client 1, disconnect.
8. On Client 2, equip a syndicate pyjama hat on client 1's character.  The faction should not have the ContrabandClothing faction.
9. On Client 1, reconnect. Client 1's character should now be part of the ContrabandClothing faction.
10. On Client 1, respawn as a pirate, check your character's faction, you should be part of the ContrabandClothing faction due to your headset.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Tingus suffers the fate of the CDET, being stunlocked for eternity in his pink plaid pyjamas.
![image](https://github.com/user-attachments/assets/e408f4ad-8622-4bb9-9631-e7ccabd92ed8)

After disconnecting, Tingus no longer has an agent, and is not considered a contraband wearer.
![image](https://github.com/user-attachments/assets/2cb9bcca-26fd-47b8-ad03-ee248b72cdd6)

Tingus rejoins and is promptly assigned the ContrabandClothing component and is, again, blasted to pieces.
![image](https://github.com/user-attachments/assets/cfff7c5d-35d5-4230-934a-76e53a4f5c14)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Faction-associated items of clothing should be properly tracked, the CDET should only attack players wearing contraband.