### PR TITLE
Draft: Handle discord webhook logic

### DIFF
--- a/Content.Server/Discord/WebhookMessages/NewsWebhooks.cs
+++ b/Content.Server/Discord/WebhookMessages/NewsWebhooks.cs
@@ -110,19 +110,6 @@ public sealed class NewsWebhooks : EntitySystem
     {
         _sawmill.Info($"Attempting to delete news post: {articleTitle}");
 
-        // Log all stored message IDs
-        if (_messageIds.Count == 0)
-        {
-            _sawmill.Warning("No stored message IDs exist.");
-        }
-        else
-        {
-            foreach (var entry in _messageIds)
-            {
-                _sawmill.Info($"Stored Message ID - Title: {entry.Key}, ID: {entry.Value}");
-            }
-        }
-
         // Attempt to find the stored message ID
         if (!_messageIds.TryGetValue(articleTitle, out var messageId))
         {

--- a/Content.Server/Discord/WebhookMessages/NewsWebhooks.cs
+++ b/Content.Server/Discord/WebhookMessages/NewsWebhooks.cs
@@ -188,13 +188,25 @@ public static class SS14ToDiscordFormatter
         if (string.IsNullOrEmpty(body))
             return string.Empty;
 
-        // Convert headings (maps [head=1-3] to bold, since Discord has no true headings)
-        body = Regex.Replace(body, @"\[head=\d\](.*?)\[/head\]", "**$1**");
+        // Convert headings ([head=1], [head=2], etc.)
+        body = Regex.Replace(body, @"\[head=(\d+)\](.*?)\[/head\]", match =>
+        {
+            int level = int.Parse(match.Groups[1].Value);
+            string text = match.Groups[2].Value;
 
-        // Convert color tags (Discord does not support colored text, so remove them)
+            return level switch
+            {
+                1 => $"# {text}", // Largest
+                2 => $"## {text}", // Medium
+                3 => $"### {text}", // Smallest
+                _ => text // Fallback (remove if unknown)
+            };
+        });
+
+        // Remove unsupported color tags
         body = Regex.Replace(body, @"\[color=[^\]]+\](.*?)\[/color\]", "$1");
 
-        // Convert italic, bold, and bullet point tags
+        // Convert bold, italic, and bullet points
         body = Regex.Replace(body, @"\[italic\](.*?)\[/italic\]", "*$1*");
         body = Regex.Replace(body, @"\[bold\](.*?)\[/bold\]", "**$1**");
         body = Regex.Replace(body, @"\[bullet\](.*?)\[/bullet\]", "- $1");

--- a/Content.Server/Discord/WebhookMessages/NewsWebhooks.cs
+++ b/Content.Server/Discord/WebhookMessages/NewsWebhooks.cs
@@ -1,11 +1,14 @@
+using System;
+using System.Numerics;
+using System.Text.RegularExpressions;
+using System.Text.Json;
+using System.Collections.Generic;
 using Content.Server.Discord;
 using Content.Shared.MassMedia.Systems;
 using Robust.Shared.Configuration;
 using Robust.Shared.GameObjects;
 using System.Threading.Tasks;
 using Content.Shared.CCVar;
-using Content.Server.CartridgeLoader.Cartridges;
-using System.Text.RegularExpressions;
 
 namespace Content.Server.Discord.WebhookMessages;
 

--- a/Content.Server/Discord/WebhookMessages/NewsWebhooks.cs
+++ b/Content.Server/Discord/WebhookMessages/NewsWebhooks.cs
@@ -161,6 +161,20 @@ public sealed class NewsWebhooks : EntitySystem
     }
 
     /// <summary>
+    /// Parses a Discord webhook URL into its ID and token.
+    /// </summary>
+    private bool TryParseWebhookUrl(string url, out string id, out string token)
+    {
+        id = string.Empty;
+        token = string.Empty;
+
+        var parts = url.Split('/');
+        if (parts.Length < 7) // Ensure the URL has enough segments
+            return false;
+
+        id = parts[5];   // The 6th element is the webhook ID
+        token = parts[6]; // The 7th element is the webhook token
+        return true;
     }
 }
 

--- a/Content.Server/Discord/WebhookMessages/NewsWebhooks.cs
+++ b/Content.Server/Discord/WebhookMessages/NewsWebhooks.cs
@@ -19,6 +19,7 @@ public sealed class NewsWebhooks : EntitySystem
     [Dependency] private readonly ILogManager _log = default!;
 
     private ISawmill _sawmill = default!;
