### PR TITLE
Fix asteroid and wreck parenting.

### DIFF
--- a/Resources/Prototypes/_NF/Entities/World/Debris/asteroids.yml
+++ b/Resources/Prototypes/_NF/Entities/World/Debris/asteroids.yml
@@ -246,7 +246,7 @@
 
 # region Asteroid Sizes
 - type: entity
-  id: NFBaseDebrisSmall
+  id: NFBaseAsteroidSmall
   name: asteroid debris small
   abstract: true
   components:
@@ -255,7 +255,7 @@
       radius: 6
 
 - type: entity
-  id: NFBaseDebrisMedium
+  id: NFBaseAsteroidMedium
   name: asteroid debris medium
   categories: [ HideSpawnMenu ]
   abstract: true
@@ -265,7 +265,7 @@
       radius: 8
 
 - type: entity
-  id: NFBaseDebrisLarge
+  id: NFBaseAsteroidLarge
   name: asteroid debris large
   categories: [ HideSpawnMenu ]
   abstract: true
@@ -275,7 +275,7 @@
       radius: 10
 
 - type: entity
-  id: NFBaseDebrisExtraLarge
+  id: NFBaseAsteroidExtraLarge
   name: asteroid debris extra large
   categories: [ HideSpawnMenu ]
   abstract: true
@@ -285,7 +285,7 @@
       radius: 12
 
 - type: entity
-  id: NFBaseDebrisHuge
+  id: NFBaseAsteroidHuge
   name: asteroid debris huge
   categories: [ HideSpawnMenu ]
   abstract: true
@@ -295,7 +295,7 @@
       radius: 16
 
 - type: entity
-  id: NFBaseDebrisExtraHuge
+  id: NFBaseAsteroidExtraHuge
   name: asteroid debris extra huge
   categories: [ HideSpawnMenu ]
   abstract: true
@@ -305,7 +305,7 @@
       radius: 18
 
 - type: entity
-  id: NFBaseDebrisEnormous
+  id: NFBaseAsteroidEnormous
   name: asteroid debris enormous
   categories: [ HideSpawnMenu ]
   abstract: true
@@ -315,7 +315,7 @@
       radius: 20
 
 - type: entity
-  id: NFBaseDebrisExtraEnormous
+  id: NFBaseAsteroidExtraEnormous
   name: asteroid debris extra enormous
   categories: [ HideSpawnMenu ]
   abstract: true
@@ -325,7 +325,7 @@
       radius: 22
 
 - type: entity
-  id: NFBaseDebrisMassive
+  id: NFBaseAsteroidMassive
   name: asteroid debris massive
   categories: [ HideSpawnMenu ]
   abstract: true
@@ -335,7 +335,7 @@
       radius: 24
 
 - type: entity
-  id: NFBaseDebrisExtraMassive
+  id: NFBaseAsteroidExtraMassive
   name: asteroid debris extra massive
   categories: [ HideSpawnMenu ]
   abstract: true
@@ -345,7 +345,7 @@
       radius: 24
 
 - type: entity
-  id: NFBaseDebrisGigantic
+  id: NFBaseAsteroidGigantic
   name: asteroid debris gigantic
   categories: [ HideSpawnMenu ]
   abstract: true
@@ -355,7 +355,7 @@
       radius: 26
 
 - type: entity
-  id: NFBaseDebrisExtraGigantic
+  id: NFBaseAsteroidExtraGigantic
   name: asteroid debris extra gigantic
   categories: [ HideSpawnMenu ]
   abstract: true
@@ -368,507 +368,495 @@
 # region Asteroid Entities
 - type: entity
   id: NFAsteroidDebrisSmall
-  parent: [NFBaseAsteroidDebris, NFBaseDebrisSmall]
-  name: asteroid debris small
+  parent: [NFBaseAsteroidDebris, NFBaseAsteroidSmall]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidDebrisMedium
-  parent: [NFBaseAsteroidDebris, NFBaseDebrisMedium]
-  name: asteroid debris medium
+  parent: [NFBaseAsteroidDebris, NFBaseAsteroidMedium]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidDebrisLarge
-  parent: [NFBaseAsteroidDebris, NFBaseDebrisLarge]
-  name: asteroid debris large
+  parent: [NFBaseAsteroidDebris, NFBaseAsteroidLarge]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidDebrisExtraLarge
-  parent: [NFBaseAsteroidDebris, NFBaseDebrisExtraLarge]
-  name: asteroid debris extra large
+  parent: [NFBaseAsteroidDebris, NFBaseAsteroidExtraLarge]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidDebrisHuge
-  parent: [NFBaseAsteroidDebris, NFBaseDebrisHuge]
-  name: asteroid debris huge
+  parent: [NFBaseAsteroidDebris, NFBaseAsteroidHuge]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidDebrisExtraHuge
-  parent: [NFBaseAsteroidDebris, NFBaseDebrisExtraHuge]
-  name: asteroid debris extra huge
+  parent: [NFBaseAsteroidDebris, NFBaseAsteroidExtraHuge]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidDebrisEnormous
-  parent: [NFBaseAsteroidDebris, NFBaseDebrisEnormous]
-  name: asteroid debris enormous
+  parent: [NFBaseAsteroidDebris, NFBaseAsteroidEnormous]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidDebrisExtraEnormous
-  parent: [NFBaseAsteroidDebris, NFBaseDebrisEnormous]
-  name: asteroid debris extra enormous
+  parent: [NFBaseAsteroidDebris, NFBaseAsteroidEnormous]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidDebrisMassive
-  parent: [NFBaseAsteroidDebris, NFBaseDebrisMassive]
-  name: asteroid debris massive
+  parent: [NFBaseAsteroidDebris, NFBaseAsteroidMassive]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidDebrisExtraMassive
-  parent: [NFBaseAsteroidDebris, NFBaseDebrisExtraMassive]
-  name: asteroid debris extra massive
+  parent: [NFBaseAsteroidDebris, NFBaseAsteroidExtraMassive]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidDebrisGigantic
-  parent: [NFBaseAsteroidDebris, NFBaseDebrisGigantic]
-  name: asteroid debris gigantic
+  parent: [NFBaseAsteroidDebris, NFBaseAsteroidGigantic]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidDebrisExtraGigantic
-  parent: [NFBaseAsteroidDebris, NFBaseDebrisExtraGigantic]
-  name: asteroid debris extra gigantic
+  parent: [NFBaseAsteroidDebris, NFBaseAsteroidExtraGigantic]
   categories: [ HideSpawnMenu ]
 # endregion Asteroid Entities
 
 # region Ice Entities
 - type: entity
   id: NFAsteroidIceDebrisSmall
-  parent: [NFBaseAsteroidIceDebris, NFBaseDebrisSmall]
+  parent: [NFBaseAsteroidIceDebris, NFBaseAsteroidSmall]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidIceDebrisMedium
-  parent: [NFBaseAsteroidIceDebris, NFBaseDebrisMedium]
+  parent: [NFBaseAsteroidIceDebris, NFBaseAsteroidMedium]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidIceDebrisLarge
-  parent: [NFBaseAsteroidIceDebris, NFBaseDebrisLarge]
+  parent: [NFBaseAsteroidIceDebris, NFBaseAsteroidLarge]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidIceDebrisExtraLarge
-  parent: [NFBaseAsteroidIceDebris, NFBaseDebrisExtraLarge]
+  parent: [NFBaseAsteroidIceDebris, NFBaseAsteroidExtraLarge]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidIceDebrisHuge
-  parent: [NFBaseAsteroidIceDebris, NFBaseDebrisHuge]
+  parent: [NFBaseAsteroidIceDebris, NFBaseAsteroidHuge]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidIceDebrisExtraHuge
-  parent: [NFBaseAsteroidIceDebris, NFBaseDebrisExtraHuge]
+  parent: [NFBaseAsteroidIceDebris, NFBaseAsteroidExtraHuge]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidIceDebrisEnormous
-  parent: [NFBaseAsteroidIceDebris, NFBaseDebrisEnormous]
+  parent: [NFBaseAsteroidIceDebris, NFBaseAsteroidEnormous]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidIceDebrisExtraEnormous
-  parent: [NFBaseAsteroidIceDebris, NFBaseDebrisExtraEnormous]
+  parent: [NFBaseAsteroidIceDebris, NFBaseAsteroidExtraEnormous]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidIceDebrisMassive
-  parent: [NFBaseAsteroidIceDebris, NFBaseDebrisMassive]
+  parent: [NFBaseAsteroidIceDebris, NFBaseAsteroidMassive]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidIceDebrisExtraMassive
-  parent: [NFBaseAsteroidIceDebris, NFBaseDebrisExtraMassive]
+  parent: [NFBaseAsteroidIceDebris, NFBaseAsteroidExtraMassive]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidIceDebrisGigantic
-  parent: [NFBaseAsteroidIceDebris, NFBaseDebrisGigantic]
+  parent: [NFBaseAsteroidIceDebris, NFBaseAsteroidGigantic]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidIceDebrisExtraGigantic
-  parent: [NFBaseAsteroidIceDebris, NFBaseDebrisExtraGigantic]
+  parent: [NFBaseAsteroidIceDebris, NFBaseAsteroidExtraGigantic]
   categories: [ HideSpawnMenu ]
 # endregion Ice Entities
 
 # region Andesite Entities
 - type: entity
   id: NFAsteroidAndesiteDebrisSmall
