### PR TITLE
Vim update

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -275,13 +275,13 @@
     baseState: vim
     openState: vim-open
     brokenState: vim-broken
-    maxEquipmentAmount: 2 # frontier 0<2
+    maxEquipmentAmount: 2 # Frontier 0<2
     # keep mouse safe
     mechToPilotDamageMultiplier: 0.1
     airtight: true
-    equipmentWhitelist: # frontier
-      tags: # frontier
-      - SmallMech # frontier
+    equipmentWhitelist: # Frontier
+      tags: # Frontier
+      - SmallMech # Frontier
     pilotWhitelist:
       tags:
       - VimPilot

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -275,9 +275,13 @@
     baseState: vim
     openState: vim-open
     brokenState: vim-broken
-    maxEquipmentAmount: 0
+    maxEquipmentAmount: 2 # frontier 0<2
     # keep mouse safe
     mechToPilotDamageMultiplier: 0.1
+    airtight: true
+    equipmentWhitelist: # frontier
+      tags: # frontier
+      - SmallMech # frontier
     airtight: true
     pilotWhitelist:
       tags:

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -282,6 +282,7 @@
     equipmentWhitelist: # frontier
       tags: # frontier
       - SmallMech # frontier
+    airtight: true
     pilotWhitelist:
       tags:
       - VimPilot

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -282,7 +282,6 @@
     equipmentWhitelist: # frontier
       tags: # frontier
       - SmallMech # frontier
-    airtight: true
     pilotWhitelist:
       tags:
       - VimPilot

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/pets.yml
@@ -5,9 +5,6 @@
   - type: GhostRole
   - type: IntrinsicRadioReceiver
   - type: CargoSellBlacklist
-  - type: Tag
-    tags:
-    - VimPilot
 
 - type: entity
   name: Clippy

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/pets.yml
@@ -5,7 +5,9 @@
   - type: GhostRole
   - type: IntrinsicRadioReceiver
   - type: CargoSellBlacklist
-
+  - type: Tag
+    tags:
+    - VimPilot
 - type: entity
   name: Clippy
   parent: [NFMobPet, MobCatGhost]

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/pets.yml
@@ -8,6 +8,7 @@
   - type: Tag
     tags:
     - VimPilot
+
 - type: entity
   name: Clippy
   parent: [NFMobPet, MobCatGhost]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added 2 clamp slots to the vim, to bring it in line with the hamtr, per whatstone's suggestion. 
added tags to base NFcat so they can pilot the vims as well 

## Why / Balance
the hamtr is cool, but only lets a hamster in. so its either make a full new mech, rename and rebrand the hamtr, or give the vim a couple slots so that our pet friends  have a little more function. 

## How to test
load local host
spawn a vim
spawn some clamps and install them
spawn cappy or any other NF cat and shove them in. enjoy the ability to move small objects
alternativly spawn any already authorized ghost pet (or vermin) and shove them in, also to enjoy the new clamps

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
NA

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: VIM can now take two small clamps so our little friends can carry around their favorite plushies.
