### PR TITLE
Fix docks disappearing in NAV when >100% UI scale

### DIFF
--- a/Content.Client/Shuttles/UI/ShuttleNavControl.xaml.cs
+++ b/Content.Client/Shuttles/UI/ShuttleNavControl.xaml.cs
@@ -374,7 +374,7 @@ public sealed partial class ShuttleNavControl : BaseShuttleControl
         const float sqrt2 = 1.41421356f;
         const float dockRadius = DockScale * sqrt2;
         // Worst-case bounds used to cull a dock:
-        Box2 viewBounds = new Box2(-dockRadius, -dockRadius, PixelSize.X + dockRadius, PixelSize.Y + dockRadius); // frontier: Size => PixelSize
+        Box2 viewBounds = new Box2(-dockRadius, -dockRadius, PixelSize.X + dockRadius, PixelSize.Y + dockRadius); // Frontier: Size<PixelSize
         if (_docks.TryGetValue(nent, out var docks))
         {
             foreach (var state in docks)

--- a/Content.Client/Shuttles/UI/ShuttleNavControl.xaml.cs
+++ b/Content.Client/Shuttles/UI/ShuttleNavControl.xaml.cs
@@ -374,7 +374,7 @@ public sealed partial class ShuttleNavControl : BaseShuttleControl
         const float sqrt2 = 1.41421356f;
         const float dockRadius = DockScale * sqrt2;
         // Worst-case bounds used to cull a dock:
-        Box2 viewBounds = new Box2(-dockRadius, -dockRadius, Size.X + dockRadius, Size.Y + dockRadius);
+        Box2 viewBounds = new Box2(-dockRadius, -dockRadius, PixelSize.X + dockRadius, PixelSize.Y + dockRadius); // frontier: Size => PixelSize
         if (_docks.TryGetValue(nent, out var docks))
         {
             foreach (var state in docks)


### PR DESCRIPTION
Fixes #2775 

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
The occlusion bounds in the dock drawing code didn't take into account UI scale, so docks passed a certain point would disappear. This patch fixes the issue.

## Why / Balance

Not being able to see docks too far to the right/bottom of the view is annoying. So is playing at 100% UI scale on a high-DPI display.

## How to test

1. Set your UI scale to >100% - the biggest you can reasonably use, the easier the issue will be to see.
2. Pilot and position a ship so that a docking port is near the bottom right of the NAV display, and observe that it no longer disappears.

## Media

Before:

![Screenshot_20250210_174642](https://github.com/user-attachments/assets/6c04e4cf-e71d-4f80-8e46-b27c8ccd83d7)

After:

![Screenshot_20250210_174544](https://github.com/user-attachments/assets/1469b9be-9318-4c5f-94f6-4f6190c55909)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- fix: Fix docks disappearing on the NAV console at >100% UI scale
