### PR TITLE
akupara holopad & revamp update

### DIFF
--- a/Resources/Maps/_NF/Shuttles/akupara.yml
+++ b/Resources/Maps/_NF/Shuttles/akupara.yml
@@ -8,6 +8,7 @@ tilemap:
   1: FloorConcreteMono
   6: FloorDark
   10: FloorDarkMono
+  13: FloorGreenCircuit
   9: FloorRGlass
   4: FloorShuttleBlack
   97: FloorSteel
@@ -15,6 +16,7 @@ tilemap:
   5: FloorTechMaint2
   8: FloorTechMaint3
   3: FloorWhite
+  11: FloorWhiteMono
   2: Lattice
   130: Plating
 entities:
@@ -24,16 +26,16 @@ entities:
     components:
     - type: MetaData
       name: Akupara
-    - type: BecomesStation
-      id: Akupara
     - type: Transform
       pos: -1.6066288,-0.53125
       parent: invalid
+    - type: BecomesStation
+      id: Akupara
     - type: MapGrid
       chunks:
         0,0:
           ind: 0,0
-          tiles: ggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAACggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAABggAAAAAAggAAAAAAggAAAAAAAwAAAAACAwAAAAADggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAAAAAADggAAAAAAggAAAAAAggAAAAAAAwAAAAAAAwAAAAABggAAAAAAggAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAAAAAABAQAAAAABggAAAAAAAwAAAAABAwAAAAADAwAAAAAAAwAAAAACAwAAAAACggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACQAAAAADAQAAAAAAggAAAAAAAwAAAAABAwAAAAADAwAAAAACAwAAAAAAAwAAAAABggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAAAwAAAAAAAwAAAAABAwAAAAABAwAAAAACAwAAAAACggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAACgAAAAAAggAAAAAAggAAAAAAggAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAgAAAAAAggAAAAAABAAAAAAABAAAAAADBAAAAAADggAAAAAAAgAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAABAAAAAADBAAAAAABBAAAAAABggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAABAAAAAAABAAAAAADBAAAAAABggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAggAAAAAAggAAAAAAggAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          tiles: ggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAACggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAACgAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAABggAAAAAAggAAAAAAggAAAAAACwAAAAAAAwAAAAADCgAAAAAACgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAAAAAADggAAAAAAggAAAAAAggAAAAAACwAAAAAAAwAAAAABggAAAAAAggAAAAAAggAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAAAAAABAQAAAAABggAAAAAAAwAAAAABAwAAAAADAwAAAAAAAwAAAAACAwAAAAACAwAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACQAAAAADAQAAAAAAggAAAAAAAwAAAAABAwAAAAADAwAAAAACAwAAAAAAAwAAAAABAwAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAAAwAAAAAAAwAAAAABAwAAAAABAwAAAAACAwAAAAACAwAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAACgAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAgAAAAAAggAAAAAABAAAAAAACgAAAAAABAAAAAAAggAAAAAAAgAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAABAAAAAAACgAAAAAADQAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAABAAAAAAACgAAAAAACgAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAggAAAAAABAAAAAAABAAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAABAAAAAAABAAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
           version: 6
         0,-1:
           ind: 0,-1
@@ -46,6 +48,10 @@ entities:
         -1,0:
           ind: -1,0
           tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAACQAAAAABHgAAAAACDAAAAAABHgAAAAAAHgAAAAABHgAAAAACggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAACQAAAAAAHgAAAAABHgAAAAAAHgAAAAABAQAAAAABAQAAAAACggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAACQAAAAABHgAAAAABDAAAAAABDAAAAAAADAAAAAABAQAAAAACAQAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAggAAAAAAHgAAAAACDAAAAAADDAAAAAABDAAAAAADDAAAAAACAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAHgAAAAABDAAAAAADDAAAAAAADAAAAAADAQAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAACQAAAAAADAAAAAADDAAAAAABDAAAAAADDAAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAggAAAAAAHgAAAAACDAAAAAABDAAAAAAADAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAHgAAAAACDAAAAAAADAAAAAABDAAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAACQAAAAACCQAAAAACCQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAggAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          version: 6
+        0,1:
+          ind: 0,1
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAggAAAAAAggAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
           version: 6
     - type: Broadphase
     - type: Physics
@@ -73,6 +79,12 @@ entities:
           decals:
             65: -5,3
         - node:
+            color: '#CC5100FF'
+            id: Bot
+          decals:
+            117: 4,5
+            118: 4,6
+        - node:
             cleanable: True
             color: '#FFFF00FF'
             id: Bot
@@ -95,6 +107,7 @@ entities:
           decals:
             79: 4,-6
             80: 3,-7
+            156: 4,13
         - node:
             color: '#FFFFFFFF'
             id: BrickTileDarkCornerSe
@@ -102,9 +115,19 @@ entities:
             74: 5,-10
         - node:
             color: '#FFFFFFFF'
+            id: BrickTileDarkEndE
+          decals:
+            158: 5,13
+        - node:
+            color: '#FFFFFFFF'
             id: BrickTileDarkInnerNw
           decals:
             81: 4,-7
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileDarkInnerSe
+          decals:
+            157: 4,13
         - node:
             color: '#FFFFFFFF'
             id: BrickTileDarkInnerSw
@@ -117,6 +140,8 @@ entities:
             71: 5,-7
             72: 5,-8
             73: 5,-9
+            153: 4,11
+            154: 4,12
         - node:
             color: '#FFFFFFFF'
             id: BrickTileDarkLineS
@@ -128,6 +153,8 @@ entities:
           decals:
             77: 3,-9
             78: 3,-8
+            150: 4,11
+            155: 4,12
         - node:
             cleanable: True
             color: '#FFFFFFFF'
@@ -169,6 +196,7 @@ entities:
           decals:
             15: 5,-13
             16: 3,-13
+            115: 6,5
         - node:
             color: '#FFFFFFFF'
             id: FlowersBROne
@@ -289,6 +317,12 @@ entities:
             53: -2,8
             54: -1,8
         - node:
+            angle: 3.141592653589793 rad
+            color: '#CC5100FF'
+            id: LoadingArea
+          decals:
+            106: 4,7
+        - node:
             color: '#FFFFFFFF'
             id: LoadingArea
           decals:
@@ -298,7 +332,7 @@ entities:
             color: '#CC5100FF'
             id: MiniTileWhiteCornerNe
           decals:
-            17: 7,9
+            89: 8,9
         - node:
             color: '#CC5100FF'
             id: MiniTileWhiteCornerNw
@@ -308,48 +342,37 @@ entities:
             color: '#CC5100FF'
             id: MiniTileWhiteCornerSe
           decals:
-            20: 5,5
-            30: 7,7
+            87: 8,7
         - node:
             color: '#CC5100FF'
             id: MiniTileWhiteCornerSw
           decals:
             19: 3,7
-            21: 4,5
-        - node:
-            color: '#CC5100FF'
-            id: MiniTileWhiteInnerSe
-          decals:
-            28: 5,7
-        - node:
-            color: '#CC5100FF'
-            id: MiniTileWhiteInnerSw
-          decals:
-            29: 4,7
         - node:
             color: '#CC5100FF'
             id: MiniTileWhiteLineE
           decals:
-            24: 5,6
-            31: 7,8
+            88: 8,8
         - node:
             color: '#CC5100FF'
             id: MiniTileWhiteLineN
           decals:
-            25: 4,9
             26: 5,9
             27: 6,9
+            91: 7,9
+            160: 4,9
         - node:
             color: '#CC5100FF'
             id: MiniTileWhiteLineS
           decals:
-            69: 6,7
+            90: 7,7
+            95: 5,7
+            105: 6,7
         - node:
             color: '#CC5100FF'
             id: MiniTileWhiteLineW
           decals:
             22: 3,8
-            23: 4,6
         - node:
             cleanable: True
             color: '#FFFFFFFF'
@@ -357,16 +380,22 @@ entities:
           decals:
             8: -0.98000634,-5.253206
         - node:
+            color: '#FFFFFFFF'
+            id: StandClear
+          decals:
+            111: 6,4
+        - node:
+            angle: 1.5707963267948966 rad
+            color: '#FFFFFFFF'
+            id: StandClear
+          decals:
+            116: 7,5
+        - node:
             angle: 4.71238898038469 rad
             color: '#FFFFFFFF'
             id: StandClear
           decals:
             82: 6,-10
-        - node:
-            color: '#FFFFFFFF'
-            id: WarnBox
-          decals:
-            14: 6,3
         - node:
             cleanable: True
             color: '#0000FFFF'
@@ -379,6 +408,11 @@ entities:
             id: WarnBoxGreyscale
           decals:
             11: 1,2
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnBoxGreyscale
+          decals:
+            114: 6,-3
         - node:
             color: '#FFFFFFFF'
             id: WarnCornerNE
@@ -413,12 +447,12 @@ entities:
             color: '#334E6DFF'
             id: WarnLineGreyscaleN
           decals:
-            84: 4,10
+            169: 4,10
         - node:
             color: '#334E6DFF'
             id: WarnLineGreyscaleS
           decals:
-            85: 4,10
+            170: 4,10
         - node:
             cleanable: True
             color: '#FF4E6DFF'
@@ -451,21 +485,27 @@ entities:
           1,0:
             0: 32767
           1,1:
-            0: 62256
+            0: 61716
+            2: 64
           1,2:
             0: 12799
             1: 32768
           1,3:
-            0: 51
-            1: 1024
+            0: 13107
+          0,4:
+            1: 8
           1,-1:
             0: 65392
+          1,4:
+            1: 4
           2,0:
             0: 1
           2,1:
-            1: 256
+            0: 4096
+            1: 512
           2,2:
-            1: 4352
+            0: 17
+            1: 4608
           -1,-3:
             1: 6144
           0,-2:
@@ -538,6 +578,21 @@ entities:
           - 0
           - 0
           - 0
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
         chunkSize: 4
     - type: GasTileOverlay
     - type: RadiationGridResistance
@@ -554,7 +609,7 @@ entities:
       devices:
       - 344
       - 353
-      - 11
+      - 246
   - uid: 3
     components:
     - type: Transform
@@ -562,13 +617,15 @@ entities:
       pos: -0.5,1.5
       parent: 1
     - type: DeviceList
+      configurators:
+      - invalid
       devices:
       - 351
       - 345
       - 349
-      - 242
-      - 243
-      - 245
+      - 247
+      - 248
+      - 250
       - 350
   - uid: 4
     components:
@@ -580,7 +637,7 @@ entities:
       devices:
       - 348
       - 343
-      - 244
+      - 249
   - uid: 5
     components:
     - type: Transform
@@ -589,12 +646,12 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 12
-      - 246
+      - 245
+      - 251
       - 346
       - 347
       - 342
-      - 352
+      - 709
 - proto: AirlockAtmosphericsGlass
   entities:
   - uid: 6
@@ -630,15 +687,21 @@ entities:
       parent: 1
 - proto: AirlockExternalGlass
   entities:
-  - uid: 150
+  - uid: 11
     components:
     - type: Transform
       pos: 3.5,-11.5
       parent: 1
-  - uid: 247
+  - uid: 12
     components:
     - type: Transform
       pos: 5.5,-11.5
+      parent: 1
+  - uid: 546
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,4.5
       parent: 1
 - proto: AirlockGlassShuttle
   entities:
@@ -673,16 +736,12 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -0.5,-0.5
       parent: 1
-    - type: Apc
-      hasAccess: True
   - uid: 18
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,-9.5
       parent: 1
-    - type: Apc
-      hasAccess: True
   - uid: 19
     components:
     - type: Transform
@@ -699,6 +758,12 @@ entities:
     components:
     - type: Transform
       pos: 3.5,-13.5
+      parent: 1
+  - uid: 28
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,4.5
       parent: 1
 - proto: AtmosFixBlockerMarker
   entities:
@@ -732,297 +797,329 @@ entities:
     - type: Transform
       pos: 2.5,14.5
       parent: 1
-  - uid: 28
-    components:
-    - type: Transform
-      pos: 6.5,14.5
-      parent: 1
   - uid: 29
-    components:
-    - type: Transform
-      pos: 7.5,11.5
-      parent: 1
-  - uid: 30
     components:
     - type: Transform
       pos: 8.5,11.5
       parent: 1
-  - uid: 31
-    components:
-    - type: Transform
-      pos: 8.5,10.5
-      parent: 1
-  - uid: 32
-    components:
-    - type: Transform
-      pos: 8.5,6.5
-      parent: 1
-  - uid: 33
+  - uid: 30
     components:
     - type: Transform
       pos: -0.5,-9.5
       parent: 1
-  - uid: 34
+  - uid: 31
     components:
     - type: Transform
       pos: 1.5,-11.5
       parent: 1
-  - uid: 35
+  - uid: 32
     components:
     - type: Transform
       pos: 9.5,-1.5
       parent: 1
-  - uid: 36
+  - uid: 33
     components:
     - type: Transform
       pos: 9.5,-11.5
       parent: 1
