### PR TITLE
Shuttle (Update): Spectre revamp and holopad addition

### DIFF
--- a/Resources/Maps/_NF/Shuttles/spectre.yml
+++ b/Resources/Maps/_NF/Shuttles/spectre.yml
@@ -781,7 +781,7 @@ entities:
       pos: 6.5,7.5
       parent: 3
     - type: Door
-      secondsUntilStateChange: -4163.5547
+      secondsUntilStateChange: -4439.459
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -3177,6 +3177,11 @@ entities:
         - 0
         - 0
         - 0
+  - uid: 1268
+    components:
+    - type: Transform
+      pos: -1.5,7.5
+      parent: 3
 - proto: ComfyChair
   entities:
   - uid: 1054
@@ -3291,6 +3296,18 @@ entities:
     components:
     - type: Transform
       pos: 7.5,4.5
+      parent: 3
+- proto: CrateEmptySpawner
+  entities:
+  - uid: 1265
+    components:
+    - type: Transform
+      pos: -6.5,3.5
+      parent: 3
+  - uid: 1266
+    components:
+    - type: Transform
+      pos: -0.5,-8.5
       parent: 3
 - proto: CurtainsPurpleOpen
   entities:
@@ -5705,10 +5722,25 @@ entities:
       parent: 3
 - proto: PottedPlantRandom
   entities:
+  - uid: 460
+    components:
+    - type: Transform
+      pos: 10.5,0.5
+      parent: 3
+  - uid: 472
+    components:
+    - type: Transform
+      pos: -9.5,0.5
+      parent: 3
   - uid: 1152
     components:
     - type: Transform
       pos: -1.5,15.5
+      parent: 3
+  - uid: 1267
+    components:
+    - type: Transform
+      pos: 2.5,7.5
       parent: 3
 - proto: PowerCellRecharger
   entities:
@@ -6393,6 +6425,23 @@ entities:
     - type: Transform
       pos: 3.5,-3.5
       parent: 3
+- proto: SpawnPointLatejoin
+  entities:
+  - uid: 344
+    components:
+    - type: Transform
+      pos: 2.5,16.5
+      parent: 3
+  - uid: 356
+    components:
+    - type: Transform
+      pos: 2.5,17.5
+      parent: 3
+  - uid: 447
+    components:
+    - type: Transform
+      pos: 2.5,18.5
+      parent: 3
 - proto: StorageCanister
   entities:
   - uid: 1067
@@ -6580,6 +6629,11 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -10.5,-2.5
+      parent: 3
+  - uid: 1264
+    components:
+    - type: Transform
+      pos: -4.5,0.5
       parent: 3
 - proto: TelecomServerFilledShuttle
   entities:


### PR DESCRIPTION
## About the PR
A few updates and additions to the Spectre, including the highly-requested rear cargo door on Engineering and easier Artifact chamber access, and a holopad for the bridge now that they've been added. Also renovated the crew lounge with more beds and personal closets for the crew, and a watercooler and hot drink dispenser.

## Why / Balance
The Spectre's interior layout has been the source of a number of minor complaints and wishes for a few quality-of-life tweaks and additions, such as the widened artifact bay doors and rear cargo door; also, the large bar was kind of extraneous given _every other second ship_ has one. Plus, we got holopads now, so I had the perfect excuse to add one to the Spectre's bridge since I was already working on it. 

## How to test
-Load up a local test instance with these changes.
-Run `mapping 28 /maps/_NF/Shuttles/spectre.yml` or simply purchase the ship at Frontier Outpost.
-Use Sandbox Menu to toggle visibility options as needed.
-Examine and test at your leisure.

## Media
![image](https://github.com/user-attachments/assets/b8e176c0-9d1d-44c7-a443-bc8d3995834f)
![image](https://github.com/user-attachments/assets/6fdb368b-eaad-42be-aa61-deb92851b72b)


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
Don't think this will cause any.

**Changelog**

:cl:
- tweak: Spectre bridge now features a holopad. 
- tweak: Spectre crew lounge now features beds for the remainder of the crew, a watercooler, and a hot drink vendor. 
- tweak: Spectre artifact chambers have been renovated with larger external blast doors, and the engineering bay has been given a large cargo blast door at the rear end.
- tweak: Spectre gyroscopes relocated to more sensible locations inside of the hull from their original positions exposed on the exterior. As a necessary result of the above, the janitor's closet was moved into the inner-right wingtip, merged with the existing portable-scrubber storage.
