### PR TITLE
Fixed missing tech and boards

### DIFF
--- a/Resources/Locale/en-US/_NF/research/technologies.ftl
+++ b/Resources/Locale/en-US/_NF/research/technologies.ftl
@@ -15,3 +15,4 @@ research-technology-industrial-medicine = Industrial Medicine
 research-technology-magnets-tech-advanced = Advanced Localized Magnetism
 research-technology-magnets-tech-combat = Localized Magnetism Combat Application
 research-technology-mobile-sanitation = Mobile Sanitation
+research-technology-chemical-dispensary = Chemical Dispensary

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -498,10 +498,12 @@
     - ProtolatheMachineCircuitboard
     - AutolatheMachineCircuitboard
     - CircuitImprinterMachineCircuitboard
-    # - BiogeneratorMachineCircuitboard # Frontier
+#    - BiogeneratorMachineCircuitboard # Frontier
     - OreProcessorMachineCircuitboard
     - ElectrolysisUnitMachineCircuitboard
     - CentrifugeMachineCircuitboard
+#    - ChemDispenserMachineCircuitboard # Frontier
+#    - ChemMasterMachineCircuitboard # Frontier
     - CondenserMachineCircuitBoard
     - HotplateMachineCircuitboard
     - UniformPrinterMachineCircuitboard

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -532,8 +532,6 @@
       - CryoPodMachineCircuitboard
       - VaccinatorMachineCircuitboard
       - DiagnoserMachineCircuitboard
-      - ChemMasterMachineCircuitboard
-      - ChemDispenserMachineCircuitboard
       - BiomassReclaimerMachineCircuitboard
       - BiogeneratorMachineCircuitboard # Frontier BiofabricatorMachineCircuitboard<BiogeneratorMachineCircuitboard
       - SurveillanceCameraRouterCircuitboard
@@ -549,17 +547,13 @@
       - TurboItemRechargerCircuitboard
       - AutolatheHyperConvectionMachineCircuitboard
       - ProtolatheHyperConvectionMachineCircuitboard
-      - ReagentGrinderMachineCircuitboard
-      - HotplateMachineCircuitboard
-      - MicrowaveMachineCircuitboard
-      - ElectricGrillMachineCircuitboard
       - CircuitImprinterHyperConvectionMachineCircuitboard
       - FatExtractorMachineCircuitboard
       - FlatpackerMachineCircuitboard
       - SheetifierMachineCircuitboard
       - ShuttleConsoleCircuitboard
       - RadarConsoleCircuitboard
-      # - TechDiskComputerCircuitboard # Frontier: no tech disks
+#      - TechDiskComputerCircuitboard # Frontier
       - DawInstrumentMachineCircuitboard
       - CloningConsoleComputerCircuitboard
       - StasisBedMachineCircuitboard
@@ -581,7 +575,6 @@
       - ThrusterMachineCircuitboard
       - GyroscopeMachineCircuitboard
       - MiniGravityGeneratorCircuitboard
-      - MiniStationAnchorCircuitboard # Frontier
       - ShuttleGunKineticCircuitboard
       - GasRecyclerMachineCircuitboard
       - SeedExtractorMachineCircuitboard
@@ -593,8 +586,6 @@
       - APECircuitboard
       - ArtifactAnalyzerMachineCircuitboard
       - ArtifactCrusherMachineCircuitboard
-      - BoozeDispenserMachineCircuitboard
-      - SodaDispenserMachineCircuitboard
       - TelecomServerCircuitboard
       - MassMediaCircuitboard
       - ReagentGrinderIndustrialMachineCircuitboard
@@ -613,12 +604,22 @@
       - MedicalAssemblerMachineCircuitboard # Frontier
       - KitchenAssemblerMachineCircuitboard # Frontier
       - ElectricRangeMachineCircuitboard # Frontier
+      - ChemDispenserMachineCircuitboard # Frontier
+      - ChemMasterMachineCircuitboard # Frontier
+      - ReagentGrinderMachineCircuitboard # Frontier
+      - HotplateMachineCircuitboard # Frontier
+      - MicrowaveMachineCircuitboard # Frontier
+      - ElectricGrillMachineCircuitboard # Frontier
+      - BoozeDispenserMachineCircuitboard # Frontier
+      - SodaDispenserMachineCircuitboard # Frontier
+      - MiniStationAnchorCircuitboard # Frontier
   - type: EmagLatheRecipes
     emagDynamicRecipes:
-      - ShuttleGunDusterCircuitboard
-      - ShuttleGunFriendshipCircuitboard
-      - ShuttleGunPerforatorCircuitboard
-      - ShuttleGunSvalinnMachineGunCircuitboard
+      # - ShuttleGunDusterCircuitboard # Frontier
+      # - ShuttleGunFriendshipCircuitboard # Frontier
+      # - ShuttleGunPerforatorCircuitboard # Frontier
+      # - ShuttleGunSvalinnMachineGunCircuitboard # Frontier
+      - ShuttleGunKineticCircuitboard # Frontier
   - type: MaterialStorage
     whitelist:
       tags:

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -498,12 +498,12 @@
     - ProtolatheMachineCircuitboard
     - AutolatheMachineCircuitboard
     - CircuitImprinterMachineCircuitboard
