### PR TITLE
Update SalvageCanisterSpawner

### DIFF
--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/spawners.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/spawners.yml
@@ -402,10 +402,10 @@
         weight: 0.25
       - id: NitrousOxideCanister
         weight: 0.25
-      - id: TritiumCanister # Frontier
-        weight: 0.05 # Frontier
-      - id: FrezonCanister # Frontier
-        weight: 0.03 # Frontier
+#      - id: TritiumCanister # Frontier
+#        weight: 0.05 # Frontier
+#      - id: FrezonCanister # Frontier
+#        weight: 0.03 # Frontier
       - id: StorageCanister # Frontier
       - id: AmmoniaCanister # Frontier
       - id: WaterVaporCanister # Frontier


### PR DESCRIPTION
## About the PR
Removed the rare ``TritiumCanister`` and ``FrezonCanister`` from the canisters loot pool so the gases from mining still has its point.

I recommend probably adding more gas to gas veins in another PR to go with this one.

## Why / Balance
MFW Wrecks getting more gas then mining.

## Technical details
Comment out.

## How to test
Spam ``spawn SalvageCanisterSpawner``

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
:cl:
- remove: Tritium and frezon canisters are no longer found on wrecks and vgroids.