-  - uid: 37
+  - uid: 34
     components:
     - type: Transform
       pos: 7.5,-12.5
       parent: 1
-  - uid: 38
+  - uid: 35
     components:
     - type: Transform
       pos: 7.5,-13.5
       parent: 1
-  - uid: 39
+  - uid: 36
     components:
     - type: Transform
       pos: 1.5,-13.5
       parent: 1
-  - uid: 40
+  - uid: 37
     components:
     - type: Transform
       pos: 1.5,-12.5
       parent: 1
-  - uid: 41
+  - uid: 38
     components:
     - type: Transform
       pos: -5.5,-5.5
       parent: 1
-  - uid: 42
+  - uid: 39
     components:
     - type: Transform
       pos: -7.5,-2.5
       parent: 1
-  - uid: 43
+  - uid: 40
     components:
     - type: Transform
       pos: -7.5,3.5
       parent: 1
-  - uid: 44
+  - uid: 41
     components:
     - type: Transform
       pos: -5.5,6.5
       parent: 1
-  - uid: 45
+  - uid: 42
     components:
     - type: Transform
       pos: -3.5,9.5
       parent: 1
-- proto: BaseGasCondenser
-  entities:
-  - uid: 46
+  - uid: 43
     components:
     - type: Transform
-      pos: 7.5,2.5
+      pos: 9.5,10.5
       parent: 1
-- proto: BenchSteelLeft
+  - uid: 44
+    components:
+    - type: Transform
+      pos: 9.5,6.5
+      parent: 1
+  - uid: 45
+    components:
+    - type: Transform
+      pos: 6.5,5.5
+      parent: 1
+  - uid: 689
+    components:
+    - type: Transform
+      pos: 7.5,11.5
+      parent: 1
+  - uid: 697
+    components:
+    - type: Transform
+      pos: 7.5,5.5
+      parent: 1
+  - uid: 708
+    components:
+    - type: Transform
+      pos: 6.5,16.5
+      parent: 1
+  - uid: 710
+    components:
+    - type: Transform
+      pos: 3.5,16.5
+      parent: 1
+- proto: BaseGasCondenser
   entities:
   - uid: 47
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -5.5,2.5
+      pos: 7.5,2.5
       parent: 1
-    - type: Physics
-      bodyType: Static
-- proto: BenchSteelRight
+- proto: Bed
+  entities:
+  - uid: 455
+    components:
+    - type: Transform
+      pos: 3.5,12.5
+      parent: 1
+  - uid: 700
+    components:
+    - type: Transform
+      pos: 3.5,13.5
+      parent: 1
+- proto: BedsheetGreen
+  entities:
+  - uid: 572
+    components:
+    - type: Transform
+      pos: 3.5,13.5
+      parent: 1
+- proto: BedsheetOrange
+  entities:
+  - uid: 720
+    components:
+    - type: Transform
+      pos: 3.5,12.5
+      parent: 1
+- proto: BenchSteelLeft
   entities:
   - uid: 48
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -5.5,3.5
+      pos: -5.5,2.5
       parent: 1
-    - type: Physics
-      bodyType: Static
-- proto: BoxLightMixed
+- proto: BenchSteelRight
   entities:
   - uid: 49
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,3.5
+      parent: 1
+- proto: BoxLightMixed
+  entities:
+  - uid: 50
     components:
     - type: Transform
       pos: 2.5,-10.5
       parent: 1
 - proto: BoxMouthSwab
   entities:
-  - uid: 50
+  - uid: 51
     components:
     - type: Transform
       pos: -0.5,2.5
       parent: 1
 - proto: BoxPaper
   entities:
-  - uid: 51
+  - uid: 52
     components:
     - type: Transform
-      pos: 3.4773202,12.98834
+      pos: 5.428748,15.020165
       parent: 1
 - proto: Bucket
   entities:
-  - uid: 52
+  - uid: 53
     components:
     - type: Transform
       pos: -0.5,2.5
       parent: 1
-  - uid: 53
+  - uid: 54
     components:
     - type: Transform
       pos: 2.5,-10.5
       parent: 1
 - proto: CableApcExtension
   entities:
-  - uid: 54
+  - uid: 55
     components:
     - type: Transform
       pos: 5.5,-5.5
       parent: 1
-  - uid: 55
+  - uid: 56
     components:
     - type: Transform
       pos: 1.5,-9.5
       parent: 1
-  - uid: 56
+  - uid: 57
     components:
     - type: Transform
       pos: 3.5,-9.5
       parent: 1
-  - uid: 57
+  - uid: 58
     components:
     - type: Transform
       pos: 2.5,-9.5
       parent: 1
-  - uid: 58
+  - uid: 59
     components:
     - type: Transform
       pos: 4.5,-9.5
       parent: 1
-  - uid: 59
+  - uid: 60
     components:
     - type: Transform
       pos: 5.5,-9.5
       parent: 1
-  - uid: 60
+  - uid: 61
     components:
     - type: Transform
       pos: 5.5,-8.5
       parent: 1
-  - uid: 61
+  - uid: 62
     components:
     - type: Transform
       pos: 5.5,-7.5
       parent: 1
-  - uid: 62
+  - uid: 63
     components:
     - type: Transform
       pos: 5.5,9.5
       parent: 1
-  - uid: 63
+  - uid: 64
     components:
     - type: Transform
       pos: -2.5,-3.5
       parent: 1
-  - uid: 64
+  - uid: 65
     components:
     - type: Transform
       pos: -3.5,2.5
       parent: 1
-  - uid: 65
+  - uid: 66
     components:
     - type: Transform
       pos: 3.5,11.5
       parent: 1
-  - uid: 66
+  - uid: 67
     components:
     - type: Transform
       pos: -2.5,-4.5
       parent: 1
-  - uid: 67
+  - uid: 68
     components:
     - type: Transform
       pos: -1.5,-0.5
       parent: 1
-  - uid: 68
+  - uid: 69
     components:
     - type: Transform
       pos: -2.5,-0.5
       parent: 1
-  - uid: 69
+  - uid: 70
     components:
     - type: Transform
       pos: -0.5,-0.5
       parent: 1
-  - uid: 70
+  - uid: 71
     components:
     - type: Transform
       pos: -3.5,1.5
       parent: 1
-  - uid: 71
+  - uid: 72
     components:
     - type: Transform
       pos: -3.5,0.5
       parent: 1
-  - uid: 72
+  - uid: 73
     components:
     - type: Transform
       pos: -1.5,5.5
       parent: 1
-  - uid: 73
+  - uid: 74
     components:
     - type: Transform
       pos: -2.5,4.5
       parent: 1
-  - uid: 74
+  - uid: 75
     components:
     - type: Transform
       pos: -0.5,5.5
       parent: 1
-  - uid: 75
+  - uid: 76
     components:
     - type: Transform
       pos: 5.5,10.5
       parent: 1
-  - uid: 76
+  - uid: 77
     components:
     - type: Transform
       pos: 0.5,6.5
       parent: 1
-  - uid: 77
+  - uid: 78
     components:
     - type: Transform
       pos: 0.5,5.5
       parent: 1
-  - uid: 78
+  - uid: 79
     components:
     - type: Transform
       pos: -2.5,5.5
       parent: 1
-  - uid: 79
+  - uid: 80
     components:
     - type: Transform
       pos: -1.5,-4.5
       parent: 1
-  - uid: 80
-    components:
-    - type: Transform
-      pos: 0.5,-5.5
-      parent: 1
   - uid: 81
     components:
     - type: Transform
-      pos: 6.5,2.5
+      pos: 0.5,-5.5
       parent: 1
   - uid: 82
     components:
@@ -1072,295 +1169,330 @@ entities:
   - uid: 91
     components:
     - type: Transform
-      pos: 6.5,0.5
+      pos: 0.5,-0.5
       parent: 1
   - uid: 92
     components:
     - type: Transform
-      pos: 0.5,-0.5
+      pos: -0.5,-4.5
       parent: 1
   - uid: 93
     components:
     - type: Transform
-      pos: -0.5,-4.5
+      pos: 5.5,8.5
       parent: 1
   - uid: 94
     components:
     - type: Transform
-      pos: 5.5,8.5
+      pos: 4.5,11.5
       parent: 1
   - uid: 95
     components:
     - type: Transform
-      pos: 4.5,11.5
+      pos: 5.5,-0.5
       parent: 1
   - uid: 96
     components:
     - type: Transform
-      pos: 5.5,-0.5
+      pos: 6.5,-0.5
       parent: 1
   - uid: 97
     components:
     - type: Transform
-      pos: 6.5,-0.5
+      pos: 3.5,-0.5
       parent: 1
   - uid: 98
     components:
     - type: Transform
-      pos: 3.5,-0.5
+      pos: 2.5,-0.5
       parent: 1
   - uid: 99
     components:
     - type: Transform
-      pos: 2.5,-0.5
+      pos: 4.5,-0.5
       parent: 1
   - uid: 100
     components:
     - type: Transform
-      pos: 4.5,-0.5
+      pos: 5.5,-11.5
       parent: 1
   - uid: 101
     components:
     - type: Transform
-      pos: 5.5,-11.5
-      parent: 1
-  - uid: 103
-    components:
-    - type: Transform
       pos: 1.5,-0.5
       parent: 1
-  - uid: 104
+  - uid: 102
     components:
     - type: Transform
       pos: 5.5,-6.5
       parent: 1
-  - uid: 105
+  - uid: 103
     components:
     - type: Transform
-      pos: 6.5,1.5
+      pos: 5.5,1.5
       parent: 1
-  - uid: 106
+  - uid: 104
     components:
     - type: Transform
       pos: 4.5,-12.5
       parent: 1
-  - uid: 107
+  - uid: 105
     components:
     - type: Transform
       pos: 3.5,-12.5
       parent: 1
-  - uid: 108
+  - uid: 106
     components:
     - type: Transform
       pos: 5.5,-12.5
       parent: 1
-  - uid: 678
+  - uid: 107
+    components:
+    - type: Transform
+      pos: 5.5,-4.5
+      parent: 1
+  - uid: 108
     components:
     - type: Transform
       pos: 5.5,7.5
       parent: 1
-- proto: CableHV
-  entities:
+  - uid: 109
+    components:
+    - type: Transform
+      pos: 5.5,0.5
+      parent: 1
   - uid: 110
     components:
     - type: Transform
-      pos: 7.5,-10.5
+      pos: 4.5,5.5
+      parent: 1
+  - uid: 111
+    components:
+    - type: Transform
+      pos: 4.5,7.5
       parent: 1
   - uid: 112
     components:
     - type: Transform
-      pos: 7.5,-8.5
+      pos: 4.5,6.5
       parent: 1
   - uid: 113
     components:
     - type: Transform
+      pos: 5.5,2.5
+      parent: 1
+  - uid: 704
+    components:
+    - type: Transform
+      pos: 5.5,12.5
+      parent: 1
+  - uid: 705
+    components:
+    - type: Transform
+      pos: 5.5,13.5
+      parent: 1
+- proto: CableHV
+  entities:
+  - uid: 114
+    components:
+    - type: Transform
+      pos: 7.5,-10.5
+      parent: 1
+  - uid: 115
+    components:
+    - type: Transform
+      pos: 7.5,-8.5
+      parent: 1
+  - uid: 116
+    components:
+    - type: Transform
       pos: 8.5,-10.5
       parent: 1
-  - uid: 114
+  - uid: 117
     components:
     - type: Transform
       pos: 7.5,-9.5
       parent: 1
-  - uid: 141
+  - uid: 118
     components:
     - type: Transform
       pos: 8.5,-8.5
       parent: 1
 - proto: CableMV
   entities:
-  - uid: 111
+  - uid: 119
     components:
     - type: Transform
       pos: 7.5,-8.5
       parent: 1
-  - uid: 115
+  - uid: 120
     components:
     - type: Transform
       pos: 4.5,0.5
       parent: 1
-  - uid: 116
+  - uid: 121
     components:
     - type: Transform
       pos: 7.5,-9.5
       parent: 1
-  - uid: 117
+  - uid: 122
     components:
     - type: Transform
       pos: 6.5,-9.5
       parent: 1
-  - uid: 118
+  - uid: 123
     components:
     - type: Transform
       pos: 2.5,-9.5
       parent: 1
-  - uid: 119
+  - uid: 124
     components:
     - type: Transform
       pos: 4.5,-9.5
       parent: 1
-  - uid: 120
+  - uid: 125
     components:
     - type: Transform
       pos: 5.5,-9.5
       parent: 1
-  - uid: 121
+  - uid: 126
     components:
     - type: Transform
       pos: 3.5,-9.5
       parent: 1
-  - uid: 122
+  - uid: 127
     components:
     - type: Transform
       pos: 1.5,-9.5
       parent: 1
-  - uid: 123
+  - uid: 128
     components:
     - type: Transform
       pos: 4.5,3.5
       parent: 1
-  - uid: 124
+  - uid: 129
     components:
     - type: Transform
       pos: 4.5,4.5
       parent: 1
-  - uid: 125
+  - uid: 130
     components:
     - type: Transform
       pos: 4.5,5.5
       parent: 1
