### PR TITLE
SBB Bodkin 1.1

### DIFF
--- a/Resources/Locale/en-US/_NF/guidebook/guides.ftl
+++ b/Resources/Locale/en-US/_NF/guidebook/guides.ftl
@@ -38,6 +38,7 @@ guide-entry-shipyard-apothecary = Apothecary
 guide-entry-shipyard-barge = Barge
 guide-entry-shipyard-bazaar = Bazaar
 guide-entry-shipyard-bocadillo = Bocadillo
+guide-entry-shipyard-bodkin = Bodkin
 guide-entry-shipyard-bookworm = Bookworm
 guide-entry-shipyard-brigand = Brigand
 guide-entry-shipyard-bulker = Bulker

--- a/Resources/Maps/_NF/Shuttles/bodkin.yml
+++ b/Resources/Maps/_NF/Shuttles/bodkin.yml
@@ -1038,6 +1038,17 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -4.5,-6.5
       parent: 2
+  - uid: 452
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-3.5
+      parent: 2
+  - uid: 453
+    components:
+    - type: Transform
+      pos: 1.5,6.5
+      parent: 2
 - proto: ButtonFrameCautionSecurity
   entities:
   - uid: 362
@@ -1486,12 +1497,19 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -0.5,4.5
       parent: 2
-- proto: ComputerWallmountWithdrawBankATM
+- proto: ComputerWallmountRadar
   entities:
   - uid: 163
     components:
     - type: Transform
       pos: -3.5,-4.5
+      parent: 2
+- proto: ComputerWallmountWithdrawBankATM
+  entities:
+  - uid: 440
+    components:
+    - type: Transform
+      pos: 4.5,-4.5
       parent: 2
 - proto: ConveyorBelt
   entities:
@@ -1640,13 +1658,6 @@ entities:
     - type: Transform
       pos: -0.5,3.5
       parent: 2
-- proto: filingCabinetDrawerRandom
-  entities:
-  - uid: 145
-    components:
-    - type: Transform
-      pos: 1.5,5.5
-      parent: 2
 - proto: FirelockEdge
   entities:
   - uid: 438
@@ -1683,6 +1694,13 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 83
+- proto: FolderSpawner
+  entities:
+  - uid: 456
+    components:
+    - type: Transform
+      pos: 1.3455672,4.655131
+      parent: 2
 - proto: GasMixerOn
   entities:
   - uid: 272
@@ -2455,10 +2473,10 @@ entities:
       parent: 2
 - proto: NFHolopadShip
   entities:
-  - uid: 437
+  - uid: 145
     components:
     - type: Transform
-      pos: -0.5,5.5
+      pos: 1.5,5.5
       parent: 2
 - proto: NFSignDock
   entities:
@@ -2571,6 +2589,13 @@ entities:
     components:
     - type: Transform
       pos: -1.5,-0.5
+      parent: 2
+- proto: PottedPlantRandom
+  entities:
+  - uid: 437
+    components:
+    - type: Transform
+      pos: -0.5,5.5
       parent: 2
 - proto: Poweredlight
   entities:
@@ -2718,6 +2743,73 @@ entities:
       rot: 3.141592653589793 rad
       pos: -1.5,-9.5
       parent: 2
+- proto: ShuttersNormalOpen
+  entities:
+  - uid: 441
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,3.5
+      parent: 2
+  - uid: 442
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,4.5
+      parent: 2
+  - uid: 443
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,4.5
+      parent: 2
+  - uid: 444
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,3.5
+      parent: 2
+  - uid: 445
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,7.5
+      parent: 2
+  - uid: 446
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,8.5
+      parent: 2
+  - uid: 447
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,7.5
+      parent: 2
+  - uid: 448
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,8.5
+      parent: 2
+  - uid: 449
+    components:
+    - type: Transform
+      pos: 0.5,9.5
+      parent: 2
+  - uid: 450
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-1.5
+      parent: 2
+  - uid: 451
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-2.5
+      parent: 2
 - proto: ShuttleWindow
   entities:
   - uid: 51
@@ -2801,6 +2893,33 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 1.5,9.5
       parent: 2
+- proto: SignalButton
+  entities:
+  - uid: 455
+    components:
+    - type: Transform
+      pos: 1.5,6.5
+      parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        443:
+        - Pressed: Toggle
+        444:
+        - Pressed: Toggle
+        442:
+        - Pressed: Toggle
+        441:
+        - Pressed: Toggle
+        445:
+        - Pressed: Toggle
+        446:
+        - Pressed: Toggle
+        449:
+        - Pressed: Toggle
+        448:
+        - Pressed: Toggle
+        447:
+        - Pressed: Toggle
 - proto: SignalButtonDirectional
   entities:
   - uid: 68
@@ -2840,6 +2959,18 @@ entities:
         10:
         - Pressed: Toggle
         13:
+        - Pressed: Toggle
+  - uid: 454
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-3.5
+      parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        451:
+        - Pressed: Toggle
+        450:
         - Pressed: Toggle
 - proto: SignAtmos
   entities:

