### PR TITLE
Pirate Shuttles, Pirate Cove: pirate-locked doors

### DIFF
--- a/Resources/Locale/en-US/_NF/prototypes/access/accesses.ftl
+++ b/Resources/Locale/en-US/_NF/prototypes/access/accesses.ftl
@@ -5,3 +5,4 @@ id-card-access-level-mercenary = Mercenary
 id-card-access-level-stc = Station Traffic Controller
 id-card-access-level-sergeant = Sergeant
 id-card-access-level-bailiff = Bailiff
+id-card-access-level-pirate = Pirate

--- a/Resources/Maps/_NF/POI/cove.yml
+++ b/Resources/Maps/_NF/POI/cove.yml
@@ -1095,7 +1095,7 @@ entities:
     - type: Transform
       pos: 8.5,5.5
       parent: 1
-- proto: AirlockHatch
+- proto: AirlockHatchPirateLocked
   entities:
   - uid: 36
     components:
@@ -1167,7 +1167,7 @@ entities:
     - type: Transform
       pos: 11.5,22.5
       parent: 1
-- proto: AirlockShuttleSyndicate
+- proto: AirlockShuttleSyndicatePirateLocked
   entities:
   - uid: 130
     components:

--- a/Resources/Maps/_NF/Shuttles/BlackMarket/barnacle.yml
+++ b/Resources/Maps/_NF/Shuttles/BlackMarket/barnacle.yml
@@ -168,7 +168,7 @@ entities:
       - 227
       - 213
       - 215
-- proto: AirlockExternalGlass
+- proto: AirlockExternalGlassPirateLocked
   entities:
   - uid: 142
     components:
@@ -180,7 +180,7 @@ entities:
     - type: Transform
       pos: -4.5,0.5
       parent: 201
-- proto: AirlockGlassShuttle
+- proto: AirlockGlassShuttleSyndicatePirateLocked
   entities:
   - uid: 18
     components:

--- a/Resources/Maps/_NF/Shuttles/BlackMarket/bocakillo.yml
+++ b/Resources/Maps/_NF/Shuttles/BlackMarket/bocakillo.yml
@@ -239,7 +239,7 @@ entities:
       parent: 2
     - type: Physics
       bodyType: Static
-- proto: AirlockExternalGlass
+- proto: AirlockExternalGlassPirateLocked
   entities:
   - uid: 11
     components:
@@ -256,7 +256,7 @@ entities:
     - type: Transform
       pos: 2.5,2.5
       parent: 2
-- proto: AirlockHatch
+- proto: AirlockHatchPirateLocked
   entities:
   - uid: 58
     components:
@@ -268,7 +268,7 @@ entities:
     - type: Transform
       pos: 0.5,3.5
       parent: 2
-- proto: AirlockShuttleSyndicate
+- proto: AirlockShuttleSyndicatePirateLocked
   entities:
   - uid: 56
     components:

--- a/Resources/Maps/_NF/Shuttles/BlackMarket/falcon.yml
+++ b/Resources/Maps/_NF/Shuttles/BlackMarket/falcon.yml
@@ -353,7 +353,7 @@ entities:
     - type: Transform
       pos: 5.5,-11.5
       parent: 3
-- proto: AirlockGlassShuttleSyndicate
+- proto: AirlockGlassShuttleSyndicatePirateLocked
   entities:
   - uid: 219
     components:
@@ -379,7 +379,7 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 9.5,-16.5
       parent: 3
-- proto: AirlockHatch
+- proto: AirlockHatchPirateLocked
   entities:
   - uid: 198
     components:
@@ -399,7 +399,7 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -1.5,-14.5
       parent: 3
-- proto: AirlockMiningGlass
+- proto: AirlockMiningGlassPirateLocked
   entities:
   - uid: 270
     components:

--- a/Resources/Maps/_NF/Shuttles/BlackMarket/menace.yml
+++ b/Resources/Maps/_NF/Shuttles/BlackMarket/menace.yml
@@ -218,7 +218,7 @@ entities:
         chunkSize: 4
     - type: GasTileOverlay
     - type: RadiationGridResistance
-- proto: AirlockExternalGlass
+- proto: AirlockExternalGlassPirateLocked
   entities:
   - uid: 8
     components:
@@ -250,7 +250,7 @@ entities:
     - type: Transform
       pos: 0.5,-1.5
       parent: 1
-- proto: AirlockGlassShuttle
+- proto: AirlockGlassShuttleSyndicatePirateLocked
   entities:
   - uid: 19
     components:

--- a/Resources/Maps/_NF/Shuttles/BlackMarket/schooner.yml
+++ b/Resources/Maps/_NF/Shuttles/BlackMarket/schooner.yml
@@ -538,7 +538,7 @@ entities:
     - type: RadiationGridResistance
     - type: BecomesStation
       id: Schooner
-- proto: AirlockGlassShuttle
+- proto: AirlockGlassShuttleSyndicatePirateLocked
   entities:
   - uid: 3
     components:

--- a/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
@@ -34,6 +34,7 @@
     - NuclearOperative
     - SyndicateAgent
     - CentralCommand
