### PR TITLE
StationJobs: protect station jobs with access levels/groups

### DIFF
--- a/Content.Server/Station/Components/StationJobsComponent.cs
+++ b/Content.Server/Station/Components/StationJobsComponent.cs
@@ -6,6 +6,7 @@ using Robust.Shared.Network;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Dictionary;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Set;
+using Content.Shared.Access; // Frontier
 
 namespace Content.Server.Station.Components;
 
@@ -79,4 +80,12 @@ public sealed partial class StationJobsComponent : Component
     /// </summary>
     [DataField("availableJobs", required: true)]
     public Dictionary<ProtoId<JobPrototype>, int[]> SetupAvailableJobs = default!;
+
+    // Frontier: when editing jobs, what accesses should be required?
+    [DataField]
+    public List<ProtoId<AccessGroupPrototype>> Groups = new();
+
+    [DataField]
+    public List<ProtoId<AccessLevelPrototype>> Tags = new();
+    // End Frontier
 }

--- a/Content.Server/StationRecords/Systems/GeneralStationRecordConsoleSystem.cs
+++ b/Content.Server/StationRecords/Systems/GeneralStationRecordConsoleSystem.cs
@@ -69,7 +69,8 @@ public sealed class GeneralStationRecordConsoleSystem : EntitySystem
         if (stationUid is EntityUid station)
         {
             // Frontier: check access - hack because we don't have an AccessReaderComponent, it's the station
-            if (TryComp(stationUid, out StationJobsComponent? stationJobs))
+            if (TryComp(stationUid, out StationJobsComponent? stationJobs) &&
+                (stationJobs.Groups.Count > 0 || stationJobs.Tags.Count > 0))
             {
                 var accessSources = _access.FindPotentialAccessItems(msg.Actor);
                 var access = _access.FindAccessTags(msg.Actor, accessSources);

--- a/Content.Server/StationRecords/Systems/GeneralStationRecordConsoleSystem.cs
+++ b/Content.Server/StationRecords/Systems/GeneralStationRecordConsoleSystem.cs
@@ -6,6 +6,8 @@ using Robust.Server.GameObjects;
 using System.Linq;
 using Content.Shared.Roles;
 using Robust.Shared.Prototypes; // Frontier
+using Content.Shared.Access.Systems; // Frontier
+using Content.Server.Station.Components; // Frontier
 
 namespace Content.Server.StationRecords.Systems;
 
@@ -16,6 +18,8 @@ public sealed class GeneralStationRecordConsoleSystem : EntitySystem
     [Dependency] private readonly StationRecordsSystem _stationRecords = default!;
     [Dependency] private readonly StationJobsSystem _stationJobsSystem = default!;
     [Dependency] private readonly StationSystem _stationSystem = default!;
+    [Dependency] private readonly AccessReaderSystem _access = default!; // Frontier
+    [Dependency] private readonly IPrototypeManager _proto = default!; // Frontier
 
     public override void Initialize()
     {
@@ -64,6 +68,34 @@ public sealed class GeneralStationRecordConsoleSystem : EntitySystem
         var stationUid = _stationSystem.GetOwningStation(uid);
         if (stationUid is EntityUid station)
         {
+            // Frontier: check access - hack because we don't have an AccessReaderComponent, it's the station
+            if (TryComp(stationUid, out StationJobsComponent? stationJobs))
+            {
+                var accessSources = _access.FindPotentialAccessItems(msg.Actor);
+                var access = _access.FindAccessTags(msg.Actor, accessSources);
+
+                // Check access groups and tags
+                bool hasAccess = stationJobs.Tags.Any(access.Contains);
+                if (!hasAccess)
+                {
+                    foreach (var group in stationJobs.Groups)
+                    {
+                        if (!_proto.TryIndex(group, out var accessGroup))
+                            continue;
+
+                        hasAccess = accessGroup.Tags.Any(access.Contains);
+                        if (hasAccess)
+                            break;
+                    }
+                }
+
+                if (!hasAccess)
+                {
+                    UpdateUserInterface((uid, component));
+                    return;
+                }
+            }
+            // End Frontier
             _stationJobsSystem.TryAdjustJobSlot(station, msg.JobProto, msg.Amount, false, true);
         }
         UpdateUserInterface((uid,component));

--- a/Resources/Prototypes/_NF/Maps/Outpost/frontier.yml
+++ b/Resources/Prototypes/_NF/Maps/Outpost/frontier.yml
@@ -31,5 +31,8 @@
             Valet: [ 1, 1 ]
             NFJanitor: [ 1, 1 ]
             MailCarrier: [ 1, 1 ]
+          tags:
+          - HeadOfPersonnel
+          - HeadOfSecurity
 # Others:
 #            Borg: [ 0, 0 ]

--- a/Resources/Prototypes/_NF/PointsOfInterest/medical.yml
+++ b/Resources/Prototypes/_NF/PointsOfInterest/medical.yml
@@ -42,5 +42,8 @@
             DirectorOfCare: [ 1, 1 ]
             Pilot: [ -1, -1 ]
             Mercenary: [ -1, -1 ]
+          tags:
+          - HeadOfPersonnel
+          - HeadOfSecurity
         - type: StationDeadDrop
           maxDeadDrops: 1 # Fewer here, players start here.

--- a/Resources/Prototypes/_NF/PointsOfInterest/nfsd.yml
+++ b/Resources/Prototypes/_NF/PointsOfInterest/nfsd.yml
@@ -49,6 +49,9 @@
             Cadet: [ 0, 0 ]
             # Others:
             PublicAffairsLiaison: [ 1, 1 ]
+          tags:
+          - HeadOfPersonnel
+          - HeadOfSecurity
         - type: StationDeadDropReporting
           messageSet: Nfsd
         - type: StationDeadDropHintExempt


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Protects interactions with station records consoles.  The StationJobsComponent now gets optional access levels and tags - any of the given tags (or any within the listed groups) is required on the person changing the access for changes to go through.

Issue: there isn't currently a single API call to do this without having an AccessReaderComponent (which really makes no sense on the station - what are you protecting), so this is currently duplicating a routine that the shipyard console uses.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Any dingus dragging a station records computer onto a grid shouldn't be able to open station job slots.  Long open pain point.

Counterpoint: you can't open slots if the last guy nodded off without reopening their own position.

## How to test
<!-- Describe the way it can be tested -->

1. Spawn a Urist, become the Urist.  Purchase a ship, edit your job listings on your ship.  No problem.
2. Drag your station records computer onto Frontier Station.  Try to edit FO's job listings.  Shouldn't work.
3. Give yourself a Station Rep ID, try again while carrying it, should work.
4. Give yourself a Sheriff's PDA, try again while it's in your PDA slot, should work.
5. Warp to NFSD Outpost, retest steps 2-4.
6. Warp to Medical Dispatch, retest steps 2-4.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

muh job

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Only the SR, sheriff and DOC can open station job slots.