### PR TITLE
Remove CentCom encryption key from SR and Sheriff

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Clothing/Ears/headsets.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Ears/headsets.yml
@@ -132,4 +132,3 @@
     containers:
       key_slots:
       - EncryptionKeyDoc
-      - EncryptionKeyCentCom

--- a/Resources/Prototypes/_NF/Entities/Clothing/Ears/headsets_alt.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Ears/headsets_alt.yml
@@ -61,7 +61,6 @@
   - type: ContainerFill
     containers:
       key_slots:
-      - EncryptionKeyCentCom
       - EncryptionKeyStationMaster
   - type: Sprite
     sprite: _NF/Clothing/Ears/Headsets/nfsd_h_brown.rsi

--- a/Resources/Prototypes/_NF/Roles/Jobs/Frontier/sr.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Frontier/sr.yml
@@ -40,4 +40,3 @@
     - RubberStampSr
     - DoorRemoteCommand
     - EncryptionKeyStationMaster
-    - EncryptionKeyCentCom


### PR DESCRIPTION
## About the PR
Removes CC encryption key from the SR and Sheriff.

## Why / Balance
We've been a little bit sloppy in giving Central Command items to non-CC actors. Generally, "Central Command" refers to the game's administration; we shouldn't blur that line. Only CC gets CC stuff.

If admins for any reason want to give CC comms access to the SR and/or Sheriff for an admeme, the encryption key can easily be given as and when it's needed.

## How to test
1. Spawn as SR. Don't have a CentComm encryption key in your bag.
2. Respawn as Sheriff. Don't have a CentComm channel in your headset. :)

## Media
N/A

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
No.

**Changelog**
:cl:
- remove: The SR and Sheriff no longer start with CentComm comms keys. Coordinate over command comms instead!