### PR TITLE
Add permanently seedless, no clip/no swab attributes to gat/capfruit, prevent swabbing bees.

### DIFF
--- a/Content.Server/Botany/SeedPrototype.cs
+++ b/Content.Server/Botany/SeedPrototype.cs
@@ -216,6 +216,23 @@ public partial class SeedData
 
     #endregion
 
+    // Frontier: no fun fields
+    #region Frontier
+    /// <summary>
+    ///     If true, the plant cannot be swabbed.
+    /// </summary>
+    [DataField] public bool PreventSwabbing;
+    /// <summary>
+    ///     If true, the plant cannot be clipped.
+    /// </summary>
+    [DataField] public bool PreventClipping;
+    /// <summary>
+    ///     If true, the plant will always be seedless.
+    /// </summary>
+    [DataField] public bool PermanentlySeedless;
+    #endregion
+    // End Frontier
+
     #region Cosmetics
 
     [DataField(required: true)]
@@ -292,6 +309,10 @@ public partial class SeedData
             Viable = Viable,
             Ligneous = Ligneous,
 
+            PreventSwabbing = PreventSwabbing, // Frontier
+            PreventClipping = PreventClipping, // Frontier
+            PermanentlySeedless = PermanentlySeedless, // Frontier
+
             PlantRsi = PlantRsi,
             PlantIconState = PlantIconState,
             CanScream = CanScream,
@@ -354,6 +375,10 @@ public partial class SeedData
             Seedless = Seedless,
             Viable = Viable,
             Ligneous = Ligneous,
+
+            PreventSwabbing = PreventSwabbing, // Frontier
+            PreventClipping = PreventClipping, // Frontier
+            PermanentlySeedless = PermanentlySeedless, // Frontier
 
             PlantRsi = other.PlantRsi,
             PlantIconState = other.PlantIconState,