+    private readonly Dictionary<string, ulong> _messageIds = new(); // Store message IDs
 
     public override void Initialize()
     {

--- a/Content.Server/Discord/WebhookMessages/NewsWebhooks.cs
+++ b/Content.Server/Discord/WebhookMessages/NewsWebhooks.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Numerics;
 using System.Text.RegularExpressions;
 using System.Text.Json;
 using System.Collections.Generic;

--- a/Content.Server/Discord/WebhookMessages/NewsWebhooks.cs
+++ b/Content.Server/Discord/WebhookMessages/NewsWebhooks.cs
@@ -1,0 +1,133 @@
+using Content.Server.Discord;
+using Content.Shared.MassMedia.Systems;
+using Robust.Shared.Configuration;
+using Robust.Shared.GameObjects;
+using System.Threading.Tasks;
+using Content.Shared.CCVar;
+using Content.Server.CartridgeLoader.Cartridges;
+using System.Text.RegularExpressions;
+
+namespace Content.Server.Discord.WebhookMessages;
+
+public sealed class NewsWebhooks : EntitySystem
+{
+    [Dependency] private readonly IConfigurationManager _cfg = default!;
+    [Dependency] private readonly DiscordWebhook _discord = default!;
+    [Dependency] private readonly ILogManager _log = default!;
+
+    private ISawmill _sawmill = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        _sawmill = _log.GetSawmill("discord-news");
+
+        _sawmill.Info("[NewsWebhooks] Initialized and ready to receive articles.");
+    }
+
+    /// <summary>
+    /// Handles a published news article and sends it to Discord.
+    /// This is called directly from NewsSystem.cs.
+    /// </summary>
+    public void HandleNewsPublished(NewsArticle article)
+    {
+        _sawmill.Info($"[NewsWebhooks] Directly received article: {article.Title} by {article.Author}");
+
+        SendNewsToDiscord(article);
+    }
+
+    private bool TryParseWebhookUrl(string url, out string id, out string token)
+    {
+        id = string.Empty;
+        token = string.Empty;
+
+        // Discord webhook format: https://discord.com/api/webhooks/{id}/{token}
+        var parts = url.Split('/');
+        if (parts.Length < 7) // Ensure the URL has enough segments
+            return false;
+
+        id = parts[5];   // The 6th element is the webhook ID
+        token = parts[6]; // The 7th element is the webhook token
+        return true;
+    }
+
+    private async Task SendNewsToDiscord(NewsArticle article)
+    {
+        // Fetch the webhook URL from config
+        var webhookUrl = _cfg.GetCVar(CCVars.DiscordNewsWebhook);
+        if (string.IsNullOrWhiteSpace(webhookUrl))
+        {
+            _sawmill.Warning("Discord webhook URL is not configured. Skipping news posting.");
+            return;
+        }
+
+        // Extract ID and Token
+        if (!TryParseWebhookUrl(webhookUrl, out var webhookId, out var webhookToken))
+        {
+            _sawmill.Error($"Invalid Discord webhook URL format: {webhookUrl}");
+            return;
+        }
+
+        _sawmill.Info($"[NewsWebhooks] Attempting to send news to Discord: {article.Title}");
+
+        // Format content using SS14ToDiscordFormatter
+        string formattedContent = SS14ToDiscordFormatter.ConvertToDiscordMarkup(article.Content);
+
+        // Construct payload
+        var payload = new WebhookPayload
+        {
+            Username = "NewsBot",
+            Embeds = new List<WebhookEmbed>
+            {
+                new()
+                {
+                    Title = article.Title,
+                    Description = formattedContent,
+                    Color = 3447003, // Discord blue
+                    Footer = new WebhookEmbedFooter
+                    {
+                        Text = $"Written by: {article.Author ?? "Unknown"}"
+                    }
+                }
+            }
+        };
+
+        // Send webhook with the correct identifier
+        var response = await _discord.CreateMessage(new WebhookIdentifier(webhookId, webhookToken), payload);
+
+        if (response.IsSuccessStatusCode)
+        {
+            _sawmill.Info($"[NewsWebhooks] Successfully sent news to Discord: {article.Title}");
+        }
+        else
+        {
+            var errorMessage = await response.Content.ReadAsStringAsync();
+            _sawmill.Error($"[NewsWebhooks] Failed to send news to Discord. Status Code: {response.StatusCode}, Response: {errorMessage}");
+        }
+    }
+}
+
+/// <summary>
+/// Converts SS14 news markup to Discord-compatible markup.
+/// </summary>
+public static class SS14ToDiscordFormatter
+{
+    public static string ConvertToDiscordMarkup(string body)
+    {
+        if (string.IsNullOrEmpty(body))
+            return string.Empty;
+
+        // Convert headings (maps [head=1-3] to bold, since Discord has no true headings)
+        body = Regex.Replace(body, @"\[head=\d\](.*?)\[/head\]", "**$1**");
+
+        // Convert color tags (Discord does not support colored text, so remove them)
+        body = Regex.Replace(body, @"\[color=[^\]]+\](.*?)\[/color\]", "$1");
+
+        // Convert italic, bold, and bullet point tags
+        body = Regex.Replace(body, @"\[italic\](.*?)\[/italic\]", "*$1*");
+        body = Regex.Replace(body, @"\[bold\](.*?)\[/bold\]", "**$1**");
+        body = Regex.Replace(body, @"\[bullet\](.*?)\[/bullet\]", "- $1");
+
+        return body;
+    }
+}

