### PR TITLE
Recolor projectiles QOL

### DIFF
--- a/Content.Client/_Emberfall/Weapons/Ranged/Overlays/Systems/TracerSystem.cs
+++ b/Content.Client/_Emberfall/Weapons/Ranged/Overlays/Systems/TracerSystem.cs
@@ -1,0 +1,97 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+using System.Numerics;
+using Content.Client._Emberfall.Weapons.Ranged.Overlays;
+using Content.Shared._Emberfall.Weapons.Ranged;
+using Robust.Client.Graphics;
+using Robust.Shared.Map;
+using Robust.Shared.Timing;
+
+namespace Content.Client._Emberfall.Weapons.Ranged.Systems;
+
+public sealed class TracerSystem : EntitySystem
+{
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly IOverlayManager _overlay = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        _overlay.AddOverlay(new TracerOverlay(this));
+
+        SubscribeLocalEvent<TracerComponent, ComponentStartup>(OnTracerStart);
+    }
+
+    private void OnTracerStart(Entity<TracerComponent> ent, ref ComponentStartup args)
+    {
+        var xform = Transform(ent);
+        var pos = _transform.GetWorldPosition(xform);
+
+        ent.Comp.Data = new TracerData(
+            new List<Vector2> { pos },
+            _timing.CurTime + TimeSpan.FromSeconds(ent.Comp.Lifetime)
+        );
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var curTime = _timing.CurTime;
+        var query = EntityQueryEnumerator<TracerComponent, TransformComponent>();
+
+        while (query.MoveNext(out var uid, out var tracer, out var xform))
+        {
+            if (curTime > tracer.Data.EndTime)
+            {
+                RemCompDeferred<TracerComponent>(uid);
+                continue;
+            }
+
+            var currentPos = _transform.GetWorldPosition(xform);
+            tracer.Data.PositionHistory.Add(currentPos);
+
+            while (tracer.Data.PositionHistory.Count > 2 &&
+                   GetTrailLength(tracer.Data.PositionHistory) > tracer.Length)
+            {
+                tracer.Data.PositionHistory.RemoveAt(0);
+            }
+        }
+    }
+
+    private static float GetTrailLength(List<Vector2> positions)
+    {
+        var length = 0f;
+        for (var i = 1; i < positions.Count; i++)
+        {
+            length += Vector2.Distance(positions[i - 1], positions[i]);
+        }
+        return length;
+    }
+
+    public void Draw(DrawingHandleWorld handle, MapId currentMap)
+    {
+        var query = EntityQueryEnumerator<TracerComponent, TransformComponent>();
+
+        while (query.MoveNext(out _, out var tracer, out var xform))
+        {
+            if (xform.MapID != currentMap)
+                continue;
+
+            var positions = tracer.Data.PositionHistory;
+
+            if (positions.Count < 2)
+                continue;
+
+            handle.SetTransform(Matrix3x2.Identity);
+
+            for (var i = 1; i < positions.Count; i++)
+            {
+                handle.DrawLine(positions[i - 1], positions[i], tracer.Color);
+            }
+        }
+    }
+}

--- a/Content.Client/_Emberfall/Weapons/Ranged/Overlays/Tracer/TracerOverlay.cs
+++ b/Content.Client/_Emberfall/Weapons/Ranged/Overlays/Tracer/TracerOverlay.cs
@@ -1,0 +1,28 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+
+using Content.Client._Emberfall.Weapons.Ranged.Systems;
+using Robust.Client.Graphics;
+using Robust.Shared.Enums;
+
+namespace Content.Client._Emberfall.Weapons.Ranged.Overlays;
+
+public sealed class TracerOverlay : Overlay
+{
+    private readonly TracerSystem _tracer;
+
+    public override OverlaySpace Space => OverlaySpace.WorldSpaceEntities;
+
+    public TracerOverlay(TracerSystem tracer)
+    {
+        _tracer = tracer;
+        IoCManager.InjectDependencies(this);
+    }
+
+    protected override void Draw(in OverlayDrawArgs args)
+    {
+        _tracer.Draw(args.WorldHandle, args.MapId);
+    }
+}

