### PR TITLE
Up the Headsets keys limits to 10

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Ears/headsets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Ears/headsets.yml
@@ -14,7 +14,7 @@
       - EncryptionKeyCommon
   - type: Headset
   - type: EncryptionKeyHolder
-    keySlots: 5 # Frontier 4<5
+    keySlots: 10 # Frontier 4<10
   - type: Sprite
     state: icon
   - type: Item

--- a/Resources/Prototypes/Entities/Clothing/Ears/headsets_alt.yml
+++ b/Resources/Prototypes/Entities/Clothing/Ears/headsets_alt.yml
@@ -127,9 +127,9 @@
   name: blood-red over-ear headset
   description: An updated, modular syndicate intercom that fits over the head and takes encryption keys (there are 5 key slots.).
   components:
-  - type: Headset
-  - type: EncryptionKeyHolder
-    keySlots: 6 # Frontier 5<6
+#  - type: Headset # Frontier: Use 10 from base
+#  - type: EncryptionKeyHolder # Frontier: Use 10 from base
+#    keySlots: 5 # Frontier: Use 10 from base
   - type: ContainerFill
     containers:
       key_slots:

--- a/Resources/Prototypes/_NF/Loadouts/Jobs/Contractor/encryption_keys.yml
+++ b/Resources/Prototypes/_NF/Loadouts/Jobs/Contractor/encryption_keys.yml
@@ -10,24 +10,28 @@
   effects:
   - !type:GroupLoadoutEffect
     proto: NFNotDoc
+  price: 20
   storage:
     back:
     - EncryptionKeyMedical
 
 - type: loadout
   id: ContractorEncryptionKeyCargo
+  price: 20
   storage:
     back:
     - EncryptionKeyCargo
 
 - type: loadout
   id: ContractorEncryptionKeyEngineering
+  price: 20
   storage:
     back:
     - EncryptionKeyEngineering
 
 - type: loadout
   id: ContractorEncryptionKeyScience
+  price: 20
   storage:
     back:
     - EncryptionKeyScience

--- a/Resources/Prototypes/_NF/Loadouts/contractor_loadout_groups.yml
+++ b/Resources/Prototypes/_NF/Loadouts/contractor_loadout_groups.yml
@@ -849,7 +849,7 @@
   id: ContractorEncryptionKey
   name: loadout-group-contractor-encryption-key
   minLimit: 0
-  maxLimit: 4
+  maxLimit: 5
   loadouts:
   - ContractorEncryptionKeyTraffic
   - ContractorEncryptionKeyMedical


### PR DESCRIPTION
## About the PR
Remove the unneeded limit for frontier headset use, just allow using all the keys cuz why the fuck not.

## Why / Balance
This is an upstream limit that make sense there where john station should not be on 5 departments

## How to test
Insert key to radio, insert 9 more

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
:cl:
- tweak: You can now insert up to 10 headset keys into any headset.
