### PR TITLE
Fix Emergency Lights

### DIFF
--- a/Content.Server/AlertLevel/AlertLevelSystem.cs
+++ b/Content.Server/AlertLevel/AlertLevelSystem.cs
@@ -172,8 +172,7 @@ public sealed class AlertLevelSystem : EntitySystem
             return;
         // End Frontier
 
-        if (!Resolve(station, ref dataComponent) // Frontier: remove component
-            || component.AlertLevels == null
+        if (component.AlertLevels == null // Frontier: remove component, resolve station to data component later
             || !component.AlertLevels.Levels.TryGetValue(level, out var detail)
             || component.CurrentLevel == level)
         {
@@ -196,7 +195,7 @@ public sealed class AlertLevelSystem : EntitySystem
         component.CurrentLevel = level;
         component.IsLevelLocked = locked;
 
-        var stationName = dataComponent.EntityName;
+        //var stationName = dataComponent.EntityName; // Frontier: remove station name
 
         var name = level.ToLower();
 
@@ -232,8 +231,9 @@ public sealed class AlertLevelSystem : EntitySystem
             }
         }
 
-        if (announce)
+        if (announce && Resolve(station, ref dataComponent)) // Frontier: add Resolve for dataComponent
         {
+            var stationName = dataComponent.EntityName; // Frontier: moved down
             _chatSystem.DispatchStationAnnouncement(station, announcementFull, playDefaultSound: playDefault,
                 colorOverride: detail.Color, sender: stationName);
         }

--- a/Content.Server/Light/EntitySystems/EmergencyLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/EmergencyLightSystem.cs
@@ -259,9 +259,9 @@ public sealed class EmergencyLightSystem : SharedEmergencyLightSystem
 
         entity.Comp.ForciblyEnabled = details.ForceEnableEmergencyLights;
         if (details.ForceEnableEmergencyLights)
-            TurnOn(entity);
+            TurnOn(entity, details.EmergencyLightColor);
         else
-            TurnOff(entity);
+            TurnOff(entity, details.EmergencyLightColor);
     }
     // End Frontier
 }

--- a/Content.Server/Light/EntitySystems/EmergencyLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/EmergencyLightSystem.cs
@@ -32,6 +32,8 @@ public sealed class EmergencyLightSystem : SharedEmergencyLightSystem
         SubscribeLocalEvent<AlertLevelChangedEvent>(OnAlertLevelChanged);
         SubscribeLocalEvent<EmergencyLightComponent, ExaminedEvent>(OnEmergencyExamine);
         SubscribeLocalEvent<EmergencyLightComponent, PowerChangedEvent>(OnEmergencyPower);
+
+        SubscribeLocalEvent<EmergencyLightComponent, MapInitEvent>(OnMapInit); // Frontier
     }
 
     private void OnEmergencyPower(Entity<EmergencyLightComponent> entity, ref PowerChangedEvent args)
@@ -245,4 +247,21 @@ public sealed class EmergencyLightSystem : SharedEmergencyLightSystem
         _appearance.SetData(entity.Owner, EmergencyLightVisuals.On, true);
         _ambient.SetAmbience(entity.Owner, true);
     }
+
+    // Frontier: ensure the lights are accurate to the station
+    private void OnMapInit(Entity<EmergencyLightComponent> entity, ref MapInitEvent ev)
+    {
+        if (!TryComp<AlertLevelComponent>(_sectorService.GetServiceEntity(), out var alert))
+            return;
+
+        if (alert.AlertLevels == null || !alert.AlertLevels.Levels.TryGetValue(alert.CurrentLevel, out var details))
+            return;
+
+        entity.Comp.ForciblyEnabled = details.ForceEnableEmergencyLights;
+        if (details.ForceEnableEmergencyLights)
+            TurnOn(entity);
+        else
+            TurnOff(entity);
+    }
+    // End Frontier
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Adds a MapInit function for emergency lights, reorders some checks in the AlertLevel system.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

I goofed, previous PR wasn't quite ready.

Emergency lights start on, pulsing in Green level. (my fault)

Constructed lights didn't match current alarm status. (upstream issue though)

## How to test
<!-- Describe the way it can be tested -->

1. Start game, join Frontier.
2. Emergency lights should be green and off.
3. Set status to red.
4. All emergency lights should be red and on (rotating PointLight).
5. Purchase a Construct.
6. The emergency light on the construct should be red and on.
7. Spawn an emergency light on the construct, it should be red and on.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

CODE RED.  Steps 5, 6, and 7 of the test are shown below.
![image](https://github.com/user-attachments/assets/c19393da-bb91-4743-aec9-e99c40c8bff6)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Emergency lights start in their appropriate state when built.