### PR TITLE
Stop NPC's from trying to plan when they wont be able to plan anyways in space

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -306,3 +306,4 @@ Resources/MapImages
 
 # Direnv stuff
 .direnv/
+/Resources/Maps/ambitionfrezonv7.yml

--- a/.gitignore
+++ b/.gitignore
@@ -306,4 +306,3 @@ Resources/MapImages
 
 # Direnv stuff
 .direnv/
-/Resources/Maps/ambitionfrezonv7.yml

--- a/Content.Server/NPC/HTN/HTNSystem.cs
+++ b/Content.Server/NPC/HTN/HTNSystem.cs
@@ -262,8 +262,9 @@ public sealed class HTNSystem : EntitySystem
 
         if (!_mapQuery.TryGetComponent(transform.MapUid, out var worldComponent))
             return true;
-
-        var chunk = _world.GetOrCreateChunk(WorldGen.WorldToChunkCoords(_transform.GetWorldPosition(transform)).Floored(), transform.MapUid.Value, worldComponent);
+        if (TryComp(entity, out TransformComponent? xform) && xform.GridUid == null)// if NPC not on a grid return false
+            return false;
+            var chunk = _world.GetOrCreateChunk(WorldGen.WorldToChunkCoords(_transform.GetWorldPosition(transform)).Floored(), transform.MapUid.Value, worldComponent);
 
         return _loadedQuery.TryGetComponent(chunk, out var loaded) && loaded.Loaders is not null;
     }

--- a/Content.Server/NPC/HTN/HTNSystem.cs
+++ b/Content.Server/NPC/HTN/HTNSystem.cs
@@ -256,18 +256,24 @@ public sealed class HTNSystem : EntitySystem
         }
     }
 
-    private bool IsNPCActive(EntityUid entity) // Frontier
+    // Frontier: prevent unneded NPC activity
+    private bool IsNPCActive(EntityUid entity)
     {
         var transform = Transform(entity);
 
+        // Pathfinding in space doesn't currently work.
+        if (transform.GridUid == null)
+            return false;
+
+        // No WorldController: we're on an expedition planet.
         if (!_mapQuery.TryGetComponent(transform.MapUid, out var worldComponent))
             return true;
-        if (TryComp(entity, out TransformComponent? xform) && xform.GridUid == null)// if NPC not on a grid return false
-            return false;
-        var chunk = _world.GetOrCreateChunk(WorldGen.WorldToChunkCoords(_transform.GetWorldPosition(transform)).Floored(), transform.MapUid.Value, worldComponent);
 
+        // Check if we're on a loaded chunk.
+        var chunk = _world.GetOrCreateChunk(WorldGen.WorldToChunkCoords(_transform.GetWorldPosition(transform)).Floored(), transform.MapUid.Value, worldComponent);
         return _loadedQuery.TryGetComponent(chunk, out var loaded) && loaded.Loaders is not null;
     }
+    // End Frontier
 
     private void AppendDebugText(HTNTask task, StringBuilder text, List<int> planBtr, List<int> btr, ref int level)
     {

--- a/Content.Server/NPC/HTN/HTNSystem.cs
+++ b/Content.Server/NPC/HTN/HTNSystem.cs
@@ -264,7 +264,7 @@ public sealed class HTNSystem : EntitySystem
             return true;
         if (TryComp(entity, out TransformComponent? xform) && xform.GridUid == null)// if NPC not on a grid return false
             return false;
-            var chunk = _world.GetOrCreateChunk(WorldGen.WorldToChunkCoords(_transform.GetWorldPosition(transform)).Floored(), transform.MapUid.Value, worldComponent);
+        var chunk = _world.GetOrCreateChunk(WorldGen.WorldToChunkCoords(_transform.GetWorldPosition(transform)).Floored(), transform.MapUid.Value, worldComponent);
 
         return _loadedQuery.TryGetComponent(chunk, out var loaded) && loaded.Loaders is not null;
     }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Makes the HTN system skip npc's that are stuck in space or they keep trying to do their current plan for as long as possible
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
NPC's that are stuck in space will continue to plan till they disapear or in some cases Forever. this change stops it.
massive npc budget improvement 
## How to test
<!-- Describe the way it can be tested -->
spawn NPC in space ( examine HTN comp for plan accumulator tick not ticking) observe npc starting to plan the instant they can on a grid

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
 tweak: Fixed NPC hang in case of tons of NPC's being in space
- fix: Fixed fun!
-->
:cl:
 fix: Fixed NPC hang in case of tons of NPC's being in space