### PR TITLE
Fix Lyrae mixer setting

### DIFF
--- a/Resources/Maps/_NF/Shuttles/lyrae.yml
+++ b/Resources/Maps/_NF/Shuttles/lyrae.yml
@@ -2419,8 +2419,8 @@ entities:
       pos: 3.5,-4.5
       parent: 2
     - type: GasMixer
-      inletTwoConcentration: 0.78
-      inletOneConcentration: 0.22
+      inletTwoConcentration: 0.21
+      inletOneConcentration: 0.79
     - type: AtmosPipeColor
       color: '#0055CCFF'
 - proto: GasPassiveVent


### PR DESCRIPTION
## About the PR
Fixes the Lyrae gas mixer setting.

## Why / Balance
The setting was incorrect, pumping in more oxygen than nitrogen.

## How to test
Load Lyrae. Look at mixer.

## Media
BEFORE:
![image](https://github.com/user-attachments/assets/131fc97e-5142-48fb-b695-1d16e0a05cde)

AFTER:
![image](https://github.com/user-attachments/assets/b2dfcb7a-03d1-4056-aa12-f0f96e199d19)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
No.

**Changelog**
N/A, just a tiny fix