### PR TITLE
Remove player characters and ghost roles from containers picked up by mechs.

### DIFF
--- a/Content.Server/Mech/Equipment/EntitySystems/MechGrabberSystem.cs
+++ b/Content.Server/Mech/Equipment/EntitySystems/MechGrabberSystem.cs
@@ -19,6 +19,8 @@ using Robust.Shared.Physics.Components;
 using Content.Shared.Whitelist; // Frontier
 using Content.Shared.Buckle.Components; // Frontier
 using Content.Shared.Buckle; // Frontier
+using Content.Shared.Humanoid; // Frontier
+using Content.Shared.Mind.Components; // Frontier
 
 namespace Content.Server.Mech.Equipment.EntitySystems;
 
@@ -190,7 +192,7 @@ public sealed class MechGrabberSystem : EntitySystem
         if (!_mech.TryChangeEnergy(equipmentComponent.EquipmentOwner.Value, component.GrabEnergyDelta))
             return;
 
-        // Frontier: Remove people from chairs
+        // Frontier: Remove people from chairs and containers
         if (TryComp<StrapComponent>(args.Args.Target, out var strapComp) && strapComp.BuckledEntities != null)
         {
             foreach (var buckleUid in strapComp.BuckledEntities)
@@ -198,7 +200,33 @@ public sealed class MechGrabberSystem : EntitySystem
                 _buckle.Unbuckle(buckleUid, args.Args.User);
             }
         }
-        // End Frontier
+
+        // Remove contained humanoids
+        // TODO: revise condition for "generic player entities"
+        if (TryComp<ContainerManagerComponent>(args.Args.Target, out var containerManager))
+        {
+            EntityCoordinates? coords = null;
+            if (TryComp(equipmentComponent.EquipmentOwner, out TransformComponent? xform)) 
+                coords = xform.Coordinates;
+
+            List<EntityUid> toRemove = new();
+            foreach (var container in containerManager.Containers)
+            {
+                toRemove.Clear();
+                foreach (var contained in container.Value.ContainedEntities)
+                {
+                    if (HasComp<HumanoidAppearanceComponent>(contained) && HasComp<MindContainerComponent>(contained))
+                    {
+                        toRemove.Add(contained);
+                    }
+                }
+                foreach (var removeUid in toRemove)
+                {
+                    _container.Remove(removeUid, container.Value, destination: coords);
+                }
+            }
+        }
+        // End Frontier: Remove people from chairs and containers
 
         _container.Insert(args.Args.Target.Value, component.ItemContainer);
         _mech.UpdateUserInterface(equipmentComponent.EquipmentOwner.Value);