+    - Pirate # Frontier
   - type: UserInterface
     interfaces:
       enum.SolarControlConsoleUiKey.Key:

--- a/Resources/Prototypes/Entities/Objects/Tools/access_configurator.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/access_configurator.yml
@@ -116,6 +116,7 @@
     - Maintenance
     - Medical
     - Mercenary # Frontier
+    - Pirate # Frontier
     - Quartermaster
     - Research
     - ResearchDirector

--- a/Resources/Prototypes/_NF/Access/pirate.yml
+++ b/Resources/Prototypes/_NF/Access/pirate.yml
@@ -1,0 +1,3 @@
+- type: accessLevel
+  id: Pirate
+  name: id-card-access-level-pirate

--- a/Resources/Prototypes/_NF/Entities/Objects/Devices/Electronics/door_access.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Devices/Electronics/door_access.yml
@@ -38,3 +38,11 @@
   components:
   - type: AccessReader
     access: [["Mercenary"], ["Captain"]]
+
+- type: entity
+  parent: DoorElectronics
+  id: DoorElectronicsPirate
+  suffix: Pirate, Locked
+  components:
+  - type: AccessReader
+    access: [["Pirate"]]

--- a/Resources/Prototypes/_NF/Entities/Structures/Doors/Airlocks/access.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Doors/Airlocks/access.yml
@@ -278,3 +278,58 @@
   - type: ContainerFill
     containers:
       board: [ DoorElectronicsSecurity ]
+
+- type: entity
+  parent: AirlockGlass
+  id: AirlockPirateGlassLocked
+  suffix: Pirate, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsPirate ]
+
+- type: entity
+  parent: AirlockExternalGlass
+  id: AirlockExternalGlassPirateLocked
+  suffix: Pirate, Glass, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsPirate ]
+
+- type: entity
+  parent: AirlockMiningGlass
+  id: AirlockMiningGlassPirateLocked
+  suffix: Pirate, Glass, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsPirate ]
+
+- type: entity
+  parent: AirlockShuttleSyndicate
+  id: AirlockShuttleSyndicatePirateLocked
+  suffix: Pirate, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsPirate ]
+
+- type: entity
+  parent: AirlockGlassShuttleSyndicate
+  id: AirlockGlassShuttleSyndicatePirateLocked
+  suffix: Pirate, Glass Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsPirate ]
+
+# Airtight Hatch
+- type: entity
+  parent: AirlockHatch
+  id: AirlockHatchPirateLocked
+  suffix: Pirate, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsPirate ]

--- a/Resources/Prototypes/_NF/Roles/Jobs/Pirates/pirate.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Pirates/pirate.yml
@@ -18,6 +18,8 @@
   weight: 20
   displayWeight: 20
   setPreference: true
+  access:
+  - Pirate
   accessGroups:
   - GeneralAccess
   special:

--- a/Resources/Prototypes/_NF/Roles/Jobs/Pirates/pirate_captain.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Pirates/pirate_captain.yml
@@ -19,6 +19,8 @@
   weight: 40
   displayWeight: 40
   setPreference: true
+  access:
+  - Pirate
   accessGroups:
   - GeneralAccess
   special:

--- a/Resources/Prototypes/_NF/Roles/Jobs/Pirates/pirate_first_mate.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Pirates/pirate_first_mate.yml
@@ -19,6 +19,8 @@
   weight: 30
   displayWeight: 30
   setPreference: true
+  access:
+  - Pirate
   accessGroups:
   - GeneralAccess
   special:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Introduces a new access for pirates.  Locks pirate shuttle doors behind pirate access.  All doors on the cove apart from the freezer and bathroom doors are Pirate access-locked.  Pirates, Pirate First Mates (this includes Clarpy), and Pirate Captains all receive the Pirate access.

Aghosts receive this access level, as well as the universal configurator having it.

**Note: the two NFSD ships that currently have unlocked docking airlocks are the Templar and the Hospitaller.**  Unsure of the best course, **I have left those as-is for the time being.**

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

The sheriff now has disposable access configurators.  This PR ensures that the NFSD cannot break into the Pirate Cove or pirate shuttles, or lock access _to_ them by simply opening or reconfiguring the doors.  Get an ID card off of a pirate.

Why a new access level?
1. Pirates shouldn't have syndicate access - LPBravo and the drop pods should still be locked to pirates.
2. Pirates shouldn't have nuclear operative access - this is used for trade crates.

Why lock these at all?
Symmetry and consistency.  Now each side's ships are locked against members of the other faction.

## How to test
<!-- Describe the way it can be tested -->

1. Spawn as each pirate role on the cove.  Open the airlocks and hatches, you should be able to.
2. Purchase each shuttle, confirm that the doors are pirate access-locked.
4. Aghost, open the pirate-locked doors, you should be able to.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

The access configurator window shown trying to edit the eastern hatch to the Pirate Cove with a sheriff's ID card.  No dice this time.
![image](https://github.com/user-attachments/assets/95cab6fc-7682-4511-8578-591f4ff3e32e)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: Pirate shuttles and the cove now have locked doors.  Only pirates currently have access to these doors.