### PR TITLE
Server- and Client-side partial stack insert functions, hotfix reversion

### DIFF
--- a/Content.Client/Materials/MaterialStorageSystem.cs
+++ b/Content.Client/Materials/MaterialStorageSystem.cs
@@ -52,6 +52,23 @@ public sealed class MaterialStorageSystem : SharedMaterialStorageSystem
         _transform.DetachEntity(toInsert, Transform(toInsert));
         return true;
     }
+
+    // Frontier: partial stack insertion
+    public override bool TryInsertMaxPossibleMaterialEntity(EntityUid user,
+        EntityUid toInsert,
+        EntityUid receiver,
+        out bool empty,
+        MaterialStorageComponent? storage = null,
+        MaterialComponent? material = null,
+        PhysicalCompositionComponent? composition = null)
+    {
+        if (!base.TryInsertMaxPossibleMaterialEntity(user, toInsert, receiver, out empty, storage, material, composition))
+            return false;
+        if (empty)
+            _transform.DetachEntity(toInsert, Transform(toInsert));
+        return true;
+    }
+    // End Frontier: partial stack insertion
 }
 
 public enum MaterialStorageVisualLayers : byte

--- a/Content.Server/Materials/MaterialStorageSystem.cs
+++ b/Content.Server/Materials/MaterialStorageSystem.cs
@@ -141,6 +141,40 @@ public sealed class MaterialStorageSystem : SharedMaterialStorageSystem
         return true;
     }
 
+    // Frontier: partial stack insertion
+    public override bool TryInsertMaxPossibleMaterialEntity(EntityUid user,
+        EntityUid toInsert,
+        EntityUid receiver,
+        out bool empty,
+        MaterialStorageComponent? storage = null,
+        MaterialComponent? material = null,
+        PhysicalCompositionComponent? composition = null)
+    {
+        empty = false;
+        if (!Resolve(receiver, ref storage) || !Resolve(toInsert, ref material, ref composition, false))
+            return false;
+        if (TryComp<ApcPowerReceiverComponent>(receiver, out var power) && !power.Powered)
+            return false;
+        // Cache old count
+        TryComp<StackComponent>(toInsert, out var stack);
+        var initialCount = stack?.Count ?? 1;
+        if (!base.TryInsertMaxPossibleMaterialEntity(user, toInsert, receiver, out empty, storage, material, composition))
+            return false;
+        _audio.PlayPvs(storage.InsertingSound, receiver);
+        _popup.PopupEntity(Loc.GetString("machine-insert-item", ("user", user), ("machine", receiver),
+            ("item", toInsert)), receiver);
+        //QueueDel(toInsert); // Frontier
+
+        // Logging
+        var newCount = stack?.Count ?? 0;
+        _adminLogger.Add(LogType.Action, LogImpact.Low,
+            $"{ToPrettyString(user):player} inserted {initialCount - newCount} {ToPrettyString(toInsert):inserted} into {ToPrettyString(receiver):receiver}");
+        if (empty)
+            Del(toInsert); // Frontier: delete immediately, don't queue
+        return true;
+    }
+    // End Frontier: partial stack insertion
+
     /// <summary>
     ///     Spawn an amount of a material in stack entities.
     ///     Note the 'amount' is material dependent.

--- a/Content.Server/Materials/MaterialStorageSystem.cs
+++ b/Content.Server/Materials/MaterialStorageSystem.cs
@@ -156,21 +156,19 @@ public sealed class MaterialStorageSystem : SharedMaterialStorageSystem
         if (TryComp<ApcPowerReceiverComponent>(receiver, out var power) && !power.Powered)
             return false;
         // Cache old count
-        TryComp<StackComponent>(toInsert, out var stack);
-        var initialCount = stack?.Count ?? 1;
+        var initialCount = TryComp<StackComponent>(toInsert, out var stack) ? stack.Count : 1;
         if (!base.TryInsertMaxPossibleMaterialEntity(user, toInsert, receiver, out empty, storage, material, composition))
             return false;
         _audio.PlayPvs(storage.InsertingSound, receiver);
         _popup.PopupEntity(Loc.GetString("machine-insert-item", ("user", user), ("machine", receiver),
             ("item", toInsert)), receiver);