-  parent: [NFBaseAsteroidAndesiteDebris, NFBaseDebrisSmall]
+  parent: [NFBaseAsteroidAndesiteDebris, NFBaseAsteroidSmall]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidAndesiteDebrisMedium
-  parent: [NFBaseAsteroidAndesiteDebris, NFBaseDebrisMedium]
+  parent: [NFBaseAsteroidAndesiteDebris, NFBaseAsteroidMedium]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidAndesiteDebrisLarge
-  parent: [NFBaseAsteroidAndesiteDebris, NFBaseDebrisLarge]
+  parent: [NFBaseAsteroidAndesiteDebris, NFBaseAsteroidLarge]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidAndesiteDebrisExtraLarge
-  parent: [NFBaseAsteroidAndesiteDebris, NFBaseDebrisExtraLarge]
+  parent: [NFBaseAsteroidAndesiteDebris, NFBaseAsteroidExtraLarge]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidAndesiteDebrisHuge
-  parent: [NFBaseAsteroidAndesiteDebris, NFBaseDebrisHuge]
+  parent: [NFBaseAsteroidAndesiteDebris, NFBaseAsteroidHuge]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidAndesiteDebrisExtraHuge
-  parent: [NFBaseAsteroidAndesiteDebris, NFBaseDebrisExtraHuge]
+  parent: [NFBaseAsteroidAndesiteDebris, NFBaseAsteroidExtraHuge]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidAndesiteDebrisEnormous
-  parent: [NFBaseAsteroidAndesiteDebris, NFBaseDebrisEnormous]
+  parent: [NFBaseAsteroidAndesiteDebris, NFBaseAsteroidEnormous]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidAndesiteDebrisExtraEnormous
-  parent: [NFBaseAsteroidAndesiteDebris, NFBaseDebrisExtraEnormous]
+  parent: [NFBaseAsteroidAndesiteDebris, NFBaseAsteroidExtraEnormous]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidAndesiteDebrisMassive
-  parent: [NFBaseAsteroidAndesiteDebris, NFBaseDebrisMassive]
+  parent: [NFBaseAsteroidAndesiteDebris, NFBaseAsteroidMassive]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidAndesiteDebrisExtraMassive
-  parent: [NFBaseAsteroidAndesiteDebris, NFBaseDebrisExtraMassive]
+  parent: [NFBaseAsteroidAndesiteDebris, NFBaseAsteroidExtraMassive]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidAndesiteDebrisGigantic
-  parent: [NFBaseAsteroidAndesiteDebris, NFBaseDebrisGigantic]
+  parent: [NFBaseAsteroidAndesiteDebris, NFBaseAsteroidGigantic]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidAndesiteDebrisExtraGigantic
-  parent: [NFBaseAsteroidAndesiteDebris, NFBaseDebrisExtraGigantic]
+  parent: [NFBaseAsteroidAndesiteDebris, NFBaseAsteroidExtraGigantic]
   categories: [ HideSpawnMenu ]
 # endregion Andesite Entities
 
 # region Basalt Entities
 - type: entity
   id: NFAsteroidBasaltDebrisSmall
-  parent: [NFBaseAsteroidBasaltDebris, NFBaseDebrisSmall]
+  parent: [NFBaseAsteroidBasaltDebris, NFBaseAsteroidSmall]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidBasaltDebrisMedium
-  parent: [NFBaseAsteroidBasaltDebris, NFBaseDebrisMedium]
+  parent: [NFBaseAsteroidBasaltDebris, NFBaseAsteroidMedium]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidBasaltDebrisLarge
-  parent: [NFBaseAsteroidBasaltDebris, NFBaseDebrisLarge]
+  parent: [NFBaseAsteroidBasaltDebris, NFBaseAsteroidLarge]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidBasaltDebrisExtraLarge
-  parent: [NFBaseAsteroidBasaltDebris, NFBaseDebrisExtraLarge]
+  parent: [NFBaseAsteroidBasaltDebris, NFBaseAsteroidExtraLarge]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidBasaltDebrisHuge
-  parent: [NFBaseAsteroidBasaltDebris, NFBaseDebrisHuge]
+  parent: [NFBaseAsteroidBasaltDebris, NFBaseAsteroidHuge]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidBasaltDebrisExtraHuge
-  parent: [NFBaseAsteroidBasaltDebris, NFBaseDebrisExtraHuge]
+  parent: [NFBaseAsteroidBasaltDebris, NFBaseAsteroidExtraHuge]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidBasaltDebrisEnormous
-  parent: [NFBaseAsteroidBasaltDebris, NFBaseDebrisEnormous]
+  parent: [NFBaseAsteroidBasaltDebris, NFBaseAsteroidEnormous]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidBasaltDebrisExtraEnormous
-  parent: [NFBaseAsteroidBasaltDebris, NFBaseDebrisExtraEnormous]
+  parent: [NFBaseAsteroidBasaltDebris, NFBaseAsteroidExtraEnormous]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidBasaltDebrisMassive
-  parent: [NFBaseAsteroidBasaltDebris, NFBaseDebrisMassive]
+  parent: [NFBaseAsteroidBasaltDebris, NFBaseAsteroidMassive]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidBasaltDebrisExtraMassive
-  parent: [NFBaseAsteroidBasaltDebris, NFBaseDebrisExtraMassive]
+  parent: [NFBaseAsteroidBasaltDebris, NFBaseAsteroidExtraMassive]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidBasaltDebrisGigantic
-  parent: [NFBaseAsteroidBasaltDebris, NFBaseDebrisGigantic]
+  parent: [NFBaseAsteroidBasaltDebris, NFBaseAsteroidGigantic]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidBasaltDebrisExtraGigantic
-  parent: [NFBaseAsteroidBasaltDebris, NFBaseDebrisExtraGigantic]
+  parent: [NFBaseAsteroidBasaltDebris, NFBaseAsteroidExtraGigantic]
   categories: [ HideSpawnMenu ]
 # endregion Basalt Entities
 
 # region Sand Entities
 - type: entity
   id: NFAsteroidSandDebrisSmall
-  parent: [NFBaseAsteroidSandDebris, NFBaseDebrisSmall]
+  parent: [NFBaseAsteroidSandDebris, NFBaseAsteroidSmall]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidSandDebrisMedium
-  parent: [NFBaseAsteroidSandDebris, NFBaseDebrisMedium]
+  parent: [NFBaseAsteroidSandDebris, NFBaseAsteroidMedium]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidSandDebrisLarge
-  parent: [NFBaseAsteroidSandDebris, NFBaseDebrisLarge]
+  parent: [NFBaseAsteroidSandDebris, NFBaseAsteroidLarge]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidSandDebrisExtraLarge
-  parent: [NFBaseAsteroidSandDebris, NFBaseDebrisExtraLarge]
+  parent: [NFBaseAsteroidSandDebris, NFBaseAsteroidExtraLarge]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidSandDebrisHuge
-  parent: [NFBaseAsteroidSandDebris, NFBaseDebrisHuge]
+  parent: [NFBaseAsteroidSandDebris, NFBaseAsteroidHuge]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidSandDebrisExtraHuge
-  parent: [NFBaseAsteroidSandDebris, NFBaseDebrisExtraHuge]
+  parent: [NFBaseAsteroidSandDebris, NFBaseAsteroidExtraHuge]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidSandDebrisEnormous
-  parent: [NFBaseAsteroidSandDebris, NFBaseDebrisEnormous]
+  parent: [NFBaseAsteroidSandDebris, NFBaseAsteroidEnormous]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidSandDebrisExtraEnormous
-  parent: [NFBaseAsteroidSandDebris, NFBaseDebrisExtraEnormous]
+  parent: [NFBaseAsteroidSandDebris, NFBaseAsteroidExtraEnormous]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidSandDebrisMassive
-  parent: [NFBaseAsteroidSandDebris, NFBaseDebrisMassive]
+  parent: [NFBaseAsteroidSandDebris, NFBaseAsteroidMassive]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidSandDebrisExtraMassive
-  parent: [NFBaseAsteroidSandDebris, NFBaseDebrisExtraMassive]
+  parent: [NFBaseAsteroidSandDebris, NFBaseAsteroidExtraMassive]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidSandDebrisGigantic
-  parent: [NFBaseAsteroidSandDebris, NFBaseDebrisGigantic]
+  parent: [NFBaseAsteroidSandDebris, NFBaseAsteroidGigantic]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidSandDebrisExtraGigantic
-  parent: [NFBaseAsteroidSandDebris, NFBaseDebrisExtraGigantic]
+  parent: [NFBaseAsteroidSandDebris, NFBaseAsteroidExtraGigantic]
   categories: [ HideSpawnMenu ]
 # endregion Sand Entities
 
 # region Chromite Entities
 - type: entity
   id: NFAsteroidChromiteDebrisSmall
