### PR TITLE
Fix 20gb memory usage for magnet code

### DIFF
--- a/Content.Shared/Storage/EntitySystems/MagnetPickupSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/MagnetPickupSystem.cs
@@ -126,6 +126,13 @@ public sealed class MagnetPickupSystem : EntitySystem
                 if (_whitelistSystem.IsWhitelistFail(storage.Whitelist, near))
                     continue;
 
+                // FRONTIER - START
+                // Makes sure that after the last insertion, there is still bag space.
+                // Using a cheap 'how many slots left' vs 'how many we need' check, and additional stack check.
+                if (!_storage.HasSlotSpaceFor(uid, near))
+                    break;
+                // FRONTIER - END
+
                 if (!_physicsQuery.TryGetComponent(near, out var physics) || physics.BodyStatus != BodyStatus.OnGround)
                     continue;
 

--- a/Content.Shared/Storage/EntitySystems/MagnetPickupSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/MagnetPickupSystem.cs
@@ -129,8 +129,10 @@ public sealed class MagnetPickupSystem : EntitySystem
                 // FRONTIER - START
                 // Makes sure that after the last insertion, there is still bag space.
                 // Using a cheap 'how many slots left' vs 'how many we need' check, and additional stack check.
+                // Note: Unfortunately, this is still 'expensive' as it checks the entire bag, however its better than
+                // to rotate an item n^n times of every item in the bag to find the best fit, for every xy coordinate it has.
                 if (!_storage.HasSlotSpaceFor(uid, near))
-                    break;
+                    continue;
                 // FRONTIER - END
 
                 if (!_physicsQuery.TryGetComponent(near, out var physics) || physics.BodyStatus != BodyStatus.OnGround)

--- a/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
@@ -1289,6 +1289,22 @@ public abstract class SharedStorageSystem : EntitySystem
         return GetCumulativeItemAreas(uid) < uid.Comp.Grid.GetArea() || HasSpaceInStacks(uid);
     }
 
+    /// FRONTIER
+    /// <summary>
+    /// Returns true if there is enough space to fit an item based on slot counts and item stack size.
+    /// </summary>
+    public bool HasSlotSpaceFor(Entity<StorageComponent?> uid, Entity<ItemComponent?> itemEnt)
+    {
+        if (!Resolve(uid, ref uid.Comp) || !Resolve(itemEnt, ref itemEnt.Comp))
+            return false;
+
+        // If the amount of spaces that's left in the bag is less than the size of the item, return false.
+        var itemSpacesNeeded = ItemSystem.GetItemShape((itemEnt, itemEnt.Comp)).GetArea();
+        var availableSpaces = uid.Comp.Grid.GetArea() - GetCumulativeItemAreas(uid);
+
+        return availableSpaces >= itemSpacesNeeded || HasSpaceInStacks(uid);
+    }
+
     private bool HasSpaceInStacks(Entity<StorageComponent?> uid, string? stackType = null)
     {
         if (!Resolve(uid, ref uid.Comp))


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
This is a bandaid fix for high memory usage for bags that use the magnet component.
It still happens when u have total, spread out, enough free slots, but this at least reduces the amount of occurrences of it happening.

![image](https://github.com/user-attachments/assets/4528baad-78be-4efd-a3a4-bb95635b471c)
![image](https://github.com/user-attachments/assets/b691b3e2-c4db-4555-b3bb-bf8069bb263f)


## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Performance fix

## How to test
<!-- Describe the way it can be tested -->
strap on your favorite magnet bag
put a giant load of items around you, fill up the bag, put even more items around you. (about 20+)
lets say you have 2 spaces left in your bag and theres a ton of items around you that each need 4 spaces.
Now, it wont cost you your computer's soul

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
None

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
Changelog not needed
