### PR TITLE
Fix: Shrapnel bolts now fit into bolt quivers

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Clothing/Belt/belts_crossbow_quiver.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Belt/belts_crossbow_quiver.yml
@@ -31,6 +31,7 @@
       - Bread
       - MailCapsule
       - WeaponMeleeStake
+      - CrossbowBoltShrapnel
   - type: Appearance
   - type: StorageContainerVisuals
     maxFillLevels: 5


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added missing tag in quiver whitelist, so shrapnel bolts now fit into bolt quivers.

## Why / Balance
Bolts go in bolt quiver.

## Technical details
<!-- Summary of code changes for easier review. -->

## How to test
1. Spawn `ClothingBeltQuiverCrossbow`
2. Spawn `CrossbowBoltShrapnel`
3. Put the bolt in the quiver

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [x] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:
- fix: Shrapnel bolts now fit into bolt quivers.
