### PR TITLE
fix borg hand exploit

### DIFF
--- a/Content.Shared/_NF/Interaction/Systems/HandPlaceholderSystem.cs
+++ b/Content.Shared/_NF/Interaction/Systems/HandPlaceholderSystem.cs
@@ -136,9 +136,6 @@ public sealed partial class HandPlaceholderSystem : EntitySystem
         if (!_hands.IsHolding(user, ent, out var hand, hands))
             return;
 
-        SetPlaceholder(target, ent);
-        SetEnabled(target, true);
-
         SetEnabled(ent, false); // allow inserting into the source container
 
         if (ent.Comp.Source is { } source)
@@ -154,5 +151,8 @@ public sealed partial class HandPlaceholderSystem : EntitySystem
 
         _hands.DoPickup(user, hand, target, hands); // Force pickup - empty hands are not okay
         _interaction.DoContactInteraction(user, target); // allow for forensics and other systems to work (why does hands system not do this???)
+
+        SetPlaceholder(target, ent);
+        SetEnabled(target, true);
     }
 }


### PR DESCRIPTION
## About the PR
changed order of enabling placeheld item so it doesnt try to swap into the aether or something

## Technical details
changed order of enabling the placeheld item to only after its held

no debug asserts threw depsite my best attempts so this will probably fix the random test fails too

## How to test
standard interaction spamming and changing from e.g. bruise packs to sutures

also putting items in a container then clicking on them to take them out no longer triggers a debug assert

## Requirements
webedit ops :rocket:

**Changelog**
i dont think treatment module on frontier has hands so no cl