### PR TITLE
Allow generators to convert raw ore to fuel-grade material.

### DIFF
--- a/Content.Server/_NF/Power/Generator/FuelGradeAdapterComponent.cs
+++ b/Content.Server/_NF/Power/Generator/FuelGradeAdapterComponent.cs
@@ -16,15 +16,15 @@ public sealed partial class FuelGradeAdapterComponent : Component
 [DataDefinition]
 public partial record struct MaterialAdapterRate
 {
-    [DataField]
+    [DataField(required: true)]
     public ProtoId<MaterialPrototype> Input;
 
-    [DataField]
+    [DataField(required: true)]
     public ProtoId<MaterialPrototype> Output;
 
     /// <summary>
     /// The conversion rate - 1 unit of input results in Rate units of output.
     /// </summary>
     [DataField]
-    public float Rate;
+    public float Rate = 1.0f;
 }

--- a/Content.Server/_NF/Power/Generator/FuelGradeAdapterComponent.cs
+++ b/Content.Server/_NF/Power/Generator/FuelGradeAdapterComponent.cs
@@ -3,12 +3,28 @@ using Robust.Shared.Prototypes; // Frontier
 
 namespace Content.Server._NF.Power.Generator;
 
+/// <summary>
+/// A component that converts materials at arbitrary rates before inserting into material storage.
+/// </summary>
 [RegisterComponent]
 public sealed partial class FuelGradeAdapterComponent : Component
 {
+    [DataField(required: true)]
+    public List<MaterialAdapterRate> Conversions;
+}
+
+[DataDefinition]
+public partial record struct MaterialAdapterRate
+{
     [DataField]
-    public ProtoId<MaterialPrototype> InputMaterial = "Plasma";
+    public ProtoId<MaterialPrototype> Input;
 
     [DataField]
-    public ProtoId<MaterialPrototype> OutputMaterial = "FuelGradePlasma";
+    public ProtoId<MaterialPrototype> Output;
+
+    /// <summary>
+    /// The conversion rate - 1 unit of input results in Rate units of output.
+    /// </summary>
+    [DataField]
+    public float Rate;
 }

--- a/Content.Server/_NF/Power/Generator/FuelGradeAdapterSystem.cs
+++ b/Content.Server/_NF/Power/Generator/FuelGradeAdapterSystem.cs
@@ -16,15 +16,18 @@ public sealed class FuelGradeAdapterSystem : EntitySystem
 
     public void OnMaterialEntityInserted(Entity<FuelGradeAdapterComponent> entity, ref MaterialEntityInsertedEvent args)
     {
-        // Convert all of the input material in the material storage into output material
+        // Convert all of the input material we can in the material storage into output material
         if (!TryComp<MaterialStorageComponent>(entity.Owner, out var materialStorage))
             return;
 
-        var inputAmount = _materialStorage.GetMaterialAmount(entity.Owner, entity.Comp.InputMaterial, materialStorage);
-        if (inputAmount > 0)
+        foreach (var conversion in entity.Comp.Conversions)
         {
-            _materialStorage.TryChangeMaterialAmount(entity.Owner, entity.Comp.InputMaterial, -inputAmount, materialStorage, dirty: false);
-            _materialStorage.TryChangeMaterialAmount(entity.Owner, entity.Comp.OutputMaterial, inputAmount, materialStorage, dirty: true);
+            var inputAmount = _materialStorage.GetMaterialAmount(entity.Owner, conversion.Input, materialStorage);
+            if (inputAmount > 0)
+            {
+                _materialStorage.TryChangeMaterialAmount(entity.Owner, conversion.Input, -inputAmount, materialStorage, dirty: false);
+                _materialStorage.TryChangeMaterialAmount(entity.Owner, conversion.Output, (int)(inputAmount * conversion.Rate), materialStorage, dirty: true);
+            }
         }
     }
 }

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/portable_generator.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/portable_generator.yml
@@ -170,7 +170,7 @@
       multiplier: 0.01
     - type: MaterialStorage
       storageLimit: 3000
-      materialWhiteList: [Plasma, FuelGradePlasma] # Frontier: add FuelGradePlasma
+      materialWhiteList: [Plasma, FuelGradePlasma, RawPlasma] # Frontier: add FuelGradePlasma, RawPlasma
     - type: PortableGenerator
       startChance: 0.8
     - type: UpgradePowerSupplier
