### PR TITLE
Add BecomesStation component to Heimdall

### DIFF
--- a/Resources/Maps/_NF/Shuttles/Nfsd/heimdall.yml
+++ b/Resources/Maps/_NF/Shuttles/Nfsd/heimdall.yml
@@ -402,6 +402,8 @@ entities:
         chunkSize: 4
     - type: GasTileOverlay
     - type: RadiationGridResistance
+    - type: BecomesStation
+      id: Heimdall
 - proto: AirAlarm
   entities:
   - uid: 53


### PR DESCRIPTION
## About the PR
Adds a `BecomesStation` component to the newly merged Heimdall.

## Why / Balance
Breaks the map renderer. Missed in review.

## Technical details
.yml

## How to test
1. Buy a Heimdall
2. VV the grid to make sure it has a BecomesStation component with the ID `Heimdall`

## Media
N/A

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.

## Breaking changes
No.

**Changelog**
N/A, just a tiny, invisible hotfix on a ship that hasn't been rolled out yet.