### PR TITLE
Spectre: Fix Disabled Thruster

### DIFF
--- a/Resources/Maps/_NF/Shuttles/spectre.yml
+++ b/Resources/Maps/_NF/Shuttles/spectre.yml
@@ -7222,8 +7222,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -8.5,4.5
       parent: 3
-    - type: Thruster
-      enabled: False
   - uid: 217
     components:
     - type: Transform
@@ -8921,7 +8919,7 @@ entities:
     - type: Transform
       pos: 5.5,12.5
       parent: 3
-- proto: WarpPointShip
+- proto: WarpPoint
   entities:
   - uid: 1203
     components:


### PR DESCRIPTION
## About the PR
The Spectre had a port lateral thruster which was turned off by default. I turned it back on. 

## Why / Balance
Fixes mapping error.

## How to test
Checkout branch, buy the ship, verify all thrusters are working.

## Media
Nope.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
No.

**Changelog**
:cl:
- fix: Fixed a disabled thruster on the Spectre.

