### PR TITLE
Update UI storage limits

### DIFF
--- a/Content.Shared/CCVar/CCVars.Interactions.cs
+++ b/Content.Shared/CCVar/CCVars.Interactions.cs
@@ -63,7 +63,7 @@ public sealed partial class CCVars
     /// Recommended that you utilise this in conjunction with <see cref="StaticStorageUI"/>
     /// </summary>
     public static readonly CVarDef<int> StorageLimit =
-        CVarDef.Create("control.storage_limit", 2, CVar.REPLICATED | CVar.SERVER); // Frontier: 1<2
+        CVarDef.Create("control.storage_limit", 3, CVar.REPLICATED | CVar.SERVER); // Frontier: 1<3
 
     /// <summary>
     /// Whether or not storage can be opened recursively.


### PR DESCRIPTION
## About the PR
Since its not bugged anymore and were adding wallets its good to up the storage limit, right now set to 3 UI but can be upped to 5 also.

## Why / Balance
QOL the storage windows limits never effected the sweaty powergamers who quick swap like its a competitive sport to.

## Technical details
Edited ``control.storage_limit``

## How to test
Start the game, put a backpack, put a belt, open them all with an extra survival box as well.

## Media
![image](https://github.com/user-attachments/assets/653619f5-19f4-440b-aec4-665e2145dc63)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
:cl:
- tweak: Grid storage UI upped to 3 windows.
