### PR TITLE
Candle lifetime increase.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/candles.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/candles.yml
@@ -33,7 +33,7 @@
       alwaysCombustible: true
       canExtinguish: true
       firestacksOnIgnite: 3.0
-      firestackFade: -0.001 #-0.01<-0.001 frontier 
+      firestackFade: -0.001 # Frontier -0.01<-0.001 
       damage:
         types:
           Heat: 0.1
@@ -55,7 +55,7 @@
       thresholds:
       - trigger:
           !type:DamageTrigger
-          damage: 1000 #100<1000 frontier
+          damage: 1000 # Frontier 100<1000 
         behaviors:
         - !type:DoActsBehavior
           acts: [ "Destruction" ]
@@ -171,7 +171,7 @@
       thresholds:
       - trigger:
           !type:DamageTrigger
-          damage: 550 #60<550 Frontier
+          damage: 550 # Frontier 60<550 
         behaviors:
         - !type:SpawnEntitiesBehavior
         - !type:DoActsBehavior


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
slows the fade time and increases the health of candles so they last for 30/50minuets instead of 3/5

## Why / Balance
candles are an RP tool. currently they last 3 min for small, 5 for large. this changes to about 30 mins for small and 50 for large.

## How to test
Load up local host
spawn a small and large candle
light them
start a timer.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Changed lifespan on candles. smalls up to 30 minuets, large up to 50

