### PR TITLE
Adds id cards and vehicle keys to wallet whitelist

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Clothing/Wallet/base_wallet.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Wallet/base_wallet.yml
@@ -32,6 +32,9 @@
       - NFCoin
       - NFShipyardVoucher
       - Card # single cards
+      - IdCard
+      tags:
+      - VehicleKey
     blacklist:
       tags:
       - Book


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
This pr adds vehicle keys(janicart, hoverbike atv keys) to wallet storage whitelist.

## Why / Balance
Sometimes you find lost id or captain who is about to go cryo gives you id with a ship deal and recently introduced wallet seems like a perfect place to store these kinds of things. Also it gives you convenient place to store your hoverbike keys so that no one can steal your 35k baby(unless they also have hoverbike keys...).

## Technical details
This pr adds IdCard value to the components field of NFBaseWallet whitelist component and VehicleKey value to tags field of the same component.

## How to test
1. Prepare janicart keys, hoverbike keys, atv keys, id card and wallet.
2. Insert janicart keys, hoverbike keys, atv keys and id card into the wallet.
Expected result: all items are successfully stored inside the wallet.

## Media
https://github.com/user-attachments/assets/9ffc3835-f3ce-4ee2-bb3f-79c26203a3ad

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [ ] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
No breaking changes

**Changelog**
:cl: BulkEngineer
- tweak: Vehicle keys and id cards can now be stored in the wallet.


