### PR TITLE
Make ghosts worthless

### DIFF
--- a/Content.Server/Ghost/GhostSystem.cs
+++ b/Content.Server/Ghost/GhostSystem.cs
@@ -1,5 +1,6 @@
 using Content.Server.Administration.Logs;
 using Content.Server.Administration.Managers; // Frontier
+using Content.Server.Cargo.Systems; // Frontier
 using Content.Server.Chat.Managers;
 using Content.Server.GameTicking;
 using Content.Server.Ghost.Components;
@@ -93,6 +94,7 @@ namespace Content.Server.Ghost
             SubscribeLocalEvent<GhostComponent, BooActionEvent>(OnActionPerform);
             SubscribeLocalEvent<GhostComponent, ToggleGhostHearingActionEvent>(OnGhostHearingAction);
             SubscribeLocalEvent<GhostComponent, InsertIntoEntityStorageAttemptEvent>(OnEntityStorageInsertAttempt);
+            SubscribeLocalEvent<GhostComponent, PriceCalculationEvent>(OnPriceCalculation); // Frontier
 
             SubscribeLocalEvent<RoundEndTextAppendEvent>(_ => MakeVisible(true));
             SubscribeLocalEvent<ToggleGhostVisibilityToAllEvent>(OnToggleGhostVisibilityToAll);
@@ -592,6 +594,14 @@ namespace Content.Server.Ghost
 
             return true;
         }
+
+        // Frontier: worthless ghosts
+        private void OnPriceCalculation(Entity<GhostComponent> ent, ref PriceCalculationEvent args)
+        {
+            args.Price = 0;
+            args.Handled = true;
+        }
+        // End Frontier
     }
 
     public sealed class GhostAttemptHandleEvent(MindComponent mind, bool canReturnGlobal) : HandledEntityEventArgs


### PR DESCRIPTION
## About the PR
Forces ghosts to appraise at 0 spesos, by subscribing to `PriceCalculationEvent` and setting the price to zero.

## Why / Balance
If an aghost happens to be over a ship while it's being sold, the value of whatever the ghost is carrying will be added to the ship's sell value. In most cases, aghosts are only worth 1k-2k. We've recently had a situation where an aghost was carrying many millions of spesos, which required administrative intervention. Bit of an oopsie. This ensures aghosts are never included in the final price no matter what.

Additionally, some people like to appraise their ships by loading and initialising the grid, then running `appraisegrid` because some old guide somewhere says to do that. If you happened to be on grid, the value of your aghost would be counted too! Oopsies.

## How to test
1. Buy a ship. Leave the ID in the console.
2. Aghost.
3. Move over to the ship, then open the shipyard console to see what it appraises at.
4. Spawn yourself a large number of spesos or some valuable items. Reopen the shipyard console, see no change in appraisal price.
5. Join the server on a second account, sell the ship with the aghost still on it. Don't become a millionaire.

## Media
N/A

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
Noperoonies.

**Changelog**
N/A