### PR TITLE
End of round respawn cleanup

### DIFF
--- a/Content.Server/Corvax/Respawn/RespawnSystem.cs
+++ b/Content.Server/Corvax/Respawn/RespawnSystem.cs
@@ -12,8 +12,9 @@ using Robust.Shared.Configuration; // Frontier
 using Content.Server.CryoSleep; // Frontier
 using Robust.Shared.Player; // Frontier
 using Content.Shared.Ghost; // Frontier
-using Content.Server.Administration.Managers;
+using Content.Server.Administration.Managers; // Frontier
 using Content.Server.Administration; // Frontier
+using Content.Shared.GameTicking; // Frontier
 
 namespace Content.Server.Corvax.Respawn;
 
@@ -44,6 +45,7 @@ public sealed class RespawnSystem : EntitySystem
         SubscribeLocalEvent<MindContainerComponent, MindRemovedMessage>(OnMindRemoved);
         SubscribeLocalEvent<MindContainerComponent, CryosleepBeforeMindRemovedEvent>(OnCryoBeforeMindRemoved);
         SubscribeLocalEvent<MindContainerComponent, CryosleepWakeUpEvent>(OnCryoWakeUp);
+        SubscribeLocalEvent<RoundRestartCleanupEvent>(OnRoundRestart); // Frontier
 
         _admin.OnPermsChanged += OnAdminPermsChanged; // Frontier
         _player.PlayerStatusChanged += PlayerStatusChanged; // Frontier
@@ -115,7 +117,7 @@ public sealed class RespawnSystem : EntitySystem
         }
     }
 
-    // Frontier: respawn handler: adjusts 
+    // Frontier: respawn handler: adjusts
     public void Respawn(ICommonSession session)
     {
         var respawnData = GetRespawnData(session.UserId);

--- a/Content.Server/Corvax/Respawn/RespawnSystem.cs
+++ b/Content.Server/Corvax/Respawn/RespawnSystem.cs
@@ -117,7 +117,7 @@ public sealed class RespawnSystem : EntitySystem
         }
     }
 
-    // Frontier: respawn handler: adjusts
+    // Frontier: respawn handler: adjusts respawn and cryo timers.
     public void Respawn(ICommonSession session)
     {
         var respawnData = GetRespawnData(session.UserId);

--- a/Content.Server/Corvax/Respawn/RespawnSystem.cs
+++ b/Content.Server/Corvax/Respawn/RespawnSystem.cs
@@ -189,5 +189,11 @@ public sealed class RespawnSystem : EntitySystem
             RaiseNetworkEvent(new RespawnResetEvent(_respawnInfo[session.UserId].RespawnTime), session);
         }
     }
+
+    // Frontier: reset game state, we have a new round.
+    private void OnRoundRestart(RoundRestartCleanupEvent ev)
+    {
+        _respawnInfo.Clear();
+    }
     // End Frontier
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Resets respawn timers at the end of a round.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

New round, new me - the respawn timers from last round shouldn't apply to the next one.

## How to test
<!-- Describe the way it can be tested -->

1. Open two clients.
2. On client 1, deadmin yourself.
3. On client 2, start the round.  Summon a throngler, kill client 1.
4. Make sure client 1 goes to a ghost (just to verify that you see a respawn timer.)
5. On client 2, end the round, start a new one.
6. On client 1, observe.  You should not have a timer on this branch (which is good), but you should on master (which is bad).

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

The issue on master: a new round starts, I was dead, I choose to observe, and I get penalized for my untimely death.
![image](https://github.com/user-attachments/assets/b4ed6baa-1918-474b-8e4d-6faffe784273)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Respawn timers are reset on a new round.