@@ -190,11 +190,18 @@
     - type: PowerSupplier
       supplyRampRate: 5000
       supplyRampTolerance: 1500
-    - type: MaterialStorageMagnetPickup # Frontier
-      range: 0.30 # Frontier
-    - type: FuelGradeAdapter # Frontier
-      inputMaterial: Plasma # Frontier
-      outputMaterial: FuelGradePlasma # Frontier
+    # Frontier: magnet pickup, fuel adapter
+    - type: MaterialStorageMagnetPickup
+      range: 0.30
+    - type: FuelGradeAdapter
+      conversions:
+      - input: Plasma
+        output: FuelGradePlasma
+        rate: 1
+      - input: RawPlasma
+        output: FuelGradePlasma
+        rate: 0.5
+    # End Frontier: magnet pickup, fuel adapter
 
 - type: entity
   name: S.U.P.E.R.P.A.C.M.A.N.-type portable generator
@@ -239,7 +246,7 @@
       multiplier: 0.01
     - type: MaterialStorage
       storageLimit: 3000
-      materialWhiteList: [Uranium, FuelGradeUranium] # Frontier: add FuelGradeUranium
+      materialWhiteList: [Uranium, FuelGradeUranium, RawUranium] # Frontier: add FuelGradeUranium, RawUranium
     - type: PortableGenerator
     - type: UpgradePowerSupplier
       powerSupplyMultiplier: 1.25
@@ -254,11 +261,18 @@
     - type: PowerSupplier
       supplyRampRate: 7500
       supplyRampTolerance: 2500
-    - type: MaterialStorageMagnetPickup # Frontier
-      range: 0.30 # Frontier
-    - type: FuelGradeAdapter # Frontier
-      inputMaterial: Uranium # Frontier
-      outputMaterial: FuelGradeUranium # Frontier
+    # Frontier: magnet pickup, fuel adapter
+    - type: MaterialStorageMagnetPickup
+      range: 0.30
+    - type: FuelGradeAdapter
+      conversions:
+      - input: Uranium
+        output: FuelGradeUranium
+        rate: 1
+      - input: RawUranium
+        output: FuelGradeUranium
+        rate: 0.5
+    # End Frontier: magnet pickup, fuel adapter
 
 - type: entity
   name: J.R.P.A.C.M.A.N.-type portable generator

--- a/Resources/Prototypes/_NF/Entities/Structures/Power/Generation/portable_generator.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Power/Generation/portable_generator.yml
@@ -92,7 +92,7 @@
     - type: SolidFuelGeneratorAdapter
       fuelMaterial: FuelGradeBananium
     - type: MaterialStorage
-      materialWhiteList: [Bananium, FuelGradeBananium]
+      materialWhiteList: [Bananium, FuelGradeBananium, RawBananium]
     - type: PowerMonitoringDevice
       sprite: _NF/Structures/Power/Generation/portable_generator.rsi
       state: portgen1
@@ -107,8 +107,13 @@
       supplyRampRate: 10000
       supplyRampTolerance: 3000
     - type: FuelGradeAdapter
-      inputMaterial: Bananium
-      outputMaterial: FuelGradeBananium
+      conversions:
+      - input: Bananium
+        output: FuelGradeBananium
+        rate: 1
+      - input: RawBananium
+        output: FuelGradeBananium
+        rate: 0.5
 
 - type: entity
   parent:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Allows generators to receive ore at a reduced efficiency compared to sheets (currently 0.5 fuel-grade material per ore).

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Makes the Pioneer just a little bit friendlier for newbies.

## Technical details
<!-- Summary of code changes for easier review. -->

The adapter now has a list of materials it will transform and a conversion rate.

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->

1. Spawn PACMAN, SUPERPACMAN, DK, and DK JR generators.
2. Spawn plasma, fuel-grade plasma, and plasma ore.
3. Insert all three into the PACMAN.  Should insert without issue, check that the amount in the generator increased for each.
4. Repeat step 2-3 with uranium for the SUPERPACMAN, and bananium for the DK/DK JR generators.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

Any forks with their own generators using the FuelGradeAdapterComponent will need to update to the new struct.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: Generators can now accept ore as fuel at reduced efficiency.