### PR TITLE
Cyborgs: don't drop on down, spawn placeholders on container events

### DIFF
--- a/Content.Server/Standing/StandingStateSystem.cs
+++ b/Content.Server/Standing/StandingStateSystem.cs
@@ -1,4 +1,5 @@
 using System.Numerics;
+using Content.Shared._NF.Standing;
 using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Standing;
@@ -25,6 +26,9 @@ public sealed class StandingStateSystem : EntitySystem
 
         if (!TryComp(uid, out HandsComponent? handsComp))
             return;
+
+        if (HasComp<PreventDropOnDownedComponent>(uid)) // Frontier: stop dropping items when falling over.
+            return; // Frontier
 
         var worldRotation = _transformSystem.GetWorldRotation(uid).ToVec();
         foreach (var hand in handsComp.Hands.Values)

--- a/Content.Shared/_NF/Standing/PreventDropOnDownedComponent.cs
+++ b/Content.Shared/_NF/Standing/PreventDropOnDownedComponent.cs
@@ -1,0 +1,7 @@
+namespace Content.Shared._NF.Standing;
+
+/// <summary>
+/// This component prevents an entity from dropping its held items when it falls over.
+/// </summary>
+[RegisterComponent]
+public sealed partial class PreventDropOnDownedComponent : Component;

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -244,6 +244,7 @@
     damageProtection:
       flatReductions:
         Heat: 10 # capable of touching light bulbs and stoves without feeling pain!
+  - type: PreventDropOnDowned # Frontier: borgs don't drop items when falling (e.g. critical/dead)
 
 - type: entity
   abstract: true


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

A fix for cyborg inventory management.

Instead of hand/dropped events, a borg's placeholder item for droppable module slots is spawned on container events (always raised).  The placeholder is spawned and placed in the slot at the time of removal.

Additionally, borgs now do not drop their items when downed - their module items should be internal.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Bug.

## How to test
<!-- Describe the way it can be tested -->

1. Spawn a service cyborg.
2. Start another client, become the cyborg, equip the module with the lighter, shaker and book bag.
3. On the first client, throngle the borg until it drops. It shouldn't drop its items.
4. Revive the borg.  On the second client, drop your droppable items.
5. Try to pick up the borg's modules and drop them on the first client.  You shouldn't get borg placeholders.
6. Remove the "- type: PreventDropOnDown" line from the cyborg definition.
7. Repeat 1-3.  The borg will still drop its items, but it should have placeholders in their spots.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Borgs no longer drop their items when downed, and should spawn a placeholder item whenever a droppable item is removed.