### PR TITLE
Protected stamps, weaker cybersun pen

### DIFF
--- a/Content.Shared/Paper/StampComponent.cs
+++ b/Content.Shared/Paper/StampComponent.cs
@@ -64,11 +64,18 @@ public sealed partial class StampComponent : Component
     [DataField("sound")]
     public SoundSpecifier? Sound = null;
 
-    // Frontier: allow reapplying stamps
+    // Frontier: allow reapplying stamps, protected stamps
     /// <summary>
     /// Whether or not a stamp can be reapplied
     /// </summary>
     [DataField("reapply")]
     public bool Reapply { get; set; } = false;
-    // End Frontier: allow reapplying stamps
+
+    /// <summary>
+    /// When true, stamped papers are marked as protected
+    /// </summary>
+
+    [DataField]
+    public bool Protected = false;
+    // End Frontier
 }

--- a/Resources/Prototypes/Entities/Objects/Misc/pen.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/pen.yml
@@ -69,7 +69,7 @@
 
 - type: entity
   id: BaseAdvancedPen
-  parent: [PenEmbeddable, BaseC3SyndicateContraband] # Frontier: add BaseC3SyndicateContraband
+  parent: PenEmbeddable
   abstract: true
   components:
   - type: Tag
@@ -93,7 +93,8 @@
 
 - type: entity
   name: Cybersun pen
-  parent: [BaseAdvancedPen, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  # parent: [BaseAdvancedPen, BaseSyndicateContraband] # Frontier
+  parent: [NFBaseUnprotectedAdvancedPen, BaseC3SyndicateContraband] # Frontier
   id: CyberPen
   description: A high-tech pen straight from Cybersun's legal department, capable of refracting hard-light at impossible angles through its diamond tip in order to write. So powerful, it's even able to rewrite officially stamped documents should the need arise.
   components:

--- a/Resources/Prototypes/Entities/Objects/Misc/rubber_stamp.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/rubber_stamp.yml
@@ -64,6 +64,7 @@
     stampedName: stamp-component-stamped-name-centcom
     stampedColor: "#006600"
     stampState: "paper_stamp-centcom"
+    protected: True # Frontier
   - type: Sprite
     state: stamp-centcom
 

--- a/Resources/Prototypes/_NF/Entities/Objects/Misc/pen.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Misc/pen.yml
@@ -10,3 +10,15 @@
   - type: Item
     sprite: _NF/Objects/Misc/pens.rsi
     heldPrefix: pen_pal
+
+- type: entity
+  id: NFBaseUnprotectedAdvancedPen
+  parent: BaseAdvancedPen
+  abstract: true
+  components:
+  - type: Tag
+    tags:
+    - Write
+    - NFWriteIgnoreUnprotectedStamps # Weaker version of WriteIgnoreStamps
+    - Pickaxe
+    - Pen

--- a/Resources/Prototypes/_NF/Entities/Objects/Misc/rubber_stamp.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Misc/rubber_stamp.yml
@@ -7,6 +7,7 @@
     stampedName: stamp-component-stamped-name-sr
     stampedColor: "#6ec0ea"
     stampState: "paper_stamp-hop"
+    protected: True
   - type: Sprite
     state: stamp-hop
 
@@ -34,6 +35,7 @@
     stampedName: stamp-component-stamped-name-hos
     stampedColor: "#4c653a"
     stampState: "paper_stamp-nf-sheriff"
+    protected: True
   - type: Sprite
     sprite: _NF/Objects/Misc/stamps.rsi
     state: stamp-sheriff

--- a/Resources/Prototypes/_NF/tags.yml
+++ b/Resources/Prototypes/_NF/tags.yml
@@ -153,3 +153,9 @@
 
 - type: Tag
   id: NFFoamRPG
+
+- type: Tag
+  id: NFWriteIgnoreUnprotectedStamps
+
+- type: Tag
+  id: NFPaperStampProtected


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Adds a Protected field to Sheriff, SR and Centcomm rubber stamps.  When a stamp with this field set to true is used to stamp a piece of paper, the paper receives a tag that notes it is protected.

The CyberPen can no longer edit papers stamped with these stamps.  The CentComm pen, however, can.

Should also fix any issue with the centcomm pen being labelled as class 3 contraband.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

The biggest issue with Cyberpen availability is (apparently) game ruining through impersonation of command jobs.  With these changes, that should hopefully be less of an issue, so we can get more lower-level fraud to spur more cheeky interaction between players.

If we need additional levels of protection (traffic tickets?  signatures only?), this could be moved from a boolean & tag to integral fields.

With this, it might be plausible to give positions like the PAL and STC weaker/equivalent versions of the cybersun pen.

## How to test
<!-- Describe the way it can be tested -->

1. Spawn a piece of paper, a pen, a cybersun pen, and a centcomm pen.
2. Spawn an SR stamp, sheriff stamp, centcomm stamp, and an engineer's stamp.
3. Sign a piece of paper.  Equip the pen, click the signed page, you should sign it again.
4. Equip the cybersun pen, click the signed page, you should edit it.
5. Equip the centcomm pen, click the signed page, you should edit it.
6. Stamp the paper with the engineer's stamp.
7. Equip the pen, click the page, you should sign it.
8. Equip the cybersun pen, click the page, you should edit it.
9. Equip the centcomm pen, click the signed page, you should edit it.
10. Spawn a piece of paper.
11. Stamp the paper with the SR's stamp.
12. Equip the pen, click the page, you should sign it.
13. Equip the cybersun pen, click the page, you should sign it.
14. Equip the centcomm pen, click the signed page, you should edit it.
15. Repeat steps 10-14 with the sheriff and centcomm stamp.
16. Bonus: send an uneditable admin fax - all of the pens should only be able to sign it.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Pages stamped with SR, Sheriff, and Centcomm stamps cannot be edited by the Cybersun pen.