-  - uid: 126
+  - uid: 131
     components:
     - type: Transform
       pos: 4.5,-7.5
       parent: 1
-  - uid: 127
+  - uid: 132
     components:
     - type: Transform
       pos: 4.5,6.5
       parent: 1
-  - uid: 128
+  - uid: 133
     components:
     - type: Transform
       pos: 3.5,-0.5
       parent: 1
-  - uid: 129
+  - uid: 134
     components:
     - type: Transform
       pos: 4.5,1.5
       parent: 1
-  - uid: 130
+  - uid: 135
     components:
     - type: Transform
       pos: 4.5,-4.5
       parent: 1
-  - uid: 131
+  - uid: 136
     components:
     - type: Transform
       pos: 4.5,-3.5
       parent: 1
-  - uid: 132
+  - uid: 137
     components:
     - type: Transform
       pos: 4.5,-5.5
       parent: 1
-  - uid: 133
+  - uid: 138
     components:
     - type: Transform
       pos: 4.5,-1.5
       parent: 1
-  - uid: 134
+  - uid: 139
     components:
     - type: Transform
       pos: 4.5,-0.5
       parent: 1
-  - uid: 135
+  - uid: 140
     components:
     - type: Transform
       pos: 4.5,-6.5
       parent: 1
-  - uid: 136
+  - uid: 141
     components:
     - type: Transform
       pos: 0.5,-0.5
       parent: 1
-  - uid: 137
+  - uid: 142
     components:
     - type: Transform
       pos: -0.5,-0.5
       parent: 1
-  - uid: 138
+  - uid: 143
     components:
     - type: Transform
       pos: 2.5,-0.5
       parent: 1
-  - uid: 139
+  - uid: 144
     components:
     - type: Transform
       pos: 1.5,-0.5
       parent: 1
-  - uid: 140
+  - uid: 145
     components:
     - type: Transform
       pos: 4.5,-2.5
       parent: 1
-  - uid: 142
+  - uid: 146
     components:
     - type: Transform
       pos: 4.5,2.5
       parent: 1
-  - uid: 143
+  - uid: 147
     components:
     - type: Transform
       pos: 4.5,-8.5
       parent: 1
-  - uid: 144
+  - uid: 148
     components:
     - type: Transform
       pos: 4.5,7.5
       parent: 1
-  - uid: 145
+  - uid: 149
     components:
     - type: Transform
       pos: 4.5,8.5
       parent: 1
-  - uid: 146
+  - uid: 150
     components:
     - type: Transform
       pos: 4.5,9.5
       parent: 1
-  - uid: 147
+  - uid: 151
     components:
     - type: Transform
       pos: 4.5,10.5
       parent: 1
-  - uid: 149
+  - uid: 152
     components:
     - type: Transform
       pos: 5.5,10.5
       parent: 1
 - proto: CableTerminal
   entities:
-  - uid: 550
+  - uid: 153
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1368,189 +1500,189 @@ entities:
       parent: 1
 - proto: Catwalk
   entities:
-  - uid: 152
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 5.5,-0.5
-      parent: 1
-  - uid: 153
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 6.5,-0.5
-      parent: 1
-  - uid: 154
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,1.5
-      parent: 1
   - uid: 155
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 4.5,1.5
+      pos: 6.5,3.5
       parent: 1
   - uid: 156
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -0.5,0.5
+      pos: 5.5,-0.5
       parent: 1
   - uid: 157
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 3.5,-4.5
+      pos: 6.5,-0.5
       parent: 1
   - uid: 158
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 2.5,-0.5
+      rot: -1.5707963267948966 rad
+      pos: 2.5,1.5
       parent: 1
   - uid: 159
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 5.5,2.5
+      pos: -0.5,0.5
       parent: 1
   - uid: 160
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 6.5,2.5
+      pos: 3.5,-4.5
       parent: 1
   - uid: 161
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 6.5,1.5
+      pos: 2.5,-0.5
       parent: 1
   - uid: 162
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 3.5,5.5
+      pos: 5.5,2.5
       parent: 1
   - uid: 163
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 2.5,5.5
+      pos: 6.5,2.5
       parent: 1
   - uid: 164
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 1.5,5.5
+      pos: 6.5,1.5
       parent: 1
   - uid: 165
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 1.5,0.5
+      pos: 3.5,5.5
       parent: 1
   - uid: 166
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 2.5,-4.5
+      pos: 2.5,5.5
       parent: 1
   - uid: 167
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 3.5,-0.5
+      pos: 1.5,5.5
       parent: 1
   - uid: 168
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 5.5,3.5
+      pos: 1.5,0.5
       parent: 1
   - uid: 169
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 5.5,1.5
+      pos: 2.5,-4.5
       parent: 1
   - uid: 170
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 3.5,-2.5
+      pos: 3.5,-0.5
       parent: 1
   - uid: 171
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 5.5,-1.5
+      pos: 5.5,3.5
       parent: 1
   - uid: 172
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,2.5
+      rot: 3.141592653589793 rad
+      pos: 5.5,1.5
       parent: 1
   - uid: 173
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 3.5,-1.5
+      pos: 5.5,-1.5
       parent: 1
   - uid: 174
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 5.5,-2.5
+      rot: -1.5707963267948966 rad
+      pos: 2.5,2.5
       parent: 1
   - uid: 175
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 0.5,0.5
+      pos: 3.5,-1.5
       parent: 1
   - uid: 176
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 1.5,-4.5
+      pos: 0.5,0.5
       parent: 1
   - uid: 177
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 6.5,-1.5
+      pos: 1.5,-4.5
       parent: 1
   - uid: 178
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 3.5,1.5
+      pos: 6.5,-1.5
       parent: 1
   - uid: 179
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 4.5,0.5
+      pos: 3.5,1.5
       parent: 1
   - uid: 180
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 5.5,0.5
+      pos: 4.5,0.5
       parent: 1
   - uid: 181
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,0.5
+      parent: 1
+  - uid: 182
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-0.5
       parent: 1
+  - uid: 184
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-2.5
+      parent: 1
+  - uid: 185
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,1.5
+      parent: 1
 - proto: ChairFolding
   entities:
-  - uid: 182
+  - uid: 186
     components:
     - type: Transform
       rot: 1.570791677632604 rad
@@ -1587,7 +1719,7 @@ entities:
           friction: 0.4
 - proto: ChairOfficeDark
   entities:
-  - uid: 183
+  - uid: 187
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1595,63 +1727,57 @@ entities:
       parent: 1
 - proto: ChairPilotSeat
   entities:
-  - uid: 184
+  - uid: 706
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 4.5,12.5
-      parent: 1
-  - uid: 185
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 5.5,12.5
+      pos: 4.5,14.5
       parent: 1
 - proto: ChemDispenser
   entities:
-  - uid: 186
-    components:
-    - type: Transform
-      pos: 6.5,9.5
-      parent: 1
-- proto: ChemistryHotplate
-  entities:
-  - uid: 198
-    components:
-    - type: Transform
-      pos: 7.5,7.5
-      parent: 1
-- proto: ChemMaster
-  entities:
-  - uid: 187
+  - uid: 190
     components:
     - type: Transform
       pos: 7.5,9.5
       parent: 1
-- proto: CigaretteSpent
-  entities:
-  - uid: 189
-    components:
-    - type: Transform
-      parent: 188
-    - type: Physics
-      canCollide: False
-  - uid: 190
-    components:
-    - type: Transform
-      parent: 188
-    - type: Physics
-      canCollide: False
-- proto: ClosetRadiationSuitFilled
+- proto: ChemistryHotplate
   entities:
   - uid: 191
     components:
     - type: Transform
-      pos: 3.5,-8.5
+      pos: 8.5,7.5
       parent: 1
-- proto: ClosetWall
+- proto: ChemMaster
   entities:
   - uid: 192
+    components:
+    - type: Transform
+      pos: 8.5,9.5
+      parent: 1
+- proto: CigaretteSpent
+  entities:
+  - uid: 194
+    components:
+    - type: Transform
+      parent: 193
+    - type: Physics
+      canCollide: False
+  - uid: 195
+    components:
+    - type: Transform
+      parent: 193
+    - type: Physics
+      canCollide: False
+- proto: ClosetRadiationSuitFilled
+  entities:
+  - uid: 196
+    components:
+    - type: Transform
+      pos: 3.5,-8.5
+      parent: 1
+- proto: ClosetWallMaintenanceFilledRandom
+  entities:
+  - uid: 197
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1661,7 +1787,7 @@ entities:
       air:
         volume: 200
         immutable: False
-        temperature: 293.14923
+        temperature: 293.14926
         moles:
         - 1.7459903
         - 6.568249
@@ -1675,17 +1801,9 @@ entities:
         - 0
         - 0
         - 0
-    - type: ContainerContainer
-      containers:
-        entity_storage: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 194
-          - 193
 - proto: ClosetWallO2N2FilledRandom
   entities:
-  - uid: 199
+  - uid: 198
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1693,78 +1811,82 @@ entities:
       parent: 1
 - proto: ComputerPowerMonitoring
   entities:
-  - uid: 109
+  - uid: 199
     components:
     - type: Transform
       pos: 8.5,-8.5
       parent: 1
+- proto: ComputerRadar
+  entities:
+  - uid: 701
+    components:
+    - type: Transform
+      pos: 5.5,3.5
+      parent: 1
 - proto: ComputerStationRecords
   entities:
-  - uid: 195
+  - uid: 200
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 3.5,11.5
-      parent: 1
-- proto: ComputerTabletopRadar
-  entities:
-  - uid: 196
-    components:
-    - type: Transform
-      pos: 5.5,13.5
+      rot: -1.5707963267948966 rad
+      pos: 5.5,11.5
       parent: 1
 - proto: ComputerTabletopShuttle
   entities:
-  - uid: 197
+  - uid: 255
     components:
     - type: Transform
-      pos: 4.5,13.5
+      pos: 4.5,15.5
       parent: 1
 - proto: CrateChemistrySupplies
   entities:
-  - uid: 526
+  - uid: 203
     components:
     - type: Transform
-      pos: 5.5,7.5
+      pos: 5.5,9.5
       parent: 1
 - proto: CrateTrashCart
   entities:
-  - uid: 201
+  - uid: 204
     components:
     - type: Transform
       pos: 7.5,-6.5
       parent: 1
-- proto: CrowbarRed
+- proto: CurtainsGreenOpen
   entities:
-  - uid: 193
+  - uid: 571
     components:
     - type: Transform
-      parent: 192
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
+      pos: 3.5,13.5
+      parent: 1
+- proto: CurtainsOrangeOpen
+  entities:
+  - uid: 718
+    components:
+    - type: Transform
+      pos: 3.5,12.5
+      parent: 1
 - proto: DefibrillatorCabinetFilled
   entities:
-  - uid: 202
+  - uid: 702
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 6.5,11.5
+      pos: 3.5,10.5
       parent: 1
 - proto: DisposalBend
   entities:
-  - uid: 203
+  - uid: 206
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-4.5
       parent: 1
-  - uid: 204
+  - uid: 207
     components:
     - type: Transform
       pos: -3.5,-4.5
       parent: 1
-  - uid: 205
+  - uid: 208
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1772,118 +1894,118 @@ entities:
       parent: 1
 - proto: DisposalPipe
   entities:
-  - uid: 206
+  - uid: 209
     components:
     - type: Transform
       pos: -4.5,4.5
       parent: 1
-  - uid: 207
+  - uid: 210
     components:
     - type: Transform
       pos: -4.5,3.5
       parent: 1
-  - uid: 208
-    components:
-    - type: Transform
-      pos: -4.5,2.5
-      parent: 1
-  - uid: 209
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -4.5,1.5
-      parent: 1
-  - uid: 210
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -4.5,0.5
-      parent: 1
   - uid: 211
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -4.5,-0.5
+      pos: -4.5,2.5
       parent: 1
   - uid: 212
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -4.5,-1.5
+      pos: -4.5,1.5
       parent: 1
   - uid: 213
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -4.5,-2.5
+      pos: -4.5,0.5
       parent: 1
   - uid: 214
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -4.5,-3.5
+      pos: -4.5,-0.5
       parent: 1
   - uid: 215
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -3.5,-5.5
+      pos: -4.5,-1.5
       parent: 1
   - uid: 216
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -1.5,-6.5
+      rot: 3.141592653589793 rad
+      pos: -4.5,-2.5
       parent: 1
   - uid: 217
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,-6.5
+      rot: 3.141592653589793 rad
+      pos: -4.5,-3.5
       parent: 1
   - uid: 218
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 5.5,-6.5
+      rot: 3.141592653589793 rad
+      pos: -3.5,-5.5
       parent: 1
   - uid: 219
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 4.5,-6.5
+      pos: -1.5,-6.5
       parent: 1
   - uid: 220
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 2.5,-6.5
+      pos: -2.5,-6.5
       parent: 1
   - uid: 221
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 1.5,-6.5
+      pos: 5.5,-6.5
       parent: 1
   - uid: 222
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 0.5,-6.5
+      pos: 4.5,-6.5
       parent: 1
   - uid: 223
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -0.5,-6.5
+      pos: 2.5,-6.5
       parent: 1
   - uid: 224
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 3.5,-6.5
+      pos: 1.5,-6.5
       parent: 1
   - uid: 225
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-6.5
+      parent: 1
+  - uid: 226
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-6.5
+      parent: 1
+  - uid: 227
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-6.5
+      parent: 1
+  - uid: 228
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1891,12 +2013,12 @@ entities:
       parent: 1
 - proto: DisposalTrunk
   entities:
