### PR TITLE
Diagonal r-plasma window sprite fix

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Windows/rplasma.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/rplasma.yml
@@ -123,7 +123,7 @@
   components:
   - type: Sprite
     drawdepth: WallTops
-    sprite: _NF/Structures/Windows/plasma_diagonal.rsi # Frontier
+    sprite: _NF/Structures/Windows/reinforced_plasma_diagonal.rsi # Frontier
     state: state0
   - type: Tag
     tags:
@@ -133,7 +133,7 @@
     key: walls # Frontier: windows<walls
     base: state
   - type: Icon
-    sprite: _NF/Structures/Windows/plasma_diagonal.rsi # Frontier
+    sprite: _NF/Structures/Windows/reinforced_plasma_diagonal.rsi # Frontier
     state: state0
   - type: Fixtures
     fixtures:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
fixes diagonal reinforced plasma windows using normal diagonal plasma window sprites

## Why / Balance
ugly

## Technical details
<!-- Summary of code changes for easier review. -->

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:
- fix: Reinforced diagonal plasma windows use the correct sprite now.