### PR TITLE
Atmos tweaks to improve tritium generation

### DIFF
--- a/Content.Shared/Atmos/Atmospherics.cs
+++ b/Content.Shared/Atmos/Atmospherics.cs
@@ -206,12 +206,12 @@ namespace Content.Shared.Atmos
         public const float FirePlasmaEnergyReleased = 160e3f; // methane is 16 kJ/mol, plus plasma's spark of magic
         public const float FireGrowthRate = 40000f;
 
-        public const float SuperSaturationThreshold = 96f;
-        public const float SuperSaturationEnds = SuperSaturationThreshold / 3;
+        public const float SuperSaturationThreshold = 30f; // Frontier: 96f<30
+        public const float SuperSaturationEnds = 10f; // Frontier: SuperSaturationThreshold / 3 < 10
 
         public const float OxygenBurnRateBase = 1.4f;
         public const float PlasmaMinimumBurnTemperature = (100f+T0C);
-        public const float PlasmaUpperTemperature = (1370f+T0C);
+        public const float PlasmaUpperTemperature = 600; // Frontier: (1370f+T0C)<600
         public const float PlasmaOxygenFullburn = 10f;
         public const float PlasmaBurnRateDelta = 9f;
 

--- a/Content.Shared/Atmos/Atmospherics.cs
+++ b/Content.Shared/Atmos/Atmospherics.cs
@@ -211,7 +211,7 @@ namespace Content.Shared.Atmos
 
         public const float OxygenBurnRateBase = 1.4f;
         public const float PlasmaMinimumBurnTemperature = (100f+T0C);
-        public const float PlasmaUpperTemperature = 600; // Frontier: (1370f+T0C)<600
+        public const float PlasmaUpperTemperature = 700; // Frontier: (1370f+T0C)<700
         public const float PlasmaOxygenFullburn = 10f;
         public const float PlasmaBurnRateDelta = 9f;
 

--- a/Resources/Prototypes/Atmospherics/reactions.yml
+++ b/Resources/Prototypes/Atmospherics/reactions.yml
@@ -13,7 +13,7 @@
 - type: gasReaction
   id: TritiumFire
   priority: -1
-  minimumTemperature: 373.149 # Same as Atmospherics.FireMinimumTemperatureToExist
+  minimumTemperature: 700 # Frontier: 373.149<700 - hot for a plasma fire
   minimumRequirements: # In this case, same as minimum mole count.
     - 0.01  # oxygen
     - 0     # nitrogen


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Hoo boy.

This PR is an attempt to make tritium generation viable through straightforward burn chambers.

As-is upstream, both the plasma and tritium fire reactions start at the same temperature.  This results in a bunch of tritium burning off as water vapour.  Since our sources of oxygen are limited, and tritium production requires an oxygen-rich mix to begin with, and consumes oxygen from the fire, we try to conserve oxygen by:
1. Enabling low temperature burn chambers to run without starting a tritium fire.  Tritium fires release a ton of energy and consume a bunch of tritium.  By increasing the temperature that tritium fires start at, we can allow for steady tritium generation under proper conditions.  An efficient burn chamber requires ensuring that your mix does not generate temperatures that will start a tritium fire and ruin the mix, but you are encouraged to run a hotter chamber to react more of the plasma and less of the oxygen.
2. Reducing the oxygen supersaturation ratio of the plasma fire reaction.  By allowing richer mixes, you allow for better optimization of oxygen use.
3. Decreasing the maximum plasma reaction rate temperature also allows for more efficient tritium reactions while encouraging some amount of "push your luck" in running hotter chambers.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Tritium generation is pretty tricky to do decently, this should make it simpler, more reliable, and more productive.

## How to test
<!-- Describe the way it can be tested -->

Try to run a burn chamber with plasma and oxygen.  See if you can get a mix that runs steadily without starting a plasma fire.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

After running a lazy, janky, guaranteed unoptimized setup, I was able to extract about 2 kmol of tritium from a large deposit's worth of oxygen and two plasma canisters through one continuous plasma burn.  No tritium fire flareups.

![image](https://github.com/user-attachments/assets/12886da2-b8b7-4aa8-9449-c1f38d2de3cd)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Plasma fires now generate tritium from more plasma-heavy mixes.
- tweak: Tritium fires now start at 700 K.