-        //QueueDel(toInsert); // Frontier
 
         // Logging
         var newCount = stack?.Count ?? 0;
         _adminLogger.Add(LogType.Action, LogImpact.Low,
-            $"{ToPrettyString(user):player} inserted {initialCount - newCount} {ToPrettyString(toInsert):inserted} into {ToPrettyString(receiver):receiver}");
+            $"{ToPrettyString(user):player} inserted {initialCount - newCount} item(s) from {ToPrettyString(toInsert):inserted} into {ToPrettyString(receiver):receiver}");
         if (empty)
-            Del(toInsert); // Frontier: delete immediately, don't queue
+            Del(toInsert);
         return true;
     }
     // End Frontier: partial stack insertion

--- a/Content.Shared/Materials/SharedMaterialStorageSystem.cs
+++ b/Content.Shared/Materials/SharedMaterialStorageSystem.cs
@@ -328,7 +328,7 @@ public abstract class SharedMaterialStorageSystem : EntitySystem
                 volumePerSheet += vol;
             }
             multiplier = availableVolume / volumePerSheet;
-            if (multiplier > stack.Count)
+            if (multiplier >= stack.Count)
             {
                 empty = true;
                 multiplier = stack.Count;

--- a/Content.Shared/Materials/SharedMaterialStorageSystem.cs
+++ b/Content.Shared/Materials/SharedMaterialStorageSystem.cs
@@ -340,6 +340,10 @@ public abstract class SharedMaterialStorageSystem : EntitySystem
             empty = true;
         }
 
+        // Inserting into a full container (or with a lingering stack)
+        if (multiplier <= 0)
+            return false;
+
         // Material Whitelist checked implicitly by CanChangeMaterialAmount();
 
         var totalVolume = 0;

--- a/Content.Shared/Materials/SharedMaterialStorageSystem.cs
+++ b/Content.Shared/Materials/SharedMaterialStorageSystem.cs
@@ -328,7 +328,11 @@ public abstract class SharedMaterialStorageSystem : EntitySystem
                 volumePerSheet += vol;
             }
             multiplier = availableVolume / volumePerSheet;
-            empty = stack.Count <= multiplier;
+            if (multiplier > stack.Count)
+            {
+                empty = true;
+                multiplier = stack.Count;
+            }
         }
         else
         {
@@ -393,12 +397,7 @@ public abstract class SharedMaterialStorageSystem : EntitySystem
     {
         if (args.Handled || !component.InsertOnInteract)
             return;
-        // Frontier: split functions
-        if (HasComp<StackComponent>(args.Used))
-            args.Handled = TryInsertMaxPossibleMaterialEntity(args.User, args.Used, uid, out _, component); // Frontier: ignore empty
-        else
-            args.Handled = TryInsertMaterialEntity(args.User, args.Used, uid, component);
-        // End Frontier
+        args.Handled = TryInsertMaxPossibleMaterialEntity(args.User, args.Used, uid, out _, component); // Frontier: use autosplit version
     }
 
     private void OnDatabaseModified(Entity<MaterialStorageComponent> ent, ref TechnologyDatabaseModifiedEvent args)

--- a/Content.Shared/Materials/SharedMaterialStorageSystem.cs
+++ b/Content.Shared/Materials/SharedMaterialStorageSystem.cs
@@ -293,18 +293,19 @@ public abstract class SharedMaterialStorageSystem : EntitySystem
         return true;
     }
 
-    // Begin Frontier : Automatically split stacks if they don't fit
+    // Frontier: partial stack insertion
     /// <summary>
     /// Tries to insert as much of an entity as possible into the material storage.
