### PR TITLE
Lower blueprint material cost

### DIFF
--- a/Resources/Prototypes/_NF/Recipes/Lathes/blueprints.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/blueprints.yml
@@ -5,7 +5,7 @@
   id: NFBaseBlueprintLatheRecipe
   completetime: 4
   materials:
-    Paper: 500
+    Paper: 300
 
 # Recipes
 ## Engineering


### PR DESCRIPTION
## About the PR
Lowers the material cost of a single blueprint from 5 sheets of paper to 3.

## Why / Balance
With a full stack of paper, the previous cost allowed you to make only 6 blueprints. Many of the more desirable blueprintable technologies are broken up into multiple blueprints – 3 blueprints for super parts, 3 for advanced tools, one per bluespace bag type, and so on. With the tweaked cost, you can print 10 blueprints. Since paper is still ever so slightly annoying to obtain, my hope is that lowering the material cost may incentivise players to use blueprints more.

## Technical details
Just a YAML change.

## How to test
1. Set up an R&D server and computer, unlock stuff.
2. Print some blueprints: they should cost 3 sheets of paper each.

## Media
![image](https://github.com/user-attachments/assets/e486deda-cb00-42c5-b138-c85c7e1807d2)

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [ ] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.

## Breaking changes
No.

**Changelog**
:cl:
- tweak: Blueprints now require only 3 sheets of paper. Go sell some cool tech!