### PR TITLE
Silence reagent dispensers on spawn.

### DIFF
--- a/Content.Server/Chemistry/EntitySystems/ReagentDispenserSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/ReagentDispenserSystem.cs
@@ -38,6 +38,7 @@ namespace Content.Server.Chemistry.EntitySystems
         [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
         [Dependency] private readonly OpenableSystem _openable = default!;
         [Dependency] private readonly LabelSystem _label = default!; // Frontier
+        [Dependency] private readonly SharedContainerSystem _containers = default!; // Frontier
 
         public override void Initialize()
         {
@@ -279,8 +280,10 @@ namespace Content.Server.Chemistry.EntitySystems
             {
                 for (var i = 0; i < packPrototype.Inventory.Count && i < component.StorageSlots.Count; i++)
                 {
+                    if (component.StorageSlots[i].ContainerSlot == null)
+                        continue;
                     var item = Spawn(packPrototype.Inventory[i], Transform(uid).Coordinates);
-                    if (!_itemSlotsSystem.TryInsert(uid, component.StorageSlots[i].ID!, item, null, excludeUserAudio: true))
+                    if (!_containers.Insert(item, component.StorageSlots[i].ContainerSlot!)) // ContainerSystem.Insert is silent.
                         QueueDel(item);
                 }
             }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Calls ContainerSystem.Insert directly instead of ItemSlot.Insert when initializing a reagent dispenser.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Currently, the reagent dispenser plays the clicky insert sound when inserting things into the dispenser.  It does this _for each item in the dispenser_ on spawn.  If you warp to a chemistry ship, your ears currently bleed.

## How to test
<!-- Describe the way it can be tested -->

1. Spawn a chemical dispenser.
2. Enjoy the silence.
3. View the contents of the chemical dispenser.
4. They should match.
5. Insert more jugs, you should be able to fit five.  Each insertion is clicky.
6. Remove and reinsert jugs.  Removal/insertion is clicky.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

The contents of a chemical dispenser after spawning.  Everything is accounted for.
![image](https://github.com/user-attachments/assets/ebaf68d1-1de2-417e-a344-2bc57a13f6ed)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Reagent dispensers no longer play a sound for inserting all jugs on initializing.