-  parent: [NFBaseAsteroidChromiteDebris, NFBaseDebrisSmall]
+  parent: [NFBaseAsteroidChromiteDebris, NFBaseAsteroidSmall]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidChromiteDebrisMedium
-  parent: [NFBaseAsteroidChromiteDebris, NFBaseDebrisMedium]
+  parent: [NFBaseAsteroidChromiteDebris, NFBaseAsteroidMedium]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidChromiteDebrisLarge
-  parent: [NFBaseAsteroidChromiteDebris, NFBaseDebrisLarge]
+  parent: [NFBaseAsteroidChromiteDebris, NFBaseAsteroidLarge]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidChromiteDebrisExtraLarge
-  parent: [NFBaseAsteroidChromiteDebris, NFBaseDebrisExtraLarge]
+  parent: [NFBaseAsteroidChromiteDebris, NFBaseAsteroidExtraLarge]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidChromiteDebrisHuge
-  parent: [NFBaseAsteroidChromiteDebris, NFBaseDebrisHuge]
+  parent: [NFBaseAsteroidChromiteDebris, NFBaseAsteroidHuge]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidChromiteDebrisExtraHuge
-  parent: [NFBaseAsteroidChromiteDebris, NFBaseDebrisExtraHuge]
+  parent: [NFBaseAsteroidChromiteDebris, NFBaseAsteroidExtraHuge]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidChromiteDebrisEnormous
-  parent: [NFBaseAsteroidChromiteDebris, NFBaseDebrisEnormous]
+  parent: [NFBaseAsteroidChromiteDebris, NFBaseAsteroidEnormous]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidChromiteDebrisExtraEnormous
-  parent: [NFBaseAsteroidChromiteDebris, NFBaseDebrisExtraEnormous]
+  parent: [NFBaseAsteroidChromiteDebris, NFBaseAsteroidExtraEnormous]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidChromiteDebrisMassive
-  parent: [NFBaseAsteroidChromiteDebris, NFBaseDebrisMassive]
+  parent: [NFBaseAsteroidChromiteDebris, NFBaseAsteroidMassive]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidChromiteDebrisExtraMassive
-  parent: [NFBaseAsteroidChromiteDebris, NFBaseDebrisExtraMassive]
+  parent: [NFBaseAsteroidChromiteDebris, NFBaseAsteroidExtraMassive]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidChromiteDebrisGigantic
-  parent: [NFBaseAsteroidChromiteDebris, NFBaseDebrisGigantic]
+  parent: [NFBaseAsteroidChromiteDebris, NFBaseAsteroidGigantic]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidChromiteDebrisExtraGigantic
-  parent: [NFBaseAsteroidChromiteDebris, NFBaseDebrisExtraGigantic]
+  parent: [NFBaseAsteroidChromiteDebris, NFBaseAsteroidExtraGigantic]
   categories: [ HideSpawnMenu ]
 # endregion Chromite Entities
 
 # region AsteroidRock Entities
 - type: entity
   id: NFAsteroidRockDebrisSmall
-  parent: [NFBaseAsteroidRockDebris, NFBaseDebrisSmall]
+  parent: [NFBaseAsteroidRockDebris, NFBaseAsteroidSmall]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidRockDebrisMedium
-  parent: [NFBaseAsteroidRockDebris, NFBaseDebrisMedium]
+  parent: [NFBaseAsteroidRockDebris, NFBaseAsteroidMedium]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidRockDebrisLarge
-  parent: [NFBaseAsteroidRockDebris, NFBaseDebrisLarge]
+  parent: [NFBaseAsteroidRockDebris, NFBaseAsteroidLarge]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidRockDebrisExtraLarge
-  parent: [NFBaseAsteroidRockDebris, NFBaseDebrisExtraLarge]
+  parent: [NFBaseAsteroidRockDebris, NFBaseAsteroidExtraLarge]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidRockDebrisHuge
-  parent: [NFBaseAsteroidRockDebris, NFBaseDebrisHuge]
+  parent: [NFBaseAsteroidRockDebris, NFBaseAsteroidHuge]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidRockDebrisExtraHuge
-  parent: [NFBaseAsteroidRockDebris, NFBaseDebrisExtraHuge]
+  parent: [NFBaseAsteroidRockDebris, NFBaseAsteroidExtraHuge]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidRockDebrisEnormous
-  parent: [NFBaseAsteroidRockDebris, NFBaseDebrisEnormous]
+  parent: [NFBaseAsteroidRockDebris, NFBaseAsteroidEnormous]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidRockDebrisExtraEnormous
-  parent: [NFBaseAsteroidRockDebris, NFBaseDebrisExtraEnormous]
+  parent: [NFBaseAsteroidRockDebris, NFBaseAsteroidExtraEnormous]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidRockDebrisMassive
-  parent: [NFBaseAsteroidRockDebris, NFBaseDebrisMassive]
+  parent: [NFBaseAsteroidRockDebris, NFBaseAsteroidMassive]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidRockDebrisExtraMassive
-  parent: [NFBaseAsteroidRockDebris, NFBaseDebrisExtraMassive]
+  parent: [NFBaseAsteroidRockDebris, NFBaseAsteroidExtraMassive]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidRockDebrisGigantic
-  parent: [NFBaseAsteroidRockDebris, NFBaseDebrisGigantic]
+  parent: [NFBaseAsteroidRockDebris, NFBaseAsteroidGigantic]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidRockDebrisExtraGigantic
-  parent: [NFBaseAsteroidRockDebris, NFBaseDebrisExtraGigantic]
+  parent: [NFBaseAsteroidRockDebris, NFBaseAsteroidExtraGigantic]
   categories: [ HideSpawnMenu ]
 # endregion AsteroidRock Entities
 
 # region Scrap Entities
 - type: entity
   id: NFAsteroidScrapDebrisSmall
