### PR TITLE
More wreck edits

### DIFF
--- a/Content.Shared/EntityTable/EntitySelectors/EntSelector.cs
+++ b/Content.Shared/EntityTable/EntitySelectors/EntSelector.cs
@@ -20,7 +20,7 @@ public sealed partial class EntSelector : EntityTableSelector
         IEntityManager entMan,
         IPrototypeManager proto)
     {
-        var num = (int) Math.Round(Amount.Get(rand, entMan, proto));
+        var num = (int) Math.Floor(Amount.Get(rand, entMan, proto)); // Frontier: Round<Floor
         for (var i = 0; i < num; i++)
         {
             yield return Id;

--- a/Content.Shared/EntityTable/EntitySelectors/EntityTableSelector.cs
+++ b/Content.Shared/EntityTable/EntitySelectors/EntityTableSelector.cs
@@ -30,7 +30,7 @@ public abstract partial class EntityTableSelector
         IEntityManager entMan,
         IPrototypeManager proto)
     {
-        var rolls = Rolls.Get(rand, entMan, proto);
+        var rolls = Math.Floor(Rolls.Get(rand, entMan, proto)); // Frontier: add Math.Floor
         for (var i = 0; i < rolls; i++)
         {
             if (!rand.Prob(Prob))

--- a/Content.Shared/EntityTable/ValueSelector/RangeNumberSelector.cs
+++ b/Content.Shared/EntityTable/ValueSelector/RangeNumberSelector.cs
@@ -7,6 +7,9 @@ namespace Content.Shared.EntityTable.ValueSelector;
 /// <summary>
 /// Gives a value between the two numbers specified, inclusive.
 /// </summary>
+/// <remarks>
+/// Frontier: output must be floored to have this behaviour
+/// </remarks>
 public sealed partial class RangeNumberSelector : NumberSelector
 {
     [DataField]

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/tables_loot.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/tables_loot.yml
@@ -187,6 +187,11 @@
     - id: FlashlightLantern
     - id: FireExtinguisher
     - id: SurvivalKnife
+    - !type:GroupSelector # Frontier
+      children: # Frontier
+      - id: BoxInflatable # Frontier
+      - id: BoxLighttube # Frontier
+      - id: BoxLightbulb # Frontier
 
 - type: entityTable
   id: SalvageEquipmentUncommon

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/tables_loot.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/tables_loot.yml
@@ -35,6 +35,10 @@
       weight: 0.5
       amount: !type:RangeNumberSelector
         range: 1, 3
+    - id: CrayonBox # Frontier
+      weight: 0.01 # Frontier
+    - id: CrayonMagic # Frontier
+      weight: 0.0001 # Frontier
 
 - type: entityTable
   id: SalvageScrapHighValue

--- a/Resources/Prototypes/_NF/Catalog/Fills/Crates/salvage.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/Crates/salvage.yml
@@ -307,3 +307,8 @@
   id: NFCrateSalvageAssortedGoodiesPlastic
   categories: [ HideSpawnMenu ]
   parent: [ CratePlastic, NFCrateSalvageAssortedGoodies ]
+
+- type: entity
+  id: NFCrateSalvageAssortedGoodiesTrashCart
+  categories: [ HideSpawnMenu ]
+  parent: [ CrateTrashCart, NFCrateSalvageAssortedGoodies ]

--- a/Resources/Prototypes/_NF/Catalog/Fills/Crates/salvage.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/Crates/salvage.yml
@@ -9,13 +9,17 @@
       entity_storage: !type:NestedSelector
         tableId: NFSalvageAssortedGoodies
         rolls: !type:RangeNumberSelector
-          range: 0, 3
+          range: -1, 3 # -1 used because of strange counting, actual values: [0, 1, 2, 3], ~25% chance of each.
 
 - type: entityTable
   id: NFSalvageAssortedGoodies
   table: !type:GroupSelector
     children:
     # Mats
+    - id: SheetSteel
+      weight: 0.15
+    - id: SheetGlass
+      weight: 0.15
     - id: SheetPlasma
       weight: 0.1
     - id: IngotGold

--- a/Resources/Prototypes/_NF/Catalog/Fills/Crates/salvage.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/Crates/salvage.yml
@@ -4,304 +4,53 @@
   categories: [ HideSpawnMenu ]
   parent: CrateGenericSteel
   components:
-  - type: StorageFill
-    contents:
-   # - id: ResearchDisk
-    #  prob: 0.1
-    #  orGroup: RD
-    - id: ResearchDisk5000
-      prob: 0.01
-      orGroup: RD
-    - id: ResearchDisk10000
-      prob: 0.005
-      orGroup: RD
-    - id: ResearchDisk10000
-      prob: 0.0025
-      orGroup: RD
-    - prob: 2 # Empty
-      orGroup: RD
-    # Normal (10%)
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: NFSalvageAssortedGoodies
+        rolls: !type:RangeNumberSelector
+          range: 0, 3
+
+- type: entityTable
+  id: NFSalvageAssortedGoodies
+  table: !type:GroupSelector
+    children:
+    # Mats
     - id: SheetPlasma
-      prob: 0.1
+      weight: 0.1
     - id: IngotGold
-      prob: 0.1
+      weight: 0.1
     - id: IngotSilver
-      prob: 0.1
+      weight: 0.1
     - id: SheetPlastic
-      prob: 0.1
+      weight: 0.1
     - id: SheetUranium
-      prob: 0.1
+      weight: 0.1
     - id: SheetPlasteel
-      prob: 0.1
+      weight: 0.1
     - id: MaterialWoodPlank
-      prob: 0.1
+      weight: 0.1
     - id: MaterialCloth
-      prob: 0.1
+      weight: 0.1
     - id: MaterialDurathread
-      prob: 0.01
+      weight: 0.01
     - id: MaterialCardboard
-      prob: 0.01
+      weight: 0.01
     - id: SheetPaper
-      prob: 0.01
+      weight: 0.01
     - id: SheetBrass
-      prob: 0.01
+      weight: 0.01
     - id: MaterialBananium
-      prob: 0.00001
+      weight: 0.00001
     - id: MaterialDiamond
-      prob: 0.0000001
+      weight: 0.0000001
     - id: MaterialBluespace
-      prob: 0.00000001 # Yes I mean it
-      #  - Service
-    - id: CrayonBox
-      prob: 0.001
-      orGroup: MarineFood
-    - id: CrayonMagic
-      prob: 0.0001
-      orGroup: MarineFood
-    - prob: 1 # Empty
-      orGroup: MarineFood
-    # Rare (~1%)
-      #  - Medical
-    - id: Brutepack1
-      prob: 0.005
-      orGroup: Meds
-    - id: Gauze1
-      prob: 0.005
-      orGroup: Meds
-    - id: Ointment1
-      prob: 0.005
-      orGroup: Meds
-    - prob: 1 # Empty
-      orGroup: Meds
-    - id: ClothingShoesBootsMagBlinding
-      prob: 0.00001
-      #  - Drip - this is a mess, replace with some random
-    - id: ClothingBeltStorageWaistbag
-      orGroup: DripLoot
-    - id: ClothingBeltBandolier
-      orGroup: DripLoot
-    - id: ClothingBeltSuspendersRed # Frontier
-      orGroup: DripLoot # Frontier
-    - id: ClothingBeltSuspendersBlack # Frontier
-      orGroup: DripLoot # Frontier
-    - id: ClothingEyesGlassesGar
-      orGroup: DripLoot
-    - id: ClothingEyesGlassesGarOrange
-      orGroup: DripLoot
-    - id: ClothingEyesGlassesGarGiga
-      orGroup: DripLoot
-    - id: ClothingEyesGlasses
-      orGroup: DripLoot
-    - id: ClothingEyesGlassesSunglasses
-      orGroup: DripLoot
-    - id: ClothingEyesEyepatch
-      orGroup: DripLoot
-    - id: ClothingEyesBlindfold
-      orGroup: DripLoot
-    - id: ClothingHandsGlovesColorPurple
-      orGroup: DripLoot
-    - id: ClothingHandsGlovesColorRed
-      orGroup: DripLoot
-    - id: ClothingHandsGlovesColorBlack
-      orGroup: DripLoot
-    - id: ClothingHandsGlovesColorBlue
-      orGroup: DripLoot
-    - id: ClothingHandsGlovesColorBrown
-      orGroup: DripLoot
-    - id: ClothingHandsGlovesColorGray
-      orGroup: DripLoot
-    - id: ClothingHandsGlovesColorGreen
-      orGroup: DripLoot
-    - id: ClothingHandsGlovesColorLightBrown
-      orGroup: DripLoot
-    - id: ClothingHandsGlovesColorOrange
-      orGroup: DripLoot
-    - id: ClothingHandsGlovesColorWhite
-      orGroup: DripLoot
-    - id: ClothingHandsGlovesColorYellowBudget
-      orGroup: DripLoot
-    - id: ClothingHandsGlovesPowerglove
-      orGroup: DripLoot
-    - id: ClothingHandsGlovesRobohands
-      orGroup: DripLoot
-    - id: ClothingHeadHatAnimalCat
-      orGroup: DripLoot
-    - id: ClothingHeadHatAnimalCatBrown
-      orGroup: DripLoot
-    - id: ClothingHeadHatAnimalCatBlack
-      orGroup: DripLoot
-    - id: ClothingHeadHatAnimalHeadslime
-      orGroup: DripLoot
-    - id: ClothingHeadHatAnimalMonkey
-      orGroup: DripLoot
-    - id: ClothingHeadBandBlack
-      orGroup: DripLoot
-    - id: ClothingHeadBandBlue
-      orGroup: DripLoot
-    - id: ClothingHeadBandGrey
-      orGroup: DripLoot
-    - id: ClothingHeadBandBrown
-      orGroup: DripLoot
-    - id: ClothingHeadHatBeaverHat
-      orGroup: DripLoot
-    - id: ClothingHeadHatBeret
-      orGroup: DripLoot
-    - id: ClothingHeadHatCasa
-      orGroup: DripLoot
-    - id: ClothingHeadHatBowlerHat
-      orGroup: DripLoot
-    - id: ClothingHeadHatCardborg
-      orGroup: DripLoot
-    - id: ClothingHeadHatFedoraBrown
-      orGroup: DripLoot
-    - id: ClothingHeadHatFedoraGrey
-      orGroup: DripLoot
-    - id: ClothingHeadHatFez
-      orGroup: DripLoot
-    - id: ClothingHeadHatWitch1
-      orGroup: DripLoot
-    - id: ClothingHeadHatPaper
-      orGroup: DripLoot
-    - id: ClothingHeadHatTophat
-      orGroup: DripLoot
-    - id: ClothingHeadHatUshanka
-      orGroup: DripLoot
-    - id: ClothingHeadHatWitch
-      orGroup: DripLoot
-    - id: ClothingHeadHatTrucker
-      orGroup: DripLoot
-    - id: ClothingHeadFishCap
-      orGroup: DripLoot
-    - id: ClothingHeadSafari
-      orGroup: DripLoot
-    - id: ClothingHeadHatHoodGoliathCloak
-      orGroup: DripLoot
-    - id: ClothingHeadHatBluesoft
-      orGroup: DripLoot
-    - id: ClothingHeadHatBluesoftFlipped
-      orGroup: DripLoot
-    - id: ClothingHeadHatCorpsoft
-      orGroup: DripLoot
-    - id: ClothingHeadHatCorpsoftFlipped
-      orGroup: DripLoot
-    - id: ClothingHeadHatGreensoft
-      orGroup: DripLoot
-    - id: ClothingHeadHatGreensoftFlipped
-      orGroup: DripLoot
-    - id: ClothingHeadHatGreysoft
-      orGroup: DripLoot
-    - id: ClothingHeadHatGreysoftFlipped
-      orGroup: DripLoot
-    - id: ClothingHeadHatOrangesoft
-      orGroup: DripLoot
-    - id: ClothingHeadHatOrangesoftFlipped
-      orGroup: DripLoot
-    - id: ClothingHeadHatPurplesoft
-      orGroup: DripLoot
-    - id: ClothingHeadHatPurplesoftFlipped
-      orGroup: DripLoot
-    - id: ClothingMaskRat
-      orGroup: DripLoot
-    - id: ClothingMaskFox
-      orGroup: DripLoot
-    - id: ClothingMaskBee
-      orGroup: DripLoot
-    - id: ClothingMaskBear
-      orGroup: DripLoot
-    - id: ClothingMaskRaven
-      orGroup: DripLoot
-    - id: ClothingMaskJackal
-      orGroup: DripLoot
-    - id: ClothingMaskBat
-      orGroup: DripLoot
-    - id: ClothingNeckCloakHerald
-      orGroup: DripLoot
-    - id: ClothingNeckCloakAdmin
-      orGroup: DripLoot
-      prob: 0.00001
-    - id: ClothingNeckCloakTrans
-      orGroup: DripLoot
-    - id: ClothingNeckHeadphones
-      orGroup: DripLoot
-    - id: ClothingNeckBling
-      orGroup: DripLoot
-    - id: ClothingNeckTieRed
-      orGroup: DripLoot
-    - id: ClothingNeckTieSci
-      orGroup: DripLoot
-    - id: ClothingOuterCoatBomber
-      orGroup: DripLoot
-    - id: ClothingOuterCoatGentle
-      orGroup: DripLoot
-    - id: ClothingOuterCoatJensen
-      orGroup: DripLoot
-    - id: ClothingOuterDameDane
-      orGroup: DripLoot
-    - id: ClothingOuterHoodieBlack
-      orGroup: DripLoot
-    - id: ClothingOuterHoodieGrey
-      orGroup: DripLoot
-    - id: ClothingOuterCardborg
-      orGroup: DripLoot
-    - id: ClothingOuterGhostSheet
-      orGroup: DripLoot
-    - id: ClothingShoesBootsWork
-      orGroup: DripLoot
-    - id: ClothingShoesBootsLaceup
-      orGroup: DripLoot
-    - id: ClothingShoesColorBlack
-      orGroup: DripLoot
-    - id: ClothingShoesColorBlue
-      orGroup: DripLoot
-    - id: ClothingShoesColorBrown
-      orGroup: DripLoot
-    - id: ClothingShoesColorGreen
-      orGroup: DripLoot
-    - id: ClothingShoesColorOrange
-      orGroup: DripLoot
-    - id: ClothingShoesColorPurple
-      orGroup: DripLoot
-    - id: ClothingShoesColorRed
-      orGroup: DripLoot
-    - id: ClothingShoesColorWhite
-      orGroup: DripLoot
-    - id: ClothingShoesColorYellow
-      orGroup: DripLoot
-    - id: ClothingShoesFlippers
-      orGroup: DripLoot
-    - id: ClothingShoesLeather
-      orGroup: DripLoot
-    - id: ClothingShoesSlippers
-      orGroup: DripLoot
-    - id: ClothingShoeSlippersDuck
-      orGroup: DripLoot
-    - id: ClothingShoesTourist
-      orGroup: DripLoot
-    - id: ClothingShoesDameDane
-      orGroup: DripLoot
-    - id: ClothingUnderSocksBee
-      orGroup: DripLoot
-    - id: ClothingUnderSocksCoder
-      orGroup: DripLoot
-    - id: ClothingUniformJumpsuitKimono
-      orGroup: DripLoot
-    - id: ClothingUniformOveralls
-      orGroup: DripLoot
-    - id: ClothingUniformJumpsuitSafari
-      orGroup: DripLoot
-    - id: ClothingUniformJumpsuitDameDane
-      orGroup: DripLoot
-    - id: ClothingUniformJumpsuitCossack
-      orGroup: DripLoot
-      prob: 0.01
-    - id: ClothingHeadHatDogEars
-      orGroup: DripLoot
-      prob: 0.00001
-    - id: ClothingHeadHatCatEars
-      prob: 0.00001
-      orGroup: DripLoot
-    - prob: 50 # Empty
-      orGroup: DripLoot
+      weight: 0.00000001 # Yes I mean it
+      # Disk
+    - id: ResearchDisk5000
+      weight: 0.001
+    - id: ResearchDisk10000
+      weight: 0.0005
 
 - type: entity
   id: NFCrateSalvageAssortedGoodiesPlastic

--- a/Resources/Prototypes/_NF/Catalog/Fills/Crates/salvage.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/Crates/salvage.yml
@@ -6,14 +6,6 @@
   components:
   - type: StorageFill
     contents:
-    - id: OxygenTankFilled
-      prob: 0.1
-      orGroup: Gas
-    - id: NitrogenTankFilled
-      prob: 0.1
-      orGroup: Gas
-    - prob: 2.0 # Empty
-      orGroup: Gas
    # - id: ResearchDisk
     #  prob: 0.1
     #  orGroup: RD
@@ -39,8 +31,6 @@
       prob: 0.1
     - id: SheetUranium
       prob: 0.1
-    - id: SheetBrass
-      prob: 0.1
     - id: SheetPlasteel
       prob: 0.1
     - id: MaterialWoodPlank
@@ -53,6 +43,14 @@
       prob: 0.01
     - id: SheetPaper
       prob: 0.01
+    - id: SheetBrass
+      prob: 0.01
+    - id: MaterialBananium
+      prob: 0.0001
+    - id: MaterialDiamond
+      prob: 0.00001
+    - id: MaterialBluespace
+      prob: 0.000001
       #  - Service
     - id: CrayonBox
       prob: 0.001
@@ -302,7 +300,7 @@
     - id: ClothingHeadHatCatEars
       prob: 0.00001
       orGroup: DripLoot
-    - prob: 40 # Empty
+    - prob: 50 # Empty
       orGroup: DripLoot
 
 - type: entity

--- a/Resources/Prototypes/_NF/Catalog/Fills/Crates/salvage.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/Crates/salvage.yml
@@ -46,11 +46,11 @@
     - id: SheetBrass
       prob: 0.01
     - id: MaterialBananium
-      prob: 0.0001
-    - id: MaterialDiamond
       prob: 0.00001
+    - id: MaterialDiamond
+      prob: 0.0000001
     - id: MaterialBluespace
-      prob: 0.000001
+      prob: 0.00000001 # Yes I mean it
       #  - Service
     - id: CrayonBox
       prob: 0.001

--- a/Resources/Prototypes/_NF/Catalog/Fills/Lockers/wardrobe_colors.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/Lockers/wardrobe_colors.yml
@@ -1,0 +1,142 @@
+- type: entity
+  id: NFWardrobeMixedFilled
+  suffix: Filled
+  parent: WardrobeMixed
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: NFSalvageWardrobe
+        rolls: !type:RangeNumberSelector
+          range: 3, 7
+
+- type: entityTable
+  id: NFSalvageWardrobe
+  table: !type:GroupSelector
+    children:
+    - id: ClothingShoesColorBlack
+    - id: ClothingShoesColorBrown
+    - id: ClothingShoesColorWhite
+    - id: ClothingOuterCoatBomber
+    - id: ClothingOuterCoatGentle
+    - id: ClothingUniformRandomShorts
+    - id: ClothingUniformRandomArmless
+    - id: ClothingUniformRandomStandard
+    - id: ClothingUniformRandomBra
+    - id: ClothingUniformRandomShirt
+    - id: ClothingBeltStorageWaistbag
+    - id: ClothingBeltBandolier
+    - id: ClothingBeltSuspendersRed
+    - id: ClothingBeltSuspendersBlack
+    - id: ClothingEyesGlassesGar
+    - id: ClothingEyesGlassesGarOrange
+    - id: ClothingEyesGlassesGarGiga
+    - id: ClothingEyesGlasses
+    - id: ClothingEyesGlassesSunglasses
+    - id: ClothingEyesEyepatch
+    - id: ClothingEyesBlindfold
+    - id: ClothingHandsGlovesColorPurple
+    - id: ClothingHandsGlovesColorRed
+    - id: ClothingHandsGlovesColorBlack
+    - id: ClothingHandsGlovesColorBlue
+    - id: ClothingHandsGlovesColorBrown
+    - id: ClothingHandsGlovesColorGray
+    - id: ClothingHandsGlovesColorGreen
+    - id: ClothingHandsGlovesColorLightBrown
+    - id: ClothingHandsGlovesColorOrange
+    - id: ClothingHandsGlovesColorWhite
+    - id: ClothingHandsGlovesColorYellowBudget
+    - id: ClothingHandsGlovesPowerglove
+    - id: ClothingHandsGlovesRobohands
+    - id: ClothingHeadHatAnimalCat
+    - id: ClothingHeadHatAnimalCatBrown
+    - id: ClothingHeadHatAnimalCatBlack
+    - id: ClothingHeadHatAnimalHeadslime
+    - id: ClothingHeadHatAnimalMonkey
+    - id: ClothingHeadBandBlack
+    - id: ClothingHeadBandBlue
+    - id: ClothingHeadBandGrey
+    - id: ClothingHeadBandBrown
+    - id: ClothingHeadHatBeaverHat
+    - id: ClothingHeadHatBeret
+    - id: ClothingHeadHatCasa
+    - id: ClothingHeadHatBowlerHat
+    - id: ClothingHeadHatCardborg
+    - id: ClothingHeadHatFedoraBrown
+    - id: ClothingHeadHatFedoraGrey
+    - id: ClothingHeadHatFez
+    - id: ClothingHeadHatWitch1
+    - id: ClothingHeadHatPaper
+    - id: ClothingHeadHatTophat
+    - id: ClothingHeadHatUshanka
+    - id: ClothingHeadHatWitch
+    - id: ClothingHeadHatTrucker
+    - id: ClothingHeadFishCap
+    - id: ClothingHeadSafari
+    - id: ClothingHeadHatHoodGoliathCloak
+    - id: ClothingHeadHatBluesoft
+    - id: ClothingHeadHatBluesoftFlipped
+    - id: ClothingHeadHatCorpsoft
+    - id: ClothingHeadHatCorpsoftFlipped
+    - id: ClothingHeadHatGreensoft
+    - id: ClothingHeadHatGreensoftFlipped
+    - id: ClothingHeadHatGreysoft
+    - id: ClothingHeadHatGreysoftFlipped
+    - id: ClothingHeadHatOrangesoft
+    - id: ClothingHeadHatOrangesoftFlipped
+    - id: ClothingHeadHatPurplesoft
+    - id: ClothingHeadHatPurplesoftFlipped
+    - id: ClothingMaskRat
+    - id: ClothingMaskFox
+    - id: ClothingMaskBee
+    - id: ClothingMaskBear
+    - id: ClothingMaskRaven
+    - id: ClothingMaskJackal
+    - id: ClothingMaskBat
+    - id: ClothingNeckCloakHerald
+    - id: ClothingNeckCloakTrans
+    - id: ClothingNeckHeadphones
+    - id: ClothingNeckBling
+    - id: ClothingNeckTieRed
+    - id: ClothingNeckTieSci
+    - id: ClothingOuterCoatBomber
+    - id: ClothingOuterCoatGentle
+    - id: ClothingOuterCoatJensen
+    - id: ClothingOuterDameDane
+    - id: ClothingOuterHoodieBlack
+    - id: ClothingOuterHoodieGrey
+    - id: ClothingOuterCardborg
+    - id: ClothingOuterGhostSheet
+    - id: ClothingShoesBootsWork
+    - id: ClothingShoesBootsLaceup
+    - id: ClothingShoesColorBlack
+    - id: ClothingShoesColorBlue
+    - id: ClothingShoesColorBrown
+    - id: ClothingShoesColorGreen
+    - id: ClothingShoesColorOrange
+    - id: ClothingShoesColorPurple
+    - id: ClothingShoesColorRed
+    - id: ClothingShoesColorWhite
+    - id: ClothingShoesColorYellow
+    - id: ClothingShoesFlippers
+    - id: ClothingShoesLeather
+    - id: ClothingShoesSlippers
+    - id: ClothingShoeSlippersDuck
+    - id: ClothingShoesTourist
+    - id: ClothingShoesDameDane
+    - id: ClothingUnderSocksBee
+    - id: ClothingUnderSocksCoder
+    - id: ClothingUniformJumpsuitKimono
+    - id: ClothingUniformOveralls
+    - id: ClothingUniformJumpsuitSafari
+    - id: ClothingUniformJumpsuitDameDane
+    - id: ClothingUniformJumpsuitCossack
+      weight: 0.01
+    - id: ClothingNeckCloakAdmin
+      weight: 0.00001
+    - id: ClothingHeadHatDogEars
+      weight: 0.00001
+    - id: ClothingHeadHatCatEars
+      weight: 0.00001
+    - id: ClothingShoesBootsMagBlinding
+      weight: 0.00001

--- a/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/dungeon_items_general.yml
+++ b/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/dungeon_items_general.yml
@@ -290,6 +290,7 @@
     - CrateEvaKit
     # Spawners from base game
     - NFCrateSalvageAssortedGoodies
+    - NFCrateSalvageAssortedGoodiesPlastic
     - SalvageMaterialCrateSpawner
     - CrateFilledSpawner
     chance: 0.9

--- a/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/salvage.yml
+++ b/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/salvage.yml
@@ -336,6 +336,8 @@
     - NFCrateSalvageAssortedGoodiesPlastic
     chance: 0.95
     rarePrototypes:
+    - CrateTradeSecureNormalFilled
+    - CrateTradeSecureHighFilled
     - CrateSalvageEquipment
 #    - CrateServiceJanitorialSupplies
     - CrateTrashCartFilled

--- a/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/salvage.yml
+++ b/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/salvage.yml
@@ -337,19 +337,11 @@
     chance: 0.95
     rarePrototypes:
     - CrateSalvageEquipment
-    - CrateServiceJanitorialSupplies
-    - CrateEmergencyInternals
-    - CrateServiceSmokeables
+#    - CrateServiceJanitorialSupplies
     - CrateTrashCartFilled
-    - CrateServiceReplacementLights
     - CrateServiceBureaucracy
-    - CrateEmergencyFire
-    - CrateEmergencyInflatablewall
-    - CrateHydroponicsTools
-    - CrateHydroponicsSeeds
-    - CrateHydroponicsSeedsMedicinal
-    - CrateHydroponicsSeedsExotic
-    rareChance: 0.1
+    - CrateArtifactContainer
+    rareChance: 0.05
     offset: 0.0
 
 - type: entity

--- a/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/salvage.yml
+++ b/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/salvage.yml
@@ -333,17 +333,19 @@
   - type: RandomSpawner
     prototypes:
     - NFCrateSalvageAssortedGoodies
+    - NFCrateSalvageAssortedGoodies
+    - NFCrateSalvageAssortedGoodies
     - NFCrateSalvageAssortedGoodiesPlastic
+    - NFCrateSalvageAssortedGoodiesPlastic
+    - NFCrateSalvageAssortedGoodiesTrashCart
     chance: 0.95
     rarePrototypes:
     - CrateTradeSecureNormalFilled
     - CrateTradeSecureHighFilled
     - CrateSalvageEquipment
-#    - CrateServiceJanitorialSupplies
     - CrateTrashCartFilled
-    - CrateServiceBureaucracy
     - CrateArtifactContainer
-    rareChance: 0.05
+    rareChance: 0.03
     offset: 0.0
 
 - type: entity

--- a/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/salvage.yml
+++ b/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/salvage.yml
@@ -426,13 +426,9 @@
     - Table
     - Rack
 #    - Dresser # WardrobeMixedFilled
-    - WardrobeMixedFilled
-#    - Bookshelf # BookshelfFilled
+    - NFWardrobeMixedFilled
     - BookshelfFilled
     - Bed
-    - SuitStorageSalv
-    - Floodlight
-    - PottedPlantRandomPlastic
     chance: 0.95
     rarePrototypes:
     - MedicalBed
@@ -443,6 +439,10 @@
     - ComfyChair
     - ChairWood
     - ChairFolding
+    - ComputerBroken
+    - MachineFrameDestroyed
+    - VehicleJanicartDestroyed
+    - PottedPlantRandomPlastic
     rareChance: 0.1
     offset: 0.0
 
@@ -485,6 +485,9 @@
     - SuitStorageAtmos
     - SuitStorageSalv
     chance: 0.95
+    rarePrototypes:
+    - SuitStorageBase
+    rareChance: 0.05
     offset: 0.0
 
 - type: entity

--- a/Resources/Prototypes/_NF/Entities/World/Debris/base_debris.yml
+++ b/Resources/Prototypes/_NF/Entities/World/Debris/base_debris.yml
@@ -2,7 +2,9 @@
   id: NFBaseDebris
   abstract: true
   components:
-    - type: OwnedDebris
-    - type: LocalityLoader
-    - type: GCAbleObject
-      queue: SpaceDebris
+  - type: OwnedDebris
+  - type: LocalityLoader
+  - type: GCAbleObject
+    queue: SpaceDebris
+  - type: ProtectedGrid
+    preventArtifactTriggers: true

--- a/Resources/Prototypes/_NF/Entities/World/Debris/wrecks.yml
+++ b/Resources/Prototypes/_NF/Entities/World/Debris/wrecks.yml
@@ -25,6 +25,8 @@
           prob: 0.2
         - id: AirlockMaint
           prob: 0.01
+        - id: Barricade
+          prob: 0.01
         # Floor loot
         - id: SalvageSpawnerScrapCommon
           prob: 3.5
@@ -32,15 +34,17 @@
           prob: 0.3
         - id: SpawnDungeonLootSeed
           prob: 0.1
-        - id: SpawnDungeonLootBureaucracy
-          prob: 0.05
-        - id: SpawnDungeonLootToolsHydroponics
-          prob: 0.05
         - id: SalvageSpawnerTreasureValuable
           prob: 0.05
         - id: SalvageSpawnerEquipment
           prob: 0.05
         - id: SalvageSpawnerEquipmentValuable
+          prob: 0.03
+        - id: SpawnDungeonClutterMedsSingle
+          prob: 0.03
+        - id: SpawnDungeonLootBureaucracy
+          prob: 0.03
+        - id: SpawnDungeonLootToolsHydroponics
           prob: 0.03
         # Machine upgrades
         - id: SalvagePartsT2Spawner

--- a/Resources/Prototypes/_NF/Entities/World/Debris/wrecks.yml
+++ b/Resources/Prototypes/_NF/Entities/World/Debris/wrecks.yml
@@ -32,6 +32,8 @@
           prob: 0.3
         - id: SpawnDungeonLootSeed
           prob: 0.1
+        - id: SpawnDungeonLootBureaucracy
+          prob: 0.05
         - id: SpawnDungeonLootToolsHydroponics
           prob: 0.05
         - id: SalvageSpawnerTreasureValuable

--- a/Resources/Prototypes/_NF/Entities/World/Debris/wrecks.yml
+++ b/Resources/Prototypes/_NF/Entities/World/Debris/wrecks.yml
@@ -30,6 +30,10 @@
           prob: 3.5
         - id: SalvageSpawnerTreasure
           prob: 0.3
+        - id: SpawnDungeonLootSeed
+          prob: 0.1
+        - id: SpawnDungeonLootToolsHydroponics
+          prob: 0.05
         - id: SalvageSpawnerTreasureValuable
           prob: 0.05
         - id: SalvageSpawnerEquipment
@@ -59,7 +63,7 @@
         - id: SalvageSuitStorageSpawner
           prob: 0.1
         - id: RandomArtifactSpawner
-          prob: 0.03
+          prob: 0.05
         # Medical
         - id: MedicalPodFilled # Medical bounties
           prob: 0.03

--- a/Resources/Prototypes/_NF/Events/nf_bluespace_dungeons_events.yml
+++ b/Resources/Prototypes/_NF/Events/nf_bluespace_dungeons_events.yml
@@ -39,6 +39,8 @@
           angularDamping: 999999
           linearDamping: 999999
         - type: LinkedLifecycleGridParent
+        - type: ProtectedGrid
+          preventArtifactTriggers: true
         protos:
         - NFVGRoidBasalt
 


### PR DESCRIPTION
## About the PR
Edited some of the loot to be more consistent, less seed crates and crates that have single item in them.
Upped artifact spawner a tiny bit, and made a change that wont allow the arti to trigger on wreck anymore.

## Why / Balance
Arti trigger and wreck and send half the loot into deep space.

## How to test
N/A

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
:cl:
- tweak: Blue wrecks should now have more interesting loot.
