### PR TITLE
Give bailiff access to chemistry and medical (since they are brigmed's boss)

### DIFF
--- a/Resources/Prototypes/_NF/Roles/Jobs/Nfsd/bailiff.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Nfsd/bailiff.yml
@@ -32,6 +32,8 @@
   - Armory
   - Sergeant
   - Bailiff
+  - Medical
+  - Chemistry
   accessGroups:
   - GeneralNfsdAccess
   special:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
Gives bailiff med and chemistry access.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bailiff is brig medic's direct superior so they need to mirror their access to chem and med.
#2740 related

## How to test
<!-- Describe the way it can be tested -->
Use bailiff to open a chemistry and medical locked door.
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- add: Added medical and chemistry access to bailiff.