### PR TITLE
Fix asteroid gas deposit entity duplication

### DIFF
--- a/Content.Server/_NF/Worldgen/Systems/Debris/RandomEntityPopulatorSystem.cs
+++ b/Content.Server/_NF/Worldgen/Systems/Debris/RandomEntityPopulatorSystem.cs
@@ -52,6 +52,7 @@ public sealed class RandomEntityPopulatorSystem : BaseWorldSystem
 
                     Spawn(proto, coords);
                 }
+                placeables.Clear();
             }
         }
     }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Fixes gas deposit duplication - a list is used to gather spawned entities, it needs to be cleared between calls.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Bug.

## How to test
<!-- Describe the way it can be tested -->

Generate large asteroids until you get one with two gas deposit sprites.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Gas deposits no longer duplicate on asteroid tiles.