### PR TITLE
FoldableSystem: revert changes to two of three fns

### DIFF
--- a/Content.Shared/Foldable/FoldableSystem.cs
+++ b/Content.Shared/Foldable/FoldableSystem.cs
@@ -42,7 +42,7 @@ public sealed class FoldableSystem : EntitySystem
 
     private void OnFoldableOpenAttempt(EntityUid uid, FoldableComponent component, ref StorageOpenAttemptEvent args)
     {
-        if (!component.IsFolded && !component.CanFoldInsideContainer) // Frontier: if things are folded or can unfold in storage, let them be stored
+        if (component.IsFolded)
             args.Cancelled = true;
     }
 
@@ -54,7 +54,7 @@ public sealed class FoldableSystem : EntitySystem
 
     public void OnStrapAttempt(EntityUid uid, FoldableComponent comp, ref StrapAttemptEvent args)
     {
-        if (!comp.IsFolded && !comp.CanFoldInsideContainer) // Frontier: if things are folded or can unfold in storage, let them be stored
+        if (comp.IsFolded)
             args.Cancelled = true;
     }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Partially reverts #3234.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

I goofed.  Only one of those changed functions is relevant (being stored in things).  The other two were fine as-is.

## Technical details
<!-- Summary of code changes for easier review. -->

Reverts conditions in StorageOpenAttemptEvent and StrapAttemptEvent handlers.  These work on the item itself, and need the item to be unfolded to actually work properly.

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->

1. Buckle yourself into an unfolded wheelchair, it should work.
2. Try to buckle yourself into a folded wheelchair.
    a. If you dragged and dropped yourself, you've found a neat bug in the VehicleSystem where the insert attempt doesn't check that it's cancelled and also spawns a virtual item instead of checking that there's an empty hand in which one can be inserted.
3. Take a body bag.  Open it when it's unfolded.
4. Insert a body into the body bag by closing it.
5. Try to fold it, shouldn't work.
6. Open the body bag, pull the corpse away from the bag.
7. Close it, fold it, should work.
8. Put the body bag and two blue caps, one flipped, one not, on top of a locker.
9. Close the locker.  All three items should fit in the locker.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
No changelog, not yet in-game.