### PR TITLE
Update mob_hostile_syndicate.yml

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_syndicate.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_syndicate.yml
@@ -485,6 +485,7 @@
   parent:
   - MobHumanoidHostileBase
   - MobHumanoidHostileAISimpleMelee
+  - NFMobRestrictions
   id: MobExperimentationVictim
   categories: [ HideSpawnMenu ]
   components:
@@ -501,6 +502,10 @@
     - type: HTN
       rootTask:
         task: SimpleHumanoidHostileCompound
+    - type: NFSalvageMobRestrictions
+      despawnIfOffLinkedGrid: false
+      addComponentsOnDeath: []
+      removeComponentsOnDeath: []
 
 # Syndicate Commander, "armed" with AK
 - type: entity


### PR DESCRIPTION
## About the PR
Allow the ``MobExperimentationVictim`` and ``MobCleanBotSyndie`` to be saved off the syndicate ftl event, but despawn if left on ship.

## Why / Balance
Bug fix, works same as clugg now.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A Less AI in space

**Changelog**
N/A