--- a/Content.Server/MassMedia/Systems/NewsSystem.cs
+++ b/Content.Server/MassMedia/Systems/NewsSystem.cs
@@ -65,6 +65,7 @@ public sealed class NewsSystem : SharedNewsSystem
         SubscribeLocalEvent<NewsReaderCartridgeComponent, NewsArticleDeletedEvent>(OnArticleDeleted);
         SubscribeLocalEvent<NewsReaderCartridgeComponent, CartridgeMessageEvent>(OnReaderUiMessage);
         SubscribeLocalEvent<NewsReaderCartridgeComponent, CartridgeUiReadyEvent>(OnReaderUiReady);
+        SubscribeLocalEvent<RoundEndTextAppendEvent>(OnRoundEndHandleNews);
     }
  
     // Frontier: article lifecycle management
@@ -357,5 +358,11 @@ public sealed class NewsSystem : SharedNewsSystem
     private void OnRequestArticleDraftMessage(Entity<NewsWriterComponent> ent, ref NewsWriterRequestDraftMessage msg)
     {
         UpdateWriterUi(ent);
+    }
+
+    private void OnRoundEndHandleNews(RoundEndTextAppendEvent ev)
+    {
+        Logger.Info("[NewsSystem] Round ending - sending stored news articles.");
+        _newsWebhooks.OnRoundEndHandleNews();
     }
 }