-  parent: [NFBaseAsteroidScrapDebris, NFBaseDebrisSmall]
+  parent: [NFBaseAsteroidScrapDebris, NFBaseAsteroidSmall]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidScrapDebrisMedium
-  parent: [NFBaseAsteroidScrapDebris, NFBaseDebrisMedium]
+  parent: [NFBaseAsteroidScrapDebris, NFBaseAsteroidMedium]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidScrapDebrisLarge
-  parent: [NFBaseAsteroidScrapDebris, NFBaseDebrisLarge]
+  parent: [NFBaseAsteroidScrapDebris, NFBaseAsteroidLarge]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidScrapDebrisExtraLarge
-  parent: [NFBaseAsteroidScrapDebris, NFBaseDebrisExtraLarge]
+  parent: [NFBaseAsteroidScrapDebris, NFBaseAsteroidExtraLarge]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidScrapDebrisHuge
-  parent: [NFBaseAsteroidScrapDebris, NFBaseDebrisHuge]
+  parent: [NFBaseAsteroidScrapDebris, NFBaseAsteroidHuge]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidScrapDebrisExtraHuge
-  parent: [NFBaseAsteroidScrapDebris, NFBaseDebrisExtraHuge]
+  parent: [NFBaseAsteroidScrapDebris, NFBaseAsteroidExtraHuge]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidScrapDebrisEnormous
-  parent: [NFBaseAsteroidScrapDebris, NFBaseDebrisEnormous]
+  parent: [NFBaseAsteroidScrapDebris, NFBaseAsteroidEnormous]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidScrapDebrisExtraEnormous
-  parent: [NFBaseAsteroidScrapDebris, NFBaseDebrisExtraEnormous]
+  parent: [NFBaseAsteroidScrapDebris, NFBaseAsteroidExtraEnormous]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidScrapDebrisMassive
-  parent: [NFBaseAsteroidScrapDebris, NFBaseDebrisMassive]
+  parent: [NFBaseAsteroidScrapDebris, NFBaseAsteroidMassive]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidScrapDebrisExtraMassive
-  parent: [NFBaseAsteroidScrapDebris, NFBaseDebrisExtraMassive]
+  parent: [NFBaseAsteroidScrapDebris, NFBaseAsteroidExtraMassive]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidScrapDebrisGigantic
-  parent: [NFBaseAsteroidScrapDebris, NFBaseDebrisGigantic]
+  parent: [NFBaseAsteroidScrapDebris, NFBaseAsteroidGigantic]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidScrapDebrisExtraGigantic
-  parent: [NFBaseAsteroidScrapDebris, NFBaseDebrisExtraGigantic]
+  parent: [NFBaseAsteroidScrapDebris, NFBaseAsteroidExtraGigantic]
   categories: [ HideSpawnMenu ]
 # endregion Scrap Entities

--- a/Resources/Prototypes/_NF/Entities/World/Debris/asteroids.yml
+++ b/Resources/Prototypes/_NF/Entities/World/Debris/asteroids.yml
@@ -244,558 +244,631 @@
       color: "#fcdec7"
 # endregion Scrap Table
 
-# region Asteroid Entities
+# region Asteroid Sizes
 - type: entity
-  id: NFAsteroidDebrisSmall
-  parent: NFBaseAsteroidDebris
+  id: NFBaseDebrisSmall
   name: asteroid debris small
-  categories: [ HideSpawnMenu ]
+  abstract: true
   components:
     - type: BlobFloorPlanBuilder
       floorPlacements: 16
       radius: 6
 
 - type: entity
-  id: NFAsteroidDebrisMedium
-  parent: NFBaseAsteroidDebris
+  id: NFBaseDebrisMedium
   name: asteroid debris medium
   categories: [ HideSpawnMenu ]
+  abstract: true
   components:
     - type: BlobFloorPlanBuilder
       floorPlacements: 24
       radius: 8
 
 - type: entity
-  id: NFAsteroidDebrisLarge
-  parent: NFBaseAsteroidDebris
+  id: NFBaseDebrisLarge
   name: asteroid debris large
   categories: [ HideSpawnMenu ]
+  abstract: true
   components:
     - type: BlobFloorPlanBuilder
       floorPlacements: 36
       radius: 10
 
 - type: entity
-  id: NFAsteroidDebrisExtraLarge
-  parent: NFBaseAsteroidDebris
+  id: NFBaseDebrisExtraLarge
   name: asteroid debris extra large
   categories: [ HideSpawnMenu ]
+  abstract: true
   components:
     - type: BlobFloorPlanBuilder
       floorPlacements: 52
       radius: 12
 
 - type: entity
-  id: NFAsteroidDebrisHuge
-  parent: NFBaseAsteroidDebris
+  id: NFBaseDebrisHuge
   name: asteroid debris huge
   categories: [ HideSpawnMenu ]
+  abstract: true
   components:
     - type: BlobFloorPlanBuilder
       floorPlacements: 72
       radius: 16
 
 - type: entity
-  id: NFAsteroidDebrisExtraHuge
-  parent: NFBaseAsteroidDebris
+  id: NFBaseDebrisExtraHuge
   name: asteroid debris extra huge
   categories: [ HideSpawnMenu ]
+  abstract: true
   components:
     - type: BlobFloorPlanBuilder
       floorPlacements: 96
       radius: 18
 
 - type: entity
-  id: NFAsteroidDebrisEnormous
-  parent: NFBaseAsteroidDebris
+  id: NFBaseDebrisEnormous
   name: asteroid debris enormous
   categories: [ HideSpawnMenu ]
+  abstract: true
   components:
     - type: BlobFloorPlanBuilder
       floorPlacements: 124
       radius: 20
 
 - type: entity
-  id: NFAsteroidDebrisExtraEnormous
-  parent: NFBaseAsteroidDebris
+  id: NFBaseDebrisExtraEnormous
   name: asteroid debris extra enormous
   categories: [ HideSpawnMenu ]
+  abstract: true
   components:
     - type: BlobFloorPlanBuilder
       floorPlacements: 156
       radius: 22
 
 - type: entity
-  id: NFAsteroidDebrisMassive
-  parent: NFBaseAsteroidDebris
+  id: NFBaseDebrisMassive
   name: asteroid debris massive
   categories: [ HideSpawnMenu ]
+  abstract: true
   components:
     - type: BlobFloorPlanBuilder
       floorPlacements: 192
       radius: 24
 
 - type: entity
-  id: NFAsteroidDebrisExtraMassive
-  parent: NFBaseAsteroidDebris
+  id: NFBaseDebrisExtraMassive
   name: asteroid debris extra massive
   categories: [ HideSpawnMenu ]
+  abstract: true
   components:
     - type: BlobFloorPlanBuilder
       floorPlacements: 232
       radius: 24
 
 - type: entity
-  id: NFAsteroidDebrisGigantic
-  parent: NFBaseAsteroidDebris
+  id: NFBaseDebrisGigantic
   name: asteroid debris gigantic
   categories: [ HideSpawnMenu ]
+  abstract: true
   components:
     - type: BlobFloorPlanBuilder
       floorPlacements: 276
       radius: 26
 
 - type: entity
-  id: NFAsteroidDebrisExtraGigantic
-  parent: NFBaseAsteroidDebris
+  id: NFBaseDebrisExtraGigantic
   name: asteroid debris extra gigantic
   categories: [ HideSpawnMenu ]
+  abstract: true
   components:
     - type: BlobFloorPlanBuilder
       floorPlacements: 324
       radius: 28
+# endregion Asteroid Sizes
+
+# region Asteroid Entities
+- type: entity
+  id: NFAsteroidDebrisSmall
+  parent: [NFBaseAsteroidDebris, NFBaseDebrisSmall]
+  name: asteroid debris small
+  categories: [ HideSpawnMenu ]
+
+- type: entity
+  id: NFAsteroidDebrisMedium
+  parent: [NFBaseAsteroidDebris, NFBaseDebrisMedium]
+  name: asteroid debris medium
+  categories: [ HideSpawnMenu ]
+
+- type: entity
+  id: NFAsteroidDebrisLarge
+  parent: [NFBaseAsteroidDebris, NFBaseDebrisLarge]
+  name: asteroid debris large
+  categories: [ HideSpawnMenu ]
+
+- type: entity
+  id: NFAsteroidDebrisExtraLarge
+  parent: [NFBaseAsteroidDebris, NFBaseDebrisExtraLarge]
+  name: asteroid debris extra large
+  categories: [ HideSpawnMenu ]
+
+- type: entity
+  id: NFAsteroidDebrisHuge
+  parent: [NFBaseAsteroidDebris, NFBaseDebrisHuge]
+  name: asteroid debris huge
+  categories: [ HideSpawnMenu ]
+
+- type: entity
+  id: NFAsteroidDebrisExtraHuge
+  parent: [NFBaseAsteroidDebris, NFBaseDebrisExtraHuge]
+  name: asteroid debris extra huge
+  categories: [ HideSpawnMenu ]
+
+- type: entity
+  id: NFAsteroidDebrisEnormous
+  parent: [NFBaseAsteroidDebris, NFBaseDebrisEnormous]
+  name: asteroid debris enormous
+  categories: [ HideSpawnMenu ]
+
+- type: entity
+  id: NFAsteroidDebrisExtraEnormous
+  parent: [NFBaseAsteroidDebris, NFBaseDebrisEnormous]
+  name: asteroid debris extra enormous
+  categories: [ HideSpawnMenu ]
+
+- type: entity
+  id: NFAsteroidDebrisMassive
+  parent: [NFBaseAsteroidDebris, NFBaseDebrisMassive]
+  name: asteroid debris massive
+  categories: [ HideSpawnMenu ]
+
+- type: entity
+  id: NFAsteroidDebrisExtraMassive
+  parent: [NFBaseAsteroidDebris, NFBaseDebrisExtraMassive]
+  name: asteroid debris extra massive
+  categories: [ HideSpawnMenu ]
+
+- type: entity
+  id: NFAsteroidDebrisGigantic
+  parent: [NFBaseAsteroidDebris, NFBaseDebrisGigantic]
+  name: asteroid debris gigantic
+  categories: [ HideSpawnMenu ]
+
+- type: entity
+  id: NFAsteroidDebrisExtraGigantic
+  parent: [NFBaseAsteroidDebris, NFBaseDebrisExtraGigantic]
+  name: asteroid debris extra gigantic
+  categories: [ HideSpawnMenu ]
 # endregion Asteroid Entities
 
 # region Ice Entities
 - type: entity
   id: NFAsteroidIceDebrisSmall
