### PR TITLE
Lockable Pirate button

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Structures/Wallmounts/switch.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Wallmounts/switch.yml
@@ -5,3 +5,11 @@
   components:
   - type: AccessReader
     access: [["Mail"]]
+
+- type: entity
+  id: LockableButtonPirate
+  suffix: Pirate
+  parent: LockableButton
+  components:
+  - type: AccessReader
+    access: [["Pirate"]]


### PR DESCRIPTION
## About the PR
Adds a lockable button with Pirate access for mapping purposes.

## Why / Balance
I thought this would be added in #2893 but it wasn't, want to use this for my own purposes.
This will be nice for pirate ships that want to use shutters, specifically in a brig.

## How to test
Spawn in as a contractor, place lockable pirate button, can't open it, spawn in pirate ID card and open.

## Media
<img width="140" alt="Screenshot 2025-02-21 at 8 24 53 pm" src="https://github.com/user-attachments/assets/6b0494cd-8321-48e2-b2e7-27af92972255" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->