-#    - BiogeneratorMachineCircuitboard # Frontier
+    # - BiogeneratorMachineCircuitboard # Frontier
     - OreProcessorMachineCircuitboard
     - ElectrolysisUnitMachineCircuitboard
     - CentrifugeMachineCircuitboard
-#    - ChemDispenserMachineCircuitboard # Frontier
-#    - ChemMasterMachineCircuitboard # Frontier
+    # - ChemDispenserMachineCircuitboard # Frontier
+    # - ChemMasterMachineCircuitboard # Frontier
     - CondenserMachineCircuitBoard
     - HotplateMachineCircuitboard
     - UniformPrinterMachineCircuitboard
@@ -553,7 +553,7 @@
       - SheetifierMachineCircuitboard
       - ShuttleConsoleCircuitboard
       - RadarConsoleCircuitboard
-#      - TechDiskComputerCircuitboard # Frontier
+      # - TechDiskComputerCircuitboard # Frontier
       - DawInstrumentMachineCircuitboard
       - CloningConsoleComputerCircuitboard
       - StasisBedMachineCircuitboard
@@ -596,7 +596,6 @@
       - FireAlarmElectronics # Nyano
       - FirelockElectronics # Nyano
       - IntercomElectronics # Nyano
-      - MailingUnitElectronics # Nyano
       - StationMapElectronics # Nyano
       - DeepFryerMachineCircuitboard # Nyano
       - SmallThrusterMachineCircuitboard # Frontier

--- a/Resources/Prototypes/Research/civilianservices.yml
+++ b/Resources/Prototypes/Research/civilianservices.yml
@@ -41,22 +41,6 @@
   - VimHarness
 
 - type: technology
-  id: FoodService
-  name: research-technology-food-service
-  icon:
-    sprite: Structures/Machines/juicer.rsi
-    state: juicer1
-  discipline: CivilianServices
-  tier: 1
-  cost: 7500
-  recipeUnlocks: #remove all of these once we have more kitchen equipment
-  - MicrowaveMachineCircuitboard
-  - ReagentGrinderMachineCircuitboard
-  - ElectricGrillMachineCircuitboard
-  - BoozeDispenserMachineCircuitboard
-  - SodaDispenserMachineCircuitboard
-
-- type: technology
   id: AudioVisualCommunication
   name: research-technology-audio-visual-communication
   icon:

--- a/Resources/Prototypes/_NF/Research/civilianservices.yml
+++ b/Resources/Prototypes/_NF/Research/civilianservices.yml
@@ -1,3 +1,49 @@
+# Tier 1
+
+- type: technology
+  id: FoodService
+  name: research-technology-food-service
+  icon:
+    sprite: Structures/Machines/juicer.rsi
+    state: juicer1
+  discipline: CivilianServices
+  tier: 1
+  cost: 7500
+  recipeUnlocks:
+  - MicrowaveMachineCircuitboard
+  - ReagentGrinderMachineCircuitboard
+  - ElectricGrillMachineCircuitboard
+  - BoozeDispenserMachineCircuitboard
+  - SodaDispenserMachineCircuitboard
+
+# Tier 2
+
+- type: technology
+  id: ChemicalDispensary
+  name: research-technology-chemical-dispensary
+  icon:
+    sprite: Structures/dispensers.rsi
+    state: industrial-working
+  discipline: CivilianServices
+  tier: 2
+  cost: 10000
+  recipeUnlocks:
+  - ChemMasterMachineCircuitboard
+  - ChemDispenserMachineCircuitboard
+
+- type: technology
+  id: IndustrialMedicine
+  name: research-technology-industrial-medicine
+  icon:
+    sprite: _NF/Structures/Machines/medical_assembler.rsi
+    state: icon
+  discipline: CivilianServices
+  tier: 2
+  cost: 5000
+  recipeUnlocks:
+  - MedicalAssemblerMachineCircuitboard
+  - HotplateMachineCircuitboard
+
 # Tier 3
 
 - type: technology
@@ -11,18 +57,6 @@
   cost: 15000
   recipeUnlocks:
   - JetpackVoid
-
-- type: technology
-  id: IndustrialMedicine
-  name: research-technology-industrial-medicine
-  icon:
-    sprite: _NF/Structures/Machines/medical_assembler.rsi
-    state: icon
-  discipline: CivilianServices
-  tier: 2
-  cost: 5000
-  recipeUnlocks:
-  - MedicalAssemblerMachineCircuitboard
 
 - type: technology
   id: AdvancedFoodService


### PR DESCRIPTION
## About the PR
Cleanup the lathe file

## Why / Balance
Restore the option to make chem machines in sci but require tech.
Clean out the shuttle guns that we missed and leave the mining one as added.

## How to test
Get the tech, print some boards.

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
:cl:
- tweak: ChemicalDispensary tech is added again, allow sci to print tier one medical machines again.
