### PR TITLE
automatically split stacks when trying to insert into limited storages such as generators

### DIFF
--- a/Content.Shared/Materials/SharedMaterialStorageSystem.cs
+++ b/Content.Shared/Materials/SharedMaterialStorageSystem.cs
@@ -142,7 +142,7 @@ public abstract class SharedMaterialStorageSystem : EntitySystem
     /// <param name="entity"></param>
     /// <param name="materials"></param>
     /// <returns>If the amount can be changed</returns>
-    public bool CanChangeMaterialAmount(Entity<MaterialStorageComponent?> entity, Dictionary<string, int> materials)
+    public bool CanChangeMaterialAmount(Entity<MaterialStorageComponent?> entity, Dictionary<string,int> materials)
     {
         if (!Resolve(entity, ref entity.Comp))
             return false;
@@ -196,7 +196,7 @@ public abstract class SharedMaterialStorageSystem : EntitySystem
     /// <param name="entity"></param>
     /// <param name="materials"></param>
     /// <returns>If the amount can be changed</returns>
-    public bool TryChangeMaterialAmount(Entity<MaterialStorageComponent?> entity, Dictionary<string, int> materials)
+    public bool TryChangeMaterialAmount(Entity<MaterialStorageComponent?> entity, Dictionary<string,int> materials)
     {
         if (!Resolve(entity, ref entity.Comp))
             return false;

--- a/Content.Shared/Materials/SharedMaterialStorageSystem.cs
+++ b/Content.Shared/Materials/SharedMaterialStorageSystem.cs
@@ -23,6 +23,8 @@ public abstract class SharedMaterialStorageSystem : EntitySystem
     [Dependency] private readonly IPrototypeManager _prototype = default!;
     [Dependency] private readonly EntityWhitelistSystem _whitelistSystem = default!;
 
+    [Dependency] private readonly SharedStackSystem _sharedStackSystem = default!; // Frontier
+
     /// <summary>
     /// Default volume for a sheet if the material's entity prototype has no material composition.
     /// </summary>
@@ -140,7 +142,7 @@ public abstract class SharedMaterialStorageSystem : EntitySystem
     /// <param name="entity"></param>
     /// <param name="materials"></param>
     /// <returns>If the amount can be changed</returns>
-    public bool CanChangeMaterialAmount(Entity<MaterialStorageComponent?> entity, Dictionary<string,int> materials)
+    public bool CanChangeMaterialAmount(Entity<MaterialStorageComponent?> entity, Dictionary<string, int> materials)
     {
         if (!Resolve(entity, ref entity.Comp))
             return false;
@@ -194,7 +196,7 @@ public abstract class SharedMaterialStorageSystem : EntitySystem
     /// <param name="entity"></param>
     /// <param name="materials"></param>
     /// <returns>If the amount can be changed</returns>
-    public bool TryChangeMaterialAmount(Entity<MaterialStorageComponent?> entity, Dictionary<string,int> materials)
+    public bool TryChangeMaterialAmount(Entity<MaterialStorageComponent?> entity, Dictionary<string, int> materials)
     {
         if (!Resolve(entity, ref entity.Comp))
             return false;
@@ -291,6 +293,86 @@ public abstract class SharedMaterialStorageSystem : EntitySystem
         return true;
     }
 
+    // Begin Frontier : Automatically split stacks if they don't fit
+    /// <summary>
+    /// Tries to insert as much of an entity as possible into the material storage.
+    /// </summary>
+    public virtual bool TryInsertMaxPossibleMaterialEntity(EntityUid user,
+        EntityUid toInsert,
+        EntityUid receiver,
+        MaterialStorageComponent? storage = null,
+        MaterialComponent? material = null,
+        PhysicalCompositionComponent? composition = null)
+    {
+        if (!Resolve(receiver, ref storage))
+            return false;
+
+        if (!Resolve(toInsert, ref material, ref composition, false))
+            return false;
+
+        if (_whitelistSystem.IsWhitelistFail(storage.Whitelist, toInsert))
+            return false;
+
+        if (HasComp<UnremoveableComponent>(toInsert))
+            return false;
+
+        int multiplier;
+        bool partialStack = false;
+        if (storage.StorageLimit is not null && HasComp<StackComponent>(toInsert))
+        {
+            var availableVolume = (int)storage.StorageLimit - GetTotalMaterialAmount(receiver, storage);
+            var volumePerSheet = 0;
+            foreach (var (_, vol) in composition.MaterialComposition)
+            {
+                volumePerSheet += vol;
+            }
+            multiplier = availableVolume / volumePerSheet;
+            partialStack = true;
+        }
+        else
+        {
+            multiplier = TryComp<StackComponent>(toInsert, out var stackComponent) ? stackComponent.Count : 1;
+        }
+
+        // Material Whitelist checked implicitly by CanChangeMaterialAmount();
+
+        var totalVolume = 0;
+        foreach (var (mat, vol) in composition.MaterialComposition)
+        {
+            if (!CanChangeMaterialAmount(receiver, mat, vol * multiplier, storage))
+                return false;
+            totalVolume += vol * multiplier;
+        }
+
+        if (!CanTakeVolume(receiver, totalVolume, storage))
+            return false;
+
+        foreach (var (mat, vol) in composition.MaterialComposition)
+        {
+            TryChangeMaterialAmount(receiver, mat, vol * multiplier, storage);
+        }
+
+        var insertingComp = EnsureComp<InsertingMaterialStorageComponent>(receiver);
+        insertingComp.EndTime = _timing.CurTime + storage.InsertionTime;
+        if (!storage.IgnoreColor)
+        {
+            _prototype.TryIndex<MaterialPrototype>(composition.MaterialComposition.Keys.First(), out var lastMat);
+            insertingComp.MaterialColor = lastMat?.Color;
+        }
+        _appearance.SetData(receiver, MaterialStorageVisuals.Inserting, true);
+        Dirty(receiver, insertingComp);
+
+        if (partialStack)
+        {
+            _sharedStackSystem.Use(toInsert, multiplier);
+        }
+
+        var ev = new MaterialEntityInsertedEvent(material);
+        RaiseLocalEvent(receiver, ref ev);
+        return true;
+    }
+    // End Frontier : Automatically split stacks if they don't fit
+
     /// <summary>
     /// Broadcasts an event that will collect a list of which materials
     /// are allowed to be inserted into the materialStorage.
@@ -312,6 +394,8 @@ public abstract class SharedMaterialStorageSystem : EntitySystem
         if (args.Handled || !component.InsertOnInteract)
             return;
         args.Handled = TryInsertMaterialEntity(args.User, args.Used, uid, component);
+        if (!args.Handled)
+            args.Handled = TryInsertMaxPossibleMaterialEntity(args.User, args.Used, uid, component); // Frontier
     }
 
     private void OnDatabaseModified(Entity<MaterialStorageComponent> ent, ref TechnologyDatabaseModifiedEvent args)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
QoL change to insert as much as possible if the stack is too large for the receiving storage.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
QoL
Stops the endless questions on the discord for why the plasma sheets don't fit in the generator

## How to test
<!-- Describe the way it can be tested -->
- Have a PACMAN or SUPERPACMAN with some amount of fuel inside
- Use a full stack of fuel on it
- See that some fuel is remaining in hand, and check that the generator storage is at capacity.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/12f5ce0f-39d9-4999-8c5e-0842dafecb96



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
None identified.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Inserting fuel into a generator by hand will automatically insert the maximum amount that will fit.
