### PR TITLE
AME controller: stop injecting if fuel slot is empty

### DIFF
--- a/Content.Server/Ame/EntitySystems/AmeControllerSystem.cs
+++ b/Content.Server/Ame/EntitySystems/AmeControllerSystem.cs
@@ -113,6 +113,10 @@ public sealed class AmeControllerSystem : EntitySystem
                 UpdateUi(uid, controller);
             }
         }
+        // Frontier: turn AME off without a fuel container
+        else
+            SetInjecting(uid, false, null, controller);
+        // End Frontier
 
         controller.Stability = group.GetTotalStability();
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Bugfix to stop the AME from injecting on update if the fuel slot is empty.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Abusable, bugfix for https://discord.com/channels/1123826877245694004/1332130518816391249

## How to test
<!-- Describe the way it can be tested -->

1. Spawn on expeditionary lodge.
2. Purchase a Pathfinder.
3. Walk onto it.
4. alt-click the AME controller, the fuel jar should pop out.
5. Wait up to 10 seconds for the next injection cycle.  The AME controller should turn off.
6. Spawn a power monitoring console and confirm that the power supplied by the AME is 0 W.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: The AME no longer provides power if the fuel slot is empty.