### PR TITLE
Replace CargoPallet with Catwalk

### DIFF
--- a/Resources/Maps/_NF/Shuttles/Expedition/anchor.yml
+++ b/Resources/Maps/_NF/Shuttles/Expedition/anchor.yml
@@ -3972,7 +3972,7 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -8.5,-27.5
       parent: 1
-- proto: CargoPallet
+- proto: Catwalk
   entities:
   - uid: 1759
     components:

--- a/Resources/Maps/_NF/Shuttles/Expedition/brigand.yml
+++ b/Resources/Maps/_NF/Shuttles/Expedition/brigand.yml
@@ -1877,7 +1877,7 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 4.5,-4.5
       parent: 1
-- proto: CargoPallet
+- proto: Catwalk
   entities:
   - uid: 667
     components:

--- a/Resources/Maps/_NF/Shuttles/Expedition/decadedove.yml
+++ b/Resources/Maps/_NF/Shuttles/Expedition/decadedove.yml
@@ -2238,7 +2238,7 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 2.5,2.5
       parent: 1
-- proto: CargoPallet
+- proto: Catwalk
   entities:
   - uid: 148
     components:

--- a/Resources/Maps/_NF/Shuttles/Expedition/dragonfly.yml
+++ b/Resources/Maps/_NF/Shuttles/Expedition/dragonfly.yml
@@ -2201,7 +2201,7 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 8.5,-8.5
       parent: 1
-- proto: CargoPallet
+- proto: Catwalk
   entities:
   - uid: 525
     components:

--- a/Resources/Maps/_NF/Shuttles/Expedition/gourd.yml
+++ b/Resources/Maps/_NF/Shuttles/Expedition/gourd.yml
@@ -5885,7 +5885,7 @@ entities:
       parent: 584
     - type: Physics
       canCollide: False
-- proto: CargoPallet
+- proto: Catwalk
   entities:
   - uid: 9
     components:

--- a/Resources/Maps/_NF/Shuttles/Expedition/pathfinder.yml
+++ b/Resources/Maps/_NF/Shuttles/Expedition/pathfinder.yml
@@ -1052,7 +1052,7 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 3.5,-2.5
       parent: 1
-- proto: CargoPallet
+- proto: Catwalk
   entities:
   - uid: 158
     components:

--- a/Resources/Maps/_NF/Shuttles/Expedition/sprinter.yml
+++ b/Resources/Maps/_NF/Shuttles/Expedition/sprinter.yml
@@ -2315,7 +2315,7 @@ entities:
       rot: 3.141592653589793 rad
       pos: -2.5,6.5
       parent: 1
-- proto: CargoPallet
+- proto: Catwalk
   entities:
   - uid: 389
     components:

--- a/Resources/Maps/_NF/Shuttles/Nfsd/wasp.yml
+++ b/Resources/Maps/_NF/Shuttles/Nfsd/wasp.yml
@@ -3741,7 +3741,7 @@ entities:
     - type: Transform
       pos: -4.527932,-25.411976
       parent: 1
-- proto: CargoPallet
+- proto: Catwalk
   entities:
   - uid: 563
     components:

--- a/Resources/Maps/_NF/Shuttles/Scrap/bison.yml
+++ b/Resources/Maps/_NF/Shuttles/Scrap/bison.yml
@@ -6537,7 +6537,7 @@ entities:
       rot: 3.141592653589793 rad
       pos: 1.5,-30.5
       parent: 1
-- proto: CargoPallet
+- proto: Catwalk
   entities:
   - uid: 2152
     components:

--- a/Resources/Maps/_NF/Shuttles/Scrap/scrap-courserx.yml
+++ b/Resources/Maps/_NF/Shuttles/Scrap/scrap-courserx.yml
@@ -1311,7 +1311,7 @@ entities:
     - type: Transform
       pos: -0.5,-11.5
       parent: 1
-- proto: CargoPallet
+- proto: Catwalk
   entities:
   - uid: 264
     components:

--- a/Resources/Maps/_NF/Shuttles/Scrap/scrap-sprinter.yml
+++ b/Resources/Maps/_NF/Shuttles/Scrap/scrap-sprinter.yml
@@ -1797,7 +1797,7 @@ entities:
     - type: Transform
       pos: 2.8113232,6.703677
       parent: 1
-- proto: CargoPallet
+- proto: Catwalk
   entities:
   - uid: 365
     components:

--- a/Resources/Maps/_NF/Shuttles/Syndicate/infiltrator.yml
+++ b/Resources/Maps/_NF/Shuttles/Syndicate/infiltrator.yml
@@ -2125,7 +2125,7 @@ entities:
       canCollide: False
     - type: Fixtures
       fixtures: {}
-- proto: CargoPallet
+- proto: Catwalk
   entities:
   - uid: 306
     components:

--- a/Resources/Maps/_NF/Shuttles/ambition.yml
+++ b/Resources/Maps/_NF/Shuttles/ambition.yml
@@ -5725,7 +5725,7 @@ entities:
     - type: Transform
       pos: -10.594801,5.7791753
       parent: 1
-- proto: CargoPallet
+- proto: Catwalk
   entities:
   - uid: 1156
     components:

--- a/Resources/Maps/_NF/Shuttles/gasbender.yml
+++ b/Resources/Maps/_NF/Shuttles/gasbender.yml
@@ -3049,7 +3049,7 @@ entities:
       rot: 3.141592653589793 rad
       pos: 6.5,-8.5
       parent: 1
-- proto: CargoPallet
+- proto: Catwalk
   entities:
   - uid: 139
     components:


### PR DESCRIPTION
## About the PR
Replace all the ``CargoPallet`` left overs on ships with ``Catwalk``

## Why / Balance
They do nothing, they cannot be destroyed, they no longer serve a use. 

## Technical details
YML Swap

## How to test
Spawn any of the ships, no ``CargoPallet``

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
No need