--- a/Content.Server/Botany/Systems/BotanySwabSystem.cs
+++ b/Content.Server/Botany/Systems/BotanySwabSystem.cs
@@ -41,8 +41,16 @@ public sealed class BotanySwabSystem : EntitySystem
     /// </summary>
     private void OnAfterInteract(EntityUid uid, BotanySwabComponent swab, AfterInteractEvent args)
     {
-        if (args.Target == null || !args.CanReach || !HasComp<PlantHolderComponent>(args.Target))
+        if (args.Target == null || !args.CanReach || !TryComp<PlantHolderComponent>(args.Target, out var plant)) // Frontier: HasComp<TryComp
             return;
+
+        // Frontier: prevent swabbing
+        if (plant.Seed != null && plant.Seed.PreventSwabbing)
+        {
+            _popupSystem.PopupEntity(Loc.GetString("botany-cannot-be-swabbed-message"), args.Args.Target.Value, args.Args.User);
+            return;
+        }
+        // End Frontier
 
         _doAfterSystem.TryStartDoAfter(new DoAfterArgs(EntityManager, args.User, swab.SwabDelay, new BotanySwabDoAfterEvent(), uid, target: args.Target, used: uid)
         {

--- a/Content.Server/Botany/Systems/BotanySwabSystem.cs
+++ b/Content.Server/Botany/Systems/BotanySwabSystem.cs
@@ -60,6 +60,14 @@ public sealed class BotanySwabSystem : EntitySystem
         if (args.Cancelled || args.Handled || !TryComp<PlantHolderComponent>(args.Args.Target, out var plant))
             return;
 
+        // Frontier: prevent swabbing
+        if (plant.Seed != null && plant.Seed.PreventSwabbing)
+        {
+            _popupSystem.PopupEntity(Loc.GetString("botany-cannot-be-swabbed-message"), args.Args.Target.Value, args.Args.User);
+            return;
+        }
+        // End Frontier
+
         if (swab.SeedData == null)
         {
             // Pick up pollen

--- a/Content.Server/Botany/Systems/BotanySwabSystem.cs
+++ b/Content.Server/Botany/Systems/BotanySwabSystem.cs
@@ -47,7 +47,7 @@ public sealed class BotanySwabSystem : EntitySystem
         // Frontier: prevent swabbing
         if (plant.Seed != null && plant.Seed.PreventSwabbing)
         {
-            _popupSystem.PopupEntity(Loc.GetString("botany-cannot-be-swabbed-message"), args.Args.Target.Value, args.Args.User);
+            _popupSystem.PopupEntity(Loc.GetString("botany-cannot-be-swabbed-message"), args.Target.Value, args.User);
             return;
         }
         // End Frontier

--- a/Content.Server/Botany/Systems/MutationSystem.cs
+++ b/Content.Server/Botany/Systems/MutationSystem.cs
@@ -88,6 +88,12 @@ public sealed class MutationSystem : EntitySystem
         CrossGasses(ref result.ExudeGasses, a.ExudeGasses);
         CrossGasses(ref result.ConsumeGasses, a.ConsumeGasses);
 
+        // Frontier: ensure clip/swab/seed safety propagates
+        result.PreventClipping |= a.PreventClipping;
+        result.PreventSwabbing |= a.PreventSwabbing;
+        result.PermanentlySeedless |= a.PermanentlySeedless;
+        // End Frontier
+
         // LINQ Explanation
         // For the list of mutation effects on both plants, use a 50% chance to pick each one.
         // Union all of the chosen mutations into one list, and pick ones with a Distinct (unique) name.

--- a/Content.Server/Botany/Systems/PlantHolderSystem.cs
+++ b/Content.Server/Botany/Systems/PlantHolderSystem.cs
@@ -239,6 +239,14 @@ public sealed class PlantHolderSystem : EntitySystem
                 return;
             }
 
+            // Frontier: prevent sampling unsamplable plants
+            if (component.Seed.PreventClipping)
+            {
+                _popup.PopupCursor(Loc.GetString("plant-holder-component-cannot-be-sampled-message"), args.User);
+                return;
+            }
+            // End Frontier
+
             if (component.Sampled)
             {
                 _popup.PopupCursor(Loc.GetString("plant-holder-component-already-sampled-message"), args.User);

--- a/Content.Server/Botany/Systems/SeedExtractorSystem.cs
+++ b/Content.Server/Botany/Systems/SeedExtractorSystem.cs
@@ -30,7 +30,7 @@ public sealed class SeedExtractorSystem : EntitySystem
             return;
 
         if (!TryComp(args.Used, out ProduceComponent? produce)) return;
-        if (!_botanySystem.TryGetSeed(produce, out var seed) || seed.Seedless)
+        if (!_botanySystem.TryGetSeed(produce, out var seed) || seed.Seedless || seed.PermanentlySeedless) // Frontier: add permanently seedless
         {
             _popupSystem.PopupCursor(Loc.GetString("seed-extractor-component-no-seeds", ("name", args.Used)),
                 args.User, PopupType.MediumCaution);

--- a/Content.Server/EntityEffects/Effects/PlantMetabolism/PlantDestroySeeds.cs
+++ b/Content.Server/EntityEffects/Effects/PlantMetabolism/PlantDestroySeeds.cs
@@ -25,7 +25,7 @@ public sealed partial class PlantDestroySeeds : EntityEffect
         var plantHolder = args.EntityManager.System<PlantHolderSystem>();
         var popupSystem = args.EntityManager.System<SharedPopupSystem>();
 
-        if (plantHolderComp.Seed.Seedless == false)
+        if (plantHolderComp.Seed.Seedless == false && plantHolderComp.Seed.PermanentlySeedless == false) // Frontier: add PermanentlySeedless check
         {
             plantHolder.EnsureUniqueSeed(args.TargetEntity, plantHolderComp);
             popupSystem.PopupEntity(

--- a/Content.Server/EntityEffects/Effects/PlantMetabolism/PlantRestoreSeeds.cs
+++ b/Content.Server/EntityEffects/Effects/PlantMetabolism/PlantRestoreSeeds.cs
@@ -19,6 +19,7 @@ public sealed partial class PlantRestoreSeeds : EntityEffect
             || plantHolderComp.Seed == null
             || plantHolderComp.Dead
             || plantHolderComp.Seed.Immutable
+            || plantHolderComp.Seed.PermanentlySeedless // Frontier
         )
             return;
 

--- a/Content.Server/_NF/Botany/Systems/PlantAnalyzerSystem.cs
+++ b/Content.Server/_NF/Botany/Systems/PlantAnalyzerSystem.cs
@@ -199,7 +199,7 @@ public sealed class PlantAnalyzerSystem : EntitySystem
     {
         MutationFlags ret = MutationFlags.None;
         if (plant.TurnIntoKudzu) ret |= MutationFlags.TurnIntoKudzu;
-        if (plant.Seedless) ret |= MutationFlags.Seedless;
+        if (plant.Seedless || plant.PermanentlySeedless) ret |= MutationFlags.Seedless;
         if (plant.Ligneous) ret |= MutationFlags.Ligneous;
         if (plant.CanScream) ret |= MutationFlags.CanScream;
 

--- a/Resources/Locale/en-US/_NF/botany/components/plant-holder-component.ftl
+++ b/Resources/Locale/en-US/_NF/botany/components/plant-holder-component.ftl
@@ -1,0 +1,1 @@
+plant-holder-component-cannot-be-sampled-message = This plant cannot be sampled!

--- a/Resources/Locale/en-US/_NF/botany/swab.ftl
+++ b/Resources/Locale/en-US/_NF/botany/swab.ftl
@@ -1,0 +1,1 @@
+botany-cannot-be-swabbed-message = You cannot swab that!

--- a/Resources/Prototypes/Hydroponics/seeds.yml
+++ b/Resources/Prototypes/Hydroponics/seeds.yml
@@ -1432,6 +1432,10 @@
       Min: 1
       Max: 5
       PotencyDivisor: 20
+  seedless: true # Frontier
+  preventSwabbing: true # Frontier
+  preventClipping: true # Frontier
+  permanentlySeedless: true # Frontier
 
 - type: seed
   id: fakeCapfruit
@@ -1458,6 +1462,10 @@
       Min: 1
       Max: 5
       PotencyDivisor: 20
+  seedless: true # Frontier
+  preventSwabbing: true # Frontier
+  preventClipping: true # Frontier
+  permanentlySeedless: true # Frontier
 
 - type: seed
   id: realCapfruit
@@ -1484,6 +1492,10 @@
       Min: 1
       Max: 5
       PotencyDivisor: 20
+  seedless: true # Frontier
+  preventSwabbing: true # Frontier
+  preventClipping: true # Frontier
+  permanentlySeedless: true # Frontier
 
 - type: seed
   id: rice

--- a/Resources/Prototypes/_NF/Entities/Objects/Specific/Hydroponics/seeds.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Specific/Hydroponics/seeds.yml
@@ -246,3 +246,4 @@
       Min: 1
       Max: 4
       PotencyDivisor: 25
+  preventSwabbing: true # they're bees


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Adds three fields to seed data: PermanentlySeedless, PreventClipping, and PreventSwabbing.

These are applied to capfruit and gatfruit to prevent mass python spam as a counterpart to #2992.  Bees are also made unswabbable (they're bees) - useful for #2964.  I've left the bee clipping for now, but it should ideally be swapped out for a net and used for bees and/or fish if added.

If it's reasonable, we could add an uplink item for a discount "do-it-yourself gatfruit farm" with 5-10 gatfruit seeds, but that isn't in the PR as-is.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Being able to get an infinite number of gatfruit out of a given seed is a nightmare.  This restricts you to anything you can harvest in one plant's lifetime.

## How to test
<!-- Describe the way it can be tested -->

Grow some gatfruit.
1. Try to get gatfruit seeds from an extractor, shouldn't work.
2. Try to get gatfruit seeds by using clippers, shouldn't work.
3. Try to crossbreed your gatfruit, shouldn't work.
4. Try to crossbreed bees, shouldn't work.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Swabbed bees, immersion ruined.
![image](https://github.com/user-attachments/assets/b7400060-48be-4e6d-a4da-931853ca6b2d)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Bees can no longer be swabbed.
- add: Gatfruit and capfruit can no longer be swabbed, clipped, and are permanently seedless.