### PR TITLE
Make chickens and ducks eat on their own.

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -243,7 +243,7 @@
     bloodMaxVolume: 100
   - type: EggLayer
     eggSpawn:
-    - id: FoodEgg
+    - id: FoodEggLaid # Frontier: FoodEgg<FoodEggLaid
   - type: ExaminableHunger
   - type: ReplacementAccent
     accent: chicken
@@ -253,6 +253,9 @@
     factions:
     - Passive
     - Chicken # Frontier
+  - type: HTN # Frontier
+    rootTask: # Frontier
+      task: RuminantCompound # Frontier
 
 - type: entity
   parent: MobChicken
@@ -306,7 +309,7 @@
 
 - type: entity
   id: FoodEggChickenFertilized
-  parent: FoodEgg
+  parent: FoodEggLaid # Frontier: FoodEgg<FoodEggLaid
   suffix: Fertilized, Chicken
   components:
   - type: Timer
@@ -690,7 +693,7 @@
     bloodMaxVolume: 100
   - type: EggLayer
     eggSpawn:
-    - id: FoodEgg
+    - id: FoodEggLaid # Frontier: FoodEgg<FoodEggLaid
   - type: ExaminableHunger
   - type: ReplacementAccent
     accent: duck
@@ -699,6 +702,9 @@
   - type: NpcFactionMember
     factions:
     - Passive
+  - type: HTN # Frontier
+    rootTask: # Frontier
+      task: RuminantCompound # Frontier
 
 - type: entity
   name: white duck #Quack
@@ -740,7 +746,7 @@
 
 - type: entity
   id: FoodEggDuckFertilized
-  parent: FoodEgg
+  parent: FoodEggLaid # Frontier: FoodEgg<FoodEggLaid
   suffix: Fertilized, Duck
   components:
     - type: Timer

--- a/Resources/Prototypes/Entities/Objects/Specific/rehydrateable.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/rehydrateable.yml
@@ -55,6 +55,7 @@
         - LowImpassable
   - type: StaticPrice
     price: 35 # The same price as dead (-20)
+  - type: BadFood # Frontier: stop eating your friends
 
 - type: entity
   parent: MonkeyCube

--- a/Resources/Prototypes/_NF/Entities/Objects/Consumable/Food/egg.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Consumable/Food/egg.yml
@@ -1,0 +1,6 @@
+- type: entity
+  parent: FoodEgg
+  id: FoodEggLaid
+  description: Farm fresh, and still warm!
+  components:
+  - type: BadFood # Don't eat your babies.

--- a/Resources/Prototypes/_NF/Recipes/Cooking/meal_recipes.yml
+++ b/Resources/Prototypes/_NF/Recipes/Cooking/meal_recipes.yml
@@ -149,9 +149,10 @@
   result: FoodMealBreakfastBagel
   time: 5
   group: Breakfast
+  reagents:
+    Egg: 12
   solids:
     FoodBagel: 1
-    FoodEgg: 2
     FoodAvocadoSlice: 1
     FoodCheeseSlice: 1
   recipeType:
@@ -163,9 +164,10 @@
   result: FoodMealBreakfastBagelPoppy
   time: 5
   group: Breakfast
+  reagents:
+    Egg: 12
   solids:
     FoodBagelPoppy: 1
-    FoodEgg: 2
     FoodAvocadoSlice: 1
     FoodCheeseSlice: 1
   recipeType:
@@ -903,10 +905,10 @@
     FoodBowlBig: 1
     FoodNoodlesBoiled: 1
     FoodSoybeans: 1
-    FoodEgg: 1
     FoodButterSlice: 1
   reagents:
     Water: 20
+    Egg: 6
   recipeType:
   - Oven
 
@@ -934,12 +936,12 @@
   solids:
     FoodBowlBig: 1
     FoodNoodlesBoiled: 1
-    FoodEgg: 1
     FoodCorn: 1
     FoodMeatBacon: 1
   reagents:
     Soysauce: 10
     Water: 10
+    Egg: 6
   recipeType:
   - Oven
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Makes chickens and ducks eat on their own, turns any laid egg (fertilized or not) into bad food (so the chickens won't immediately turn around and eat it.

Replaces recipes with FoodEgg to use Egg reagent (6 per egg).

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Ranch gaming.  Make sure to keep your chickens adequately contained.  Resolves #3079.

## Technical details
<!-- Summary of code changes for easier review. -->

The RuminantCompound is the same as the MouseCompound, but I figured if they ever changed, it'd be safer to use the livestock version than the mouse one.

The egg change is needed because we're using new prototypes for laid eggs (and those wouldn't work with fertilized eggs either - breakfast balut bagel is real).

Note that chickens still don't get hungry very quickly, but if you feed them to the point they'll lay an egg, they'll lose 60 hunger and are likely to eat again.  There's a large middle range between when they'll eat (starving, ~10 hunger) and when they'll lay eggs (60 hunger), and that sucks, but it's consistent with how it was.

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->

1. Spawn chickens or grow them from cubes.
2. Wait until they're starving (or change their Actual & BaseDecayRate in HungerComponent)
3. Spawn some animal cubes, she shouldn't eat them.
4. Spawn some wheat, she shouldn't eat it.
5. Spawn some apples, she _should_ eat them.
6. Wait until she's at 60 hunger (force feed if necessary)
7. She should lay an egg.
8. Wait until she's starving again (see Actual/BaseDecayRate in HungerComponent)
9. She shouldn't eat her laid egg.
10. Make a breakfast bagel with the laid egg and one from a carton, should work fine.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Egg.
![image](https://github.com/user-attachments/assets/34a73fa6-6b17-4385-8d72-87329a85d0e8)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: Chickens and ducks will now eat on their own.
- tweak: Grazing animals will not eat laid eggs or animal cubes.