### PR TITLE
Adjust Medborg Starting Modules

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/robotics.yml
+++ b/Resources/Prototypes/Recipes/Lathes/robotics.yml
@@ -162,15 +162,15 @@
 
 # Medical Modules
 
-- type: latheRecipe
-  parent: BaseGoldBorgModuleRecipe
-  id: BorgModuleAdvancedTreatment
-  result: BorgModuleAdvancedTreatment
+#- type: latheRecipe
+#  parent: BaseGoldBorgModuleRecipe
+#  id: BorgModuleAdvancedTreatment
+#  result: BorgModuleAdvancedTreatment
 
-- type: latheRecipe
-  parent: BaseGoldBorgModuleRecipe
-  id: BorgModuleDefibrillator
-  result: BorgModuleDefibrillator
+#- type: latheRecipe
+#  parent: BaseGoldBorgModuleRecipe
+#  id: BorgModuleDefibrillator
+#  result: BorgModuleDefibrillator
 
 # Science Modules
 

--- a/Resources/Prototypes/Research/civilianservices.yml
+++ b/Resources/Prototypes/Research/civilianservices.yml
@@ -145,8 +145,8 @@
   tier: 2
   cost: 5000
   recipeUnlocks:
-  - BorgModuleAdvancedTreatment
-  - BorgModuleDefibrillator
+  # - BorgModuleAdvancedTreatment
+  # - BorgModuleDefibrillator
   - BorgModuleAdvancedParamedic # Frontier
 
 - type: technology

--- a/Resources/Prototypes/borg_types.yml
+++ b/Resources/Prototypes/borg_types.yml
@@ -152,6 +152,8 @@
 
   defaultModules:
   - BorgModuleTreatment
+  - BorgModuleAdvancedTreatment
+  - BorgModuleDefibrillator
 
   radioChannels:
   - Science


### PR DESCRIPTION
## About the PR
This adds the Cyborg Modules called Advanced Treatment Module and Defibrillator Module to the starting chassis for medical cyborgs. 

## Why / Balance
This puts Medical Cyborgs on-par with the starting modules of the Engineering, Salvage, Janitor, and Service chassis. These all receive the necessary modules to be effective in their job role from the start. The Medical Chassis currently only starts with basic treatment, unable to perform any medical task beyond a first-aid kit.

Why not submit this upstream?
In Frontier specifically, it's quite likely a cyborg assists a crew not equipped to perform science. If the cyborg player had already selected a medical chassis, or wished to, they are effectively locked out of their role for the shift or forced to find a new ship to assist. Upstream this does not present the same issue as the station always has a science department. 

## How to test
- Run the Fork
- Spawn and control a Cyborg
- Select Medical Chassis

## Media
![image](https://github.com/user-attachments/assets/09e3c02e-8245-42a9-b675-ae4f8f8cfe7d)
![image](https://github.com/user-attachments/assets/7a7e0223-cdf1-4975-a9a5-b425380b2e52)

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- add: Added Cyborg Modules, Advanced Treatment and Defibrillator, to Medical Cyborg 
- remove: Removed crafting recipes and research for Advanced Treatment and Defibrillator Modules
