### PR TITLE
Disable atmospheric devices on expedition maps.

### DIFF
--- a/Content.Server/Atmos/EntitySystems/AirFilterSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/AirFilterSystem.cs
@@ -31,9 +31,12 @@ public sealed class AirFilterSystem : EntitySystem
         if (air.Pressure >= intake.Pressure)
             return;
 
-        var map = _atmosphere.AllowMapGasExtraction ? args.Map : null; // Frontier
+        // Frontier: check running gas extraction
+        if (!_atmosphere.AtmosInputCanRunOnMap(args.Map))
+            return;
+        // End Frontier
 
-        var environment = _atmosphere.GetContainingMixture(uid, args.Grid, map, true, true); // Frontier: args.Map<map
+        var environment = _atmosphere.GetContainingMixture(uid, args.Grid, args.Map, true, true);
         // nothing to intake from
         if (environment == null)
             return;

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.API.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.API.cs
@@ -166,12 +166,6 @@ public partial class AtmosphereSystem
             && Resolve(gridEnt, ref gridEnt.Comp1, false)
             && gridEnt.Comp1.Tiles.TryGetValue(gridTile, out var tile))
         {
-            // Frontier: hack to avoid infinite gas extraction from planets
-            if (tile.MapAtmosphere && map == null)
-            {
-                return GasMixture.SpaceGas;
-            }
-            // End Frontier
             if (excite)
             {
                 AddActiveTile(gridEnt.Comp1, tile);

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Utils.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Utils.cs
@@ -4,6 +4,7 @@ using Content.Server.Maps;
 using Content.Shared.Atmos;
 using Content.Shared.Atmos.Components;
 using Content.Shared.Maps;
+using Content.Shared.Shuttles.Components;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 
@@ -113,4 +114,19 @@ public partial class AtmosphereSystem
 
         _tile.PryTile(tileRef);
     }
+
+    // Frontier: disable atmos off maps
+    /// <summary>
+    ///     Checks if atmos input devices are allowed to run on the given map entity.
+    /// </summary>
+    /// <param name="mapGrid">The map in question.</param>
+    public bool AtmosInputCanRunOnMap(EntityUid? mapUid)
+    {
+        // Frontier: check running gas extraction
+        if (!TryComp<MapComponent>(mapUid, out var mapComp))
+            return false;
+
+        return AllowMapGasExtraction || HasComp<FTLMapComponent>(mapUid) || mapComp.MapId == _gameTicker.DefaultMap;
+    }
+    // End Frontier: disable atmos off maps
 }

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Utils.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Utils.cs
@@ -4,7 +4,7 @@ using Content.Server.Maps;
 using Content.Shared.Atmos;
 using Content.Shared.Atmos.Components;
 using Content.Shared.Maps;
-using Content.Shared.Shuttles.Components;
+using Content.Shared.Shuttles.Components; // Frontier
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.cs
@@ -2,6 +2,7 @@ using Content.Server.Administration.Logs;
 using Content.Server.Atmos.Components;
 using Content.Server.Body.Systems;
 using Content.Server.Fluids.EntitySystems;
+using Content.Server.GameTicking; // Frontier
 using Content.Server.NodeContainer.EntitySystems;
 using Content.Shared.Atmos.EntitySystems;
 using Content.Shared.Decals;
@@ -38,6 +39,7 @@ public sealed partial class AtmosphereSystem : SharedAtmosphereSystem
     [Dependency] private readonly TileSystem _tile = default!;
     [Dependency] private readonly MapSystem _map = default!;
     [Dependency] public readonly PuddleSystem Puddle = default!;
+    [Dependency] private readonly GameTicker _gameTicker = default!; // Frontier
 
     private const float ExposedUpdateDelay = 1f;
     private float _exposedTimer = 0f;

