### PR TITLE
Sector-wide mail, no mail to SSD players

### DIFF
--- a/Content.Server/_DV/Mail/Components/MailTeleporterComponent.cs
+++ b/Content.Server/_DV/Mail/Components/MailTeleporterComponent.cs
@@ -11,11 +11,11 @@ namespace Content.Server._DV.Mail.Components
     {
 
         // Not starting accumulator at 0 so mail carriers have some deliveries to make shortly after roundstart.
-        [DataField]
-        public float Accumulator = 1995f; // Frontier 285<1995 (285*7)
+        // [DataField]
+        // public float Accumulator = 285f;
 
-        [DataField]
-        public TimeSpan TeleportInterval = TimeSpan.FromMinutes(35); // Frontier: 5<35 (5*7)
+        // [DataField]
+        // public TimeSpan TeleportInterval = TimeSpan.FromMinutes(5);
 
         /// <summary>
         /// The sound that's played when new mail arrives.
@@ -23,24 +23,24 @@ namespace Content.Server._DV.Mail.Components
         [DataField]
         public SoundSpecifier TeleportSound = new SoundPathSpecifier("/Audio/Effects/teleport_arrival.ogg");
 
-        /// <summary>
-        /// The MailDeliveryPoolPrototype that's used to select what mail this
-        /// teleporter can deliver.
-        /// </summary>
-        [DataField("mailPool")]
-        public string MailPool = "RandomNFMailDeliveryPool"; // Frontier: use our own mail pool (TODO: migrate to frontier.yml instance?)
+        // /// <summary>
+        // /// The MailDeliveryPoolPrototype that's used to select what mail this
+        // /// teleporter can deliver.
+        // /// </summary>
+        // [DataField]
+        // public string MailPool = "RandomNFMailDeliveryPool";
 
-        /// <summary>
-        /// How many mail candidates do we need per actual delivery sent when
-        /// the mail goes out? The number of candidates is divided by this number
-        /// to determine how many deliveries will be teleported in.
-        /// It does not determine unique recipients. That is random.
-        /// </summary>
-        [DataField]
-        public int CandidatesPerDelivery = 4; // Frontier: 8<4
+        // /// <summary>
+        // /// How many mail candidates do we need per actual delivery sent when
+        // /// the mail goes out? The number of candidates is divided by this number
+        // /// to determine how many deliveries will be teleported in.
+        // /// It does not determine unique recipients. That is random.
+        // /// </summary>
+        // [DataField]
+        // public int CandidatesPerDelivery = 8;
 
-        [DataField]
-        public int MinimumDeliveriesPerTeleport = 1;
+        // [DataField]
+        // public int MinimumDeliveriesPerTeleport = 1;
 
         /// <summary>
         /// Do not teleport any more mail in, if there are at least this many
@@ -61,62 +61,48 @@ namespace Content.Server._DV.Mail.Components
         [DataField]
         public int MaximumUndeliveredParcels = 5;
 
-        /// <summary>
-        /// Any item that breaks or is destroyed in less than this amount of
-        /// damage is one of the types of items considered fragile.
-        /// </summary>
-        [DataField]
-        public int FragileDamageThreshold = 10;
+        // /// <summary>
+        // /// Any item that breaks or is destroyed in less than this amount of
+        // /// damage is one of the types of items considered fragile.
+        // /// </summary>
+        // [DataField]
+        // public int FragileDamageThreshold = 10;
 
-        /// <summary>
-        /// What's the bonus for delivering a fragile package intact?
-        /// </summary>
-        [DataField]
-        public int FragileBonus = 2000; // Frontier 100<2000
+        // /// <summary>
+        // /// What's the bonus for delivering a fragile package intact?
+        // /// </summary>
+        // [DataField]
+        // public int FragileBonus = 100;
 
-        /// <summary>
-        /// What's the malus for failing to deliver a fragile package?
-        /// </summary>
-        [DataField]
-        public int FragileMalus = -100;
+        // /// <summary>
+        // /// What's the malus for failing to deliver a fragile package?
+        // /// </summary>
+        // [DataField]
+        // public int FragileMalus = -100;
 
-        /// <summary>
-        /// What's the chance for any one delivery to be marked as priority mail?
-        /// </summary>
-        [DataField]
-        public float PriorityChance = 0.07f; // Frontier: 0.1f<0.07f
+        // /// <summary>
+        // /// What's the chance for any one delivery to be marked as priority mail?
+        // /// </summary>
+        // [DataField]
+        // public float PriorityChance = 0.1f;
 
-        /// <summary>
-        /// How long until a priority delivery is considered as having failed
-        /// if not delivered?
-        /// </summary>
-        [DataField]
-        public TimeSpan PriorityDuration = TimeSpan.FromMinutes(45); // Frontier 5<45
+        // /// <summary>
+        // /// How long until a priority delivery is considered as having failed
+        // /// if not delivered?
+        // /// </summary>
+        // [DataField]
+        // public TimeSpan PriorityDuration = TimeSpan.FromMinutes(5);
 
-        /// <summary>
-        /// What's the bonus for delivering a priority package on time?
-        /// </summary>
-        [DataField]
-        public int PriorityBonus = 5000; // Frontier 250<5000
+        // /// <summary>
+        // /// What's the bonus for delivering a priority package on time?
+        // /// </summary>
+        // [DataField]
+        // public int PriorityBonus = 250;
 
-        /// <summary>
-        /// What's the malus for failing to deliver a priority package?
-        /// </summary>
-        [DataField]
-        public int PriorityMalus = -250;
-
-        // Frontier: Large mail
-        /// <summary>
-        /// What's the bonus for delivering a large package intact?
-        /// </summary>
-        [DataField]
-        public int LargeBonus = 5000; // Frontier: 1500<5000
-
-        /// <summary>
-        /// What's the malus for failing to deliver a large package?
-        /// </summary>
-        [DataField]
-        public int LargeMalus = -500;
-        // End Frontier: Large mail
+        // /// <summary>
+        // /// What's the malus for failing to deliver a priority package?
+        // /// </summary>
+        // [DataField]
+        // public int PriorityMalus = -250;
     }
 }