-  - uid: 226
+  - uid: 229
     components:
     - type: Transform
       pos: -4.5,5.5
       parent: 1
-  - uid: 227
+  - uid: 230
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1904,96 +2026,102 @@ entities:
       parent: 1
 - proto: DisposalUnit
   entities:
-  - uid: 228
+  - uid: 231
     components:
     - type: Transform
       pos: -4.5,5.5
       parent: 1
 - proto: DrinkMugDog
   entities:
-  - uid: 229
+  - uid: 232
     components:
     - type: Transform
-      pos: 3.3366952,12.51959
+      pos: 5.647498,14.62954
       parent: 1
 - proto: EmergencyLight
   entities:
-  - uid: 230
+  - uid: 233
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,1.5
       parent: 1
-  - uid: 231
+  - uid: 234
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-12.5
       parent: 1
-  - uid: 232
+  - uid: 235
     components:
     - type: Transform
       pos: 5.5,9.5
       parent: 1
-  - uid: 233
+  - uid: 236
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,-5.5
       parent: 1
-  - uid: 234
+  - uid: 237
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-10.5
       parent: 1
-  - uid: 235
+  - uid: 238
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-5.5
       parent: 1
-  - uid: 236
+  - uid: 239
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,6.5
       parent: 1
-  - uid: 237
+  - uid: 240
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,1.5
       parent: 1
-  - uid: 238
+  - uid: 241
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,6.5
       parent: 1
+  - uid: 388
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,11.5
+      parent: 1
 - proto: ExtinguisherCabinetFilled
   entities:
-  - uid: 239
+  - uid: 242
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-10.5
       parent: 1
-  - uid: 240
+  - uid: 243
     components:
     - type: Transform
       pos: 1.5,9.5
       parent: 1
 - proto: FaxMachineShip
   entities:
-  - uid: 241
+  - uid: 352
     components:
     - type: Transform
-      pos: 3.5,13.5
+      pos: 5.5,15.5
       parent: 1
 - proto: Firelock
   entities:
-  - uid: 12
+  - uid: 245
     components:
     - type: Transform
       pos: 4.5,10.5
@@ -2003,7 +2131,7 @@ entities:
       - 5
 - proto: FirelockGlass
   entities:
-  - uid: 11
+  - uid: 246
     components:
     - type: Transform
       pos: 1.5,0.5
@@ -2011,7 +2139,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 2
-  - uid: 242
+  - uid: 247
     components:
     - type: Transform
       pos: 1.5,-4.5
@@ -2019,7 +2147,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 3
-  - uid: 243
+  - uid: 248
     components:
     - type: Transform
       pos: -0.5,0.5
@@ -2027,15 +2155,17 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 3
-  - uid: 244
+  - uid: 249
     components:
     - type: Transform
       pos: 3.5,-4.5
       parent: 1
     - type: DeviceNetwork
+      configurators:
+      - invalid
       deviceLists:
       - 4
-  - uid: 245
+  - uid: 250
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2044,7 +2174,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 3
-  - uid: 246
+  - uid: 251
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2070,7 +2200,7 @@ entities:
       parent: 1
     - type: Fixtures
       fixtures: {}
-- proto: FloraTree03
+- proto: FloraTree
   entities:
   - uid: 254
     components:
@@ -2079,10 +2209,10 @@ entities:
       parent: 1
 - proto: FolderSpawner
   entities:
-  - uid: 255
+  - uid: 244
     components:
     - type: Transform
-      pos: 3.7129288,12.558204
+      pos: 5.319373,14.582665
       parent: 1
 - proto: GasFilter
   entities:
@@ -2145,7 +2275,7 @@ entities:
       inletTwoConcentration: 0.78
       inletOneConcentration: 0.22
     - type: AtmosPipeColor
-      color: '#66FFFFFF'
+      color: '#00FFFFFF'
     - type: Label
       currentLabel: Air
     - type: NameModifier
@@ -2240,6 +2370,21 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FFAA00FF'
+  - uid: 289
+    components:
+    - type: Transform
+      pos: 6.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00FFFFFF'
+  - uid: 695
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00FFFFFF'
 - proto: GasPipeFourway
   entities:
   - uid: 271
@@ -2249,16 +2394,23 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FFAA00FF'
-  - uid: 272
-    components:
-    - type: Transform
-      pos: 5.5,3.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#66FFFFFF'
 - proto: GasPipeStraight
   entities:
-  - uid: 273
+  - uid: 46
+    components:
+    - type: Transform
+      pos: 4.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00FFFFFF'
+  - uid: 183
+    components:
+    - type: Transform
+      pos: 4.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00FFFFFF'
+  - uid: 272
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2266,7 +2418,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FFAA00FF'
-  - uid: 274
+  - uid: 273
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2274,7 +2426,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FFAA00FF'
-  - uid: 275
+  - uid: 274
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2282,28 +2434,28 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FFAA00FF'
-  - uid: 276
+  - uid: 275
     components:
     - type: Transform
       pos: 2.5,1.5
       parent: 1
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 277
+  - uid: 276
     components:
     - type: Transform
       pos: 3.5,1.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0000FFFF'
-  - uid: 278
+  - uid: 277
     components:
     - type: Transform
       pos: 3.5,2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0000FFFF'
-  - uid: 279
+  - uid: 278
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2311,10 +2463,18 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 280
+  - uid: 279
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
+      pos: 3.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FFAA00FF'
+  - uid: 280
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 3.5,-1.5
       parent: 1
     - type: AtmosPipeColor
@@ -2322,20 +2482,11 @@ entities:
   - uid: 281
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 3.5,-1.5
+      pos: 4.5,10.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#FFAA00FF'
+      color: '#00FFFFFF'
   - uid: 282
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 5.5,8.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#66FFFFFF'
-  - uid: 283
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2343,7 +2494,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FFAA00FF'
-  - uid: 284
+  - uid: 283
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2351,7 +2502,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FFAA00FF'
-  - uid: 285
+  - uid: 284
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2359,7 +2510,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FFAA00FF'
-  - uid: 286
+  - uid: 285
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2367,7 +2518,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FFAA00FF'
-  - uid: 287
+  - uid: 286
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2375,7 +2526,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FFAA00FF'
-  - uid: 288
+  - uid: 287
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2383,7 +2534,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FFAA00FF'
-  - uid: 289
+  - uid: 288
     components:
     - type: Transform
       pos: 3.5,6.5
@@ -2393,27 +2544,18 @@ entities:
   - uid: 290
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 5.5,9.5
+      pos: 6.5,6.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#66FFFFFF'
+      color: '#00FFFFFF'
   - uid: 291
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 5.5,10.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#66FFFFFF'
-  - uid: 292
     components:
     - type: Transform
       pos: 3.5,10.5
       parent: 1
     - type: AtmosPipeColor
       color: '#FFAA00FF'
-  - uid: 293
+  - uid: 292
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2421,7 +2563,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FFAA00FF'
-  - uid: 294
+  - uid: 293
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2429,14 +2571,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FFAA00FF'
-  - uid: 295
+  - uid: 294
     components:
     - type: Transform
       pos: 3.5,9.5
       parent: 1
     - type: AtmosPipeColor
       color: '#FFAA00FF'
-  - uid: 296
+  - uid: 295
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2444,111 +2586,101 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FFAA00FF'
-  - uid: 297
+  - uid: 296
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,1.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#66FFFFFF'
-  - uid: 298
+      color: '#00FFFFFF'
+  - uid: 297
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,1.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#66FFFFFF'
-  - uid: 299
+      color: '#00FFFFFF'
+  - uid: 298
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,1.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#66FFFFFF'
-  - uid: 300
+      color: '#00FFFFFF'
+  - uid: 299
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,1.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#66FFFFFF'
-  - uid: 301
+      color: '#00FFFFFF'
+  - uid: 300
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,1.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#66FFFFFF'
-  - uid: 302
+      color: '#00FFFFFF'
+  - uid: 301
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,0.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#66FFFFFF'
-  - uid: 303
+      color: '#00FFFFFF'
+  - uid: 302
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,-0.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#66FFFFFF'
-  - uid: 304
+      color: '#00FFFFFF'
+  - uid: 303
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,-1.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#66FFFFFF'
-  - uid: 305
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 5.5,-2.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#66FFFFFF'
-  - uid: 306
+      color: '#00FFFFFF'
+  - uid: 304
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,-3.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#66FFFFFF'
+      color: '#00FFFFFF'
+  - uid: 305
+    components:
+    - type: Transform
+      pos: 5.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00FFFFFF'
+  - uid: 306
+    components:
+    - type: Transform
+      pos: 6.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00FFFFFF'
   - uid: 307
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 5.5,4.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#66FFFFFF'
-  - uid: 308
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 5.5,5.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#66FFFFFF'
-  - uid: 309
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,1.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#66FFFFFF'
-  - uid: 310
+      color: '#00FFFFFF'
+  - uid: 308
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2556,7 +2688,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FFAA00FF'
-  - uid: 311
+  - uid: 309
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2564,7 +2696,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FFAA00FF'
-  - uid: 312
+  - uid: 310
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2572,7 +2704,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FFAA00FF'
-  - uid: 313
+  - uid: 311
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2580,7 +2712,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FFAA00FF'
-  - uid: 314
+  - uid: 312
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2588,7 +2720,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FFAA00FF'
-  - uid: 315
+  - uid: 313
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2596,7 +2728,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FFAA00FF'
-  - uid: 316
+  - uid: 314
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2604,7 +2736,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FFAA00FF'
-  - uid: 317
+  - uid: 315
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2612,7 +2744,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FFAA00FF'
-  - uid: 318
+  - uid: 316
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2620,7 +2752,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FFAA00FF'
-  - uid: 319
+  - uid: 317
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2628,14 +2760,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FFAA00FF'
-  - uid: 320
-    components:
-    - type: Transform
-      pos: 5.5,7.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#66FFFFFF'
-  - uid: 321
+  - uid: 319
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2643,7 +2768,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FFAA00FF'
-  - uid: 322
+  - uid: 320
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2651,7 +2776,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FFAA00FF'
-  - uid: 323
+  - uid: 321
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2659,7 +2784,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FFAA00FF'
-  - uid: 324
+  - uid: 322
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2667,8 +2792,38 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FFAA00FF'
+  - uid: 434
+    components:
+    - type: Transform
+      pos: 6.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00FFFFFF'
+  - uid: 696
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00FFFFFF'
 - proto: GasPipeTJunction
   entities:
+  - uid: 323
+    components:
+    - type: Transform
+      pos: 5.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00FFFFFF'
+  - uid: 324
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00FFFFFF'
   - uid: 325
     components:
     - type: Transform
@@ -2676,15 +2831,15 @@ entities:
       pos: 5.5,1.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#66FFFFFF'
+      color: '#00FFFFFF'
   - uid: 326
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 5.5,6.5
+      rot: 1.5707963267948966 rad
+      pos: 4.5,7.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#66FFFFFF'
+      color: '#00FFFFFF'
   - uid: 327
     components:
     - type: Transform
@@ -2725,11 +2880,11 @@ entities:
   - uid: 332
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 5.5,2.5
+      rot: -1.5707963267948966 rad
+      pos: 6.5,3.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#66FFFFFF'
+      color: '#00FFFFFF'
   - uid: 333
     components:
     - type: Transform
@@ -2758,12 +2913,20 @@ entities:
   - uid: 336
     components:
     - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00FFFFFF'
+  - uid: 337
+    components:
+    - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,3.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0000FFFF'
-  - uid: 337
+  - uid: 338
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2771,7 +2934,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FFAA00FF'
-  - uid: 338
+  - uid: 339
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2779,14 +2942,6 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 339
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 6.5,3.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#66FFFFFF'
   - uid: 340
     components:
     - type: Transform
@@ -2813,13 +2968,16 @@ entities:
   - uid: 342
     components:
     - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 5.5,11.5
       parent: 1
     - type: DeviceNetwork
+      configurators:
+      - invalid
       deviceLists:
       - 5
     - type: AtmosPipeColor
-      color: '#66FFFFFF'
+      color: '#00FFFFFF'
   - uid: 343
     components:
     - type: Transform
@@ -2830,18 +2988,18 @@ entities:
       deviceLists:
       - 4
     - type: AtmosPipeColor
-      color: '#66FFFFFF'
+      color: '#00FFFFFF'
   - uid: 344
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
+      rot: -3.141592653589793 rad
       pos: 6.5,2.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
       - 2
     - type: AtmosPipeColor