--- a/Content.Server/Atmos/Piping/Unary/EntitySystems/GasPassiveVentSystem.cs
+++ b/Content.Server/Atmos/Piping/Unary/EntitySystems/GasPassiveVentSystem.cs
@@ -24,9 +24,12 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
 
         private void OnPassiveVentUpdated(EntityUid uid, GasPassiveVentComponent vent, ref AtmosDeviceUpdateEvent args)
         {
-            var map = _atmosphereSystem.AllowMapGasExtraction ? args.Map : null; // Frontier
+            // Frontier: check running gas extraction
+            if (!_atmosphereSystem.AtmosInputCanRunOnMap(args.Map))
+                return;
+            // End Frontier
 
-            var environment = _atmosphereSystem.GetContainingMixture(uid, args.Grid, map, true, true); // Frontier: args.Map<map
+            var environment = _atmosphereSystem.GetContainingMixture(uid, args.Grid, args.Map, true, true);
 
             if (environment == null)
                 return;

--- a/Content.Server/Atmos/Piping/Unary/EntitySystems/GasVentPumpSystem.cs
+++ b/Content.Server/Atmos/Piping/Unary/EntitySystems/GasVentPumpSystem.cs
@@ -86,9 +86,12 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
                 return;
             }
 
-            var map = _atmosphereSystem.AllowMapGasExtraction ? args.Map : null; // Frontier
+            // Frontier: check running gas extraction
+            if (!_atmosphereSystem.AtmosInputCanRunOnMap(args.Map))
+                return;
+            // End Frontier
 
-            var environment = _atmosphereSystem.GetContainingMixture(uid, args.Grid, map, true, true); // Frontier: args.Map<map
+            var environment = _atmosphereSystem.GetContainingMixture(uid, args.Grid, args.Map, true, true);
 
             // We're in an air-blocked tile... Do nothing.
             if (environment == null)

--- a/Content.Server/Atmos/Piping/Unary/EntitySystems/GasVentScrubberSystem.cs
+++ b/Content.Server/Atmos/Piping/Unary/EntitySystems/GasVentScrubberSystem.cs
@@ -69,10 +69,13 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
             if (args.Grid is not {} grid)
                 return;
 
-            var map = _atmosphereSystem.AllowMapGasExtraction ? args.Map : null; // Frontier
+            // Frontier: check running gas extraction
+            if (!_atmosphereSystem.AtmosInputCanRunOnMap(args.Map))
+                return;
+            // End Frontier
 
             var position = _transformSystem.GetGridTilePositionOrDefault(uid);
-            var environment = _atmosphereSystem.GetTileMixture(grid, map, position, true); // Frontier: args.Map<map
+            var environment = _atmosphereSystem.GetTileMixture(grid, args.Map, position, true);
 
             Scrub(timeDelta, scrubber, environment, outlet);
 

--- a/Content.Server/Atmos/Portable/PortableScrubberSystem.cs
+++ b/Content.Server/Atmos/Portable/PortableScrubberSystem.cs
@@ -57,6 +57,11 @@ namespace Content.Server.Atmos.Portable
             if (!component.Enabled)
                 return;
 
+            // Frontier: check running gas extraction
+            if (!_atmosphereSystem.AtmosInputCanRunOnMap(args.Map))
+                return;
+            // End Frontier
+
             // If we are on top of a connector port, empty into it.
             if (_nodeContainer.TryGetNode(uid, component.PortName, out PortablePipeNode? portableNode)
                 && portableNode.ConnectionsEnabled)
@@ -75,10 +80,8 @@ namespace Content.Server.Atmos.Portable
             if (args.Grid is not {} grid)
                 return;
 
-            var map = _atmosphereSystem.AllowMapGasExtraction ? args.Map : null; // Frontier
-
             var position = _transformSystem.GetGridTilePositionOrDefault(uid);
-            var environment = _atmosphereSystem.GetTileMixture(grid, map, position, true); // Frontier: args.Map<map
+            var environment = _atmosphereSystem.GetTileMixture(grid, args.Map, position, true);
 
             var running = Scrub(timeDelta, component, environment);
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Disables atmospheric devices entirely when not on the FTL or default map.

As an alternative, we could set the only gas mixture available on expeditions to none.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Fixes https://github.com/new-frontiers-14/frontier-station-14/issues/3110.

## Technical details
<!-- Summary of code changes for easier review. -->

Adds a function to AtmosphereSystem.Utils to check that an atmos device can run on a particular map, replaces returning SpaceMixture when exposed to map atmos with failing to do anything on non-default maps.

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->

1. Recreate procedure from #3110, shouldn't work.
2. Ride the bus, release ammonia while in FTL, it should siphon off even when in FTL.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Not this time.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
probably not