### PR TITLE
Add desk bell to the service techfab.

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/lathe.yml
@@ -158,6 +158,7 @@
       - ClothingHeadHatCone
       - FireExtinguisher
       - WetFloorSign
+      - DeskBell
     dynamicRecipes:
     # Shared lathe recipes
     ## Advanced tools
@@ -566,7 +567,7 @@
       - PowerCageRechargerCircuitboard
       - PowerCageHigh
       - PowerCageMedium
-      - PowerCageSmall 
+      - PowerCageSmall
     dynamicRecipes:
       - BoxShellTranquilizer
       - ExplosivePayload

--- a/Resources/Prototypes/_NF/Recipes/Lathes/service.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/service.yml
@@ -76,7 +76,7 @@
 - type: latheRecipe
   id: FoodCondimentSqueezeBottleClear
   result: FoodCondimentSqueezeBottleClear
-  parent: BaseServiceItemsRecipe  
+  parent: BaseServiceItemsRecipe
   applyMaterialDiscount: false
   materials:
     Plastic: 50
@@ -102,7 +102,15 @@
 - type: latheRecipe
   id: DrinkIceBucketEmpty
   result: DrinkIceBucketEmpty
-  parent: BaseServiceItemsRecipe  
+  parent: BaseServiceItemsRecipe
   completetime: 2
   materials:
     Steel: 100
+
+- type: latheRecipe
+  id: DeskBell
+  result: DeskBell
+  parent: BaseServiceItemsRecipe
+  completetime: 2
+  materials:
+    Steel: 200


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds a desk bell recipe to the service techfab.

## Why / Balance
Requested on the Discord. Not all service ships come with a desk bell premapped and some players would like to add them to their custom food ship builds.

## How to test
Put two pieces of steel in a service techfab.
Create desk bell.
Ding the bell a few times just to make sure.

## Media
![image](https://github.com/user-attachments/assets/3944b50b-5c13-4609-b383-21084fc96d65)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
None.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added desk bell to the service techfab.