--- a/Content.Server/_DV/Mail/EntitySystems/MailSystem.cs
+++ b/Content.Server/_DV/Mail/EntitySystems/MailSystem.cs
@@ -1,7 +1,4 @@
 using Content.Server.Access.Systems;
-using Content.Server.Cargo.Components;
-using Content.Server.Cargo.Systems;
-using Content.Server.Chat.Systems;
 using Content.Server.Damage.Components;
 using Content.Server._DV.Cargo.Components;
 using Content.Server._DV.Cargo.Systems;
@@ -12,7 +9,6 @@ using Content.Server.Destructible.Thresholds;
 using Content.Server.Destructible;
 using Content.Server.Mind;
 using Content.Server.Popups;
-using Content.Server.Power.Components;
 using Content.Server.Spawners.EntitySystems;
 using Content.Server.Station.Systems;
 using Content.Shared.Access.Components;
@@ -50,6 +46,9 @@ using Content.Server.Station.Components; // Frontier
 using Robust.Shared.Enums; // Frontier
 using Content.Shared._NF.Bank.Components; // Frontier
 using Content.Shared._NF.Bank.BUI; // Frontier
+using Content.Shared.SSDIndicator; // Frontier
+using Content.Server.Power.EntitySystems; // Frontier
+using Content.Server._NF.Mail.Components; // Frontier
 
 namespace Content.Server._DV.Mail.EntitySystems
 {
@@ -72,10 +71,10 @@ namespace Content.Server._DV.Mail.EntitySystems
         [Dependency] private readonly SharedSolutionContainerSystem _solution = default!;
         [Dependency] private readonly StationSystem _stationSystem = default!;
         [Dependency] private readonly TagSystem _tagSystem = default!;
+        [Dependency] private readonly LogisticStatsSystem _logisticsStatsSystem = default!;
         [Dependency] private readonly SectorServiceSystem _sectorService = default!; // Frontier
         [Dependency] private readonly BankSystem _bank = default!; // Frontier
-
-        [Dependency] private readonly LogisticStatsSystem _logisticsStatsSystem = default!;
+        [Dependency] private readonly PowerReceiverSystem _powerReceiver = default!; // Frontier
 
         private ISawmill _sawmill = default!;
 
@@ -101,20 +100,17 @@ namespace Content.Server._DV.Mail.EntitySystems
         {
             base.Update(frameTime);
 
-            var query = EntityQueryEnumerator<MailTeleporterComponent>();
-            while (query.MoveNext(out var uid, out var mailTeleporter))
+            // Frontier: sector-wide mail
+            if (TryComp(_sectorService.GetServiceEntity(), out SectorMailComponent? mail))
             {
-                if (TryComp<ApcPowerReceiverComponent>(uid, out var power) && !power.Powered)
-                    continue;
+                mail.Accumulator += frameTime;
+                if (mail.Accumulator < mail.TeleportInterval.TotalSeconds)
+                    return;
 
-                mailTeleporter.Accumulator += frameTime;
-
-                if (mailTeleporter.Accumulator < mailTeleporter.TeleportInterval.TotalSeconds)
-                    continue;
-
-                mailTeleporter.Accumulator -= (float)mailTeleporter.TeleportInterval.TotalSeconds;
-                SpawnMail(uid, mailTeleporter);
+                mail.Accumulator -= (float)mail.TeleportInterval.TotalSeconds;
+                SpawnMail(mail);
             }
+            // End Frontier
         }
 
         /// <summary>
@@ -123,12 +119,12 @@ namespace Content.Server._DV.Mail.EntitySystems
         private void OnSpawnPlayer(PlayerSpawningEvent args)
         {
             if (args.SpawnResult == null ||
-                args.Job == null )
+                args.Job == null)
             {
                 return;
             }
 
-            //if (!HasComp<StationMailRouterComponent>(station)) # Frontier - We dont need to test this.
+            //if (!HasComp<StationMailRouterComponent>(station)) // Frontier - We dont need to test this.
             //    return;
 
             EnsureComp<MailReceiverComponent>(args.SpawnResult.Value);
@@ -166,16 +162,16 @@ namespace Content.Server._DV.Mail.EntitySystems
             if (!component.IsPriority)
                 return;
 
-                // This is a successful delivery. Keep the failure timer from triggering.
-                component.PriorityCancelToken?.Cancel();
+            // This is a successful delivery. Keep the failure timer from triggering.
+            component.PriorityCancelToken?.Cancel();
 
-                // The priority tape is visually considered to be a part of the
-                // anti-tamper lock, so remove that too.
-                _appearanceSystem.SetData(uid, MailVisuals.IsPriority, false);
+            // The priority tape is visually considered to be a part of the
+            // anti-tamper lock, so remove that too.
+            _appearanceSystem.SetData(uid, MailVisuals.IsPriority, false);
 
-                // The examination code depends on this being false to not show
-                // the priority tape description anymore.
-                component.IsPriority = false;
+            // The examination code depends on this being false to not show
+            // the priority tape description anymore.
+            component.IsPriority = false;
         }
 
         /// <summary>