-      color: '#66FFFFFF'
+      color: '#00FFFFFF'
   - uid: 345
     components:
     - type: Transform
@@ -2852,18 +3010,18 @@ entities:
       deviceLists:
       - 3
     - type: AtmosPipeColor
-      color: '#66FFFFFF'
+      color: '#00FFFFFF'
   - uid: 346
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
+      rot: -3.141592653589793 rad
       pos: 4.5,6.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
       - 5
     - type: AtmosPipeColor
-      color: '#66FFFFFF'
+      color: '#00FFFFFF'
 - proto: GasVentScrubber
   entities:
   - uid: 347
@@ -2921,16 +3079,6 @@ entities:
       - 3
     - type: AtmosPipeColor
       color: '#FFAA00FF'
-  - uid: 352
-    components:
-    - type: Transform
-      pos: 3.5,11.5
-      parent: 1
-    - type: DeviceNetwork
-      deviceLists:
-      - 5
-    - type: AtmosPipeColor
-      color: '#FFAA00FF'
   - uid: 353
     components:
     - type: Transform
@@ -2940,6 +3088,18 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 2
+    - type: AtmosPipeColor
+      color: '#FFAA00FF'
+  - uid: 709
+    components:
+    - type: Transform
+      pos: 3.5,11.5
+      parent: 1
+    - type: DeviceNetwork
+      configurators:
+      - invalid
+      deviceLists:
+      - 5
     - type: AtmosPipeColor
       color: '#FFAA00FF'
 - proto: GasVolumePump
@@ -2967,267 +3127,294 @@ entities:
       parent: 1
 - proto: Grille
   entities:
+  - uid: 188
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,14.5
+      parent: 1
+  - uid: 189
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,13.5
+      parent: 1
+  - uid: 201
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,16.5
+      parent: 1
+  - uid: 202
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,16.5
+      parent: 1
   - uid: 356
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 5.5,14.5
+      rot: 3.141592653589793 rad
+      pos: 9.5,8.5
       parent: 1
-  - uid: 357
+  - uid: 358
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-3.5
       parent: 1
-  - uid: 358
+  - uid: 359
     components:
     - type: Transform
       pos: -1.5,-8.5
       parent: 1
-  - uid: 359
+  - uid: 360
     components:
     - type: Transform
       pos: 0.5,-8.5
       parent: 1
-  - uid: 360
+  - uid: 361
     components:
     - type: Transform
       pos: -0.5,-8.5
       parent: 1
-  - uid: 361
+  - uid: 362
     components:
     - type: Transform
       pos: -2.5,-8.5
       parent: 1
-  - uid: 362
+  - uid: 363
     components:
     - type: Transform
       pos: -4.5,6.5
       parent: 1
-  - uid: 363
+  - uid: 364
     components:
     - type: Transform
       pos: -5.5,5.5
       parent: 1
-  - uid: 364
+  - uid: 365
     components:
     - type: Transform
       pos: -7.5,0.5
       parent: 1
-  - uid: 365
+  - uid: 366
     components:
     - type: Transform
       pos: -2.5,9.5
       parent: 1
-  - uid: 366
+  - uid: 367
     components:
     - type: Transform
       pos: -1.5,9.5
       parent: 1
-  - uid: 367
+  - uid: 368
     components:
     - type: Transform
       pos: -0.5,9.5
       parent: 1
-  - uid: 368
+  - uid: 369
     components:
     - type: Transform
       pos: 0.5,9.5
       parent: 1
-  - uid: 369
+  - uid: 370
     components:
     - type: Transform
       pos: 0.5,-1.5
       parent: 1
-  - uid: 370
+  - uid: 371
     components:
     - type: Transform
       pos: 0.5,-2.5
       parent: 1
-  - uid: 371
+  - uid: 372
     components:
     - type: Transform
       pos: 1.5,-2.5
       parent: 1
-  - uid: 372
+  - uid: 373
     components:
     - type: Transform
       pos: 0.5,2.5
       parent: 1
-  - uid: 373
+  - uid: 374
     components:
     - type: Transform
       pos: 0.5,3.5
       parent: 1
-  - uid: 374
-    components:
-    - type: Transform
-      pos: 1.5,3.5
-      parent: 1
   - uid: 375
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 8.5,-0.5
+      pos: 1.5,3.5
       parent: 1
   - uid: 376
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 9.5,0.5
+      pos: 8.5,-0.5
       parent: 1
   - uid: 377
     components:
     - type: Transform
-      pos: 4.5,14.5
-      parent: 1
-  - uid: 378
-    components:
-    - type: Transform
-      pos: 3.5,14.5
+      rot: 3.141592653589793 rad
+      pos: 9.5,0.5
       parent: 1
   - uid: 379
     components:
     - type: Transform
-      pos: 2.5,13.5
-      parent: 1
-  - uid: 380
-    components:
-    - type: Transform
-      pos: 2.5,12.5
-      parent: 1
-  - uid: 381
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 6.5,12.5
-      parent: 1
-  - uid: 382
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 2.5,-6.5
+      pos: 3.5,14.5
       parent: 1
   - uid: 383
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 2.5,8.5
+      pos: 2.5,-6.5
       parent: 1
   - uid: 384
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 9.5,1.5
+      pos: 2.5,8.5
       parent: 1
   - uid: 385
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 8.5,1.5
+      pos: 9.5,1.5
       parent: 1
   - uid: 386
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 9.5,-0.5
+      pos: 8.5,1.5
       parent: 1
   - uid: 387
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 6.5,13.5
-      parent: 1
-  - uid: 388
-    components:
-    - type: Transform
       rot: 3.141592653589793 rad
-      pos: 2.5,-7.5
+      pos: 9.5,-0.5
       parent: 1
   - uid: 389
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 2.5,7.5
+      pos: 2.5,-7.5
       parent: 1
   - uid: 390
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 8.5,7.5
+      pos: 2.5,7.5
       parent: 1
   - uid: 391
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 8.5,8.5
+      pos: -7.5,2.5
       parent: 1
   - uid: 392
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 8.5,9.5
+      pos: -4.5,-5.5
       parent: 1
   - uid: 393
     components:
     - type: Transform
-      pos: -7.5,2.5
+      pos: -5.5,-4.5
       parent: 1
   - uid: 394
     components:
     - type: Transform
-      pos: -4.5,-5.5
+      pos: -7.5,1.5
       parent: 1
   - uid: 395
     components:
     - type: Transform
-      pos: -5.5,-4.5
+      pos: -7.5,-1.5
       parent: 1
   - uid: 396
     components:
     - type: Transform
-      pos: -7.5,1.5
+      pos: -7.5,-0.5
       parent: 1
   - uid: 397
     components:
     - type: Transform
-      pos: -7.5,-1.5
+      rot: 3.141592653589793 rad
+      pos: 9.5,9.5
       parent: 1
   - uid: 398
     components:
     - type: Transform
-      pos: -7.5,-0.5
+      rot: 3.141592653589793 rad
+      pos: 9.5,7.5
       parent: 1
-- proto: GrilleDiagonal
-  entities:
   - uid: 399
     components:
     - type: Transform
-      pos: -5.5,6.5
+      rot: 3.141592653589793 rad
+      pos: 8.5,6.5
       parent: 1
   - uid: 400
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -7.5,-2.5
+      rot: 3.141592653589793 rad
+      pos: 8.5,10.5
       parent: 1
+  - uid: 509
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,13.5
+      parent: 1
+  - uid: 573
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,15.5
+      parent: 1
+  - uid: 589
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,6.5
+      parent: 1
+  - uid: 634
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,15.5
+      parent: 1
+- proto: GrilleDiagonal
+  entities:
   - uid: 401
     components:
     - type: Transform
-      pos: -7.5,3.5
+      pos: -5.5,6.5
       parent: 1
   - uid: 402
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -3.5,-8.5
+      pos: -7.5,-2.5
       parent: 1
   - uid: 403
     components:
     - type: Transform
-      pos: -3.5,9.5
+      pos: -7.5,3.5
       parent: 1
   - uid: 404
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-8.5
+      parent: 1
+  - uid: 405
+    components:
+    - type: Transform
+      pos: -3.5,9.5
+      parent: 1
+  - uid: 406
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3235,7 +3422,7 @@ entities:
       parent: 1
 - proto: Gyroscope
   entities:
-  - uid: 405
+  - uid: 407
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3243,117 +3430,117 @@ entities:
       parent: 1
 - proto: hydroponicsSoil
   entities:
-  - uid: 406
+  - uid: 408
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-5.5
       parent: 1
-  - uid: 407
+  - uid: 409
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,6.5
       parent: 1
-  - uid: 408
+  - uid: 410
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,2.5
       parent: 1
-  - uid: 409
+  - uid: 411
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,4.5
       parent: 1
-  - uid: 410
+  - uid: 412
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,7.5
       parent: 1
-  - uid: 411
+  - uid: 413
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-1.5
       parent: 1
-  - uid: 412
+  - uid: 414
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-3.5
       parent: 1
-  - uid: 413
+  - uid: 415
     components:
     - type: Transform
       pos: 0.5,6.5
       parent: 1
-  - uid: 414
+  - uid: 416
     components:
     - type: Transform
       pos: 0.5,-6.5
       parent: 1
-  - uid: 415
+  - uid: 417
     components:
     - type: Transform
       pos: 0.5,7.5
       parent: 1
-  - uid: 416
-    components:
-    - type: Transform
-      pos: 0.5,-5.5
-      parent: 1
-  - uid: 417
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -3.5,-1.5
-      parent: 1
   - uid: 418
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -3.5,-3.5
+      pos: 0.5,-5.5
       parent: 1
   - uid: 419
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -1.5,-6.5
+      pos: -3.5,-1.5
       parent: 1
   - uid: 420
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -1.5,-5.5
+      pos: -3.5,-3.5
       parent: 1
   - uid: 421
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -2.5,7.5
+      pos: -1.5,-6.5
       parent: 1
   - uid: 422
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -2.5,4.5
+      pos: -1.5,-5.5
       parent: 1
   - uid: 423
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -2.5,-6.5
+      pos: -2.5,7.5
       parent: 1
   - uid: 424
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -2.5,6.5
+      pos: -2.5,4.5
       parent: 1
   - uid: 425
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-6.5
+      parent: 1
+  - uid: 426
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,6.5
+      parent: 1
+  - uid: 427
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3361,121 +3548,131 @@ entities:
       parent: 1
 - proto: IntercomCommon
   entities:
-  - uid: 102
+  - uid: 428
     components:
     - type: Transform
       pos: 4.5,4.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
 - proto: Jug
   entities:
-  - uid: 441
+  - uid: 429
     components:
     - type: Transform
-      pos: 6.676878,7.612425
+      pos: 7.5737395,7.631172
       parent: 1
-  - uid: 444
+  - uid: 430
     components:
     - type: Transform
-      pos: 6.426878,7.81555
+      pos: 7.4018645,7.849922
       parent: 1
 - proto: KitchenReagentGrinder
   entities:
-  - uid: 426
+  - uid: 431
     components:
     - type: Transform
       pos: 3.5,7.5
       parent: 1
 - proto: LockerAtmosphericsFilledHardsuit
   entities:
-  - uid: 427
+  - uid: 432
     components:
     - type: Transform
-      pos: 6.5,-2.5
+      pos: 4.5,-2.5
       parent: 1
 - proto: LockerBotanistFilled
   entities:
-  - uid: 428
+  - uid: 433
     components:
     - type: Transform
       pos: 1.5,-6.5
       parent: 1
 - proto: LockerCaptain
   entities:
-  - uid: 429
+  - uid: 719
     components:
     - type: Transform
-      pos: 5.5,11.5
+      pos: 3.5,11.5
       parent: 1
 - proto: LockerChemistryFilled
   entities:
-  - uid: 148
+  - uid: 435
     components:
     - type: Transform
-      pos: 5.5,6.5
+      pos: 6.5,9.5
+      parent: 1
+- proto: LockerWallMaterialsBasic10Filled
+  entities:
+  - uid: 436
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-3.5
       parent: 1
 - proto: LockerWallMaterialsFuelUraniumFilled
   entities:
-  - uid: 249
+  - uid: 437
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 9.5,-9.5
+      pos: 9.5,-10.5
       parent: 1
 - proto: MachineCentrifuge
   entities:
-  - uid: 431
+  - uid: 438
     components:
     - type: Transform
       pos: 3.5,9.5
       parent: 1
 - proto: MachineElectrolysisUnit
   entities:
-  - uid: 432
+  - uid: 439
     components:
     - type: Transform
       pos: 3.5,8.5
       parent: 1
 - proto: MaintenancePlantSpawner
   entities:
-  - uid: 433
+  - uid: 440
     components:
     - type: Transform
       pos: -2.5,-2.5
       parent: 1
 - proto: MaterialReclaimer
   entities:
-  - uid: 434
+  - uid: 441
     components:
     - type: Transform
       pos: 8.5,-6.5
       parent: 1
 - proto: MopBucketFull
   entities:
