### PR TITLE
Increased NFSD and Pirate role times.

### DIFF
--- a/Resources/Prototypes/_NF/Roles/Jobs/Nfsd/bailiff.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Nfsd/bailiff.yml
@@ -5,23 +5,13 @@
   playTimeTracker: JobWarden
   requirements:
     - !type:OverallPlaytimeRequirement
-      time: 108000 # 30 hours
+      time: 172800 # 48 hours
     - !type:DepartmentTimeRequirement
       department: Security
-      time: 64800 # 18 hours
+      time: 129600 # 36 hours
     - !type:RoleTimeRequirement
       role: JobSeniorOfficer
-      time: 21600 # 6 hours
-  alternateRequirementSets:
-    longerPlaytimeLessSec:
-    - !type:OverallPlaytimeRequirement
-      time: 720000 # 200 hours
-    - !type:DepartmentTimeRequirement
-      department: Security
       time: 43200 # 12 hours
-    - !type:RoleTimeRequirement
-      role: JobSeniorOfficer
-      time: 21600 # 6 hours
   startingGear: BailiffGear
   icon: JobIconBailiff
   supervisors: job-supervisors-sheriff

--- a/Resources/Prototypes/_NF/Roles/Jobs/Nfsd/brigmedic.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Nfsd/brigmedic.yml
@@ -12,7 +12,10 @@
   alternateRequirementSets:
     longerPlaytimeLessSec:
     - !type:OverallPlaytimeRequirement
-      time: 360000 # 100 hours
+      time: 540000 # 150 hours
+    - !type:DepartmentTimeRequirement
+      department: Security
+      time: 21600 # 6 hours
   startingGear: BrigmedicGear
   icon: JobIconBrigmedicNF
   supervisors: job-supervisors-bailiff

--- a/Resources/Prototypes/_NF/Roles/Jobs/Nfsd/cadet.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Nfsd/cadet.yml
@@ -8,7 +8,7 @@
       time: 21600 # 6 hours
     - !type:DepartmentTimeRequirement
       department: Security
-      time: 64800 # 18 hours
+      time: 86400 # 24 hours
       inverted: true # Leave slots open for newer, less confident players.
   startingGear: CadetGear
   icon: JobIconCadetNF

--- a/Resources/Prototypes/_NF/Roles/Jobs/Nfsd/deputy.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Nfsd/deputy.yml
@@ -12,7 +12,7 @@
   alternateRequirementSets:
     longerPlaytimeLessSec:
     - !type:OverallPlaytimeRequirement
-      time: 360000 # 100 hours
+      time: 540000 # 150 hours
   startingGear: DeputyGear
   icon: JobIconDeputy
   supervisors: job-supervisors-sergeant

--- a/Resources/Prototypes/_NF/Roles/Jobs/Nfsd/nfdetective.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Nfsd/nfdetective.yml
@@ -12,7 +12,10 @@
   alternateRequirementSets:
     longerPlaytimeLessSec:
     - !type:OverallPlaytimeRequirement
-      time: 360000 # 100 hours
+      time: 540000 # 150 hours
+    - !type:DepartmentTimeRequirement
+      department: Security
+      time: 21600 # 6 hours
   startingGear: NFDetectiveGear
   icon: JobIconNFDetective
   supervisors: job-supervisors-bailiff

--- a/Resources/Prototypes/_NF/Roles/Jobs/Nfsd/public_affairs.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Nfsd/public_affairs.yml
@@ -12,7 +12,10 @@
   alternateRequirementSets:
     longerPlaytimeLessSec:
     - !type:OverallPlaytimeRequirement
-      time: 360000 # 100 hours
+      time: 540000 # 150 hours
+    - !type:DepartmentTimeRequirement
+      department: Security
+      time: 21600 # 6 hours
   startingGear: PublicAffairGear
   icon: "JobIconPublicAffairsLiaison"
   supervisors: job-supervisors-cadet

--- a/Resources/Prototypes/_NF/Roles/Jobs/Nfsd/senior_officer.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Nfsd/senior_officer.yml
@@ -5,20 +5,13 @@
   playTimeTracker: JobSeniorOfficer
   requirements:
     - !type:OverallPlaytimeRequirement
-      time: 108000 # 30 hours
+      time: 129600 # 36 hours
     - !type:DepartmentTimeRequirement
       department: Security
-      time: 43200 # 18 hours
+      time: 86400 # 24 hours
     - !type:RoleTimeRequirement
       role: JobSecurityOfficer
-      time: 64800 # 12 hours
-  alternateRequirementSets:
-    longerPlaytimeLessSec:
-    - !type:OverallPlaytimeRequirement
-      time: 540000 # 150 hours
-    - !type:RoleTimeRequirement
-      role: JobSecurityOfficer
-      time: 21600 # 6 hours
+      time: 43200 # 12 hours
   startingGear: SeniorOfficerGear
   icon: JobIconSergeant
   supervisors: job-supervisors-bailiff

--- a/Resources/Prototypes/_NF/Roles/Jobs/Nfsd/sheriff.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Nfsd/sheriff.yml
@@ -5,26 +5,13 @@
   playTimeTracker: JobHeadOfSecurity
   requirements:
     - !type:OverallPlaytimeRequirement