--- a/Content.Server/MassMedia/Systems/NewsSystem.cs
+++ b/Content.Server/MassMedia/Systems/NewsSystem.cs
@@ -115,7 +115,7 @@ public sealed class NewsSystem : SharedNewsSystem
         var article = articles[msg.ArticleNum];
         if (CanUse(msg.Actor, ent.Owner))
         {
-            _newsWebhooks.DeleteNewsFromDiscord(article.Title);
+            _newsWebhooks.DeleteNewsFromDiscord(article);
             
             _adminLogger.Add(
                 LogType.Chat, LogImpact.Medium,

--- a/Content.Server/MassMedia/Systems/NewsSystem.cs
+++ b/Content.Server/MassMedia/Systems/NewsSystem.cs
@@ -115,6 +115,8 @@ public sealed class NewsSystem : SharedNewsSystem
         var article = articles[msg.ArticleNum];
         if (CanUse(msg.Actor, ent.Owner))
         {
+            _newsWebhooks.DeleteNewsFromDiscord(article.Title);
+            
             _adminLogger.Add(
                 LogType.Chat, LogImpact.Medium,
                 $"{ToPrettyString(msg.Actor):actor} deleted news article {article.Title} by {article.Author}: {article.Content}"
@@ -200,7 +202,7 @@ public sealed class NewsSystem : SharedNewsSystem
         }
 
         UpdateWriterDevices();
-        _newsWebhooks.HandleNewsPublished(article);
+        _newsWebhooks.SendNewsToDiscord(article);
     }
     #endregion
 

--- a/Content.Server/MassMedia/Systems/NewsSystem.cs
+++ b/Content.Server/MassMedia/Systems/NewsSystem.cs
@@ -20,6 +20,7 @@ using Robust.Shared.Audio.Systems;
 using Content.Shared.IdentityManagement;
 using Robust.Shared.Timing;
 using Content.Shared.GameTicking; // Frontier
+using Content.Server.Discord.WebhookMessages;
 
 namespace Content.Server.MassMedia.Systems;
 
@@ -35,6 +36,8 @@ public sealed class NewsSystem : SharedNewsSystem
     [Dependency] private readonly StationSystem _station = default!;
     [Dependency] private readonly GameTicker _ticker = default!;
     [Dependency] private readonly IChatManager _chatManager = default!;
+    [Dependency] private readonly NewsWebhooks _newsWebhooks = default!;
+
 
     public override void Initialize()
     {
@@ -197,6 +200,7 @@ public sealed class NewsSystem : SharedNewsSystem
         }
 
         UpdateWriterDevices();
+        _newsWebhooks.HandleNewsPublished(article);
     }
     #endregion
 

--- a/Content.Shared/CCVar/CCVars.Discord.cs
+++ b/Content.Shared/CCVar/CCVars.Discord.cs
@@ -41,16 +41,20 @@ public sealed partial class CCVars
     public static readonly CVarDef<string> DiscordVoteWebhook =
         CVarDef.Create("discord.vote_webhook", string.Empty, CVar.SERVERONLY);
     /// <summary>
+    ///     URL of the Discord webhook which will relay all votekick votes. If left empty, disables the webhook.
+    /// </summary>
+    public static readonly CVarDef<string> DiscordVotekickWebhook =
+        CVarDef.Create("discord.votekick_webhook", string.Empty, CVar.SERVERONLY);
+    /// <summary>
     ///     URL of the Discord webhook which will forward news articles
     /// </summary>
     public static readonly CVarDef<string> DiscordNewsWebhook =
         CVarDef.Create("discord.news_webhook", string.Empty, CVar.SERVERONLY);
     /// <summary>
-    ///     URL of the Discord webhook which will relay all votekick votes. If left empty, disables the webhook.
+    ///     Boolean for live posting of articles, false by default.
     /// </summary>
-    public static readonly CVarDef<string> DiscordVotekickWebhook =
-        CVarDef.Create("discord.votekick_webhook", string.Empty, CVar.SERVERONLY);
-
+    public static readonly CVarDef<bool> DiscordLiveNewsPosting =
+        CVarDef.Create("discord.live_news_posting", false, CVar.SERVERONLY);
     /// <summary>
     ///     URL of the Discord webhook which will relay round restart messages.
     /// </summary>

--- a/Content.Shared/CCVar/CCVars.Discord.cs
+++ b/Content.Shared/CCVar/CCVars.Discord.cs
@@ -40,7 +40,9 @@ public sealed partial class CCVars
     /// </summary>
     public static readonly CVarDef<string> DiscordVoteWebhook =
         CVarDef.Create("discord.vote_webhook", string.Empty, CVar.SERVERONLY);
-
+    /// <summary>
+    ///     URL of the Discord webhook which will forward news articles
+    /// </summary>
     public static readonly CVarDef<string> DiscordNewsWebhook =
         CVarDef.Create("discord.news_webhook", string.Empty, CVar.SERVERONLY);
     /// <summary>

--- a/Content.Shared/CCVar/CCVars.Discord.cs
+++ b/Content.Shared/CCVar/CCVars.Discord.cs
@@ -41,6 +41,8 @@ public sealed partial class CCVars
     public static readonly CVarDef<string> DiscordVoteWebhook =
         CVarDef.Create("discord.vote_webhook", string.Empty, CVar.SERVERONLY);
 
+    public static readonly CVarDef<string> DiscordNewsWebhook =
+        CVarDef.Create("discord.news_webhook", string.Empty, CVar.SERVERONLY);
     /// <summary>
     ///     URL of the Discord webhook which will relay all votekick votes. If left empty, disables the webhook.
     /// </summary>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Adds discord webhook integration for News. When articles are posted at the reporters console, they can be sent to discord to archival in a channel via webhook.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It's more aesthetic and for archival for later reading and does not change any game mechanics

## How to test
<!-- Describe the way it can be tested -->
add
[discord]
news_webhook = "https://discord.com/api/webhooks/ID/KEY"
to server_settings.toml
Write an article and watch the discord channel you retrieved and entered the webhook url for.
Delete an article and watch it delete from discord.
Use mark up, and watch it convert SS14 markup to discord markup (Does not work with colors, discord limitation.)

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
No ingame changes.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
No breaking changes. It taps into existing functionality and does not modify it.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Discord NewsSystem Webhook integration, posting articles to discord.
- tweak: NewsSystem also publishes to New Webhook integration.
-->