-    /// Only happens if there is a storage limit.
     /// </summary>
     public virtual bool TryInsertMaxPossibleMaterialEntity(EntityUid user,
         EntityUid toInsert,
         EntityUid receiver,
+        out bool empty,
         MaterialStorageComponent? storage = null,
         MaterialComponent? material = null,
         PhysicalCompositionComponent? composition = null)
     {
+        empty = false;
         if (!Resolve(receiver, ref storage))
             return false;
 
@@ -318,16 +319,22 @@ public abstract class SharedMaterialStorageSystem : EntitySystem
             return false;
 
         int multiplier;
-        if (storage.StorageLimit is null || !HasComp<StackComponent>(toInsert)) // this function only runs if insterting already failed somehow, only consider splitting if the storage has a storage limit
-            return false;
-
-        var availableVolume = (int)storage.StorageLimit - GetTotalMaterialAmount(receiver, storage);
-        var volumePerSheet = 0;
-        foreach (var (_, vol) in composition.MaterialComposition)
+        if (storage.StorageLimit is not null && TryComp<StackComponent>(toInsert, out var stack))
         {
-            volumePerSheet += vol;
+            var availableVolume = (int)storage.StorageLimit - GetTotalMaterialAmount(receiver, storage);
+            var volumePerSheet = 0;
+            foreach (var (_, vol) in composition.MaterialComposition)
+            {
+                volumePerSheet += vol;
+            }
+            multiplier = availableVolume / volumePerSheet;
+            empty = stack.Count <= multiplier;
         }
-        multiplier = availableVolume / volumePerSheet;
+        else
+        {
+            multiplier = TryComp<StackComponent>(toInsert, out var stackComponent) ? stackComponent.Count : 1;
+            empty = true;
+        }
 
         // Material Whitelist checked implicitly by CanChangeMaterialAmount();
 
@@ -357,15 +364,14 @@ public abstract class SharedMaterialStorageSystem : EntitySystem
         _appearance.SetData(receiver, MaterialStorageVisuals.Inserting, true);
         Dirty(receiver, insertingComp);
 
-
-        _sharedStackSystem.Use(toInsert, multiplier);
-
+        if (!empty)
+            _sharedStackSystem.Use(toInsert, multiplier);
 
         var ev = new MaterialEntityInsertedEvent(material);
         RaiseLocalEvent(receiver, ref ev);
         return true;
     }
-    // End Frontier : Automatically split stacks if they don't fit
+    // End Frontier: partial stack insertion
 
     /// <summary>
     /// Broadcasts an event that will collect a list of which materials
@@ -387,9 +393,12 @@ public abstract class SharedMaterialStorageSystem : EntitySystem
     {
         if (args.Handled || !component.InsertOnInteract)
             return;
-        args.Handled = TryInsertMaterialEntity(args.User, args.Used, uid, component);
-        if (!args.Handled)
-            args.Handled = TryInsertMaxPossibleMaterialEntity(args.User, args.Used, uid, component); // Frontier
+        // Frontier: split functions
+        if (HasComp<StackComponent>(args.Used))
+            args.Handled = TryInsertMaxPossibleMaterialEntity(args.User, args.Used, uid, out _, component); // Frontier: ignore empty
+        else
+            args.Handled = TryInsertMaterialEntity(args.User, args.Used, uid, component);
+        // End Frontier
     }
 
     private void OnDatabaseModified(Entity<MaterialStorageComponent> ent, ref TechnologyDatabaseModifiedEvent args)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Largely reverts #2943.

Adds missing server- and client-side functions that override TryInsertMaxPossibleMaterialEntity - these functions handled the entity deletion or simulated client-side deletion and exist for the base TryInsertMaterialEntity function.  TryInsertMaxPossible now respects the bounds of the stack, and the material storage interaction now _only_ calls TryInsertMaxPossible rather than running two insertion checks.

A new output boolean (currently named `empty`) tells whether or not the item or stack was exhausted and needs to be deleted.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

This PR aims to fix the root cause of the issue behind the hotfix PR.  The public API of a class should behave straightforwardly, and "insert all material that fits" shouldn't stop working because a material storage is unlimited, or you insert a single item.  The previous implementation was fine, although it made some assertions given how it was used rather than being a general "insert as much as you can" function.

I believe this is cleaner.

## How to test
<!-- Describe the way it can be tested -->

Take an engineering techfab.
Unwrench it.
Spawn 30 steel.
Try to insert steel into the techfab.
Shouldn't work.
Anchor it.
Try to insert steel.
Should work.
Check the amount of steel in the inventory, should be 30 sheets.
Spawn a pacman.
Spawn two fuel-grade plasma containers.
Split one.
Insert the full one and one of the halves.
They should both fit.
Remove the StackComponent from the other half plasma container.
Try to insert it, it shouldn't work.
Eject all the plasma from the pacman, split one off from that stack, return 29 to the machine.
Try to insert the un-stacked half pacman.
It should fit and set the capacity to 30.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Testing the PR.
![image](https://github.com/user-attachments/assets/226e1d08-0bcd-42f9-8770-2e736dc3f0d3)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
Bugfix, hopefully no in-game consequences.