-      time: 129600 # 36 hours
+      time: 216000 # 60 hours
     - !type:DepartmentTimeRequirement
       department: Security
-      time: 86400 # 24 hours
+      time: 172800 # 48 hours
     - !type:RoleTimeRequirement
       role: JobWarden
-      time: 21600 # 6 hours
-    - !type:RoleTimeRequirement
-      role: JobSeniorOfficer
       time: 43200 # 12 hours
-  alternateRequirementSets:
-    longerPlaytimeLessSec:
-    - !type:OverallPlaytimeRequirement
-      time: 1080000 # 300 hours
-    - !type:DepartmentTimeRequirement
-      department: Security
-      time: 64800 # 18 hours
-    - !type:RoleTimeRequirement
-      role: JobWarden
-      time: 21600 # 6 hours
   whitelisted: true
   startingGear: SheriffGear
   alwaysUseSpawner: true

--- a/Resources/Prototypes/_NF/Roles/Jobs/Pirates/pirate.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Pirates/pirate.yml
@@ -8,7 +8,7 @@
       time: 86400 # 24 hours
     - !type:DepartmentTimeRequirement
       department: Security
-      time: 10800 # 3 hrs
+      time: 21600 # 6 hrs
   startingGear: PirateNFGear
   alwaysUseSpawner: true
   hideConsoleVisibility: true

--- a/Resources/Prototypes/_NF/Roles/Jobs/Pirates/pirate_captain.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Pirates/pirate_captain.yml
@@ -8,7 +8,7 @@
       time: 172800 # 48 hours
     - !type:RoleTimeRequirement
       role: JobSeniorOfficer
-      time: 10800 # 3 hours
+      time: 21600 # 6 hours
   whitelisted: true
   startingGear: PirateCaptainNFGear
   alwaysUseSpawner: true

--- a/Resources/Prototypes/_NF/Roles/Jobs/Pirates/pirate_first_mate.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Pirates/pirate_first_mate.yml
@@ -8,7 +8,7 @@
       time: 129600 # 36 hours
     - !type:DepartmentTimeRequirement
       department: Security
-      time: 10800 # 3 hours
+      time: 21600 # 6 hours
   whitelisted: true
   startingGear: PirateFirstMateNFGear
   alwaysUseSpawner: true


### PR DESCRIPTION
Formats NFSD and Pirate role times to fit a 12 hour standard and increases the amount of NFSD officers must play in the department to advance. Ensures that Command roles cannot skip department times with general playtimes due to the increased responsibility and unique playstyle of the department.

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Increased cadet lockout period from 18 to 24 hours.
Increased the cadet bypass requirements on Deputy, Brigmedic, PAL and Detective from 100 to 150 hours.
Added a 6 - hour Security requirement on Brigmedic, PAL, and Detective on the cadet bypass requirements.
Increased the playtime requirement on Sergeant to 12 hours Deputy, 24 hours Security, 36 hours server.
Increased the playtime requirement on Bailiff to 12 hours Sergeant, 36 hours Security, 48 hours server.
Increased the playtime requirement on Sheriff to 12 hours Bailiff, 48 hours department, 60 hours server.
Removed the security bypass requirements on Sergeant, Bailiff, and Sheriff.
Increased Pirate and First Mate Security requirement to 6 hours.
Increased Captain Sergeant requirement to 6 hours.

## Why / Balance
The times for NFSD have been increased to abide by a 12 hour standard instead of a 6 hour standard, and the time to bypass cadet hours has been increased significantly. This will give increased time for bad actors to be caught and corrected, both by ingame players and OOC by game admins.

The 'specialist' roles- brigmedic, detective, and public affairs liason- have a 6 hour security requirement if you qualify for it through 150 hours. If someone is skipping the cadet training, they should not be getting their feet under them on top of trying to learn and meet the requirements of those roles.

The security playtime bypass has been removed for Sheriff, Bailiff and Sergeant. These roles are held to a higher standard in regards to SOP and Space Law, and you should not be able to skip the time needed to gain both comfort and familiarity with these systems with out-of-department playtime. One should play and gain experience in the department in order to progress through the department.

Sheriff playtime requirements are relatively similar to what they currently are, ignoring changes caused by cumulative changes below them and shifting the extra sergeant hours into bailiff. This is because Sheriff is mostly locked behind whitelisting more than playtime and hours.

Pirate playtime requirements have been increased in sympathy to the increased NFSD hours. Players should finish their cadet training before playing pirate to give more time for lessons on matters of increased escalation requirements and such to settle in. Increases to Pirate Captain time with Sergeant is mostly to keep in line with all other changes in the PR.

## Technical details
Changed numbers and comments to align with the above changes.

## How to test
Remove your hours.
Check the playtime requirements on the loadout screen ingame.
Witness the increased job requirements.

Alternatively: Open and witness the .yaml files.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: Increased NFSD job hour requirements across the board, and removed the ability to bypass NFSD Command requirements with general server time.
- tweak: Increased pirate time requirements.