### PR TITLE
BetterBorg Hotfix: Unremoveable after equip

### DIFF
--- a/Content.Server/Silicons/Borgs/BorgSystem.Modules.cs
+++ b/Content.Server/Silicons/Borgs/BorgSystem.Modules.cs
@@ -250,9 +250,7 @@ public sealed partial class BorgSystem
                 }
 
                 // Just in case, make sure the borg can't drop the placeholder.
-                if (HasComp<HandPlaceholderComponent>(item))
-                    EnsureComp<UnremoveableComponent>(item);
-                else
+                if (!HasComp<HandPlaceholderComponent>(item))
                 {
                     var placeComp = EnsureComp<HandPlaceholderRemoveableComponent>(item);
                     placeComp.Whitelist = itemProto.Whitelist;
@@ -271,6 +269,16 @@ public sealed partial class BorgSystem
             component.HandCounter++;
             _hands.AddHand(chassis, handId, HandLocation.Middle, hands);
             _hands.DoPickup(chassis, hands.Hands[handId], item, hands);
+            if (hands.Hands[handId].HeldEntity != item)
+            {
+                // If we didn't pick up our expected item, delete the hand.  No free hands!
+                _hands.RemoveHand(chassis, handId);
+            }
+            else if (HasComp<HandPlaceholderComponent>(item))
+            {
+                // Placeholders can't be put down, must be changed after picked up (otherwise it'll fail to pick up)
+                EnsureComp<UnremoveableComponent>(item);
+            }
             component.DroppableProvidedItems.Add(handId, (item, itemProto));
         }
         // End Frontier: droppable cyborg items


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

When re-equipping items from a borg's provided item container:
1. If the item is an actual item, equip it as usual.
2. If the item is a placeholder, create a hand, equip it, make sure it's equipped, and if so, you're fine.
3. If the item equipped is not your item (e.g. an empty hand), delete the hand.  No free hands, ever.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

I goofed.

## How to test
<!-- Describe the way it can be tested -->

1. Become service borg
2. Swap to your service module.
3. Drop your borg shaker and borg lighter.
4. Unequip the service module, re-equip the service module.
5. Your shaker and lighter placeholder items should _still exist_ in your hands.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

The book bag and shaker here are unequipped, placeholder items.
![image](https://github.com/user-attachments/assets/c621d9de-7bb6-4237-9f37-e9dafc062fb6)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
Not in-game yet.