### PR TITLE
Use original vessel index as ID in bounty console

### DIFF
--- a/Content.Client/_NF/BountyContracts/UI/BountyContractUiFragmentCreate.xaml.cs
+++ b/Content.Client/_NF/BountyContracts/UI/BountyContractUiFragmentCreate.xaml.cs
@@ -74,14 +74,12 @@ public sealed partial class BountyContractUiFragmentCreate : Control
 
         // update ships dropdown
         VesselSelector.Clear();
-        int listIndex = 0;
         for (var i = 0; i < _vessels.Count; i++)
         {
             if (string.IsNullOrWhiteSpace(_vessels[i]))
                 continue;
 
-            VesselSelector.AddItem(_vessels[i], listIndex);
-            listIndex++;
+            VesselSelector.AddItem(_vessels[i], i);
         }
 
         // set vessel to unknown


### PR DESCRIPTION
## About the PR
In the bounty console, use the original vessel index as the dropdown item ID, not the new index.

## Why / Balance
Just two lines above where the vessels are added, we sometimes skip items:
```csharp
if (string.IsNullOrWhiteSpace(_vessels[i]))
    continue;

VesselSelector.AddItem(_vessels[i], listIndex);
listIndex++;
```

Unfortunately, later on in GetVessel, we use the item ID as an index into `_vessels`:
```csharp
var id = VesselSelector.SelectedId;
if (id < _vessels.Count)
    vessel = _vessels[id];
```

If an item has indeed been skipped, the ID will point to the wrong index in `_vessels`! The simplest solution of all is to skip the `listIndex` dance and just use the original index, which allows us to get back to the right value in `_vessels` with no hassle of any kind. Easy peasy.

It appears index 1 is often something with an empty name. Unsure if this is a new bug or not, but it was recently discovered at any rate.

## How to test
1. Create bounties with many different vessels.
2. Ensure the vessel is always corect.

## Media
N/A

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
No.

**Changelog**
:cl:
- fix: The Bounty Contracts PDA app should now choose the right vessel when you create a bounty.