-  - uid: 435
+  - uid: 442
     components:
     - type: Transform
       pos: 2.5,-9.5
       parent: 1
 - proto: MopItem
   entities:
-  - uid: 436
+  - uid: 443
     components:
     - type: Transform
       pos: 2.5,-10.5
       parent: 1
 - proto: NFAshtray
   entities:
-  - uid: 188
+  - uid: 193
     components:
     - type: Transform
       pos: 8.666961,0.29252875
       parent: 1
     - type: Storage
       storedItems:
-        189:
+        194:
           position: 0,0
           _rotation: South
-        190:
+        195:
           position: 1,0
           _rotation: South
     - type: ContainerContainer
@@ -3484,11 +3681,18 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 189
-          - 190
+          - 194
+          - 195
+- proto: NFHolopadShip
+  entities:
+  - uid: 703
+    components:
+    - type: Transform
+      pos: 5.5,12.5
+      parent: 1
 - proto: NitrogenCanister
   entities:
-  - uid: 437
+  - uid: 444
     components:
     - type: Transform
       anchored: True
@@ -3498,7 +3702,7 @@ entities:
       bodyType: Static
 - proto: OxygenCanister
   entities:
-  - uid: 438
+  - uid: 445
     components:
     - type: Transform
       anchored: True
@@ -3508,39 +3712,37 @@ entities:
       bodyType: Static
 - proto: PestSpray
   entities:
-  - uid: 439
+  - uid: 446
     components:
     - type: Transform
       pos: -0.5,2.5
       parent: 1
 - proto: PlantBGoneSpray
   entities:
-  - uid: 440
+  - uid: 447
     components:
     - type: Transform
       pos: -0.5,2.5
       parent: 1
 - proto: PortableGeneratorSuperPacmanShuttle
   entities:
-  - uid: 545
+  - uid: 448
     components:
     - type: Transform
       pos: 8.5,-10.5
       parent: 1
     - type: FuelGenerator
-      on: False
-    - type: Physics
-      bodyType: Static
+      targetPower: 26000
 - proto: PosterContrabandAmbrosiaVulgaris
   entities:
-  - uid: 442
+  - uid: 449
     components:
     - type: Transform
       pos: 2.5,9.5
       parent: 1
 - proto: PosterContrabandKudzu
   entities:
-  - uid: 443
+  - uid: 450
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3548,91 +3750,91 @@ entities:
       parent: 1
 - proto: PottedPlantRandom
   entities:
-  - uid: 200
-    components:
-    - type: Transform
-      pos: 5.5,9.5
-      parent: 1
-  - uid: 445
+  - uid: 451
     components:
     - type: Transform
       pos: 5.5,-4.5
       parent: 1
+  - uid: 690
+    components:
+    - type: Transform
+      pos: 5.5,7.5
+      parent: 1
 - proto: Poweredlight
   entities:
-  - uid: 446
+  - uid: 452
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,7.5
+      parent: 1
+  - uid: 453
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,7.5
       parent: 1
-  - uid: 447
+  - uid: 454
     components:
     - type: Transform
       pos: 1.5,-6.5
       parent: 1
-  - uid: 448
+  - uid: 487
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 3.5,11.5
-      parent: 1
-  - uid: 449
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 7.5,7.5
+      rot: -1.5707963267948966 rad
+      pos: 5.5,12.5
       parent: 1
 - proto: PoweredLightPostSmall
   entities:
-  - uid: 450
+  - uid: 456
     components:
     - type: Transform
       pos: -3.5,0.5
       parent: 1
 - proto: PoweredlightSodium
   entities:
-  - uid: 451
-    components:
-    - type: Transform
-      pos: 6.5,3.5
-      parent: 1
-  - uid: 452
+  - uid: 457
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 6.5,-2.5
+      pos: 5.5,-2.5
+      parent: 1
+  - uid: 458
+    components:
+    - type: Transform
+      pos: 5.5,3.5
       parent: 1
 - proto: PoweredSmallLight
   entities:
-  - uid: 453
+  - uid: 459
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,-8.5
       parent: 1
-  - uid: 454
+  - uid: 460
     components:
     - type: Transform
       pos: 2.5,-4.5
       parent: 1
-  - uid: 455
+  - uid: 461
     components:
     - type: Transform
       pos: 2.5,5.5
       parent: 1
-  - uid: 456
+  - uid: 462
     components:
     - type: Transform
       pos: 4.5,-12.5
       parent: 1
-  - uid: 457
+  - uid: 463
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-10.5
       parent: 1
-  - uid: 458
+  - uid: 464
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3640,126 +3842,112 @@ entities:
       parent: 1
 - proto: Rack
   entities:
-  - uid: 459
+  - uid: 465
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-2.5
+      parent: 1
+  - uid: 466
     components:
     - type: Transform
       pos: -0.5,2.5
       parent: 1
-  - uid: 460
+  - uid: 467
     components:
     - type: Transform
       pos: 2.5,-10.5
       parent: 1
-  - uid: 461
-    components:
-    - type: Transform
-      pos: 4.5,-2.5
-      parent: 1
 - proto: Railing
   entities:
-  - uid: 462
+  - uid: 468
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,0.5
       parent: 1
-  - uid: 463
+  - uid: 469
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,0.5
       parent: 1
-  - uid: 464
+  - uid: 470
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-0.5
       parent: 1
-  - uid: 465
+  - uid: 471
     components:
     - type: Transform
       pos: -4.5,1.5
       parent: 1
 - proto: RailingCornerSmall
   entities:
-  - uid: 466
+  - uid: 472
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,1.5
       parent: 1
-  - uid: 467
+  - uid: 473
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,1.5
       parent: 1
-  - uid: 468
+  - uid: 474
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,-0.5
       parent: 1
-  - uid: 469
+  - uid: 475
     components:
     - type: Transform
       pos: -3.5,-0.5
       parent: 1
 - proto: RandomPosterLegit
   entities:
-  - uid: 470
+  - uid: 476
     components:
     - type: Transform
-      pos: 7.5,3.5
+      pos: 6.5,10.5
       parent: 1
-  - uid: 471
+  - uid: 477
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-3.5
+      parent: 1
+  - uid: 478
     components:
     - type: Transform
       pos: 2.5,-8.5
       parent: 1
-  - uid: 472
-    components:
-    - type: Transform
-      pos: 6.5,-3.5
-      parent: 1
 - proto: RandomProduce
   entities:
-  - uid: 473
+  - uid: 479
     components:
     - type: Transform
       pos: 0.5,7.5
       parent: 1
 - proto: ReinforcedWindow
   entities:
-  - uid: 474
-    components:
-    - type: Transform
-      pos: -7.5,1.5
-      parent: 1
-  - uid: 475
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -7.5,-1.5
-      parent: 1
-  - uid: 476
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 4.5,-3.5
-      parent: 1
-  - uid: 477
-    components:
-    - type: Transform
-      pos: 2.5,-6.5
-      parent: 1
-  - uid: 478
+  - uid: 357
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 6.5,12.5
+      pos: 6.5,14.5
       parent: 1
-  - uid: 479
+  - uid: 378
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,15.5
+      parent: 1
+  - uid: 380
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3768,235 +3956,276 @@ entities:
   - uid: 480
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 8.5,1.5
+      pos: 9.5,9.5
       parent: 1
   - uid: 481
     components:
     - type: Transform
-      pos: -7.5,0.5
+      pos: 9.5,8.5
       parent: 1
   - uid: 482
     components:
     - type: Transform
-      pos: 0.5,-2.5
+      pos: 9.5,7.5
       parent: 1
   - uid: 483
     components:
     - type: Transform
-      pos: 0.5,9.5
+      pos: -7.5,1.5
       parent: 1
   - uid: 484
     components:
     - type: Transform
-      pos: -0.5,9.5
+      rot: 1.5707963267948966 rad
+      pos: -7.5,-1.5
       parent: 1
   - uid: 485
     components:
     - type: Transform
-      pos: -1.5,9.5
+      rot: 3.141592653589793 rad
+      pos: 4.5,-3.5
       parent: 1
   - uid: 486
     components:
     - type: Transform
+      pos: 2.5,-6.5
+      parent: 1
+  - uid: 489
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,1.5
+      parent: 1
+  - uid: 490
+    components:
+    - type: Transform
+      pos: -7.5,0.5
+      parent: 1
+  - uid: 491
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 1
+  - uid: 492
+    components:
+    - type: Transform
+      pos: 0.5,9.5
+      parent: 1
+  - uid: 493
+    components:
+    - type: Transform
+      pos: -0.5,9.5
+      parent: 1
+  - uid: 494
+    components:
+    - type: Transform
+      pos: -1.5,9.5
+      parent: 1
+  - uid: 495
+    components:
+    - type: Transform
       pos: -7.5,-0.5
       parent: 1
-  - uid: 487
+  - uid: 496
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,9.5
       parent: 1
-  - uid: 488
+  - uid: 497
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-8.5
       parent: 1
-  - uid: 489
+  - uid: 498
     components:
     - type: Transform
       pos: -1.5,-8.5
       parent: 1
-  - uid: 490
+  - uid: 499
     components:
     - type: Transform
       pos: -0.5,-8.5
       parent: 1
-  - uid: 491
+  - uid: 500
     components:
     - type: Transform
       pos: 0.5,-8.5
       parent: 1
-  - uid: 492
+  - uid: 501
     components:
     - type: Transform
       pos: 0.5,-1.5
       parent: 1
-  - uid: 493
+  - uid: 502
     components:
     - type: Transform
       pos: 0.5,3.5
       parent: 1
-  - uid: 494
+  - uid: 503
     components:
     - type: Transform
       pos: 0.5,2.5
       parent: 1
-  - uid: 495
+  - uid: 504
     components:
     - type: Transform
       pos: 1.5,3.5
       parent: 1
-  - uid: 496
+  - uid: 505
     components:
     - type: Transform
       pos: 1.5,-2.5
       parent: 1
-  - uid: 497
+  - uid: 506
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,2.5
       parent: 1
-  - uid: 498
+  - uid: 507
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,7.5
       parent: 1
-  - uid: 499
+  - uid: 508
     components:
     - type: Transform
       pos: 3.5,14.5
       parent: 1
-  - uid: 500
+  - uid: 511
     components:
     - type: Transform
-      pos: 2.5,12.5
-      parent: 1
-  - uid: 501
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 8.5,7.5
-      parent: 1
-  - uid: 502
-    components:
-    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 2.5,13.5
       parent: 1
-  - uid: 503
+  - uid: 512
     components:
     - type: Transform
-      pos: 4.5,14.5
+      rot: -1.5707963267948966 rad
+      pos: 4.5,16.5
       parent: 1
-  - uid: 504
-    components:
-    - type: Transform
-      pos: 5.5,14.5
-      parent: 1
-  - uid: 505
+  - uid: 513
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,0.5
       parent: 1
-  - uid: 506
+  - uid: 514
     components:
     - type: Transform
       pos: 2.5,-7.5
       parent: 1
-  - uid: 507
+  - uid: 515
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,8.5
       parent: 1
-  - uid: 508
+  - uid: 516
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,-0.5
       parent: 1
-  - uid: 509
+  - uid: 517
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,1.5
       parent: 1
-  - uid: 510
+  - uid: 518
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,-0.5
       parent: 1
-  - uid: 511
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 8.5,9.5
-      parent: 1
-  - uid: 512
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 8.5,8.5
-      parent: 1
-  - uid: 513
+  - uid: 519
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-4.5
       parent: 1
-  - uid: 514
+  - uid: 520
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-5.5
       parent: 1
-  - uid: 515
+  - uid: 521
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,6.5
       parent: 1
-  - uid: 516
+  - uid: 522
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,5.5
       parent: 1
+  - uid: 523
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,10.5
+      parent: 1
+  - uid: 524
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,6.5
+      parent: 1
+  - uid: 570
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,15.5
+      parent: 1
+  - uid: 692
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,6.5
+      parent: 1
+  - uid: 698
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,16.5
+      parent: 1
 - proto: ReinforcedWindowDiagonal
   entities:
-  - uid: 517
+  - uid: 525
     components:
     - type: Transform
       pos: -7.5,3.5
       parent: 1
-  - uid: 518
+  - uid: 526
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-8.5
       parent: 1
-  - uid: 519
+  - uid: 527
     components:
     - type: Transform
       pos: -3.5,9.5
       parent: 1
-  - uid: 520
+  - uid: 528
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,-2.5
       parent: 1
-  - uid: 521
+  - uid: 529
     components:
     - type: Transform
       pos: -5.5,6.5
       parent: 1
-  - uid: 522
+  - uid: 530
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4004,111 +4233,163 @@ entities:
       parent: 1
 - proto: SeedExtractor
   entities:
-  - uid: 523
+  - uid: 531
     components:
     - type: Transform
       pos: 1.5,7.5
       parent: 1
-- proto: SheetGlass10
+- proto: ShelfChemistry
   entities:
-  - uid: 524
+  - uid: 532
     components:
     - type: Transform
