### PR TITLE
Disable the removel of gravity generator and anchors while they are on

### DIFF
--- a/Content.Server/Gravity/GravityGeneratorSystem.cs
+++ b/Content.Server/Gravity/GravityGeneratorSystem.cs
@@ -1,7 +1,11 @@
 using Content.Server.Emp; // Frontier: Upstream - #28984
+using Content.Server.Popups;
 using Content.Server.Power.Components;
 using Content.Server.Power.EntitySystems;
+using Content.Shared.Construction.Components; // Frontier
 using Content.Shared.Gravity;
+using Content.Shared.Tools.Components; // Frontier
+using Content.Shared.Popups; // Frontier
 
 namespace Content.Server.Gravity;
 
@@ -9,6 +13,8 @@ public sealed class GravityGeneratorSystem : EntitySystem
 {
     [Dependency] private readonly GravitySystem _gravitySystem = default!;
     [Dependency] private readonly SharedPointLightSystem _lights = default!;
+
+    [Dependency] private readonly PopupSystem _popupSystem = default!; // Frontier
 
     public override void Initialize()
     {
@@ -18,7 +24,7 @@ public sealed class GravityGeneratorSystem : EntitySystem
         SubscribeLocalEvent<GravityGeneratorComponent, ChargedMachineActivatedEvent>(OnActivated);
         SubscribeLocalEvent<GravityGeneratorComponent, ChargedMachineDeactivatedEvent>(OnDeactivated);
         // SubscribeLocalEvent<GravityGeneratorComponent, EmpPulseEvent>(OnEmpPulse); // Frontier: Upstream - #28984
-        SubscribeLocalEvent<GravityGeneratorComponent, UnanchorAttemptEvent>(OnUnanchorAttempt);
+        SubscribeLocalEvent<GravityGeneratorComponent, UnanchorAttemptEvent>(OnUnanchorAttempt); // Frontier
         SubscribeLocalEvent<GravityGeneratorComponent, ToolUseAttemptEvent>(OnToolUseAttempt); // Frontier
     }
 
@@ -66,11 +72,11 @@ public sealed class GravityGeneratorSystem : EntitySystem
     /// </summary>
     private void OnUnanchorAttempt(Entity<GravityGeneratorComponent> ent, ref UnanchorAttemptEvent args)
     {
-        if (!ent.Comp.SwitchedOn)
+        if (!ent.Comp.GravityActive)
             return;
 
         _popupSystem.PopupEntity(
-            Loc.GetString("station-anchor-unanchoring-failed"),
+            Loc.GetString("gravity-generator-unanchoring-failed"),
             ent,
             args.User,
             PopupType.Medium);
@@ -83,7 +89,7 @@ public sealed class GravityGeneratorSystem : EntitySystem
     /// </summary>
     private void OnToolUseAttempt(Entity<GravityGeneratorComponent> ent, ref ToolUseAttemptEvent args)
     {
-        if (!ent.Comp.SwitchedOn)
+        if (!ent.Comp.GravityActive)
             return;
 
         foreach (var quality in args.Qualities)
@@ -92,7 +98,7 @@ public sealed class GravityGeneratorSystem : EntitySystem
             if (quality == "Prying")
             {
                 _popupSystem.PopupEntity(
-                    Loc.GetString("station-anchor-unanchoring-failed"),
+                    Loc.GetString("gravity-generator-unanchoring-failed"),
                      ent,
                      args.User,
                      PopupType.Medium);

--- a/Resources/Locale/en-US/_NF/gravity/gravity-generator-component.ftl
+++ b/Resources/Locale/en-US/_NF/gravity/gravity-generator-component.ftl
@@ -1,0 +1,3 @@
+### Gravity Generator
+
+gravity-generator-unanchoring-failed = Can't unanchor an active gravity generator


### PR DESCRIPTION
## About the PR
Honestly why is this not a base game option, works out of box.

## Why / Balance
Cant just turn off and remove the machines without waiting for them to go off.

## How to test
Buy a ship, try to remove gravity gen, wrench it off, no work, wait for it to turn off then try.

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
:cl:
- tweak: Gravity generator and station anchor now has to be off before removing them.
