### PR TITLE
Remove valet job

### DIFF
--- a/Resources/Maps/_NF/Outpost/frontier.yml
+++ b/Resources/Maps/_NF/Outpost/frontier.yml
@@ -32062,13 +32062,6 @@ entities:
     - type: Transform
       pos: 13.5,15.5
       parent: 2173
-- proto: SpawnPointValet
-  entities:
-  - uid: 4446
-    components:
-    - type: Transform
-      pos: -0.5,5.5
-      parent: 2173
 - proto: SpawnVehicleSecway
   entities:
   - uid: 2681

--- a/Resources/Maps/_NF/Test/dev_map.yml
+++ b/Resources/Maps/_NF/Test/dev_map.yml
@@ -7048,13 +7048,6 @@ entities:
     - type: Transform
       pos: -3.5,2.5
       parent: 179
-- proto: SpawnPointValet
-  entities:
-  - uid: 1346
-    components:
-    - type: Transform
-      pos: -3.5,2.5
-      parent: 179
 - proto: SpawnVehicleATV
   entities:
   - uid: 1176

--- a/Resources/Prototypes/Nyanotrasen/Entities/Markers/Spawners/jobs.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Markers/Spawners/jobs.yml
@@ -23,18 +23,6 @@
       - state: prisoner
 
 - type: entity
-  id: SpawnPointValet
-  parent: SpawnPointJobBase
-  name: valet
-  components:
-  - type: SpawnPoint
-    job_id: Valet
-  - type: Sprite
-    layers:
-      - state: green
-      - state: passenger
-
-- type: entity
   id: SpawnPointPrisonGuard
   parent: SpawnPointJobBase
   name: prison guard

--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Civilian/valet.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Civilian/valet.yml
@@ -1,39 +1,39 @@
-﻿- type: job
-  id: Valet
-  name: job-name-valet
-  description: job-description-valet
-  playTimeTracker: JobValet
-  requirements:
-    - !type:OverallPlaytimeRequirement
-      time: 10800
-  startingGear: ValetGear
-  alwaysUseSpawner: true
-  icon: "JobIconValet" # Frontier: JobIconServiceWorker<JobIconValet
-  supervisors: job-supervisors-sr
-  weight: 60 # Frontier
-  displayWeight: 10 # Frontier
-  canBeAntag: false
-  access:
-  - Maintenance
-  - External # Frontier
-  - Service
-  - Frontier # Frontier
-  special:
-  - !type:AddImplantSpecial
-    implants: [ MindShieldImplant ]
-  - !type:GiveItemOnHolidaySpecial # Frontier
-    holiday: FrontierBirthday # Frontier
-    prototype: FrontierBirthdayGift # Frontier
-
+﻿#- type: job
+#  id: Valet
+#  name: job-name-valet
+#  description: job-description-valet
+#  playTimeTracker: JobValet
+#  requirements:
+#    - !type:OverallPlaytimeRequirement
+#      time: 10800
+#  startingGear: ValetGear
+# alwaysUseSpawner: true
+#  icon: "JobIconValet" # Frontier: JobIconServiceWorker<JobIconValet
+#  supervisors: job-supervisors-sr
+#  weight: 60 # Frontier
+#  displayWeight: 10 # Frontier
+#  canBeAntag: false
+#  access:
+#  - Maintenance
+#  - External # Frontier
+#  - Service
+#  - Frontier # Frontier
+#  special:
+#  - !type:AddImplantSpecial
+#    implants: [ MindShieldImplant ]
+#  - !type:GiveItemOnHolidaySpecial # Frontier
+#    holiday: FrontierBirthday # Frontier
+#    prototype: FrontierBirthdayGift # Frontier
+#
 # Frontier: valet loadout
-- type: startingGear
-  id: ValetGear
-  equipment:
-    head: ClothingHeadHatBellhop
-    gloves: ClothingHandsGlovesColorWhite
-    id: ValetPDA
-  storage:
-    back:
-    - EncryptionKeyService # Frontier
-    - ShipVoucherFrontierValet
+#- type: startingGear
+#  id: ValetGear
+#  equipment:
+#    head: ClothingHeadHatBellhop
+#    gloves: ClothingHandsGlovesColorWhite
+#    id: ValetPDA
+#  storage:
+#    back:
+#    - EncryptionKeyService # Frontier
+#    - ShipVoucherFrontierValet
 # End Frontier

