### PR TITLE
Cargo Containers: An alternative to crate hauling

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Objects/Devices/Misc/ship_vouchers.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Devices/Misc/ship_vouchers.yml
@@ -121,15 +121,3 @@
     access:
     - Brig # odd, but potentially restricts cadets in lieu of a security guard-only access level
 
-
-
-- type: entity
-  parent: BaseShipVoucher
-  id: CargoVoucher
-  name: Cargo Crate Voucher
-  description: Allows for purchasing and selling of cargo containers.
-  components:
-  - type: CargoVoucher
-    destroyOnEmpty: false
-    access:
-    - Maintenance # An access every ID card starts with

--- a/Resources/Prototypes/_NF/Entities/Objects/Devices/Misc/ship_vouchers.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Devices/Misc/ship_vouchers.yml
@@ -121,3 +121,15 @@
     access:
     - Brig # odd, but potentially restricts cadets in lieu of a security guard-only access level
 
+
+
+- type: entity
+  parent: BaseShipVoucher
+  id: CargoVoucher
+  name: Cargo Crate Voucher
+  description: Allows for purchasing and selling of cargo containers.
+  components:
+  - type: CargoVoucher
+    destroyOnEmpty: false
+    access:
+    - Maintenance # An access every ID card starts with

--- a/Resources/Prototypes/_NF/Entities/Objects/Devices/Misc/ship_vouchers.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Devices/Misc/ship_vouchers.yml
@@ -120,3 +120,16 @@
   - type: ShipyardVoucher
     access:
     - Brig # odd, but potentially restricts cadets in lieu of a security guard-only access level
+
+
+
+- type: entity
+  parent: BaseShipVoucher
+  id: CargoVoucher
+  name: Cargo Crate Voucher
+  description: Allows for purchasing and selling of cargo containers.
+  components:
+  - type: CargoVoucher
+    destroyOnEmpty: false
+    access:
+    - Maintenance # An access every ID card starts with


### PR DESCRIPTION

## About the PR
Collaboration with  @Temoffy and @Alkheemist , adds a group of grids purchasable with specialized vouchers that allow you to buy and purchase said grids without the need for a second ID card
## Why / Balance
Discourages crate jamming to maximise profits at the cost of server performance
## How to test
Work in progress

## Media
Work in progress
## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
Work in progress
**Changelog**
🆑 

- Adds cargo containers for sale from Trade Outpost/Trade Mall