--- a/Resources/Prototypes/_NF/Guidebook/shipyard.yml
+++ b/Resources/Prototypes/_NF/Guidebook/shipyard.yml
@@ -10,6 +10,7 @@
   - ShipyardBarge
   - ShipyardBazaar
   - ShipyardBocadillo
+  - ShipyardBodkin
   - ShipyardBookworm
   - ShipyardBrigand
   - ShipyardBulker
@@ -78,6 +79,11 @@
   id: ShipyardBocadillo
   name: guide-entry-shipyard-bocadillo
   text: "/ServerInfo/_NF/Guidebook/Shipyard/Bocadillo.xml"
+
+- type: guideEntry
+  id: ShipyardBodkin
+  name: guide-entry-shipyard-bodkin
+  text: "/ServerInfo/_NF/Guidebook/Shipyard/Bodkin.xml"
 
 - type: guideEntry
   id: ShipyardBookworm

--- a/Resources/Prototypes/_NF/Shipyard/bodkin.yml
+++ b/Resources/Prototypes/_NF/Shipyard/bodkin.yml
@@ -13,7 +13,7 @@
   parent: BaseVessel
   name: SBB Bodkin
   description: The smaller sibling to the Broadhead, the SBB Bodkin is designed for rockhopping and salvage recovery.
-  price: 39000 #Grid appraises at 35693. Slapped on a ~10% markup.
+  price: 41000 #Grid appraises at 37000. Slapped on a ~10% markup.
   category: Medium
   group: Shipyard
   shuttlePath: /Maps/_NF/Shuttles/bodkin.yml

--- a/Resources/Prototypes/_NF/Shipyard/bodkin.yml
+++ b/Resources/Prototypes/_NF/Shipyard/bodkin.yml
@@ -13,7 +13,7 @@
   parent: BaseVessel
   name: SBB Bodkin
   description: The smaller sibling to the Broadhead, the SBB Bodkin is designed for rockhopping and salvage recovery.
-  price: 41000 #Grid appraises at 37000. Slapped on a ~10% markup.
+  price: 39000 #Grid appraises at 35000. Slapped on a ~10% markup.
   category: Medium
   group: Shipyard
   shuttlePath: /Maps/_NF/Shuttles/bodkin.yml

--- a/Resources/ServerInfo/_NF/Guidebook/Shipyard/Bodkin.xml
+++ b/Resources/ServerInfo/_NF/Guidebook/Shipyard/Bodkin.xml
@@ -1,0 +1,29 @@
+<Document>
+  # BODKIN-CLASS SALVAGE SHUTTLE
+  <Box>
+  <GuideEntityEmbed Entity="ClothingOuterHardsuitLuxury"/>
+  <GuideEntityEmbed Entity="Pickaxe"/>
+  <GuideEntityEmbed Entity="SalvageTechfabNF"/>
+  <GuideEntityEmbed Entity="OreProcessor"/>
+  <GuideEntityEmbed Entity="PosterLegitCarpMount"/>
+  </Box>
+  [color=#a4885c]Ship Size:[/color] Medium
+
+  [color=#a4885c]Recommended Crew:[/color] 1-3
+
+  [color=#a4885c]Power Gen Type:[/color] Uranium
+
+  [color=#a4885c]Expeditions:[/color] None
+
+  [color=#a4885c]IFF Console:[/color] None
+
+  "The smaller sibling to the Broadhead, the SBB Bodkin is designed for rockhopping and salvage recovery."
+
+  [italic]Brought to you by BlueBird Starship Design & Construction.[/italic]
+
+  # GETTING THE MOST OUT OF THE BODKIN
+
+  - The consider using the blast doors at the rear of the vessel for boarding wrecks and asteroids. This is the quickest way to get your loot into the cargo bay!
+  - The Bodkin comes with three hardsuits. Hire some people to work with you and make a team!
+  - The Bodkin comes with a withdraw-only ATM so you can sell your salvage to others who might need it, such as scientists. 
+</Document>


### PR DESCRIPTION
## About the PR
Updated the SBB Bodkin, adding a couple of new things along with a guidebook entry. In fact, the first guidebook entry of anything I've mapped! Wow!

The Bodkin now gets a wallmount mass scanner in the cargo bay area, allowing the salvage crew to coordinate with the pilot and see what's around them. 
Shutters were added to the windows on the bridge and in the rest area. Not sure why I didn't include those to begin with.

Guidebook entry created. Omitted the preflight checklist as frankly the shuttle spawns with everything working, so a checklist isn't necessary. 

## Why / Balance
New features were added to the game, things that the Bodkin could make use of, so now it does. Also brings it in line with other standard features on shuttles.
Hopefully the arbitration script doesn't kill my wife and children this time. 

## How to test
Checkout the branch, buy the ship, peruse the guidebook.

## Media
![2024-12-31 17_15_35-MyServer - Frontier Station](https://github.com/user-attachments/assets/9585c114-0158-43ba-ab03-b972f9a7f612)

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None.

**Changelog**
:cl:
- tweak: Updated the SBB Bodkin and gave it a guidebook entry.
