### PR TITLE
Rename scrap circuitry to fried circuitry

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Materials/scrap.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/scrap.yml
@@ -93,7 +93,7 @@
 - type: entity
   parent: BaseScrap
   id: ScrapGlass
-  name: scrap circuitry
+  name: fried circuitry # Frontier: scrap<fried - prevent confusion with scrap ore
   description: A huge lump of various circuits, strangely fused together. You could likely extract some materials out of this.
   components:
   - type: Sprite


### PR DESCRIPTION
## About the PR
Renames _scrap circuitry_ to _fried circuitry_.

## Why / Balance
On about a dozen occasions, I've watched people try to put scrap circuitry in the scrap processor. It's visually similar to scrap chunks, and people seem to think it's somehow compatible. It is my hope that changing it to "fried circuitry" might disabuse people of this notion and make it ever clearer that this is junk that goes in the material reclaimer, not scrap to be refined.

## How to test
1. Spawn fried circuitry.
2. Behold the new name.

## Media
N/A

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
No.

**Changelog**
:cl:
- tweak: Scrap circuitry has been renamed to fried circuitry. Put it in the material reclaimer, not the scrap processor!
