### PR TITLE
Reduce shuttle tech to one tech

### DIFF
--- a/Resources/Prototypes/Research/arsenal.yml
+++ b/Resources/Prototypes/Research/arsenal.yml
@@ -180,6 +180,8 @@
   - MagazineGrenadeEmpty
   - GrenadeFlash
   - GrenadeBlast
+  - GrenadeEMP #Frontier
+  - PowerCageHigh #frontier
 #  - ShuttleGunSvalinnMachineGunCircuitboard # Frontier
 #  - ShuttleGunPerforatorCircuitboard # Frontier
 #  - ShuttleGunFriendshipCircuitboard # Frontier
@@ -217,18 +219,18 @@
   - WeaponLaserSvalinn
   - NFBlueprintWeaponLaserSvalinn # Frontier
 
-- type: technology
-  id: AdvancedShuttleWeapon
-  name: research-technology-advanced-shuttle-weapon
-  icon:
-    sprite: Objects/Weapons/Guns/Ammunition/Magazine/Grenade/grenade_cartridge.rsi
-    state: icon
-  discipline: Arsenal
-  tier: 3
-  cost: 15000
-  recipeUnlocks:
-  - GrenadeEMP
-  - PowerCageHigh
+# - type: technology #Frontier
+#  id: AdvancedShuttleWeapon
+#  name: research-technology-advanced-shuttle-weapon
+#  icon:
+#    sprite: Objects/Weapons/Guns/Ammunition/Magazine/Grenade/grenade_cartridge.rsi
+#    state: icon
+#  discipline: Arsenal
+#  tier: 3
+#  cost: 15000
+#  recipeUnlocks:
+#  - GrenadeEMP
+#  - PowerCageHigh
 #  - ShuttleGunDusterCircuitboard # Frontier
-  technologyPrerequisites:
-  - BasicShuttleArmament
+#  technologyPrerequisites:
+#  - BasicShuttleArmament


### PR DESCRIPTION


## About the PR
Merges "Basic" and "Advanced" shuttle armaments into just basic shuttle armaments
## Why / Balance
Considering advanced shuttle tech has all of... an EMP grenade and a high capacity power cage, there's no need for two techs. Bumped the price of basic shuttle arma up to 17.5K to compensate.

## How to test
Load server
check the guidebook
notice the tech

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Merged Advanced and Basic shuttle tech into one.