-  parent: [NFBaseAsteroidIceDebris, NFAsteroidDebrisSmall]
+  parent: [NFBaseAsteroidIceDebris, NFBaseDebrisSmall]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidIceDebrisMedium
-  parent: [NFBaseAsteroidIceDebris, NFAsteroidDebrisMedium]
+  parent: [NFBaseAsteroidIceDebris, NFBaseDebrisMedium]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidIceDebrisLarge
-  parent: [NFBaseAsteroidIceDebris, NFAsteroidDebrisLarge]
+  parent: [NFBaseAsteroidIceDebris, NFBaseDebrisLarge]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidIceDebrisExtraLarge
-  parent: [NFBaseAsteroidIceDebris, NFAsteroidDebrisExtraLarge]
+  parent: [NFBaseAsteroidIceDebris, NFBaseDebrisExtraLarge]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidIceDebrisHuge
-  parent: [NFBaseAsteroidIceDebris, NFAsteroidDebrisHuge]
+  parent: [NFBaseAsteroidIceDebris, NFBaseDebrisHuge]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidIceDebrisExtraHuge
-  parent: [NFBaseAsteroidIceDebris, NFAsteroidDebrisExtraHuge]
+  parent: [NFBaseAsteroidIceDebris, NFBaseDebrisExtraHuge]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidIceDebrisEnormous
-  parent: [NFBaseAsteroidIceDebris, NFAsteroidDebrisEnormous]
+  parent: [NFBaseAsteroidIceDebris, NFBaseDebrisEnormous]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidIceDebrisExtraEnormous
-  parent: [NFBaseAsteroidIceDebris, NFAsteroidDebrisExtraEnormous]
+  parent: [NFBaseAsteroidIceDebris, NFBaseDebrisExtraEnormous]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidIceDebrisMassive
-  parent: [NFBaseAsteroidIceDebris, NFAsteroidDebrisMassive]
+  parent: [NFBaseAsteroidIceDebris, NFBaseDebrisMassive]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidIceDebrisExtraMassive
-  parent: [NFBaseAsteroidIceDebris, NFAsteroidDebrisExtraMassive]
+  parent: [NFBaseAsteroidIceDebris, NFBaseDebrisExtraMassive]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidIceDebrisGigantic
-  parent: [NFBaseAsteroidIceDebris, NFAsteroidDebrisGigantic]
+  parent: [NFBaseAsteroidIceDebris, NFBaseDebrisGigantic]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidIceDebrisExtraGigantic
-  parent: [NFBaseAsteroidIceDebris, NFAsteroidDebrisExtraGigantic]
+  parent: [NFBaseAsteroidIceDebris, NFBaseDebrisExtraGigantic]
   categories: [ HideSpawnMenu ]
 # endregion Ice Entities
 
 # region Andesite Entities
 - type: entity
   id: NFAsteroidAndesiteDebrisSmall
-  parent: [NFBaseAsteroidAndesiteDebris, NFAsteroidDebrisSmall]
+  parent: [NFBaseAsteroidAndesiteDebris, NFBaseDebrisSmall]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidAndesiteDebrisMedium
-  parent: [NFBaseAsteroidAndesiteDebris, NFAsteroidDebrisMedium]
+  parent: [NFBaseAsteroidAndesiteDebris, NFBaseDebrisMedium]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidAndesiteDebrisLarge
-  parent: [NFBaseAsteroidAndesiteDebris, NFAsteroidDebrisLarge]
+  parent: [NFBaseAsteroidAndesiteDebris, NFBaseDebrisLarge]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidAndesiteDebrisExtraLarge
-  parent: [NFBaseAsteroidAndesiteDebris, NFAsteroidDebrisExtraLarge]
+  parent: [NFBaseAsteroidAndesiteDebris, NFBaseDebrisExtraLarge]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidAndesiteDebrisHuge
-  parent: [NFBaseAsteroidAndesiteDebris, NFAsteroidDebrisHuge]
+  parent: [NFBaseAsteroidAndesiteDebris, NFBaseDebrisHuge]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidAndesiteDebrisExtraHuge
-  parent: [NFBaseAsteroidAndesiteDebris, NFAsteroidDebrisExtraHuge]
+  parent: [NFBaseAsteroidAndesiteDebris, NFBaseDebrisExtraHuge]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidAndesiteDebrisEnormous
-  parent: [NFBaseAsteroidAndesiteDebris, NFAsteroidDebrisEnormous]
+  parent: [NFBaseAsteroidAndesiteDebris, NFBaseDebrisEnormous]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidAndesiteDebrisExtraEnormous
-  parent: [NFBaseAsteroidAndesiteDebris, NFAsteroidDebrisExtraEnormous]
+  parent: [NFBaseAsteroidAndesiteDebris, NFBaseDebrisExtraEnormous]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidAndesiteDebrisMassive
-  parent: [NFBaseAsteroidAndesiteDebris, NFAsteroidDebrisMassive]
+  parent: [NFBaseAsteroidAndesiteDebris, NFBaseDebrisMassive]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidAndesiteDebrisExtraMassive
-  parent: [NFBaseAsteroidAndesiteDebris, NFAsteroidDebrisExtraMassive]
+  parent: [NFBaseAsteroidAndesiteDebris, NFBaseDebrisExtraMassive]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidAndesiteDebrisGigantic
-  parent: [NFBaseAsteroidAndesiteDebris, NFAsteroidDebrisGigantic]
+  parent: [NFBaseAsteroidAndesiteDebris, NFBaseDebrisGigantic]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidAndesiteDebrisExtraGigantic
-  parent: [NFBaseAsteroidAndesiteDebris, NFAsteroidDebrisExtraGigantic]
+  parent: [NFBaseAsteroidAndesiteDebris, NFBaseDebrisExtraGigantic]
   categories: [ HideSpawnMenu ]
 # endregion Andesite Entities
 
 # region Basalt Entities
 - type: entity
   id: NFAsteroidBasaltDebrisSmall
-  parent: [NFBaseAsteroidBasaltDebris, NFAsteroidDebrisSmall]
+  parent: [NFBaseAsteroidBasaltDebris, NFBaseDebrisSmall]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidBasaltDebrisMedium
-  parent: [NFBaseAsteroidBasaltDebris, NFAsteroidDebrisMedium]
+  parent: [NFBaseAsteroidBasaltDebris, NFBaseDebrisMedium]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidBasaltDebrisLarge
-  parent: [NFBaseAsteroidBasaltDebris, NFAsteroidDebrisLarge]
+  parent: [NFBaseAsteroidBasaltDebris, NFBaseDebrisLarge]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidBasaltDebrisExtraLarge
-  parent: [NFBaseAsteroidBasaltDebris, NFAsteroidDebrisExtraLarge]
+  parent: [NFBaseAsteroidBasaltDebris, NFBaseDebrisExtraLarge]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidBasaltDebrisHuge
-  parent: [NFBaseAsteroidBasaltDebris, NFAsteroidDebrisHuge]
+  parent: [NFBaseAsteroidBasaltDebris, NFBaseDebrisHuge]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidBasaltDebrisExtraHuge
-  parent: [NFBaseAsteroidBasaltDebris, NFAsteroidDebrisExtraHuge]
+  parent: [NFBaseAsteroidBasaltDebris, NFBaseDebrisExtraHuge]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidBasaltDebrisEnormous
-  parent: [NFBaseAsteroidBasaltDebris, NFAsteroidDebrisEnormous]
+  parent: [NFBaseAsteroidBasaltDebris, NFBaseDebrisEnormous]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidBasaltDebrisExtraEnormous
-  parent: [NFBaseAsteroidBasaltDebris, NFAsteroidDebrisExtraEnormous]
+  parent: [NFBaseAsteroidBasaltDebris, NFBaseDebrisExtraEnormous]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidBasaltDebrisMassive
-  parent: [NFBaseAsteroidBasaltDebris, NFAsteroidDebrisMassive]
+  parent: [NFBaseAsteroidBasaltDebris, NFBaseDebrisMassive]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidBasaltDebrisExtraMassive
-  parent: [NFBaseAsteroidBasaltDebris, NFAsteroidDebrisExtraMassive]
+  parent: [NFBaseAsteroidBasaltDebris, NFBaseDebrisExtraMassive]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidBasaltDebrisGigantic
-  parent: [NFBaseAsteroidBasaltDebris, NFAsteroidDebrisGigantic]
+  parent: [NFBaseAsteroidBasaltDebris, NFBaseDebrisGigantic]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidBasaltDebrisExtraGigantic
-  parent: [NFBaseAsteroidBasaltDebris, NFAsteroidDebrisExtraGigantic]
+  parent: [NFBaseAsteroidBasaltDebris, NFBaseDebrisExtraGigantic]
   categories: [ HideSpawnMenu ]
 # endregion Basalt Entities
 
 # region Sand Entities
 - type: entity
   id: NFAsteroidSandDebrisSmall