--- a/Content.Server/Mech/Equipment/EntitySystems/MechGrabberSystem.cs
+++ b/Content.Server/Mech/Equipment/EntitySystems/MechGrabberSystem.cs
@@ -215,7 +215,9 @@ public sealed class MechGrabberSystem : EntitySystem
                 toRemove.Clear();
                 foreach (var contained in container.Value.ContainedEntities)
                 {
-                    if (HasComp<HumanoidAppearanceComponent>(contained) && HasComp<MindContainerComponent>(contained))
+                    if (HasComp<HumanoidAppearanceComponent>(contained)
+                        && TryComp<MindContainerComponent>(contained, out var mindContainer)
+                        && mindContainer.HasMind)
                     {
                         toRemove.Add(contained);
                     }

--- a/Content.Server/Mech/Equipment/EntitySystems/MechGrabberSystem.cs
+++ b/Content.Server/Mech/Equipment/EntitySystems/MechGrabberSystem.cs
@@ -20,6 +20,7 @@ using Content.Shared.Whitelist; // Frontier
 using Content.Shared.Buckle.Components; // Frontier
 using Content.Shared.Buckle; // Frontier
 using Content.Shared.Mind.Components; // Frontier
+using Content.Server.Ghost.Roles.Components; // Frontier
 
 namespace Content.Server.Mech.Equipment.EntitySystems;
 
@@ -214,7 +215,8 @@ public sealed class MechGrabberSystem : EntitySystem
                 toRemove.Clear();
                 foreach (var contained in container.Value.ContainedEntities)
                 {
-                    if (TryComp<MindContainerComponent>(contained, out var mindContainer)
+                    if (HasComp<GhostRoleComponent>(contained)
+                        || TryComp<MindContainerComponent>(contained, out var mindContainer)
                         && mindContainer.HasMind)
                     {
                         toRemove.Add(contained);

--- a/Content.Server/Mech/Equipment/EntitySystems/MechGrabberSystem.cs
+++ b/Content.Server/Mech/Equipment/EntitySystems/MechGrabberSystem.cs
@@ -19,7 +19,6 @@ using Robust.Shared.Physics.Components;
 using Content.Shared.Whitelist; // Frontier
 using Content.Shared.Buckle.Components; // Frontier
 using Content.Shared.Buckle; // Frontier
-using Content.Shared.Humanoid; // Frontier
 using Content.Shared.Mind.Components; // Frontier
 
 namespace Content.Server.Mech.Equipment.EntitySystems;
@@ -215,8 +214,7 @@ public sealed class MechGrabberSystem : EntitySystem
                 toRemove.Clear();
                 foreach (var contained in container.Value.ContainedEntities)
                 {
-                    if (HasComp<HumanoidAppearanceComponent>(contained)
-                        && TryComp<MindContainerComponent>(contained, out var mindContainer)
+                    if (TryComp<MindContainerComponent>(contained, out var mindContainer)
                         && mindContainer.HasMind)
                     {
                         toRemove.Add(contained);

--- a/Content.Server/_NF/Mech/Equipment/EntitySystems.cs/MechForkSystem.cs
+++ b/Content.Server/_NF/Mech/Equipment/EntitySystems.cs/MechForkSystem.cs
@@ -24,6 +24,7 @@ using Content.Shared._NF.Cargo.Components;
 using Content.Server.Actions;
 using Content.Shared._NF.Mech.Equipment.Events;
 using Content.Shared.Mind.Components;
+using Content.Server.Ghost.Roles.Components;
 
 namespace Content.Server._NF.Mech.Equipment.EntitySystems;
 
@@ -282,7 +283,8 @@ public sealed class MechForkSystem : EntitySystem
                 toRemove.Clear();
                 foreach (var contained in container.Value.ContainedEntities)
                 {
-                    if (TryComp<MindContainerComponent>(contained, out var mindContainer)
+                    if (HasComp<GhostRoleComponent>(contained)
+                        || TryComp<MindContainerComponent>(contained, out var mindContainer)
                         && mindContainer.HasMind)
                     {
                         toRemove.Add(contained);

--- a/Content.Server/_NF/Mech/Equipment/EntitySystems.cs/MechForkSystem.cs
+++ b/Content.Server/_NF/Mech/Equipment/EntitySystems.cs/MechForkSystem.cs
@@ -283,7 +283,9 @@ public sealed class MechForkSystem : EntitySystem
                 toRemove.Clear();
                 foreach (var contained in container.Value.ContainedEntities)
                 {
-                    if (HasComp<HumanoidAppearanceComponent>(contained) && HasComp<MindContainerComponent>(contained))
+                    if (HasComp<HumanoidAppearanceComponent>(contained)
+                        && TryComp<MindContainerComponent>(contained, out var mindContainer)
+                        && mindContainer.HasMind)
                     {
                         toRemove.Add(contained);
                     }

--- a/Content.Server/_NF/Mech/Equipment/EntitySystems.cs/MechForkSystem.cs
+++ b/Content.Server/_NF/Mech/Equipment/EntitySystems.cs/MechForkSystem.cs
@@ -23,7 +23,6 @@ using Content.Server._NF.Mech.Equipment.Components;
 using Content.Shared._NF.Cargo.Components;
 using Content.Server.Actions;
 using Content.Shared._NF.Mech.Equipment.Events;
-using Content.Shared.Humanoid;
 using Content.Shared.Mind.Components;
 
 namespace Content.Server._NF.Mech.Equipment.EntitySystems;
@@ -283,8 +282,7 @@ public sealed class MechForkSystem : EntitySystem
                 toRemove.Clear();
                 foreach (var contained in container.Value.ContainedEntities)
                 {
-                    if (HasComp<HumanoidAppearanceComponent>(contained)
-                        && TryComp<MindContainerComponent>(contained, out var mindContainer)
+                    if (TryComp<MindContainerComponent>(contained, out var mindContainer)
                         && mindContainer.HasMind)
                     {
                         toRemove.Add(contained);

--- a/Content.Server/_NF/Mech/Equipment/EntitySystems.cs/MechForkSystem.cs
+++ b/Content.Server/_NF/Mech/Equipment/EntitySystems.cs/MechForkSystem.cs
@@ -23,6 +23,8 @@ using Content.Server._NF.Mech.Equipment.Components;
 using Content.Shared._NF.Cargo.Components;
 using Content.Server.Actions;
 using Content.Shared._NF.Mech.Equipment.Events;
+using Content.Shared.Humanoid;
+using Content.Shared.Mind.Components;
 
 namespace Content.Server._NF.Mech.Equipment.EntitySystems;
 
@@ -264,6 +266,32 @@ public sealed class MechForkSystem : EntitySystem
             foreach (var buckleUid in strapComp.BuckledEntities)
             {
                 _buckle.Unbuckle(buckleUid, args.Args.User);
+            }
+        }
+
+        // Remove contained humanoids
+        // TODO: revise condition for "generic player entities"
+        if (TryComp<ContainerManagerComponent>(args.Args.Target, out var containerManager))
+        {
+            EntityCoordinates? coords = null;
+            if (TryComp(equipmentComponent.EquipmentOwner, out TransformComponent? xform)) 
+                coords = xform.Coordinates;
+
+            List<EntityUid> toRemove = new();
+            foreach (var container in containerManager.Containers)
+            {
+                toRemove.Clear();
+                foreach (var contained in container.Value.ContainedEntities)
+                {
+                    if (HasComp<HumanoidAppearanceComponent>(contained) && HasComp<MindContainerComponent>(contained))
+                    {
+                        toRemove.Add(contained);
+                    }
+                }
+                foreach (var removeUid in toRemove)
+                {
+                    _container.Remove(removeUid, container.Value, destination: coords);
+                }
             }
         }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Removes people from crates when being picked up by mechs.  Should deposit them at the feet of the mech when they're picked up.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

"Fixes" https://discord.com/channels/1123826877245694004/1360140435183505599.

The problem is caused by things escaping a box when the box is contained inside a container within the mech.  If we can stop that by preventing things from entering into the mech in the first place, that seems reasonable, so that's the approach taken here.

## Technical details
<!-- Summary of code changes for easier review. -->

Applies a function (twice, once in the MechGrabberSystem, once in the MechForkSystem (yes, nasty), that checks all containers on the item being picked up, looks for entities with a present mind (present/non-ghosted[?] SSD players) or a ghost role (possible future players), and removes them from the container.

This still allows emergency medical pods, for example, to be picked up without removing the corpse inside.

Note: this will allow non-present ghost roles to be inserted.  We could add that condition.

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->

1. Connect on two clients, spawn in as a character on both.
2. Spawn an Emu with battery.
3. Spawn a chest and a Urist.
4. On Client 2, get in the chest along with the Urist.
5. On Client 1, get in the Emu, pick up the chest.
6. Client 2's player character should exit the mech and the chest should be inserted into the mech.
7. On Client 1, get out of the Emu, spawn a Ripley, a hydraulic clamp, and insert it into the Ripley.
8. Spawn another chest and a Urist, and on Client 2, get in the chest along with the Urist.
9. On Client 1, get in the Ripley, swap to the hydraulic clamp, and pick up the chest.
10. The player character should escape from the chest, appear near the mech, and the chest should be picked up.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Player characters or ghost roles being picked up by a mech inside a container will be removed.