### PR TITLE
Fix LinkedLifecycleGridSystem player check

### DIFF
--- a/Content.Server/_NF/StationEvents/EventSystems/LinkedLifecycleGridSystem.cs
+++ b/Content.Server/_NF/StationEvents/EventSystems/LinkedLifecycleGridSystem.cs
@@ -1,5 +1,6 @@
 using System.Numerics;
 using Content.Server.StationEvents.Components;
+using Content.Shared.Bank.Components;
 using Content.Shared.Humanoid;
 using Content.Shared.Mech.Components;
 using Content.Shared.Mind;
@@ -93,8 +94,8 @@ public sealed class LinkedLifecycleGridSystem : EntitySystem
         List<(Entity<TransformComponent> Entity, EntityUid MapUid, Vector2 LocalPosition)> reparentEntities = new();
         HashSet<EntityUid> handledEntities = new();
 
-        // Get humanoids
-        var mobQuery = AllEntityQuery<HumanoidAppearanceComponent, MobStateComponent, TransformComponent>();
+        // Get player characters
+        var mobQuery = AllEntityQuery<HumanoidAppearanceComponent, BankAccountComponent, TransformComponent>();
         while (mobQuery.MoveNext(out var mobUid, out _, out _, out var xform))
         {
             handledEntities.Add(mobUid);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Changes the LinkedLifecycleGridSystem to stop matching false positives with humanoid characters.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Bug report: https://discord.com/channels/1123826877245694004/1331093959648219186

Medical bounties currently have MindContainer, which was being matched against for grid despawn prevention.  This replaces it with BankAccountComponent - this is hacky, but will match player characters, which is the intent.  We could add an "NFPlayerComponent" or some tag after spawning to the same effect.  I believe admin-spawned characters won't match this, though I'm not sure.

## How to test
<!-- Describe the way it can be tested -->

1. Fly to a wreck.
2. Make sure there's a medical pod on the wreck.
3. Spawn a Urist on the wreck, give them BankAccountComponent.
4. Face north.
5. Fly forward for about 300 meters - check your Content.Server console, there should be a message when the wreck despawns.
6. Fly backward for about 300 meters.  The Urist should be there, the body in the medical pod should not.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Wreck corpses should no longer linger after wrecks despawn.