-  parent: [NFBaseAsteroidSandDebris, NFAsteroidDebrisSmall]
+  parent: [NFBaseAsteroidSandDebris, NFBaseDebrisSmall]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidSandDebrisMedium
-  parent: [NFBaseAsteroidSandDebris, NFAsteroidDebrisMedium]
+  parent: [NFBaseAsteroidSandDebris, NFBaseDebrisMedium]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidSandDebrisLarge
-  parent: [NFBaseAsteroidSandDebris, NFAsteroidDebrisLarge]
+  parent: [NFBaseAsteroidSandDebris, NFBaseDebrisLarge]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidSandDebrisExtraLarge
-  parent: [NFBaseAsteroidSandDebris, NFAsteroidDebrisExtraLarge]
+  parent: [NFBaseAsteroidSandDebris, NFBaseDebrisExtraLarge]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidSandDebrisHuge
-  parent: [NFBaseAsteroidSandDebris, NFAsteroidDebrisHuge]
+  parent: [NFBaseAsteroidSandDebris, NFBaseDebrisHuge]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidSandDebrisExtraHuge
-  parent: [NFBaseAsteroidSandDebris, NFAsteroidDebrisExtraHuge]
+  parent: [NFBaseAsteroidSandDebris, NFBaseDebrisExtraHuge]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidSandDebrisEnormous
-  parent: [NFBaseAsteroidSandDebris, NFAsteroidDebrisEnormous]
+  parent: [NFBaseAsteroidSandDebris, NFBaseDebrisEnormous]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidSandDebrisExtraEnormous
-  parent: [NFBaseAsteroidSandDebris, NFAsteroidDebrisExtraEnormous]
+  parent: [NFBaseAsteroidSandDebris, NFBaseDebrisExtraEnormous]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidSandDebrisMassive
-  parent: [NFBaseAsteroidSandDebris, NFAsteroidDebrisMassive]
+  parent: [NFBaseAsteroidSandDebris, NFBaseDebrisMassive]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidSandDebrisExtraMassive
-  parent: [NFBaseAsteroidSandDebris, NFAsteroidDebrisExtraMassive]
+  parent: [NFBaseAsteroidSandDebris, NFBaseDebrisExtraMassive]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidSandDebrisGigantic
-  parent: [NFBaseAsteroidSandDebris, NFAsteroidDebrisGigantic]
+  parent: [NFBaseAsteroidSandDebris, NFBaseDebrisGigantic]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidSandDebrisExtraGigantic
-  parent: [NFBaseAsteroidSandDebris, NFAsteroidDebrisExtraGigantic]
+  parent: [NFBaseAsteroidSandDebris, NFBaseDebrisExtraGigantic]
   categories: [ HideSpawnMenu ]
 # endregion Sand Entities
 
 # region Chromite Entities
 - type: entity
   id: NFAsteroidChromiteDebrisSmall
-  parent: [NFBaseAsteroidChromiteDebris, NFAsteroidDebrisSmall]
+  parent: [NFBaseAsteroidChromiteDebris, NFBaseDebrisSmall]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidChromiteDebrisMedium
-  parent: [NFBaseAsteroidChromiteDebris, NFAsteroidDebrisMedium]
+  parent: [NFBaseAsteroidChromiteDebris, NFBaseDebrisMedium]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidChromiteDebrisLarge
-  parent: [NFBaseAsteroidChromiteDebris, NFAsteroidDebrisLarge]
+  parent: [NFBaseAsteroidChromiteDebris, NFBaseDebrisLarge]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidChromiteDebrisExtraLarge
-  parent: [NFBaseAsteroidChromiteDebris, NFAsteroidDebrisExtraLarge]
+  parent: [NFBaseAsteroidChromiteDebris, NFBaseDebrisExtraLarge]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidChromiteDebrisHuge
-  parent: [NFBaseAsteroidChromiteDebris, NFAsteroidDebrisHuge]
+  parent: [NFBaseAsteroidChromiteDebris, NFBaseDebrisHuge]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidChromiteDebrisExtraHuge
-  parent: [NFBaseAsteroidChromiteDebris, NFAsteroidDebrisExtraHuge]
+  parent: [NFBaseAsteroidChromiteDebris, NFBaseDebrisExtraHuge]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidChromiteDebrisEnormous
-  parent: [NFBaseAsteroidChromiteDebris, NFAsteroidDebrisEnormous]
+  parent: [NFBaseAsteroidChromiteDebris, NFBaseDebrisEnormous]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidChromiteDebrisExtraEnormous
-  parent: [NFBaseAsteroidChromiteDebris, NFAsteroidDebrisExtraEnormous]
+  parent: [NFBaseAsteroidChromiteDebris, NFBaseDebrisExtraEnormous]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidChromiteDebrisMassive
-  parent: [NFBaseAsteroidChromiteDebris, NFAsteroidDebrisMassive]
+  parent: [NFBaseAsteroidChromiteDebris, NFBaseDebrisMassive]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidChromiteDebrisExtraMassive
-  parent: [NFBaseAsteroidChromiteDebris, NFAsteroidDebrisExtraMassive]
+  parent: [NFBaseAsteroidChromiteDebris, NFBaseDebrisExtraMassive]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidChromiteDebrisGigantic
-  parent: [NFBaseAsteroidChromiteDebris, NFAsteroidDebrisGigantic]
+  parent: [NFBaseAsteroidChromiteDebris, NFBaseDebrisGigantic]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidChromiteDebrisExtraGigantic
-  parent: [NFBaseAsteroidChromiteDebris, NFAsteroidDebrisExtraGigantic]
+  parent: [NFBaseAsteroidChromiteDebris, NFBaseDebrisExtraGigantic]
   categories: [ HideSpawnMenu ]
 # endregion Chromite Entities
 
 # region AsteroidRock Entities
 - type: entity
   id: NFAsteroidRockDebrisSmall
