### PR TITLE
BorgSystem: check droppable items for duped mods

### DIFF
--- a/Content.Server/Silicons/Borgs/BorgSystem.Modules.cs
+++ b/Content.Server/Silicons/Borgs/BorgSystem.Modules.cs
@@ -369,7 +369,9 @@ public sealed partial class BorgSystem
                     continue;
 
                 if (containedItemModuleComp.Items.Count == itemModuleComp.Items.Count &&
-                    containedItemModuleComp.Items.All(itemModuleComp.Items.Contains))
+                    containedItemModuleComp.DroppableItems.Count == itemModuleComp.DroppableItems.Count && // Frontier
+                    containedItemModuleComp.Items.All(itemModuleComp.Items.Contains) &&
+                    containedItemModuleComp.DroppableItems.All(x => itemModuleComp.DroppableItems.Contains(x, new DroppableBorgItemComparer()))) // Frontier
                 {
                     if (user != null)
                         Popup.PopupEntity(Loc.GetString("borg-module-duplicate"), uid, user.Value);
@@ -380,6 +382,29 @@ public sealed partial class BorgSystem
 
         return true;
     }
+
+    // Frontier: droppable borg item comparator
+    private sealed class DroppableBorgItemComparer : IEqualityComparer<DroppableBorgItem>
+    {
+        public bool Equals(DroppableBorgItem? x, DroppableBorgItem? y)
+        {
+            // Same object
+            if (ReferenceEquals(x, y))
+                return true;
+            // Comparisons vs. null
+            if (x is null || y is null)
+                return false;
+            // Otherwise, use EntProtoId of item to keep
+            return x.ID == y.ID;
+        }
+
+        public int GetHashCode(DroppableBorgItem obj)
+        {
+            if (obj is null) return 0;
+            return obj.ID.GetHashCode();
+        }
+    }
+    // End Frontier
 
     /// <summary>
     /// Check if a module can be removed from a borg.

--- a/Content.Server/Silicons/Borgs/BorgSystem.Modules.cs
+++ b/Content.Server/Silicons/Borgs/BorgSystem.Modules.cs
@@ -363,6 +363,7 @@ public sealed partial class BorgSystem
 
         if (TryComp<ItemBorgModuleComponent>(module, out var itemModuleComp))
         {
+            var droppableComparer = new DroppableBorgItemComparer(); // Frontier: cached comparer
             foreach (var containedModuleUid in component.ModuleContainer.ContainedEntities)
             {
                 if (!TryComp<ItemBorgModuleComponent>(containedModuleUid, out var containedItemModuleComp))
@@ -371,7 +372,7 @@ public sealed partial class BorgSystem
                 if (containedItemModuleComp.Items.Count == itemModuleComp.Items.Count &&
                     containedItemModuleComp.DroppableItems.Count == itemModuleComp.DroppableItems.Count && // Frontier
                     containedItemModuleComp.Items.All(itemModuleComp.Items.Contains) &&
-                    containedItemModuleComp.DroppableItems.All(x => itemModuleComp.DroppableItems.Contains(x, new DroppableBorgItemComparer()))) // Frontier
+                    containedItemModuleComp.DroppableItems.All(x => itemModuleComp.DroppableItems.Contains(x, droppableComparer))) // Frontier
                 {
                     if (user != null)
                         Popup.PopupEntity(Loc.GetString("borg-module-duplicate"), uid, user.Value);
@@ -388,19 +389,20 @@ public sealed partial class BorgSystem
     {
         public bool Equals(DroppableBorgItem? x, DroppableBorgItem? y)
         {
-            // Same object
+            // Same object (or both null)
             if (ReferenceEquals(x, y))
                 return true;
-            // Comparisons vs. null
-            if (x is null || y is null)
+            // One-side null
+            if (x == null || y == null)
                 return false;
-            // Otherwise, use EntProtoId of item to keep
+            // Otherwise, use EntProtoId of item
             return x.ID == y.ID;
         }
 
         public int GetHashCode(DroppableBorgItem obj)
         {
-            if (obj is null) return 0;
+            if (obj is null)
+                return 0;
             return obj.ID.GetHashCode();
         }
     }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Fixes an issue where droppable items weren't being considered in equality checks for duplicated modules.  This led to some cases where modules were considered duplicates (e.g. fire extinguisher and jetpack) because their set of fixed items is empty.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Impromptu bug report from Discord.

## How to test
<!-- Describe the way it can be tested -->

1. Spawn a borg, inhabit it, pick the generic chassis, exit the borg.
2. Spawn two fire extinguisher modules and two jetpack modules.
3. Unlock and screwdriver the borg.
4. Try to insert both fire extinguisher modules.  The first should work, the second should fail (it's duplicated).
5. Try to insert both jetpack modules.  The first should work (the bug has been fixed), the second should fail (it's duplicated).
6. Repeat with the GPS module (only fixed items).
7. Inhabit the borg, drop your fire extinguisher, swap back to your other character, try to insert the fire extinguisher module, it should still fail (duplicated).

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Borgs should now properly detect duplicated modules.