### PR TITLE
No more hidden radio messages

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers_shipyard.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers_shipyard.yml
@@ -130,7 +130,7 @@
       state: blackmarket_key
   - type: ShipyardConsole
     shipyardChannel: Syndicate
-    secretShipyardChannel: Nfsd
+    #secretShipyardChannel: Nfsd #Find out via communicating with other players
     taxAccounts:
       Invalid: 0.30
     ignoreBaseSaleRate: true # Fixed 70% sale rate.
@@ -161,7 +161,7 @@
       state: blackmarket_key
   - type: ShipyardConsole
     shipyardChannel: Freelance
-    secretShipyardChannel: Nfsd
+    #secretShipyardChannel: Nfsd #Find out via communicating with other players
     taxAccounts:
       Invalid: 0.30
     ignoreBaseSaleRate: true # Fixed 70% sale rate.


### PR DESCRIPTION
## About the PR
Disables the NFSD radio message regarding the purchase of pirate and syndicate ships

## Why / Balance
Actually has NFSD communicate with other players instead of just somehow knowing someone bought a pirate ship/syndie ship somehow

## Technical details
SecretShipyard tag is commented out

## How to test
pop a syndie, NFSD, and freelancer key in your headset
buy a ship
notice only the syndie/freelancer radio gets notified of it
Rejoice that you can play the game easier?

## Media
![image](https://github.com/user-attachments/assets/c9983ba6-0911-45d1-b659-f5d147acfc5a)

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.
## Changelog
🆑
- tweak: NFSD no longer get notified about the purchase of black market ships