### PR TITLE
Trade crates: fix time reference

### DIFF
--- a/Content.Server/_NF/Cargo/Systems/CargoSystem.TradeCrates.cs
+++ b/Content.Server/_NF/Cargo/Systems/CargoSystem.TradeCrates.cs
@@ -1,5 +1,6 @@
 using System.Threading;
 using Content.Server._NF.Trade;
+using Content.Server.GameTicking;
 using Content.Shared._NF.Trade;
 using Content.Shared.Examine;
 using Timer = Robust.Shared.Timing.Timer;
@@ -8,6 +9,7 @@ namespace Content.Server.Cargo.Systems; // Needs to collide with base namespace
 
 public sealed partial class CargoSystem
 {
+    [Dependency] private GameTicker _gameTicker = default!;
     private readonly List<EntityUid> _destinations = new();
 
     private void InitializeTradeCrates()
@@ -87,7 +89,8 @@ public sealed partial class CargoSystem
             Loc.GetString("trade-crate-priority-active") :
             Loc.GetString("trade-crate-priority-inactive"));
 
-        ev.PushMarkup(Loc.GetString("trade-crate-priority-time", ("time", ent.Comp.ExpressDeliveryTime.Value.ToString(@"hh\:mm\:ss"))));
+        var shiftTime = ent.Comp.ExpressDeliveryTime - _gameTicker.RoundStartTimeSpan;
+        ev.PushMarkup(Loc.GetString("trade-crate-priority-time", ("time", shiftTime.Value.ToString(@"hh\:mm\:ss"))));
     }
 
     private void DisableTradeCratePriority(EntityUid uid)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Fixes the time reference used for trading crate description text.

As a reminder, GameTiming.CurTime is effectively the total simulated uptime of the server.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

I goofed.  Again.  The same goof as before.

## How to test
<!-- Describe the way it can be tested -->

1. Start a round.
2. Warp to the Trade Outpost.
3. Buy some crates.
4. Check the time on the crates, should be ~28:00 minutes.
5. Wait about a minute.
6. `golobby`, `startround`
7. Warp to the Trade Outpost.
8. Buy some crates.
9. Check the time on the crates, should _still_ be ~28:00 minutes.  On the head of master, this might be 30 - not shift time, but uptime.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Following the test procedure, this is what you should see at step 9 (and 4).
![image](https://github.com/user-attachments/assets/f1e25ec7-22df-47c6-82d0-f560aced6ad6)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Trading crates should report their delivery time correctly.