### PR TITLE
Fill Sheriff's Locker & Move SR Access config to their locker.

### DIFF
--- a/Resources/Maps/_NF/POI/nfsd.yml
+++ b/Resources/Maps/_NF/POI/nfsd.yml
@@ -13850,13 +13850,6 @@ entities:
     - type: Transform
       pos: 18.5,23.5
       parent: 1
-- proto: MedalCaseNfsd
-  entities:
-  - uid: 72
-    components:
-    - type: Transform
-      pos: 4.382657,9.643819
-      parent: 1
 - proto: MedicalBed
   entities:
   - uid: 41

--- a/Resources/Maps/_NF/POI/nfsd.yml
+++ b/Resources/Maps/_NF/POI/nfsd.yml
@@ -13719,7 +13719,7 @@ entities:
     - type: Transform
       pos: 7.5,13.5
       parent: 1
-- proto: LockerNfsdSheriff
+- proto: LockerNfsdSheriffFilled
   entities:
   - uid: 218
     components:

--- a/Resources/Prototypes/_NF/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/Lockers/heads.yml
@@ -45,7 +45,6 @@
       - id: CommsComputerCircuitboard # Frontier
       - id: MedalCase # Frontier
       - id: Demag # Frontier
-      - id: AccessConfigurator # Frontier
 
 - type: entity
   id: LockerNfsdSheriffFilled
@@ -59,7 +58,6 @@
       - id: CommsComputerCircuitboard # Frontier
       - id: MedalCaseNfsd # Frontier
       - id: Demag # Frontier
-      - id: AccessConfigurator # Frontier
 
 - type: entity
   parent: GunSafe

--- a/Resources/Prototypes/_NF/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/Lockers/heads.yml
@@ -45,6 +45,21 @@
       - id: CommsComputerCircuitboard # Frontier
       - id: MedalCase # Frontier
       - id: Demag # Frontier
+      - id: AccessConfigurator # Frontier
+
+- type: entity
+  id: LockerNfsdSheriffFilled
+  suffix: Filled
+  parent: LockerNfsdSheriff
+  components:
+  - type: StorageFill
+    contents:
+      - id: ShriffIDCard
+      - id: BoxHandcuff # Frontier
+      - id: CommsComputerCircuitboard # Frontier
+      - id: MedalCaseNfsd # Frontier
+      - id: Demag # Frontier
+      - id: AccessConfigurator # Frontier
 
 - type: entity
   parent: GunSafe

--- a/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/cart.yml
+++ b/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/cart.yml
@@ -25,6 +25,7 @@
     EncryptionKeyService: 4294967295 #Infinite
     EncryptionKeyNfsd: 5
     EncryptionKeyCommand: 5
+    AccessConfigurator: 2
 
 - type: vendingMachineInventory
   id: NFPTechNfsdInventory
@@ -70,3 +71,4 @@
     ClothingNeckNfsdBadgeWarden: 10
     ClothingNeckNfsdBadgeSheriff: 3
     ClothingMaskGasSheriff: 3
+    AccessConfigurator: 2

--- a/Resources/Prototypes/_NF/Roles/Jobs/Frontier/sr.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Frontier/sr.yml
@@ -39,6 +39,5 @@
     - Flash
     - RubberStampSr
     - DoorRemoteCommand
-    # - AccessConfigurator # Moved to SR Locker.
     - EncryptionKeyStationMaster
     - EncryptionKeyCentCom

--- a/Resources/Prototypes/_NF/Roles/Jobs/Frontier/sr.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Frontier/sr.yml
@@ -39,6 +39,6 @@
     - Flash
     - RubberStampSr
     - DoorRemoteCommand
-    - AccessConfigurator
+    # - AccessConfigurator # Moved to SR Locker.
     - EncryptionKeyStationMaster
     - EncryptionKeyCentCom


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Filled the Sheriff's Locker on the NFSD Outpost (ID Card, Cuff Box, Demag, Access Config, etc.)
Moved the SR's Access Config from their bag to their locker.

EDIT: Access config is in the PTechs now, not locker.

## Why / Balance
Firstly, currently if an SR is not ingame, no access configurator exists, which is a problem if needed by for example the DoC or the Sheriff.
Also, the sheriff used to get a few things in their locker, including the demag, but now they just don't. With this PR they get a demag, which is arguably more important for them then for the SR, alongside an access configurator for if they want to change NFSD Accesses (Add an armory lock to a bought armory crate, make certain areas on ships require higher access, etc.) Alongside some misc things such as a cuff box, comms console board, nfsd medal case, etc.

Also sidenote, yes I know that there is now an nfsd medal case on the Sheriff's desk and in their locker, but I feel like having extras doesn't hurt, for example if 2 civillians both deserve one of the civ medals.

## How to test
Spawn as SR, Check the lockers for both Sheriff and SR.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: BramvanZijp
- add: Added several items to the Sheriff's Locker, including a Demag.
- add: The PTech and NFSD PTech now both have 2 access configurators.
- remove: The Station Representative no longer spawns with an access configurator in their bag.
