### PR TITLE
Add monkey/kobold cube to loadout under tools (Merry Christmas Aka)

### DIFF
--- a/Resources/Prototypes/_NF/Loadouts/Jobs/Contractor/tools.yml
+++ b/Resources/Prototypes/_NF/Loadouts/Jobs/Contractor/tools.yml
@@ -156,7 +156,7 @@
 - type: loadout
   id: ContractorKoboldCubeWrapped
   name: kobold cube
-  description: Unwrap this to get a monkey cube.
+  description: Unwrap this to get a kobold cube.
   previewEntity: KoboldCubeWrapped
   effects:
   - !type:GroupLoadoutEffect

--- a/Resources/Prototypes/_NF/Loadouts/Jobs/Contractor/tools.yml
+++ b/Resources/Prototypes/_NF/Loadouts/Jobs/Contractor/tools.yml
@@ -140,3 +140,27 @@
   storage:
     back:
       - BibleUserImplanter
+
+- type: loadout
+  id: ContractorMonkeyCubeWrapped
+  name: monkey cube
+  description: Unwrap this to get a monkey cube.
+  previewEntity: MonkeyCubeWrapped
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: ContractorT2
+  price: 500
+  inhand:
+    - MonkeyCubeWrapped
+
+- type: loadout
+  id: ContractorKoboldCubeWrapped
+  name: kobold cube
+  description: Unwrap this to get a monkey cube.
+  previewEntity: KoboldCubeWrapped
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: ContractorT2
+  price: 500
+  inhand:
+    - KoboldCubeWrapped

--- a/Resources/Prototypes/_NF/Loadouts/contractor_loadout_groups.yml
+++ b/Resources/Prototypes/_NF/Loadouts/contractor_loadout_groups.yml
@@ -705,6 +705,8 @@
   - ContractorHandheldCrewMonitor
   - ContractorHypoMini
   - ContractorBible
+  - ContractorMonkeyCubeWrapped
+  - ContractorKoboldCubeWrapped
 
 - type: loadoutGroup
   id: ContractorFun # Left Hand - 1 only


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Contractors, pilots, and mercs can choose a monkey or kobold cube in loadout.  
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
CaptainHonesty wanted it and it seemed harmless enough.
## How to test
<!-- Describe the way it can be tested -->
Choose a cube and spawn in.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/de3e9fc6-03a9-400a-8dcb-4f97b9faf6ef)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
Nah
**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Added monkey and kobold cubes to loadout under tools.

