### PR TITLE
Remove duplicated recipe type from chocolate donut recipe

### DIFF
--- a/Resources/Prototypes/_NF/Recipes/Cooking/meal_recipes.yml
+++ b/Resources/Prototypes/_NF/Recipes/Cooking/meal_recipes.yml
@@ -281,7 +281,6 @@
     FoodDonutPlain: 1
   recipeType:
   - Assembler
-  - Assembler
 
 - type: microwaveMealRecipe
   id: RecipeDonutBluePumpkin


### PR DESCRIPTION
## About the PR
Removes duplicated recipeType `Assembler` from chocolate donut recipe.

## Why / Balance
It's causing errors in my cookbook, man. :(

## How to test
1. Make a chocolate donut, I dunno. It has no outward effect.

## Media
N/A

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
This is not a breaking change. It is a fixing change.

**Changelog**
N/A, exactly no outwardly visible effect.