### PR TITLE
Add BRB sign to the service techfab.

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/lathe.yml
@@ -159,6 +159,7 @@
       - FireExtinguisher
       - WetFloorSign
       - DeskBell
+      - BrbSign
     dynamicRecipes:
     # Shared lathe recipes
     ## Advanced tools

--- a/Resources/Prototypes/_NF/Recipes/Lathes/service.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/service.yml
@@ -114,3 +114,10 @@
   completetime: 2
   materials:
     Steel: 200
+
+- type: latheRecipe
+  id: BrbSign
+  result: BrbSign
+  parent: BaseServiceItemsRecipe
+  materials:
+    Cardboard: 200


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds a BRB sign recipe to the service techfab.

## Why / Balance
Allows service ships to alert customers they are currently not there and will be right back.

## How to test
Put two pieces of cardboard in a service techfab (or work your way up to creating it from two pieces of wood).
Create BRB sign.
Hide in the back from customers.

## Media
![image](https://github.com/user-attachments/assets/2c73af8a-4ee0-4ccb-8f00-8bd9080bddf4)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added BRB sign to the service techfab.
