### PR TITLE
Turrets take increased explosive damage

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/turrets.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/turrets.yml
@@ -123,6 +123,9 @@
       thresholds: # Frontier
         0: Alive # Frontier
         500: Dead # Frontier: bandaid fix, value here should be high enough to prevent situations when mob(turret) changes it's state before being destoyed
+    - type: ExplosionResistance
+      damageCoefficient: 1.5 #Frontier, takes 50% more damage from explosives.
+
 
 - type: entity
   parent: [BaseWeaponTurret, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband


### PR DESCRIPTION


## About the PR
Turrets take 50% extra damage from explosions
## Why / Balance
Speaking from experience, turrets are *not* fun to engage with, they deal 115 damage per second, which is likely significantly more than any other gun in the game, and with how many there are dotted around events, it causes deaths every time someone gets near them, even prepared

So lets make em a bit easier to kill with preperations.
## How to test
Load a server
Spawn a turret
Throw a grenade at the turret (with no gravity to simulate event conditions if you waant
Watch the turret either die, or take significantly less bullets too kill.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Turrets take more damage from exploksions. 