--- a/Resources/Prototypes/Nyanotrasen/Roles/play_time_trackers.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/play_time_trackers.yml
@@ -5,8 +5,5 @@
   id: JobPrisoner
 
 - type: playTimeTracker
-  id: JobValet
-
-- type: playTimeTracker
   id: JobPrisonGuard
 

--- a/Resources/Prototypes/_NF/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_NF/Loadouts/role_loadouts.yml
@@ -76,28 +76,6 @@
   - ContractorBureaucracy
   - NFSpeciesSpecific
 
-# Frontier
-- type: roleLoadout
-  id: JobValet
-  groups:
-  - ContractorNeck
-  - ValetJumpsuit
-  - ContractorBackpack
-  - ValetOuterClothing
-  - ContractorShoes
-  - ContractorFace
-  - ContractorGlasses
-  - ContractorBelt
-  - ContractorEars
-  - ContractorEncryptionKey
-  - ContractorBoxSurvival
-  - ContractorCartridge
-  - ContractorImplanter
-  - ContractorFun
-  - ContractorTrinkets
-  - ContractorBureaucracy
-  - NFSpeciesSpecific
-
 - type: roleLoadout
   id: JobNFJanitor
   groups:

--- a/Resources/Prototypes/_NF/Maps/Outpost/frontier.yml
+++ b/Resources/Prototypes/_NF/Maps/Outpost/frontier.yml
@@ -28,7 +28,6 @@
             StationRepresentative: [ 1, 1 ]
             StationTrafficController: [ 1, 1 ]
             SecurityGuard: [ 1, 1 ]
-            Valet: [ 1, 1 ]
             NFJanitor: [ 1, 1 ]
             MailCarrier: [ 1, 1 ]
 # Others:

--- a/Resources/Prototypes/_NF/Maps/debug.yml
+++ b/Resources/Prototypes/_NF/Maps/debug.yml
@@ -17,7 +17,6 @@
             StationRepresentative: [ -1, -1 ]
             StationTrafficController: [ -1, -1 ]
             SecurityGuard: [ -1, -1 ]
-            Valet: [ -1, -1 ]
             NFJanitor: [ -1, -1 ]
             MailCarrier: [ -1, -1 ]
             Sheriff: [ -1, -1]

--- a/Resources/Prototypes/_NF/Roles/Jobs/departments.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/departments.yml
@@ -8,7 +8,7 @@
   - StationRepresentative
   - DirectorOfCare
   - StationTrafficController
-  - Valet # nyano
+#  - Valet # nyano
   - NFJanitor
   - MailCarrier # nyano
   - SecurityGuard

--- a/Resources/Prototypes/_NF/Roles/Jobs/departments.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/departments.yml
@@ -8,7 +8,6 @@
   - StationRepresentative
   - DirectorOfCare
   - StationTrafficController
-#  - Valet # nyano
   - NFJanitor
   - MailCarrier # nyano
   - SecurityGuard

--- a/Resources/Prototypes/_NF/StatusIcon/job.yml
+++ b/Resources/Prototypes/_NF/StatusIcon/job.yml
@@ -69,14 +69,6 @@
   jobName: job-name-station-traffic-controller
   allowSelection: false # Frontier: no impersonating command staff, literally 1984
 
-- type: jobIcon
-  parent: JobIcon
-  id: JobIconValet
-  icon:
-    sprite: /Textures/_NF/Interface/Misc/job_icons.rsi
-    state: valet
-  jobName: job-name-valet
-
 # NFSD positions
 
 - type: jobIcon


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Title, remove the valet job forever never to be seen, their body dumped to the cold vastness of space.

This job gave its utility while it could, it died the day cargo was removed from frontier and has become a sit down and RP to teach people simulator, something that the station guard cannot do while doing it way better so this role has become nothing else but bloat and can be perfectly removed to give more stuff to the station guards to go.

This is is a draft while i just take down most of their code little by little.

**Changelog**

:cl: Leander
- remove: Removed Valet Job

