### PR TITLE
Fix certain donuts being unable to fit inside a donut box

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/donut.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/donut.yml
@@ -111,6 +111,7 @@
   - type: Tag
     tags:
     - Meat
+    - Donut # Frontier
 # Tastes like meat.
 
 - type: entity
@@ -315,6 +316,7 @@
   - type: Tag
     tags:
     - Fruit
+    - Donut # Frontier
 # Tastes like jelly-donut, green apples.
 
 - type: entity
@@ -381,6 +383,7 @@
   - type: Tag
     tags:
     - Fruit
+    - Donut # Frontier
 # Tastes like jelly-donut, blue pumpkin.
 
 - type: entity
@@ -403,6 +406,7 @@
   - type: Tag
     tags:
     - Fruit # Apparently this is a fruit. Huh.
+    - Donut # Frontier
 # Tastes like jelly-donut, tropical sweetness.
 
 - type: entity


### PR DESCRIPTION
## About the PR
Blue-Pumpkin jelly donuts, Bungo jelly donuts, Apple jelly donuts, and meat donuts were unable to fit inside a donut box due to being erroneously marked as non-donuts due to tags being overwritten. This PR fixes this by defining the Donut tag WITH the fruit/meat tag.

## Why / Balance
Because it makes no sense that a donut made of fruit or meat cannot fit inside a standard issue donut box.

## How to test
<!-- Describe the way it can be tested -->
1. Spawn a donut box.
2. Spawn a blue-pumpkin jelly-donut, bungo jelly-donut, apple jelly-donut, and meat donut.
3. Place each donut inside the donut box one-by-one.
4. mmm donuts.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/8b22ce06-69e1-4335-b43b-ec135f1685c1)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- fix: Fixed certain jelly-filled donuts, and a particularly meaty one, being unable to fit inside a donut box.