@@ -223,8 +219,8 @@ namespace Content.Server._DV.Mail.EntitySystems
                 // DeltaV - Add earnings to logistic stats
                 ExecuteForEachLogisticsStats((logisticStats) =>
                 {
-                        _logisticsStatsSystem.AddOpenedMailEarnings(logisticStats,
-                            component.Bounty);
+                    _logisticsStatsSystem.AddOpenedMailEarnings(logisticStats,
+                        component.Bounty);
                 });
             }
 
@@ -458,7 +454,7 @@ namespace Content.Server._DV.Mail.EntitySystems
         /// <remarks>
         /// This is separate mostly so the unit tests can get to it.
         /// </remarks>
-        public void SetupMail(EntityUid uid, MailTeleporterComponent component, MailRecipient recipient)
+        public void SetupMail(EntityUid uid, SectorMailComponent component, MailRecipient recipient) // Frontier: MailTeleporterComponent<SectorMailComponent
         {
             var mailComp = EnsureComp<MailComponent>(uid);
 
@@ -512,7 +508,7 @@ namespace Content.Server._DV.Mail.EntitySystems
 
                 mailComp.PriorityCancelToken = new CancellationTokenSource();
 
-                Timer.Spawn((int) component.PriorityDuration.TotalMilliseconds,
+                Timer.Spawn((int)component.PriorityDuration.TotalMilliseconds,
                     () =>
                     {
                         if (!mailComp.IsProfitable) // Frontier: only penalize and adjust stats if profitable
@@ -580,10 +576,12 @@ namespace Content.Server._DV.Mail.EntitySystems
 
             while (query.MoveNext(out var uid, out var mailTeleporter))
             {
-                // Frontier: skip station checks
+                // Frontier: skip station checks, ensure teleporter is powered
                 // var teleporterStation = _stationSystem.GetOwningStation(uid);
                 // if (receiverStation != teleporterStation)
                 //     continue;
+                if (!_powerReceiver.IsPowered(uid))
+                    continue;
                 // End Frontier
                 teleporterComponent = mailTeleporter;
                 teleporterUid = uid;
@@ -650,7 +648,7 @@ namespace Content.Server._DV.Mail.EntitySystems
         /// <summary>
         /// Get the list of valid mail recipients for a mail teleporter.
         /// </summary>
-        private List<MailRecipient> GetMailRecipientCandidates(EntityUid uid)
+        private List<MailRecipient> GetMailRecipientCandidates() // Frontier: remove EntityUid arg
         {
             var candidateList = new List<MailRecipient>();
             var query = EntityQueryEnumerator<MailReceiverComponent>();
@@ -665,7 +663,12 @@ namespace Content.Server._DV.Mail.EntitySystems
                 // if (receiverStation != teleporterStation)
                 //     continue;
 
+                // Are you on expedition or in FTL? No mail for you.
                 if (location.MapID != Transform(receiverUid).MapID)
+                    continue;
+
+                // Is this player displaying as SSD? If so, skip 'em.
+                if (TryComp(receiverUid, out SSDIndicatorComponent? ssd) && ssd.IsSSD)
                     continue;
                 // End Frontier
 
@@ -676,31 +679,48 @@ namespace Content.Server._DV.Mail.EntitySystems
             return candidateList;
         }
 
+        // Frontier: sector-wide mail
+        sealed class MailTeleporterSpawnData(Entity<MailTeleporterComponent> entity)
+        {
+            public Entity<MailTeleporterComponent> Entity = entity;
+            public bool HadMail = false;
+        }
+
         /// <summary>
         /// Handle the spawning of all the mail for a mail teleporter.
         /// </summary>
-        private void SpawnMail(EntityUid uid, MailTeleporterComponent? component = null)
+        private void SpawnMail(SectorMailComponent component)
         {
-            if (!Resolve(uid, ref component))
+            // Get list of valid teleporters.
+            List<MailTeleporterSpawnData> validTeleporters = new();
+            var teleporterQuery = EntityQueryEnumerator<MailTeleporterComponent>();
+            while (teleporterQuery.MoveNext(out var uid, out var mailTeleporter))
             {
-                _sawmill.Error($"Tried to SpawnMail on {ToPrettyString(uid)} without a valid MailTeleporterComponent!");
+                if (_powerReceiver.IsPowered(uid)
+                    && GetUndeliveredParcelCount(uid) < mailTeleporter.MaximumUndeliveredParcels)
+                {
+                    validTeleporters.Add(new MailTeleporterSpawnData((uid, mailTeleporter)));
+                }
+            }
+
+            // If list of teleporters is empty, return.
+            if (validTeleporters.Count <= 0)
+            {
+                _sawmill.Info("List of valid mail teleporters was empty!");
                 return;
             }
 
-            if (GetUndeliveredParcelCount(uid) >= component.MaximumUndeliveredParcels)
-                return;
-
-            var candidateList = GetMailRecipientCandidates(uid);
+            var candidateList = GetMailRecipientCandidates();
 
             if (candidateList.Count <= 0)
             {
-                _sawmill.Error("List of mail candidates was empty!");
+                _sawmill.Info("List of mail candidates was empty!");
                 return;
             }
 
             if (!_prototypeManager.TryIndex<MailDeliveryPoolPrototype>(component.MailPool, out var pool))
             {
-                _sawmill.Error($"Can't index {ToPrettyString(uid)}'s MailPool {component.MailPool}!");
+                _sawmill.Error($"Can't find MailPool {component.MailPool}!");
                 return;
             }
 
@@ -748,18 +768,27 @@ namespace Content.Server._DV.Mail.EntitySystems
                     return;
                 }
 
-                var coordinates = Transform(uid).Coordinates;
+                var index = _random.Next(validTeleporters.Count);
+
+                var coordinates = Transform(validTeleporters[index].Entity).Coordinates;
                 var mail = EntityManager.SpawnEntity(chosenParcel, coordinates);
                 SetupMail(mail, component, candidate);
+                validTeleporters[index].HadMail = true;
 
                 _tagSystem.AddTag(mail, "Mail"); // Frontier
             }
 
-            if (_containerSystem.TryGetContainer(uid, "queued", out var queued))
-                _containerSystem.EmptyContainer(queued);
+            for (int i = 0; i < validTeleporters.Count; i++)
+            {
+                // Remove queued contents (e.g. from admemes)
+                if (_containerSystem.TryGetContainer(validTeleporters[i].Entity, "queued", out var queued))
+                    validTeleporters[i].HadMail |= _containerSystem.EmptyContainer(queued).Count > 0;
 
-            _audioSystem.PlayPvs(component.TeleportSound, uid);
+                if (validTeleporters[i].HadMail)
+                    _audioSystem.PlayPvs(validTeleporters[i].Entity.Comp.TeleportSound, validTeleporters[i].Entity);
+            }
         }
+        // End Frontier: sector-wide mail
 
         private void OpenMail(EntityUid uid, MailComponent? component = null, EntityUid? user = null)
         {
@@ -769,7 +798,7 @@ namespace Content.Server._DV.Mail.EntitySystems
             _audioSystem.PlayPvs(component.OpenSound, uid);
 
             if (user != null)
-                _handsSystem.TryDrop((EntityUid) user);
+                _handsSystem.TryDrop((EntityUid)user);
 
             if (!_containerSystem.TryGetContainer(uid, "contents", out var contents))
             {

--- a/Content.Server/_DV/Mail/MailCommands.cs
+++ b/Content.Server/_DV/Mail/MailCommands.cs
@@ -6,6 +6,9 @@ using Content.Shared.Administration;
 using Content.Server.Administration;
 using Content.Server._DV.Mail.Components;
 using Content.Server._DV.Mail.EntitySystems;
+using Content.Server._NF.SectorServices;
+using Content.Server._DV.Cargo.Components;
+using Content.Server._NF.Mail.Components;
 
 namespace Content.Server._DV.Mail;
 
@@ -28,7 +31,7 @@ public sealed class MailToCommand : LocalizedCommands // Frontier: IConsoleComma
 
     public override void Execute(IConsoleShell shell, string argStr, string[] args) // Frontier: async < override
     {
-        if (args.Length < 4)
+        if (args.Length < 2)
         {
             shell.WriteError(Loc.GetString("shell-wrong-arguments-number"));
             return;
@@ -46,19 +49,21 @@ public sealed class MailToCommand : LocalizedCommands // Frontier: IConsoleComma
             return;
         }
 
-        if (!bool.TryParse(args[2], out var isFragile))
+        // Frontier: optional arguments, large mail
+        var isFragile = false;
+        if (args.Length > 2 && !bool.TryParse(args[2], out isFragile))
         {
             shell.WriteError(Loc.GetString("shell-invalid-bool"));
             return;
         }
 
-        if (!bool.TryParse(args[3], out var isPriority))
+        var isPriority = false;
+        if (args.Length > 3 && !bool.TryParse(args[3], out isPriority))
         {
             shell.WriteError(Loc.GetString("shell-invalid-bool"));
             return;
         }
 
-        // Frontier: Large Mail
         var isLarge = false;
         if (args.Length > 4 && !bool.TryParse(args[4], out isLarge))
         {
@@ -68,9 +73,17 @@ public sealed class MailToCommand : LocalizedCommands // Frontier: IConsoleComma
         var mailPrototype = isLarge ? BlankLargeMailPrototype : BlankMailPrototype;
         // End Frontier
 
-
         var mailSystem = _entitySystemManager.GetEntitySystem<MailSystem>();
         var containerSystem = _entitySystemManager.GetEntitySystem<SharedContainerSystem>();
+        var sectorService = _entitySystemManager.GetEntitySystem<SectorServiceSystem>(); // Frontier
+
+        // Frontier: sector-wide mail
+        if (!_entityManager.TryGetComponent(sectorService.GetServiceEntity(), out SectorMailComponent? sectorMail))
+        {
+            shell.WriteLine(Loc.GetString("command-mailto-no-mailservice"));
+            return;
+        }
+        // End Frontier
 
         if (!_entityManager.HasComponent<MailReceiverComponent>(recipientUid))
         {
@@ -131,11 +144,11 @@ public sealed class MailToCommand : LocalizedCommands // Frontier: IConsoleComma
         mailComponent.IsPriority = isPriority;
         mailComponent.IsLarge = isLarge;
 
-        mailSystem.SetupMail(mailUid, teleporterComponent, recipient.Value);
+        mailSystem.SetupMail(mailUid, sectorMail, recipient.Value); // Frontier: use SectorMailComponent
 
         var teleporterQueue = containerSystem.EnsureContainer<Container>((EntityUid)teleporterUid, "queued");
         containerSystem.Insert(mailUid, teleporterQueue);
-        shell.WriteLine(Loc.GetString("command-mailto-success", ("timeToTeleport", teleporterComponent.TeleportInterval.TotalSeconds - teleporterComponent.Accumulator)));
+        shell.WriteLine(Loc.GetString("command-mailto-success", ("timeToTeleport", sectorMail.TeleportInterval.TotalSeconds - sectorMail.Accumulator))); // Frontier: use SectorMailComponent
     }
 
     // Frontier: completion
@@ -168,13 +181,15 @@ public sealed class MailNowCommand : IConsoleCommand
     public string Help => Loc.GetString("command-mailnow-help", ("command", Command));
 
     [Dependency] private readonly IEntityManager _entityManager = default!;
+    [Dependency] private readonly IEntitySystemManager _entitySystemManager = default!; // Frontier
 
     public async void Execute(IConsoleShell shell, string argStr, string[] args)
     {
-        foreach (var mailTeleporter in _entityManager.EntityQuery<MailTeleporterComponent>())
-        {
-            mailTeleporter.Accumulator += (float) mailTeleporter.TeleportInterval.TotalSeconds - mailTeleporter.Accumulator;
-        }
+        var sectorService = _entitySystemManager.GetEntitySystem<SectorServiceSystem>();
+        // Frontier: sector-wide mail
+        if (_entityManager.TryGetComponent(sectorService.GetServiceEntity(), out SectorMailComponent? mail))
+            mail.Accumulator = (float)mail.TeleportInterval.TotalSeconds;
+        // End Frontier: sector-wide mail
 
         shell.WriteLine(Loc.GetString("command-mailnow-success"));
     }

--- a/Content.Server/_DV/Mail/MailCommands.cs
+++ b/Content.Server/_DV/Mail/MailCommands.cs
@@ -31,7 +31,7 @@ public sealed class MailToCommand : LocalizedCommands // Frontier: IConsoleComma
 
     public override void Execute(IConsoleShell shell, string argStr, string[] args) // Frontier: async < override
     {
-        if (args.Length < 2)
+        if (args.Length < 2) // Frontier: 4<2 - optional arguments
         {
             shell.WriteError(Loc.GetString("shell-wrong-arguments-number"));
             return;

--- a/Content.Server/_NF/Mail/Components/SectorMailComponent.cs
+++ b/Content.Server/_NF/Mail/Components/SectorMailComponent.cs
@@ -1,0 +1,113 @@
+using Content.Server._DV.Mail;
+using Content.Server._DV.Mail.EntitySystems;
+
+namespace Content.Server._NF.Mail.Components;
+
+/// <summary>
+/// Tracks all mail statistics for mail activity in the sector.
+/// </summary>
+[RegisterComponent, Access([typeof(MailSystem), typeof(MailNowCommand)])]
+public sealed partial class SectorMailComponent : Component // Frontier: Station->Sector
+{
+    [DataField]
+    public float Accumulator = 1995f;
+
+    [DataField]
+    public TimeSpan TeleportInterval = TimeSpan.FromMinutes(35);
+
+    /// <summary>
+    /// The MailDeliveryPoolPrototype that's used to select what mail this
+    /// teleporter can deliver.
+    /// </summary>
+    [DataField]
+    public string MailPool = "RandomNFMailDeliveryPool"; // Frontier: use our own mail pool
+
+    /// <summary>
+    /// How many mail candidates do we need per actual delivery sent when
+    /// the mail goes out? The number of candidates is divided by this number
+    /// to determine how many deliveries will be teleported in.
+    /// It does not determine unique recipients. That is random.
+    /// </summary>
+    [DataField]
+    public int CandidatesPerDelivery = 4;
+
+    [DataField]
+    public int MinimumDeliveriesPerTeleport = 1;
+
+    /// <summary>
+    /// Do not teleport any more mail in, if there are at least this many
+    /// undelivered parcels.
+    /// </summary>
+    /// <remarks>
+    /// Currently this works by checking how many MailComponent entities
+    /// are sitting on the teleporter's tile.
+    ///
+    /// It should be noted that if the number of actual deliveries to be
+    /// made based on the number of candidates divided by candidates per
+    /// delivery exceeds this number, the teleporter will spawn more mail
+    /// than this number.
+    ///
+    /// This is just a simple check to see if anyone's been picking up the
+    /// mail lately to prevent entity bloat for the sake of performance.
+    /// </remarks>
+    [DataField]
+    public int MaximumUndeliveredParcels = 5;
+
+    /// <summary>
+    /// Any item that breaks or is destroyed in less than this amount of
+    /// damage is one of the types of items considered fragile.
+    /// </summary>
+    [DataField]
+    public int FragileDamageThreshold = 10;
+
+    /// <summary>
+    /// What's the bonus for delivering a fragile package intact?
+    /// </summary>
+    [DataField]
+    public int FragileBonus = 2000;
+
+    /// <summary>
+    /// What's the malus for failing to deliver a fragile package?
+    /// </summary>
+    [DataField]
+    public int FragileMalus = -100;
+
+    /// <summary>
+    /// What's the chance for any one delivery to be marked as priority mail?
+    /// </summary>
+    [DataField]
+    public float PriorityChance = 0.07f;
+
+    /// <summary>
+    /// How long until a priority delivery is considered as having failed
+    /// if not delivered?
+    /// </summary>
+    [DataField]
+    public TimeSpan PriorityDuration = TimeSpan.FromMinutes(45);
+
+    /// <summary>
+    /// What's the bonus for delivering a priority package on time?
+    /// </summary>
+    [DataField]
+    public int PriorityBonus = 5000;
+
+    /// <summary>
+    /// What's the malus for failing to deliver a priority package?
+    /// </summary>
+    [DataField]
+    public int PriorityMalus = -250;
+
+    // Frontier: Large mail
+    /// <summary>
+    /// What's the bonus for delivering a large package intact?
+    /// </summary>
+    [DataField]
+    public int LargeBonus = 5000;
+
+    /// <summary>
+    /// What's the malus for failing to deliver a large package?
+    /// </summary>
+    [DataField]
+    public int LargeMalus = -500;
+    // End Frontier: Large mail
+}

--- a/Resources/Locale/en-US/_NF/mail/mail.ftl
+++ b/Resources/Locale/en-US/_NF/mail/mail.ftl
@@ -2,3 +2,5 @@ mail-large-item-name-unaddressed = package
 mail-large-item-name-addressed = package ({$recipient})
 mail-large-desc-far = A large package.
 mail-large-desc-close = A large package addressed to {CAPITALIZE($name)}, {$job}. Last known location: {$station}.
+
+command-mailto-no-mailservice = Unable to get mail service.

--- a/Resources/Prototypes/_NF/Mail/mail.yml
+++ b/Resources/Prototypes/_NF/Mail/mail.yml
@@ -1607,22 +1607,31 @@
       # Bugs (weight: 2)
       - id: MobCockroach
         orGroup: Critter
-        prob: 0.45
+        prob: 0.34
       - id: MobSlug
         orGroup: Critter
-        prob: 0.45
+        prob: 0.34
       - id: MobBee
         orGroup: Critter
-        prob: 0.45
+        prob: 0.34
       - id: MobButterfly
         orGroup: Critter
-        prob: 0.45
+        prob: 0.34
+      - id: MobSnail
+        orGroup: Critter
+        prob: 0.34
         # Uncommon
       - id: MobMothroach
         orGroup: Critter
         prob: 0.15
         # Rare
       - id: MobRosyMothroach
+        orGroup: Critter
+        prob: 0.05
+      - id: MobSnailMoth
+        orGroup: Critter
+        prob: 0.05
+      - id: MobSnailSpeed
         orGroup: Critter
         prob: 0.05
       # Small reptiles (weight: 1)

--- a/Resources/Prototypes/_NF/Mail/mail.yml
+++ b/Resources/Prototypes/_NF/Mail/mail.yml
@@ -1607,19 +1607,16 @@
       # Bugs (weight: 2)
       - id: MobCockroach
         orGroup: Critter
-        prob: 0.36
+        prob: 0.45
       - id: MobSlug
         orGroup: Critter
-        prob: 0.36
-      - id: MobArgocyteSlurva # honorary bug?
-        orGroup: Critter
-        prob: 0.36
+        prob: 0.45
       - id: MobBee
         orGroup: Critter
-        prob: 0.36
+        prob: 0.45
       - id: MobButterfly
         orGroup: Critter
-        prob: 0.36
+        prob: 0.45
         # Uncommon
       - id: MobMothroach
         orGroup: Critter

--- a/Resources/Prototypes/_NF/SectorServices/services.yml
+++ b/Resources/Prototypes/_NF/SectorServices/services.yml
@@ -4,9 +4,10 @@
   - type: SectorPirateBountyDatabase
 
 - type: sectorService
-  id: MailMetrics
+  id: Mail
   components:
   - type: SectorLogisticStats
+  - type: SectorMail # Contains sector-wide mail parameters
 
 - type: sectorService
   id: ShuttleRecords


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Makes mail a sector-wide occurrence.  Mail deliveries will now occur every 35 minutes regardless of the state of the mail teleporters.  No teleporters are powered on?  No mail.  Tough.

For the mail teleporters that are on, the delivery will be split randomly between these.  More mail teleporters should not mean more mail, merely more places where mail can spawn.  Don't want to run between the Trade Mall and Frontier Outpost?  Okay, pick one, and disable the other mail teleporter.

Parameters have been pushed largely from the mail teleporter into a new SectorMailComponent - this does mean that mail can no longer be controlled per-teleporter.

If you are capable of showing an SSD icon and you are considered as SSD by the game, you are ineligible to receive mail.

The isPriority and isFragile `mailto` command parameters are now optional.  `mailto 123 456` will work.

Slurva was removed from the critter pool and replaced with snails since they turn to ash on Frontier Outpost.  RIP little buddy; snail mail real.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

The amount of mail, and therefore the amount of work that you need to do as a mail carrier, should be predictable.  Shifts should not be rolling in cash or cash-starved because the dice said "we're running with X today".

Deliveries to characters that are SSD are unlikely to be delivered, so why spawn them?

## How to test
<!-- Describe the way it can be tested -->

1. Move to the mail teleporter on Frontier Outpost.
2. Run mailnow (might need to run it a few times if the Trade Mall is selected).  You should get mail.
3. Run mailnow a bunch.  You should stop summoning messages once there are five letters on the mailbox.
4. Clear the mailbox.  Aghost from your character.
5. Run mailnow, there should be no new mail.  The mailbox should not make noise.
6. Aghost again, return to your character.
7. Run mailnow, you should receive mail.
8. Turn off the mailbox, run mailnow, you should not receive mail.
9. Run `mailto <your character's UID> <a random object's UID>`.  It should work, and you should receive a letter in the next shipment from the first valid teleporter the game can find - it must be receiving power to queue up!

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

```
                  _
          __..--''/\
    _..-''_.\`|  /  \
   \`-._  `.-'_ /    \
    \   ``-.(|\)`._   \
     \    ,'       `-._\
      \  /     _..--''
       \/_..-''       SSt
```

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Mail now arrives regularly in batches and splits between running teleporters.
- tweak: Players no longer receive mail while SSD.