-      pos: 4.626763,-2.5124123
-      parent: 1
-- proto: SheetSteel10
-  entities:
-  - uid: 525
-    components:
-    - type: Transform
-      pos: 4.423638,-2.3405373
+      rot: -1.5707963267948966 rad
+      pos: 5.5,5.5
       parent: 1
 - proto: ShuttersNormalOpen
   entities:
-  - uid: 527
+  - uid: 533
     components:
     - type: Transform
       pos: 9.5,1.5
       parent: 1
-  - uid: 528
+  - uid: 534
     components:
     - type: Transform
       pos: 8.5,1.5
       parent: 1
-  - uid: 529
+  - uid: 535
     components:
     - type: Transform
       pos: 9.5,0.5
       parent: 1
-  - uid: 530
+  - uid: 536
     components:
     - type: Transform
       pos: 9.5,-0.5
       parent: 1
-  - uid: 531
+  - uid: 537
     components:
     - type: Transform
       pos: 8.5,-0.5
       parent: 1
-  - uid: 532
+  - uid: 538
     components:
     - type: Transform
-      pos: 8.5,9.5
+      pos: 9.5,9.5
       parent: 1
-  - uid: 533
+  - uid: 539
     components:
     - type: Transform
-      pos: 8.5,8.5
+      pos: 9.5,8.5
       parent: 1
-  - uid: 534
+  - uid: 540
     components:
     - type: Transform
-      pos: 8.5,7.5
+      pos: 9.5,7.5
+      parent: 1
+  - uid: 542
+    components:
+    - type: Transform
+      pos: 8.5,6.5
+      parent: 1
+  - uid: 543
+    components:
+    - type: Transform
+      pos: 8.5,10.5
+      parent: 1
+  - uid: 693
+    components:
+    - type: Transform
+      pos: 6.5,6.5
+      parent: 1
+  - uid: 699
+    components:
+    - type: Transform
+      pos: 3.5,14.5
+      parent: 1
+  - uid: 707
+    components:
+    - type: Transform
+      pos: 2.5,13.5
+      parent: 1
+  - uid: 711
+    components:
+    - type: Transform
+      pos: 3.5,15.5
+      parent: 1
+  - uid: 712
+    components:
+    - type: Transform
+      pos: 4.5,16.5
+      parent: 1
+  - uid: 713
+    components:
+    - type: Transform
+      pos: 5.5,16.5
+      parent: 1
+  - uid: 714
+    components:
+    - type: Transform
+      pos: 6.5,15.5
+      parent: 1
+  - uid: 715
+    components:
+    - type: Transform
+      pos: 6.5,14.5
+      parent: 1
+  - uid: 716
+    components:
+    - type: Transform
+      pos: 6.5,13.5
       parent: 1
 - proto: ShuttersRadiation
   entities:
-  - uid: 535
+  - uid: 545
     components:
     - type: Transform
       pos: 6.5,-9.5
       parent: 1
-- proto: SignalButton
+- proto: ShuttersWindow
   entities:
-  - uid: 536
+  - uid: 694
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 7.5,-2.5
+      pos: 7.5,5.5
       parent: 1
-    - type: DeviceLinkSource
-      linkedPorts:
-        528:
-        - Pressed: Toggle
-        527:
-        - Pressed: Toggle
-        529:
-        - Pressed: Toggle
-        530:
-        - Pressed: Toggle
-        531:
-        - Pressed: Toggle
 - proto: SignalButtonDirectional
   entities:
-  - uid: 151
+  - uid: 318
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 6.5,6.5
+      pos: 7.5,3.5
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        534:
+        694:
         - Pressed: Toggle
-        533:
+  - uid: 547
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,6.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        542:
         - Pressed: Toggle
-        532:
+        540:
         - Pressed: Toggle
-  - uid: 537
+        539:
+        - Pressed: Toggle
+        538:
+        - Pressed: Toggle
+        543:
+        - Pressed: Toggle
+        693:
+        - Pressed: Toggle
+  - uid: 548
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4116,11 +4397,53 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
+        545:
+        - Pressed: Toggle
+  - uid: 549
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-1.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        537:
+        - Pressed: Toggle
+        536:
+        - Pressed: Toggle
         535:
+        - Pressed: Toggle
+        533:
+        - Pressed: Toggle
+        534:
+        - Pressed: Toggle
+  - uid: 717
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,12.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        707:
+        - Pressed: Toggle
+        699:
+        - Pressed: Toggle
+        711:
+        - Pressed: Toggle
+        712:
+        - Pressed: Toggle
+        713:
+        - Pressed: Toggle
+        714:
+        - Pressed: Toggle
+        715:
+        - Pressed: Toggle
+        716:
         - Pressed: Toggle
 - proto: SignAtmos
   entities:
-  - uid: 539
+  - uid: 550
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4128,7 +4451,7 @@ entities:
       parent: 1
 - proto: SignChem
   entities:
-  - uid: 540
+  - uid: 551
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4136,7 +4459,7 @@ entities:
       parent: 1
 - proto: SignHydro1
   entities:
-  - uid: 541
+  - uid: 552
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4144,14 +4467,21 @@ entities:
       parent: 1
 - proto: SignRadiationMed
   entities:
-  - uid: 248
+  - uid: 553
     components:
     - type: Transform
-      pos: 9.5,-10.5
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-9.5
       parent: 1
 - proto: SignSpace
   entities:
-  - uid: 543
+  - uid: 554
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,4.5
+      parent: 1
+  - uid: 555
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4159,21 +4489,21 @@ entities:
       parent: 1
 - proto: SinkWide
   entities:
-  - uid: 544
+  - uid: 556
     components:
     - type: Transform
       pos: 2.5,-9.5
       parent: 1
 - proto: SMESBasic
   entities:
-  - uid: 676
+  - uid: 557
     components:
     - type: Transform
       pos: 7.5,-10.5
       parent: 1
 - proto: SpawnPointLatejoin
   entities:
-  - uid: 546
+  - uid: 558
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4181,70 +4511,70 @@ entities:
       parent: 1
 - proto: SprayBottleSpaceCleaner
   entities:
-  - uid: 679
+  - uid: 559
     components:
     - type: Transform
       pos: 2.5,-10.5
       parent: 1
 - proto: SprayPainter
   entities:
-  - uid: 547
+  - uid: 560
     components:
     - type: Transform
-      pos: 4.4587674,-2.5606894
+      pos: 3.5,-2.5
       parent: 1
 - proto: StorageCanister
   entities:
-  - uid: 548
+  - uid: 561
     components:
     - type: Transform
       pos: 2.5,-2.5
       parent: 1
-  - uid: 549
+  - uid: 562
     components:
     - type: Transform
       pos: 1.5,-1.5
       parent: 1
 - proto: SubstationBasic
   entities:
-  - uid: 677
+  - uid: 563
     components:
     - type: Transform
       pos: 7.5,-8.5
       parent: 1
 - proto: SuitStorageEVAHydro
   entities:
-  - uid: 551
+  - uid: 564
     components:
     - type: Transform
       pos: 1.5,-7.5
       parent: 1
 - proto: TableCounterMetal
   entities:
-  - uid: 430
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 6.5,7.5
-      parent: 1
-  - uid: 538
+  - uid: 565
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,7.5
       parent: 1
-  - uid: 552
+  - uid: 566
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,7.5
+      parent: 1
+  - uid: 567
     components:
     - type: Transform
       pos: 3.5,7.5
       parent: 1
-  - uid: 553
+  - uid: 568
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,9.5
       parent: 1
-  - uid: 554
+  - uid: 569
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4252,72 +4582,66 @@ entities:
       parent: 1
 - proto: TableReinforced
   entities:
-  - uid: 555
+  - uid: 205
     components:
     - type: Transform
-      pos: 5.5,13.5
+      pos: 5.5,14.5
       parent: 1
-  - uid: 556
+  - uid: 382
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 3.5,12.5
+      pos: 4.5,15.5
       parent: 1
-  - uid: 557
+  - uid: 488
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 3.5,13.5
-      parent: 1
-  - uid: 558
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,13.5
+      pos: 5.5,15.5
       parent: 1
 - proto: Thruster
   entities:
-  - uid: 559
+  - uid: 574
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,11.5
       parent: 1
-  - uid: 560
+  - uid: 575
     components:
     - type: Transform
       pos: 1.5,11.5
       parent: 1
-  - uid: 561
+  - uid: 576
     components:
     - type: Transform
       pos: 7.5,11.5
       parent: 1
-  - uid: 562
+  - uid: 577
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,11.5
       parent: 1
-  - uid: 563
+  - uid: 578
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,-13.5
       parent: 1
-  - uid: 564
+  - uid: 579
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-13.5
       parent: 1
-  - uid: 565
+  - uid: 580
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,-12.5
       parent: 1
-  - uid: 566
+  - uid: 581
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4325,306 +4649,320 @@ entities:
       parent: 1
 - proto: TrashBag
   entities:
-  - uid: 567
+  - uid: 582
     components:
     - type: Transform
       pos: 2.5,-10.5
       parent: 1
 - proto: VendingMachineAtmosDrobe
   entities:
-  - uid: 568
+  - uid: 583
     components:
     - type: Transform
       pos: 3.5,-7.5
       parent: 1
 - proto: VendingMachineChemDrobe
   entities:
-  - uid: 569
+  - uid: 584
     components:
     - type: Transform
-      pos: 5.5,5.5
+      pos: 6.5,7.5
       parent: 1
 - proto: VendingMachineHydrobe
   entities:
-  - uid: 570
+  - uid: 585
     components:
     - type: Transform
       pos: 3.5,-6.5
       parent: 1
 - proto: VendingMachineNutri
   entities:
-  - uid: 571
+  - uid: 586
     components:
     - type: Transform
       pos: -5.5,-2.5
       parent: 1
 - proto: VendingMachineSeedsUnlocked
   entities:
-  - uid: 572
+  - uid: 587
     components:
     - type: Transform
       pos: 1.5,8.5
       parent: 1
 - proto: WallReinforced
   entities:
-  - uid: 573
+  - uid: 381
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 9.5,-7.5
+      pos: 6.5,12.5
       parent: 1
-  - uid: 574
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -5.5,-3.5
-      parent: 1
-  - uid: 575
-    components:
-    - type: Transform
-      pos: -4.5,-7.5
-      parent: 1
-  - uid: 576
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -6.5,-2.5
-      parent: 1
-  - uid: 577
-    components:
-    - type: Transform
-      pos: -6.5,-3.5
-      parent: 1
-  - uid: 578
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -6.5,3.5
-      parent: 1
-  - uid: 579
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -3.5,8.5
-      parent: 1
-  - uid: 580
-    components:
-    - type: Transform
-      pos: -6.5,4.5
-      parent: 1
-  - uid: 581
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -3.5,-7.5
-      parent: 1
-  - uid: 582
-    components:
-    - type: Transform
-      pos: -4.5,8.5
-      parent: 1
-  - uid: 583
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -4.5,-6.5
-      parent: 1
-  - uid: 584
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -5.5,4.5
-      parent: 1
-  - uid: 585
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -4.5,7.5
-      parent: 1
-  - uid: 586
+  - uid: 510
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 8.5,-4.5
+      pos: 2.5,12.5
       parent: 1
-  - uid: 587
+  - uid: 541
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 9.5,-10.5
+      pos: 7.5,6.5
+      parent: 1
+  - uid: 544
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,10.5
       parent: 1
   - uid: 588
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 4.5,-13.5
-      parent: 1
-  - uid: 589
-    components:
-    - type: Transform
-      pos: 7.5,10.5
+      rot: 1.5707963267948966 rad
+      pos: 5.5,4.5
       parent: 1
   - uid: 590
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 6.5,11.5
+      pos: 9.5,-7.5
       parent: 1
   - uid: 591
     components:
     - type: Transform
-      pos: 7.5,6.5
+      rot: 3.141592653589793 rad
+      pos: -5.5,-3.5
       parent: 1
   - uid: 592
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 8.5,2.5
+      pos: -4.5,-7.5
       parent: 1
   - uid: 593
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 6.5,-11.5
+      pos: -6.5,-2.5
       parent: 1
   - uid: 594
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 9.5,-9.5
+      pos: -6.5,-3.5
       parent: 1
   - uid: 595
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 8.5,-2.5
+      rot: 3.141592653589793 rad
+      pos: -6.5,3.5
       parent: 1
   - uid: 596
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 7.5,-3.5
+      rot: 3.141592653589793 rad
+      pos: -3.5,8.5
       parent: 1
   - uid: 597
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 6.5,4.5
+      pos: -6.5,4.5
       parent: 1
   - uid: 598
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,-13.5
+      rot: 3.141592653589793 rad
+      pos: -3.5,-7.5
       parent: 1
   - uid: 599
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 2.5,-11.5
+      pos: -4.5,8.5
       parent: 1
   - uid: 600
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,10.5
+      rot: 3.141592653589793 rad
+      pos: -4.5,-6.5
       parent: 1
   - uid: 601
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 0.5,10.5
+      rot: 3.141592653589793 rad
+      pos: -5.5,4.5
       parent: 1
   - uid: 602
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 6.5,-13.5
+      pos: -4.5,7.5
       parent: 1
   - uid: 603
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 7.5,4.5
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-4.5
       parent: 1
   - uid: 604
     components:
     - type: Transform