--- a/Content.Shared/_Emberfall/Weapons/Ranged/TracerComponent.cs
+++ b/Content.Shared/_Emberfall/Weapons/Ranged/TracerComponent.cs
@@ -1,0 +1,51 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+using System.Numerics;
+using Robust.Shared.GameStates;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._Emberfall.Weapons.Ranged;
+
+/// <summary>
+/// Added to projectiles to give them tracer effects
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class TracerComponent : Component
+{
+    /// <summary>
+    /// How long the tracer effect should remain visible for after firing
+    /// </summary>
+    [DataField]
+    public float Lifetime = 10f;
+
+    /// <summary>
+    /// The maximum length of the tracer trail
+    /// </summary>
+    [DataField]
+    public float Length = 2f;
+
+    /// <summary>
+    /// Color of the tracer line effect
+    /// </summary>
+    [DataField]
+    public Color Color = Color.Red;
+
+    [ViewVariables]
+    public TracerData Data = default!;
+}
+
+[Serializable, NetSerializable, DataRecord]
+public struct TracerData(List<Vector2> positionHistory, TimeSpan endTime)
+{
+    /// <summary>
+    /// The history of positions this tracer has moved through
+    /// </summary>
+    public List<Vector2> PositionHistory = positionHistory;
+
+    /// <summary>
+    /// When this tracer effect should end
+    /// </summary>
+    public TimeSpan EndTime = endTime;
+}

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Content under these subdirectories originate from their respective forks and may
 | `_Corvax` | Corvax Frontier | https://github.com/Corvax-Frontier/Frontier | AGPL 3.0 |
 | `_DV` | Delta-V | https://github.com/DeltaV-Station/Delta-v | AGPL 3.0 |
 | `_EE` | Einstein Engines | https://github.com/Simple-Station/Einstein-Engines | AGPL 3.0 |
+| `_Emberfall` | Emberfall | https://github.com/emberfall-14/emberfall | MPL 2.0 |
 | `_EstacaoPirata` | Estacao Pirata | https://github.com/Day-OS/estacao-pirata-14 | AGPL 3.0 |
 | `_Goobstation` | Goob Station | https://github.com/Goob-Station/Goob-Station | AGPL 3.0 |
 | `_Impstation` | Impstation | https://github.com/impstation/imp-station-14 | AGPL 3.0 |

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/antimateriel.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/antimateriel.yml
@@ -14,3 +14,6 @@
     - Structural
   - type: StaminaDamageOnCollide
     damage: 60
+  - type: Tracer # Frontier
+    color: "#FFFFFFFF" # Frontier
+    length: 5

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -131,6 +131,8 @@
     damage:
       types:
         Blunt: 1
+  - type: Tracer # Frontier
+    color: "#E98C23FF" # Frontier
 
 - type: entity
   id: BaseBulletIncendiary
@@ -149,6 +151,7 @@
     energy: 7.0
   - type: IgniteOnCollide
     fireStacks: 0.25
+  - type: Tracer # Frontier
 
 - type: entity
   id: BaseBulletAP
@@ -165,6 +168,8 @@
       types:
         Piercing: 11 # 20% decrease
     ignoreResistances: true
+  - type: Tracer # Frontier
+    color: "#000000FF" # Frontier
 
 - type: entity
   id: BaseBulletUranium
@@ -180,6 +185,12 @@
     damage:
       types:
         Radiation: 11
+  - type: Tracer # Frontier
+    color: "#9BE792FF" # Frontier
+  - type: PointLight # Frontier
+    radius: 1.1 # Frontier
+    energy: 1 # Frontier
+    color: "#9BE792FF" # Frontier
 
 # Energy projectiles
 - type: entity
@@ -1182,6 +1193,8 @@
       path: /Audio/Weapons/Guns/Hits/snap.ogg
   - type: StaminaDamageOnCollide
     damage: 22 # 5 hits to stun sounds reasonable
+  - type: Tracer
+    color: "#206EEFFF"
 
 - type: entity
   id: BaseBulletEmp

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/misc.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/misc.yml
@@ -32,7 +32,7 @@
         loop: true
   - type: PointLight
     enabled: true
-    color: "#c0e0f8"
+    color: "#C0E0F8"
     radius: 9.0
     energy: 3.0
     netsync: false
@@ -52,9 +52,9 @@
     sprite: Objects/Weapons/Guns/Projectiles/magic.rsi
     state: magicm_red
     scale: 0.3,0.3
-    color: "#ff8080"
+    color: "#FF8080"
   - type: PointLight
-    color: "#ff8080"
+    color: "#FF8080"
 
 - type: entity
   id: HoloFlareYellow


### PR DESCRIPTION
## About the PR
Used the _Emberfall ``TracerSystem.cs`` to color existing projectiles without adding new ones.

Rubber now blue
Practice now orange
BulletAP now black
Incendiary now red
AntiMateriel now white with long tail
Uranium now green and has small glow

## Why / Balance
Its now super clear what you get shot at with, making the projectile more easy to read while you die. 

## Technical details
Small added system that add a trail to projectile, only works well for items with despawn on hit since Milon didn't consider adding it to something else :trollface: 

## How to test
Grab any gun and swap ammo, shot

## Media
Need to see in game, hard to take picture to do justice to it.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A No balance change

**Changelog**
:cl:
- tweak: All the basic bullets gun projectiles except the basic type now have added visual changes QOL.