-  parent: [NFBaseAsteroidRockDebris, NFAsteroidDebrisSmall]
+  parent: [NFBaseAsteroidRockDebris, NFBaseDebrisSmall]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidRockDebrisMedium
-  parent: [NFBaseAsteroidRockDebris, NFAsteroidDebrisMedium]
+  parent: [NFBaseAsteroidRockDebris, NFBaseDebrisMedium]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidRockDebrisLarge
-  parent: [NFBaseAsteroidRockDebris, NFAsteroidDebrisLarge]
+  parent: [NFBaseAsteroidRockDebris, NFBaseDebrisLarge]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidRockDebrisExtraLarge
-  parent: [NFBaseAsteroidRockDebris, NFAsteroidDebrisExtraLarge]
+  parent: [NFBaseAsteroidRockDebris, NFBaseDebrisExtraLarge]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidRockDebrisHuge
-  parent: [NFBaseAsteroidRockDebris, NFAsteroidDebrisHuge]
+  parent: [NFBaseAsteroidRockDebris, NFBaseDebrisHuge]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidRockDebrisExtraHuge
-  parent: [NFBaseAsteroidRockDebris, NFAsteroidDebrisExtraHuge]
+  parent: [NFBaseAsteroidRockDebris, NFBaseDebrisExtraHuge]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidRockDebrisEnormous
-  parent: [NFBaseAsteroidRockDebris, NFAsteroidDebrisEnormous]
+  parent: [NFBaseAsteroidRockDebris, NFBaseDebrisEnormous]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidRockDebrisExtraEnormous
-  parent: [NFBaseAsteroidRockDebris, NFAsteroidDebrisExtraEnormous]
+  parent: [NFBaseAsteroidRockDebris, NFBaseDebrisExtraEnormous]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidRockDebrisMassive
-  parent: [NFBaseAsteroidRockDebris, NFAsteroidDebrisMassive]
+  parent: [NFBaseAsteroidRockDebris, NFBaseDebrisMassive]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidRockDebrisExtraMassive
-  parent: [NFBaseAsteroidRockDebris, NFAsteroidDebrisExtraMassive]
+  parent: [NFBaseAsteroidRockDebris, NFBaseDebrisExtraMassive]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidRockDebrisGigantic
-  parent: [NFBaseAsteroidRockDebris, NFAsteroidDebrisGigantic]
+  parent: [NFBaseAsteroidRockDebris, NFBaseDebrisGigantic]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidRockDebrisExtraGigantic
-  parent: [NFBaseAsteroidRockDebris, NFAsteroidDebrisExtraGigantic]
+  parent: [NFBaseAsteroidRockDebris, NFBaseDebrisExtraGigantic]
   categories: [ HideSpawnMenu ]
 # endregion AsteroidRock Entities
 
 # region Scrap Entities
 - type: entity
   id: NFAsteroidScrapDebrisSmall
-  parent: [NFBaseAsteroidScrapDebris, NFAsteroidDebrisSmall]
+  parent: [NFBaseAsteroidScrapDebris, NFBaseDebrisSmall]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidScrapDebrisMedium
-  parent: [NFBaseAsteroidScrapDebris, NFAsteroidDebrisMedium]
+  parent: [NFBaseAsteroidScrapDebris, NFBaseDebrisMedium]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidScrapDebrisLarge
-  parent: [NFBaseAsteroidScrapDebris, NFAsteroidDebrisLarge]
+  parent: [NFBaseAsteroidScrapDebris, NFBaseDebrisLarge]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidScrapDebrisExtraLarge
-  parent: [NFBaseAsteroidScrapDebris, NFAsteroidDebrisExtraLarge]
+  parent: [NFBaseAsteroidScrapDebris, NFBaseDebrisExtraLarge]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidScrapDebrisHuge
-  parent: [NFBaseAsteroidScrapDebris, NFAsteroidDebrisHuge]
+  parent: [NFBaseAsteroidScrapDebris, NFBaseDebrisHuge]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidScrapDebrisExtraHuge
-  parent: [NFBaseAsteroidScrapDebris, NFAsteroidDebrisExtraHuge]
+  parent: [NFBaseAsteroidScrapDebris, NFBaseDebrisExtraHuge]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidScrapDebrisEnormous
-  parent: [NFBaseAsteroidScrapDebris, NFAsteroidDebrisEnormous]
+  parent: [NFBaseAsteroidScrapDebris, NFBaseDebrisEnormous]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidScrapDebrisExtraEnormous
-  parent: [NFBaseAsteroidScrapDebris, NFAsteroidDebrisExtraEnormous]
+  parent: [NFBaseAsteroidScrapDebris, NFBaseDebrisExtraEnormous]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidScrapDebrisMassive
-  parent: [NFBaseAsteroidScrapDebris, NFAsteroidDebrisMassive]
+  parent: [NFBaseAsteroidScrapDebris, NFBaseDebrisMassive]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidScrapDebrisExtraMassive
-  parent: [NFBaseAsteroidScrapDebris, NFAsteroidDebrisExtraMassive]
+  parent: [NFBaseAsteroidScrapDebris, NFBaseDebrisExtraMassive]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidScrapDebrisGigantic
-  parent: [NFBaseAsteroidScrapDebris, NFAsteroidDebrisGigantic]
+  parent: [NFBaseAsteroidScrapDebris, NFBaseDebrisGigantic]
   categories: [ HideSpawnMenu ]
 
 - type: entity
   id: NFAsteroidScrapDebrisExtraGigantic
-  parent: [NFBaseAsteroidScrapDebris, NFAsteroidDebrisExtraGigantic]
+  parent: [NFBaseAsteroidScrapDebris, NFBaseDebrisExtraGigantic]
   categories: [ HideSpawnMenu ]
 # endregion Scrap Entities

--- a/Resources/Prototypes/_NF/Entities/World/Debris/asteroids.yml
+++ b/Resources/Prototypes/_NF/Entities/World/Debris/asteroids.yml
@@ -5,7 +5,6 @@
   parent: NFBaseDebris
   abstract: true
   components:
-    - type: MapGrid
     - type: BlobFloorPlanBuilder
       floorTileset:
       - FloorAsteroidSand
@@ -24,7 +23,6 @@
             orGroup: rock
             prob: 0.0002
     - type: IFF
-      flags: HideLabel
       color: "#d67e27"
     - type: RandomEntityPopulator
       entries: &gasDeposits
@@ -59,7 +57,7 @@
 # region Snow Table
 - type: entity
   id: NFBaseAsteroidIceDebris
-  parent: NFBaseAsteroidDebris
+  parent: NFBaseDebris
   abstract: true
   components:
     - type: BlobFloorPlanBuilder
@@ -87,7 +85,7 @@
 # region Andesite Table
 - type: entity
   id: NFBaseAsteroidAndesiteDebris
-  parent: NFBaseAsteroidDebris
+  parent: NFBaseDebris
   abstract: true
   components:
     - type: BlobFloorPlanBuilder
@@ -115,7 +113,7 @@
 # region Basalt Table
 - type: entity
   id: NFBaseAsteroidBasaltDebris
-  parent: NFBaseAsteroidDebris
+  parent: NFBaseDebris
   abstract: true
   components:
     - type: BlobFloorPlanBuilder
@@ -143,7 +141,7 @@
 # region Sand Table
 - type: entity
   id: NFBaseAsteroidSandDebris
-  parent: NFBaseAsteroidDebris
+  parent: NFBaseDebris
   abstract: true
   components:
     - type: BlobFloorPlanBuilder
@@ -171,7 +169,7 @@
 # region Chromite Table
 - type: entity
   id: NFBaseAsteroidChromiteDebris
-  parent: NFBaseAsteroidDebris
+  parent: NFBaseDebris
   abstract: true
   components:
     - type: BlobFloorPlanBuilder
@@ -199,7 +197,7 @@
 # region AsteroidRock Table
 - type: entity
   id: NFBaseAsteroidRockDebris
-  parent: NFBaseAsteroidDebris
+  parent: NFBaseDebris
   abstract: true
   components:
     - type: BlobFloorPlanBuilder
@@ -227,7 +225,7 @@
 # region Scrap Table
 - type: entity
   id: NFBaseAsteroidScrapDebris
-  parent: NFBaseAsteroidDebris
+  parent: NFBaseDebris
   abstract: true
   components:
     - type: BlobFloorPlanBuilder

--- a/Resources/Prototypes/_NF/Entities/World/Debris/base_debris.yml
+++ b/Resources/Prototypes/_NF/Entities/World/Debris/base_debris.yml
@@ -1,4 +1,5 @@
-﻿- type: entity
+﻿# A floating, singular grid, useful for space junk or asteroids
+- type: entity
   id: NFBaseDebris
   abstract: true
   components:
@@ -10,3 +11,6 @@
   - type: ProtectedGrid
     preventArtifactTriggers: true
   - type: PreventPilot
+  - type: MapGrid
+  - type: IFF
+    flags: HideLabel

--- a/Resources/Prototypes/_NF/Entities/World/Debris/base_debris.yml
+++ b/Resources/Prototypes/_NF/Entities/World/Debris/base_debris.yml
@@ -7,10 +7,10 @@
   - type: LocalityLoader
   - type: GCAbleObject
     queue: SpaceDebris
+  - type: MapGrid
   - type: LinkedLifecycleGridParent
   - type: ProtectedGrid
     preventArtifactTriggers: true
   - type: PreventPilot
-  - type: MapGrid
   - type: IFF
     flags: HideLabel

--- a/Resources/Prototypes/_NF/Entities/World/Debris/wrecks.yml
+++ b/Resources/Prototypes/_NF/Entities/World/Debris/wrecks.yml
@@ -1,5 +1,5 @@
 ﻿- type: entity