-      pos: 2.5,11.5
+      rot: 1.5707963267948966 rad
+      pos: 9.5,-10.5
       parent: 1
   - uid: 605
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 0.5,-9.5
+      pos: 4.5,-13.5
       parent: 1
   - uid: 606
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 9.5,-6.5
+      pos: 6.5,11.5
       parent: 1
   - uid: 607
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 2.5,-12.5
+      pos: 8.5,2.5
       parent: 1
   - uid: 608
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,10.5
+      rot: 3.141592653589793 rad
+      pos: 6.5,-11.5
       parent: 1
   - uid: 609
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 6.5,-12.5
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-9.5
       parent: 1
   - uid: 610
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,-10.5
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-2.5
       parent: 1
   - uid: 611
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 8.5,-1.5
+      pos: 7.5,-3.5
       parent: 1
   - uid: 612
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,5.5
+      parent: 1
+  - uid: 613
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-13.5
+      parent: 1
+  - uid: 614
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-11.5
+      parent: 1
+  - uid: 615
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,10.5
+      parent: 1
+  - uid: 616
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,10.5
+      parent: 1
+  - uid: 617
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-13.5
+      parent: 1
+  - uid: 618
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,4.5
+      parent: 1
+  - uid: 619
+    components:
+    - type: Transform
+      pos: 2.5,11.5
+      parent: 1
+  - uid: 620
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-9.5
+      parent: 1
+  - uid: 621
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-6.5
+      parent: 1
+  - uid: 622
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-12.5
+      parent: 1
+  - uid: 623
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,10.5
+      parent: 1
+  - uid: 624
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-12.5
+      parent: 1
+  - uid: 625
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-10.5
+      parent: 1
+  - uid: 626
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-1.5
+      parent: 1
+  - uid: 627
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,3.5
       parent: 1
-  - uid: 613
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 6.5,5.5
-      parent: 1
-  - uid: 614
+  - uid: 628
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,-8.5
       parent: 1
-  - uid: 615
+  - uid: 629
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 8.5,-11.5
       parent: 1
-  - uid: 616
+  - uid: 630
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,-5.5
       parent: 1
-  - uid: 617
+  - uid: 631
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4632,274 +4970,275 @@ entities:
       parent: 1
 - proto: WallReinforcedDiagonal
   entities:
-  - uid: 618
+  - uid: 154
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 6.5,14.5
-      parent: 1
-  - uid: 619
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 8.5,6.5
-      parent: 1
-  - uid: 620
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 9.5,-11.5
-      parent: 1
-  - uid: 621
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 1.5,-11.5
-      parent: 1
-  - uid: 622
-    components:
-    - type: Transform
-      pos: 2.5,14.5
-      parent: 1
-  - uid: 623
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 8.5,10.5
-      parent: 1
-  - uid: 624
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 9.5,-5.5
-      parent: 1
-  - uid: 625
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -0.5,-9.5
-      parent: 1
-  - uid: 626
-    components:
-    - type: Transform
-      pos: -0.5,10.5
-      parent: 1
-- proto: WallSolid
-  entities:
-  - uid: 627
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 7.5,-4.5
-      parent: 1
-  - uid: 628
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 8.5,-7.5
-      parent: 1
-  - uid: 629
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 7.5,-7.5
-      parent: 1
-  - uid: 630
-    components:
-    - type: Transform
-      pos: 4.5,-11.5
-      parent: 1
-  - uid: 631
-    components:
-    - type: Transform
-      pos: 4.5,4.5
+      pos: 3.5,16.5
       parent: 1
   - uid: 632
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -0.5,1.5
+      pos: 9.5,10.5
       parent: 1
   - uid: 633
     components:
     - type: Transform
-      pos: 1.5,6.5
-      parent: 1
-  - uid: 634
-    components:
-    - type: Transform
-      pos: 3.5,6.5
+      rot: 3.141592653589793 rad
+      pos: 9.5,6.5
       parent: 1
   - uid: 635
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,-5.5
+      rot: 3.141592653589793 rad
+      pos: 9.5,-11.5
       parent: 1
   - uid: 636
     components:
     - type: Transform
-      pos: 2.5,6.5
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-11.5
       parent: 1
   - uid: 637
     components:
     - type: Transform
-      pos: 3.5,4.5
+      pos: 2.5,14.5
       parent: 1
   - uid: 638
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 2.5,-5.5
+      pos: 9.5,-5.5
       parent: 1
   - uid: 639
     components:
     - type: Transform
-      pos: 6.5,10.5
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-9.5
       parent: 1
   - uid: 640
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,-5.5
+      pos: -0.5,10.5
       parent: 1
+  - uid: 691
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,16.5
+      parent: 1
+- proto: WallSolid
+  entities:
   - uid: 641
     components:
     - type: Transform
-      pos: 6.5,-3.5
+      rot: 1.5707963267948966 rad
+      pos: 5.5,6.5
       parent: 1
   - uid: 642
     components:
     - type: Transform
-      pos: 3.5,-3.5
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-4.5
       parent: 1
   - uid: 643
     components:
     - type: Transform
-      pos: 5.5,4.5
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-7.5
       parent: 1
   - uid: 644
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,-9.5
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-7.5
       parent: 1
   - uid: 645
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 7.5,3.5
+      pos: 4.5,-11.5
       parent: 1
   - uid: 646
     components:
     - type: Transform
-      pos: 5.5,10.5
+      pos: 4.5,4.5
       parent: 1
   - uid: 647
     components:
     - type: Transform
-      pos: 3.5,10.5
+      rot: -1.5707963267948966 rad
+      pos: -0.5,1.5
       parent: 1
   - uid: 648
     components:
     - type: Transform
-      pos: 7.5,-2.5
+      pos: 1.5,6.5
       parent: 1
   - uid: 649
     components:
     - type: Transform
-      pos: 6.5,6.5
+      pos: 3.5,6.5
       parent: 1
   - uid: 650
     components:
     - type: Transform
-      pos: 6.5,-10.5
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-5.5
       parent: 1
   - uid: 651
     components:
     - type: Transform
-      pos: 6.5,-8.5
+      pos: 2.5,6.5
       parent: 1
   - uid: 652
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 5.5,-3.5
+      pos: 3.5,4.5
       parent: 1
   - uid: 653
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 2.5,-8.5
+      pos: 2.5,-5.5
       parent: 1
   - uid: 654
+    components:
+    - type: Transform
+      pos: 6.5,10.5
+      parent: 1
+  - uid: 655
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-5.5
+      parent: 1
+  - uid: 656
+    components:
+    - type: Transform
+      pos: 6.5,-3.5
+      parent: 1
+  - uid: 657
+    components:
+    - type: Transform
+      pos: 3.5,-3.5
+      parent: 1
+  - uid: 658
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-9.5
+      parent: 1
+  - uid: 659
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,3.5
+      parent: 1
+  - uid: 660
+    components:
+    - type: Transform
+      pos: 5.5,10.5
+      parent: 1
+  - uid: 661
+    components:
+    - type: Transform
+      pos: 3.5,10.5
+      parent: 1
+  - uid: 662
+    components:
+    - type: Transform
+      pos: 7.5,-2.5
+      parent: 1
+  - uid: 663
+    components:
+    - type: Transform
+      pos: 6.5,-10.5
+      parent: 1
+  - uid: 664
+    components:
+    - type: Transform
+      pos: 6.5,-8.5
+      parent: 1
+  - uid: 665
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-3.5
+      parent: 1
+  - uid: 666
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-8.5
+      parent: 1
+  - uid: 667
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-8.5
       parent: 1
-  - uid: 655
+  - uid: 668
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,9.5
       parent: 1
-  - uid: 656
+  - uid: 669
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,9.5
       parent: 1
-  - uid: 657
+  - uid: 670
     components:
     - type: Transform
       pos: 2.5,-3.5
       parent: 1
-  - uid: 658
+  - uid: 671
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,-0.5
       parent: 1
-  - uid: 659
+  - uid: 672
     components:
     - type: Transform
       pos: 1.5,-3.5
       parent: 1
-  - uid: 660
+  - uid: 673
     components:
     - type: Transform
       pos: 0.5,1.5
       parent: 1
-  - uid: 661
+  - uid: 674
     components:
     - type: Transform
       pos: 1.5,4.5
       parent: 1
-  - uid: 662
+  - uid: 675
     components:
     - type: Transform
       pos: 2.5,4.5
       parent: 1
-  - uid: 663
+  - uid: 676
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,1.5
       parent: 1
-  - uid: 664
+  - uid: 677
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,-0.5
       parent: 1
-  - uid: 665
+  - uid: 678
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,-0.5
       parent: 1
-  - uid: 666
+  - uid: 679
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4907,15 +5246,14 @@ entities:
       parent: 1
 - proto: WarningAir
   entities:
-  - uid: 667
+  - uid: 680
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 6.5,4.5
+      pos: 7.5,-2.5
       parent: 1
 - proto: WarningN2
   entities:
-  - uid: 668
+  - uid: 681
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4923,43 +5261,43 @@ entities:
       parent: 1
 - proto: WarningO2
   entities:
-  - uid: 669
+  - uid: 682
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,4.5
       parent: 1
-- proto: WarpPointShip
+- proto: WarpPoint
   entities:
-  - uid: 670
+  - uid: 683
     components:
     - type: Transform
       pos: 0.5,0.5
       parent: 1
 - proto: WaterTankHighCapacity
   entities:
-  - uid: 671
+  - uid: 684
     components:
     - type: Transform
       pos: -0.5,-1.5
       parent: 1
 - proto: WeedSpray
   entities:
-  - uid: 672
+  - uid: 685
     components:
     - type: Transform
       pos: -0.5,2.5
       parent: 1
 - proto: WeldingFuelTankFull
   entities:
-  - uid: 673
+  - uid: 686
     components:
     - type: Transform
-      pos: 7.5,-1.5
+      pos: 5.5,-2.5
       parent: 1
 - proto: WindoorSecure
   entities:
-  - uid: 674
+  - uid: 687
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4969,23 +5307,14 @@ entities:
       lastSignals:
         DoorStatus: True
     - type: Door
-      secondsUntilStateChange: -16643.004
+      secondsUntilStateChange: -31290.842
       state: Opening
 - proto: WindowReinforcedDirectional
   entities:
-  - uid: 675
+  - uid: 688
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,-5.5
       parent: 1
-- proto: Wrench
-  entities:
-  - uid: 194
-    components:
-    - type: Transform
-      parent: 192
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
 ...

--- a/Resources/ServerInfo/_NF/Guidebook/Shipyard/Akupara.xml
+++ b/Resources/ServerInfo/_NF/Guidebook/Shipyard/Akupara.xml
@@ -51,7 +51,7 @@
   - Check if the S.U.P.E.R.P.A.C.M.A.N. generator unit is anchored to the floor.
   - Check if the S.U.P.E.R.P.A.C.M.A.N. generator unit has fuel. For extended flights make sure that you have enough fuel stockpiled to sustain prolonged power generation during flight.
   - Check if the S.U.P.E.R.P.A.C.M.A.N. generator unit is set to HV output.
-  - Set Target Power for 32 [bold]k[/bold]W.
+  - Set Target Power for 26 [bold]k[/bold]W.
   - Start the S.U.P.E.R.P.A.C.M.A.N. generator unit.
 
   ## 2. Atmospherics
@@ -112,7 +112,7 @@
 
   ## Sidenotes
 
-  * - Akupara-class vessels are equipped with three APC units that can be used to appraise the ship's total power consumption. Unmodified Akupara-class vessels require 32 kW of power to remain operational.
+  * - Akupara-class vessels are equipped with three APC units that can be used to appraise the ship's total power consumption. Unmodified Akupara-class vessels require 26 kW of power to remain operational.
 
   ** - Since the Akupara's distribution loop uses a gas mixer, it does not need pre-mixed air for optimal atmospherics. However, it features a port to accept pre-mixed air.
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Continuation from https://github.com/new-frontiers-14/frontier-station-14/pull/2603, due to my build breaking
The holopad was added and the bridge was given much love to make space for it: beds and shutters were also installed.
New atmos airlock slightly adjusted to allow for emptying cans while flying without getting dragged of into space by it
Mass scanner moved to atmos: it wasn't being useful next to the shuttle console.

## Why / Balance
Ship holopads were added. Holopads are awesome and the Akupara is large enough to warrant the installation of one

## How to test
-mapping 420 /maps/_NF/Shuttles/akupara.yml and inspect
-purchase the akupara at frontier and inspect
-check the guidebook to see correct power guideline information (26kw)

## Media
![2025-1-31_15 33 12](https://github.com/user-attachments/assets/8a610e6c-85ba-4ddf-96ee-518ad11267a3)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none anticipated

**Changelog**
:cl:
- tweak: Akupara: The bridge has been revised to include bunks and a holopad. Mass scanner relocated to atmos. New airlock installed at atmos.
