### PR TITLE
Random appearance for random pills

### DIFF
--- a/Content.Server/_NF/Chemistry/RandomPillSystem.cs
+++ b/Content.Server/_NF/Chemistry/RandomPillSystem.cs
@@ -1,0 +1,26 @@
+using Content.Shared.Chemistry.Components;
+using Robust.Shared.Random;
+
+namespace Content.Server._NF.Chemistry.EntitySystems;
+
+public sealed class RandomPillSystem : EntitySystem
+{
+    [Dependency] private IRobustRandom _random = default!;
+
+    public const int MaxPill = 21;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<PillComponent, ComponentInit>(OnInit);
+    }
+
+    private void OnInit(EntityUid uid, PillComponent component, ref ComponentInit componentInit)
+    {
+        if (component.Random)
+        {
+            component.PillType = (uint)_random.Next(MaxPill);
+            Dirty(uid, component);
+        }
+    }
+}

--- a/Content.Server/_NF/Chemistry/RandomPillSystem.cs
+++ b/Content.Server/_NF/Chemistry/RandomPillSystem.cs
@@ -1,7 +1,7 @@
 using Content.Shared.Chemistry.Components;
 using Robust.Shared.Random;
 
-namespace Content.Server._NF.Chemistry.EntitySystems;
+namespace Content.Server._NF.Chemistry;
 
 public sealed class RandomPillSystem : EntitySystem
 {

--- a/Content.Server/_NF/Chemistry/RandomPillSystem.cs
+++ b/Content.Server/_NF/Chemistry/RandomPillSystem.cs
@@ -5,22 +5,22 @@ namespace Content.Server._NF.Chemistry;
 
 public sealed class RandomPillSystem : EntitySystem
 {
-    [Dependency] private IRobustRandom _random = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
 
-    public const int MaxPill = 21;
+    public const int MaxPillType = 21;
 
     public override void Initialize()
     {
         base.Initialize();
-        SubscribeLocalEvent<PillComponent, ComponentInit>(OnInit);
+        SubscribeLocalEvent<PillComponent, MapInitEvent>(OnMapInit);
     }
 
-    private void OnInit(EntityUid uid, PillComponent component, ref ComponentInit componentInit)
+    private void OnMapInit(Entity<PillComponent> ent, ref MapInitEvent componentInit)
     {
-        if (component.Random)
+        if (ent.Comp.Random)
         {
-            component.PillType = (uint)_random.Next(MaxPill);
-            Dirty(uid, component);
+            ent.Comp.PillType = (uint)_random.Next(MaxPillType);
+            Dirty(ent);
         }
     }
 }

--- a/Content.Shared/Chemistry/Components/PillComponent.cs
+++ b/Content.Shared/Chemistry/Components/PillComponent.cs
@@ -16,6 +16,6 @@ public sealed partial class PillComponent : Component
     /// <summary>
     /// Frontier: if true, pill appearance will be randomly generated on init.
     /// </summary>
-    [DataField("random", serverOnly: true)]
+    [DataField(serverOnly: true)]
     public bool Random;
 }

--- a/Content.Shared/Chemistry/Components/PillComponent.cs
+++ b/Content.Shared/Chemistry/Components/PillComponent.cs
@@ -12,4 +12,10 @@ public sealed partial class PillComponent : Component
     [DataField("pillType")]
     [ViewVariables(VVAccess.ReadWrite)]
     public uint PillType;
+
+    /// <summary>
+    /// Frontier: if true, pill appearance will be randomly generated on init.
+    /// </summary>
+    [DataField("random", serverOnly: true)]
+    public bool Random;
 }

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/randompill.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/randompill.yml
@@ -86,6 +86,8 @@
   - type: RandomFillSolution
     solution: food
     weightedRandomId: RandomFillStrangePill
+  - type: Pill # Frontier
+    random: true # Frontier
 # RandomSprite does not work with pill component
   # - type: Sprite
   #   sprite: Objects/Specific/Chemistry/pills.rsi


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Adds a flag to PillComponent that randomly swaps pill state on init, and swaps strange pills to use these.

Dirty needed to propagate state to client.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Ever think it's boring that floor pills are always orange and purple?

## How to test
<!-- Describe the way it can be tested -->

Spawn strange pills.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

The colours.
![image](https://github.com/user-attachments/assets/e230de0d-c7e6-4d85-8037-39c9d0dfcdfc)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

I have a hunch this might fail some of the init and save tests.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
Trivial, no changelog.