-  id: NFBaseScrapDebris
+  id: NFBaseWreckDebris
   parent: NFBaseDebris
   abstract: true
   components:
@@ -98,7 +98,7 @@
     color: "#88b0d1"
 
 - type: entity
-  id: NFBaseScrapDebrisBrass
+  id: NFBaseWreckDebrisBrass
   parent: NFBaseDebris
   abstract: true
   components:
@@ -159,77 +159,124 @@
   - type: IFF
     color: "#E1C16E"
 
+# region Wreck Sizes
 - type: entity
-  id: NFScrapDebrisSmall
-  parent: NFBaseScrapDebris
-  name: scrap debris small
+  id: NFBaseWreckSmall
+  name: wreck debris small
   categories: [ HideSpawnMenu ]
+  abstract: true
   components:
   - type: BlobFloorPlanBuilder
     floorPlacements: 52
     radius: 12
 
 - type: entity
-  id: NFScrapDebrisMedium
-  parent: NFBaseScrapDebris
-  name: scrap debris medium
+  id: NFBaseWreckMedium
+  name: wreck debris medium
   categories: [ HideSpawnMenu ]
+  abstract: true
   components:
   - type: BlobFloorPlanBuilder
     floorPlacements: 72
     radius: 14
 
 - type: entity
-  id: NFScrapDebrisLarge
-  parent: NFBaseScrapDebris
-  name: scrap debris large
+  id: NFBaseWreckLarge
+  name: wreck debris large
   categories: [ HideSpawnMenu ]
+  abstract: true
   components:
   - type: BlobFloorPlanBuilder
     floorPlacements: 96
     radius: 16
 
 - type: entity
-  id: NFScrapDebrisExtraLarge
-  parent: NFBaseScrapDebris
-  name: scrap debris large extra large
+  id: NFBaseWreckExtraLarge
+  name: wreck debris large extra large
   categories: [ HideSpawnMenu ]
+  abstract: true
   components:
   - type: BlobFloorPlanBuilder
     floorPlacements: 124
     radius: 18
 
 - type: entity
-  id: NFScrapDebrisHuge
-  parent: NFBaseScrapDebris
-  name: scrap debris huge
+  id: NFBaseWreckHuge
+  name: wreck debris huge
   categories: [ HideSpawnMenu ]
+  abstract: true
   components:
   - type: BlobFloorPlanBuilder
     floorPlacements: 156
     radius: 20
 
 - type: entity
-  id: NFScrapDebrisExtraHuge
-  parent: NFBaseScrapDebris
-  name: scrap debris extra huge
+  id: NFBaseWreckExtraHuge
+  name: wreck debris extra huge
   categories: [ HideSpawnMenu ]
+  abstract: true
   components:
   - type: BlobFloorPlanBuilder
     floorPlacements: 192
     radius: 22
 
 - type: entity
-  id: NFScrapDebrisEnormous
-  parent: NFBaseScrapDebris
-  name: scrap debris enormous
+  id: NFBaseWreckEnormous
+  name: wreck debris enormous
   categories: [ HideSpawnMenu ]
+  abstract: true
   components:
   - type: BlobFloorPlanBuilder
     floorPlacements: 232
     radius: 24
+# endregion Wreck Sizes
+
+# region Wrecks
+- type: entity
+  id: NFWreckDebrisSmall
+  parent: [NFBaseWreckDebris, NFBaseWreckSmall]
+  categories: [ HideSpawnMenu ]
 
 - type: entity
-  id: NFScrapDebrisBrassLarge
-  parent: [NFBaseScrapDebrisBrass, NFScrapDebrisLarge]
+  id: NFWreckDebrisMedium
+  parent: [NFBaseWreckDebris, NFBaseWreckMedium]
   categories: [ HideSpawnMenu ]
+
+- type: entity
+  id: NFWreckDebrisLarge
+  parent: [NFBaseWreckDebris, NFBaseWreckLarge]
+  name: scrap debris large
+  categories: [ HideSpawnMenu ]
+
+- type: entity
+  id: NFWreckDebrisExtraLarge
+  parent: [NFBaseWreckDebris, NFBaseWreckExtraLarge]
+  categories: [ HideSpawnMenu ]
+
+- type: entity
+  id: NFWreckDebrisHuge
+  parent: [NFBaseWreckDebris, NFBaseWreckHuge]
+  categories: [ HideSpawnMenu ]
+
+- type: entity
+  id: NFWreckDebrisExtraHuge
+  parent: [NFBaseWreckDebris, NFBaseWreckExtraHuge]
+  categories: [ HideSpawnMenu ]
+
+- type: entity
+  id: NFWreckDebrisEnormous
+  parent: [NFBaseWreckDebris, NFBaseWreckEnormous]
+  categories: [ HideSpawnMenu ]
+# endregion Wrecks
+
+# region Brass Wrecks
+- type: entity
+  id: NFWreckDebrisBrassLarge
+  parent: [NFBaseWreckDebrisBrass, NFBaseWreckLarge]
+  categories: [ HideSpawnMenu ]
+
+- type: entity
+  id: NFWreckDebrisBrassExtraLarge
+  parent: [NFBaseWreckDebrisBrass, NFBaseWreckExtraLarge]
+  categories: [ HideSpawnMenu ]
+# endregion Brass Wrecks

--- a/Resources/Prototypes/_NF/Entities/World/Debris/wrecks.yml
+++ b/Resources/Prototypes/_NF/Entities/World/Debris/wrecks.yml
@@ -3,7 +3,6 @@
   parent: NFBaseDebris
   abstract: true
   components:
-  - type: MapGrid
   - type: BlobFloorPlanBuilder
     floorTileset:
       - Plating
@@ -96,12 +95,11 @@
         - id: GrilleBroken
           prob: 0.25
   - type: IFF
-    flags: HideLabel
     color: "#88b0d1"
 
 - type: entity
   id: NFBaseScrapDebrisBrass
-  parent: NFBaseScrapDebris
+  parent: NFBaseDebris
   abstract: true
   components:
   - type: BlobFloorPlanBuilder

--- a/Resources/Prototypes/_NF/World/Biomes/basic.yml
+++ b/Resources/Prototypes/_NF/World/Biomes/basic.yml
@@ -135,22 +135,24 @@
     - type: NoiseDrivenDebrisSelector
       noiseChannel: Wreck
       debrisTable:
-        # - id: NFScrapDebrisSmall
+        # - id: NFWreckDebrisSmall
           # prob: 1
-        # - id: NFScrapDebrisMedium
+        # - id: NFWreckDebrisMedium
           # prob: 1
-        # - id: NFScrapDebrisLarge
+        # - id: NFWreckDebrisLarge
           # prob: 1
-        - id: NFScrapDebrisExtraLarge
+        - id: NFWreckDebrisExtraLarge
           prob: 1
-        - id: NFScrapDebrisHuge
+        - id: NFWreckDebrisHuge
           prob: 0.6
-        - id: NFScrapDebrisExtraHuge
+        - id: NFWreckDebrisExtraHuge
           prob: 0.15
-        - id: NFScrapDebrisEnormous
+        - id: NFWreckDebrisEnormous
           prob: 0.08
-        - id: NFScrapDebrisBrassLarge
-          prob: 0.01
+        - id: NFWreckDebrisBrassLarge
+          prob: 0.008
+        - id: NFWreckDebrisBrassExtraLarge
+          prob: 0.002
     - type: NoiseRangeCarver
       ranges:
         - 0.4, 0.6


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Creates abstract entities for base wrecks/asteroid sizes that do not inherit from instances of wrecks/asteroids.

All concrete wrecks/asteroids inherit from an abstract size and an abstract biome/template with layout.

Added a rare(r) extra large brass wreck since we're in the neighbourhood.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Previous implementation had scrap asteroids inheriting off of the orange rock asteroid template twice, leading to gas deposits on scrap asteroids.

## How to test
<!-- Describe the way it can be tested -->

1. Spawn a gas deposit locator.
2. Spawn a bunch of scrap asteroids (they can overlap)
3. The locator should not ping when near them.
4. Repeat step 2 for rock asteroids.
5. The locator should (likely) ping when near them.
6. Spawn some wrecks, they should spawn as normal.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

Forks defining their own asteroid sets might need changes to deleted IDs.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Scrap asteroids no longer spawn with gas deposits.