### PR TITLE
Adds magboots to departmental EVA storage

### DIFF
--- a/Resources/Prototypes/_NF/Catalog/Fills/StorageFillTemplates/departmental_eva.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/StorageFillTemplates/departmental_eva.yml
@@ -10,6 +10,7 @@
     - id: ClothingOuterEVASuitContractor
     - id: ClothingMaskBreath
     - id: JetpackMiniFilled
+    - id: ClothingShoesBootsMag
 
 - type: entity
   abstract: true
@@ -22,6 +23,7 @@
     - id: ClothingOuterEVASuitPilot
     - id: ClothingMaskPilot
     - id: JetpackMiniFilled
+    - id: ClothingShoesBootsMag
 
 - type: entity
   abstract: true
@@ -34,6 +36,7 @@
     - id: ClothingOuterEVASuitSr
     - id: ClothingMaskBreath
     - id: JetpackMiniFilled
+    - id: ClothingShoesBootsMag
 
 - type: entity
   abstract: true
@@ -46,6 +49,7 @@
     - id: ClothingOuterEVASuitCaptain
     - id: ClothingMaskGasCaptain
     - id: JetpackMiniFilled
+    - id: ClothingShoesBootsMag
 
 - type: entity
   abstract: true
@@ -58,6 +62,7 @@
     - id: ClothingOuterEVASuitEngineer
     - id: ClothingMaskGas
     - id: JetpackMiniFilled
+    - id: ClothingShoesBootsMag
 
 - type: entity
   abstract: true
@@ -70,6 +75,7 @@
     - id: ClothingOuterEVASuitAtmosTech
     - id: ClothingMaskGasAtmos
     - id: JetpackMiniFilled
+    - id: ClothingShoesBootsMag
 
 - type: entity
   abstract: true
@@ -82,6 +88,7 @@
     - id: ClothingOuterEVASuitCargo
     - id: ClothingMaskBreath
     - id: JetpackMiniFilled
+    - id: ClothingShoesBootsMag
 
 - type: entity
   abstract: true
@@ -107,6 +114,7 @@
     - id: ClothingOuterEVASuitMedic
     - id: ClothingMaskBreathMedical
     - id: JetpackMiniFilled
+    - id: ClothingShoesBootsMag
 
 - type: entity
   abstract: true
@@ -120,6 +128,7 @@
     - id: ClothingMaskBreathMedical
     - id: JetpackMiniFilled
     - id: FlashlightLantern
+    - id: ClothingShoesBootsMag
 
 - type: entity
   abstract: true
@@ -132,6 +141,7 @@
     - id: ClothingOuterEVASuitScientist
     - id: ClothingMaskBreath
     - id: JetpackMiniFilled
+    - id: ClothingShoesBootsMag
 
 - type: entity
   abstract: true
@@ -144,6 +154,7 @@
     - id: ClothingOuterEVASuitJanitor
     - id: ClothingMaskBreath
     - id: JetpackMiniFilled
+    - id: ClothingShoesBootsMag
 
 - type: entity
   abstract: true
@@ -156,6 +167,7 @@
     - id: ClothingOuterEVASuitServiceWorker
     - id: ClothingMaskBreath
     - id: JetpackMiniFilled
+    - id: ClothingShoesBootsMag
 
 - type: entity
   abstract: true
@@ -169,6 +181,7 @@
     - id: ClothingMaskBreath
     - id: JetpackMiniFilled
     - id: Lantern
+    - id: ClothingShoesBootsMag
 
 - type: entity
   abstract: true
@@ -251,6 +264,7 @@
     - id: ClothingOuterEVASuitHydro
     - id: ClothingMaskBreath
     - id: JetpackMiniFilled
+    - id: ClothingShoesBootsMag
 
 - type: entity
   abstract: true
@@ -263,6 +277,7 @@
     - id: ClothingOuterEVASuitMailman
     - id: ClothingMaskBreath
     - id: JetpackMiniFilled
+    - id: ClothingShoesBootsMag
 
 - type: entity
   abstract: true
@@ -276,6 +291,7 @@
     - id: ClothingMaskGasMercenary
     - id: JetpackMiniFilled
     - id: FlashlightSeclite
+    - id: ClothingShoesBootsMag
 
 - type: entity
   abstract: true
@@ -289,6 +305,7 @@
     - id: ClothingMaskGasSecurity
     - id: JetpackMiniFilled
     - id: FlashlightSeclite
+    - id: ClothingShoesBootsMag
 
 - type: entity
   abstract: true
@@ -302,6 +319,7 @@
     - id: ClothingMaskGasNfsd
     - id: JetpackNfsdFilled
     - id: FlashlightNfsdLite
+    - id: ClothingShoesBootsMag
 
 # Other EVA Suits
 - type: entity
@@ -316,6 +334,7 @@
     - id: ClothingMaskBreath
     - id: JetpackMiniFilled
     - id: Lantern
+    - id: ClothingShoesBootsMag
 
 # Emergency
 - type: entity
@@ -330,6 +349,7 @@
     - id: ClothingMaskBreath
     - id: JetpackMiniFilled
     - id: FlashlightLantern
+    - id: ClothingShoesBootsMag
 
 # Player factions
 - type: entity
@@ -343,11 +363,12 @@
     - id: ClothingOuterEVASuitLvhi
     - id: ClothingMaskBreath
     - id: JetpackMiniFilled
+    - id: ClothingShoesBootsMag
 
 - type: entity
   abstract: true
   id: StorageFillEVASuitFsb
-  description: Contains a standard issue Far Star Biotech (FSB) EVA suit. 
+  description: Contains a standard issue Far Star Biotech (FSB) EVA suit.
   components:
   - type: StorageFill
     contents:
@@ -355,3 +376,4 @@
     - id: ClothingOuterEVASuitFsb
     - id: ClothingMaskBreath
     - id: JetpackMiniFilled
+    - id: ClothingShoesBootsMag


### PR DESCRIPTION
## About the PR
Adds magboots to departmental EVA storage template, so every EVA bundle and storage unit (also replaced gas tanks with smaller ones for boxer EVA suits to make room for boots).

## Why / Balance
QoL

## Technical details
yml changes

## How to test
1. Spawn EVA bundles and/or EVA wall lockers, notice magboots are there.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [x] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:
- add: Added magboots to EVA storage.
