### PR TITLE
Add cyborg rechargers for Ambition, Anchor and Gourd.

### DIFF
--- a/Resources/Maps/_NF/Shuttles/Expedition/anchor.yml
+++ b/Resources/Maps/_NF/Shuttles/Expedition/anchor.yml
@@ -1,6 +1,17 @@
 meta:
-  format: 6
-  postmapinit: false
+  format: 7
+  category: Grid
+  engineVersion: 250.0.0
+  forkId: ""
+  forkVersion: ""
+  time: 04/18/2025 17:20:41
+  entityCount: 1900
+maps: []
+grids:
+- 1
+orphans:
+- 1
+nullspace: []
 tilemap:
   0: Space
   14: FloorBar
@@ -833,6 +844,11 @@ entities:
           decals:
             244: 12,-24
         - node:
+            color: '#FFFFFFFF'
+            id: peace
+          decals:
+            313: 14.229797,-10.101359
+        - node:
             cleanable: True
             color: '#FFFFFFFF'
             id: peace
@@ -993,7 +1009,8 @@ entities:
             1: 240
             0: 40960
           -1,-8:
-            0: 54508
+            0: 54476
+            3: 32
           -1,-7:
             0: 56573
           -1,-6:
@@ -1001,7 +1018,8 @@ entities:
           -1,-9:
             0: 16384
           0,-8:
-            0: 53553
+            0: 53521
+            4: 32
             1: 128
           0,-7:
             0: 53757
@@ -1014,9 +1032,9 @@ entities:
           1,-6:
             0: 63214
           1,-7:
-            3: 34
+            5: 34
             0: 57344
-            4: 136
+            6: 136
           2,-7:
             0: 30304
           2,-6:
@@ -1078,6 +1096,36 @@ entities:
           - 0
           - 0
           - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.14996
+          moles:
+          - 20.078888
+          - 75.53487
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.14996
+          moles:
+          - 21.824879
+          - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
           - 0
           - 0
           - 0
@@ -2260,11 +2308,6 @@ entities:
       parent: 1
 - proto: Bookshelf
   entities:
-  - uid: 93
-    components:
-    - type: Transform
-      pos: -16.5,-12.5
-      parent: 1
   - uid: 95
     components:
     - type: Transform
@@ -2276,6 +2319,23 @@ entities:
     components:
     - type: Transform
       pos: -15.5,-8.5
+      parent: 1
+- proto: BorgCharger
+  entities:
+  - uid: 453
+    components:
+    - type: Transform
+      pos: 1.5,-30.5
+      parent: 1
+  - uid: 779
+    components:
+    - type: Transform
+      pos: -16.5,-12.5
+      parent: 1
+  - uid: 1266
+    components:
+    - type: Transform
+      pos: 15.5,-8.5
       parent: 1
 - proto: BoxCandle
   entities:
@@ -3972,28 +4032,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -8.5,-27.5
       parent: 1
-- proto: Catwalk
-  entities:
-  - uid: 1759
-    components:
-    - type: Transform
-      pos: 12.5,-8.5
-      parent: 1
-  - uid: 1773
-    components:
-    - type: Transform
-      pos: 12.5,-9.5
-      parent: 1
-  - uid: 1803
-    components:
-    - type: Transform
-      pos: 13.5,-9.5
-      parent: 1
-  - uid: 1804
-    components:
-    - type: Transform
-      pos: 13.5,-8.5
-      parent: 1
 - proto: Carpet
   entities:
   - uid: 70
@@ -4130,6 +4168,26 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -8.5,-27.5
       parent: 1
+  - uid: 1759
+    components:
+    - type: Transform
+      pos: 12.5,-8.5
+      parent: 1
+  - uid: 1773
+    components:
+    - type: Transform
+      pos: 12.5,-9.5
+      parent: 1
+  - uid: 1803
+    components:
+    - type: Transform
+      pos: 13.5,-9.5
+      parent: 1
+  - uid: 1804
+    components:
+    - type: Transform
+      pos: 13.5,-8.5
+      parent: 1
 - proto: Chair
   entities:
   - uid: 608
@@ -4203,20 +4261,6 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-5.5
-      parent: 1
-- proto: ChairOfficeDark
-  entities:
-  - uid: 866
-    components:
-    - type: Transform
-      pos: 3.5,-13.5
-      parent: 1
-- proto: ChairOfficeLight
-  entities:
-  - uid: 453
-    components:
-    - type: Transform
-      pos: 16.5,-18.5
       parent: 1
 - proto: ChairPilotSeat
   entities:
@@ -4303,13 +4347,24 @@ entities:
     - type: Transform
       pos: -2.5,-30.5
       parent: 1
-- proto: ClosetEmergencyN2FilledRandom
-  entities:
-  - uid: 779
-    components:
-    - type: Transform
-      pos: 1.5,-30.5
-      parent: 1
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14923
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
 - proto: ClosetL3JanitorFilled
   entities:
   - uid: 343
@@ -4355,6 +4410,14 @@ entities:
     components:
     - type: Transform
       pos: 6.5,-18.5
+      parent: 1
+- proto: ClosetWallN2FilledRandom
+  entities:
+  - uid: 866
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-27.5
       parent: 1
 - proto: ClothingBeltChaplainSashFilled
   entities:
@@ -9374,6 +9437,13 @@ entities:
     - type: Transform
       pos: -4.5,6.5
       parent: 1
+- proto: PosterLegitSafetyMothEpi
+  entities:
+  - uid: 690
+    components:
+    - type: Transform
+      pos: 18.5,-19.5
+      parent: 1
 - proto: PosterLegitSafetyMothHardhat
   entities:
   - uid: 815
@@ -9381,21 +9451,14 @@ entities:
     - type: Transform
       pos: 18.5,-16.5
       parent: 1
-- proto: PosterLegitSMEpi
-  entities:
-  - uid: 690
-    components:
-    - type: Transform
-      pos: 18.5,-19.5
-      parent: 1
-- proto: PosterLegitSMPills
+- proto: PosterLegitSafetyMothPills
   entities:
   - uid: 816
     components:
     - type: Transform
       pos: 18.5,-18.5
       parent: 1
-- proto: PosterLegitSMPoisoning
+- proto: PosterLegitSafetyMothPoisoning
   entities:
   - uid: 791
     components:
@@ -11296,6 +11359,11 @@ entities:
       parent: 1
 - proto: WallShuttle
   entities:
+  - uid: 93
+    components:
+    - type: Transform
+      pos: -17.5,-12.5
+      parent: 1
   - uid: 176
     components:
     - type: Transform
@@ -11831,11 +11899,6 @@ entities:
     components:
     - type: Transform
       pos: 6.5,2.5
-      parent: 1
-  - uid: 1469
-    components:
-    - type: Transform
-      pos: -17.5,-12.5
       parent: 1
   - uid: 1470
     components:

--- a/Resources/Maps/_NF/Shuttles/Expedition/gourd.yml
+++ b/Resources/Maps/_NF/Shuttles/Expedition/gourd.yml
@@ -1,6 +1,17 @@
 meta:
-  format: 6
-  postmapinit: false
+  format: 7
+  category: Grid
+  engineVersion: 250.0.0
+  forkId: ""
+  forkVersion: ""
+  time: 04/18/2025 16:55:22
+  entityCount: 2016
+maps: []
+grids:
+- 1
+orphans:
+- 1
+nullspace: []
 tilemap:
   0: Space
   14: FloorBar
@@ -3615,6 +3626,23 @@ entities:
     - type: Transform
       pos: -1.8859248,28.547873
       parent: 1
+- proto: BorgCharger
+  entities:
+  - uid: 662
+    components:
+    - type: Transform
+      pos: 6.5,-10.5
+      parent: 1
+  - uid: 724
+    components:
+    - type: Transform
+      pos: -9.5,13.5
+      parent: 1
+  - uid: 852
+    components:
+    - type: Transform
+      pos: 10.5,13.5
+      parent: 1
 - proto: ButtonFrameCaution
   entities:
   - uid: 131
@@ -5885,53 +5913,6 @@ entities:
       parent: 584
     - type: Physics
       canCollide: False
-- proto: Catwalk
-  entities:
-  - uid: 9
-    components:
-    - type: Transform
-      pos: 12.5,3.5
-      parent: 1
-  - uid: 10
-    components:
-    - type: Transform
-      pos: 13.5,1.5
-      parent: 1
-  - uid: 55
-    components:
-    - type: Transform
-      pos: 13.5,0.5
-      parent: 1
-  - uid: 573
-    components:
-    - type: Transform
-      pos: 13.5,2.5
-      parent: 1
-  - uid: 814
-    components:
-    - type: Transform
-      pos: 12.5,-0.5
-      parent: 1
-  - uid: 820
-    components:
-    - type: Transform
-      pos: 12.5,1.5
-      parent: 1
-  - uid: 821
-    components:
-    - type: Transform
-      pos: 13.5,-0.5
-      parent: 1
-  - uid: 873
-    components:
-    - type: Transform
-      pos: 12.5,0.5
-      parent: 1
-  - uid: 1389
-    components:
-    - type: Transform
-      pos: 12.5,2.5
-      parent: 1
 - proto: Carpet
   entities:
   - uid: 728
@@ -6318,10 +6299,30 @@ entities:
       parent: 1
 - proto: Catwalk
   entities:
+  - uid: 9
+    components:
+    - type: Transform
+      pos: 12.5,3.5
+      parent: 1
+  - uid: 10
+    components:
+    - type: Transform
+      pos: 13.5,1.5
+      parent: 1
   - uid: 11
     components:
     - type: Transform
       pos: 12.5,-1.5
+      parent: 1
+  - uid: 55
+    components:
+    - type: Transform
+      pos: 13.5,0.5
+      parent: 1
+  - uid: 573
+    components:
+    - type: Transform
+      pos: 13.5,2.5
       parent: 1
   - uid: 694
     components:
@@ -6371,11 +6372,31 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 3.5,0.5
       parent: 1
+  - uid: 814
+    components:
+    - type: Transform
+      pos: 12.5,-0.5
+      parent: 1
   - uid: 817
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,1.5
+      parent: 1
+  - uid: 820
+    components:
+    - type: Transform
+      pos: 12.5,1.5
+      parent: 1
+  - uid: 821
+    components:
+    - type: Transform
+      pos: 13.5,-0.5
+      parent: 1
+  - uid: 873
+    components:
+    - type: Transform
+      pos: 12.5,0.5
       parent: 1
   - uid: 874
     components:
@@ -6420,36 +6441,15 @@ entities:
     - type: Transform
       pos: -7.5,1.5
       parent: 1
+  - uid: 1389
+    components:
+    - type: Transform
+      pos: 12.5,2.5
+      parent: 1
   - uid: 1494
     components:
     - type: Transform
       pos: -7.5,0.5
-      parent: 1
-- proto: ChairOfficeLight
-  entities:
-  - uid: 662
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 3.5,27.5
-      parent: 1
-  - uid: 724
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -5.4361367,2.6951075
-      parent: 1
-  - uid: 852
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -11.516135,1.7039237
-      parent: 1
-  - uid: 1149
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -2.5,27.5
       parent: 1
 - proto: ChairPilotSeat
   entities:
@@ -11236,8 +11236,7 @@ entities:
   - uid: 960
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 6.5,-10.5
+      pos: 1.5,-6.5
       parent: 1
   - uid: 1282
     components:

--- a/Resources/Maps/_NF/Shuttles/ambition.yml
+++ b/Resources/Maps/_NF/Shuttles/ambition.yml
@@ -1,6 +1,17 @@
 meta:
-  format: 6
-  postmapinit: false
+  format: 7
+  category: Grid
+  engineVersion: 250.0.0
+  forkId: ""
+  forkVersion: ""
+  time: 04/18/2025 16:44:31
+  entityCount: 2554
+maps: []
+grids:
+- 1
+orphans:
+- 1
+nullspace: []
 tilemap:
   0: Space
   10: FloorCarpetOffice
@@ -1861,6 +1872,12 @@ entities:
       rot: 3.141592653589793 rad
       pos: 1.5,34.5
       parent: 1
+    - type: Door
+      secondsUntilStateChange: -941.6914
+      state: Opening
+    - type: DeviceLinkSource
+      lastSignals:
+        DoorStatus: True
 - proto: AirlockMaint
   entities:
   - uid: 2421
@@ -3411,6 +3428,8 @@ entities:
     - type: Transform
       pos: 0.5,3.5
       parent: 1
+    - type: DeviceLinkSink
+      invokeCounter: 7
   - uid: 1890
     components:
     - type: Transform
@@ -3493,6 +3512,19 @@ entities:
     components:
     - type: Transform
       pos: 4.5,0.5
+      parent: 1
+- proto: BorgCharger
+  entities:
+  - uid: 1875
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,7.5
+      parent: 1
+  - uid: 2143
+    components:
+    - type: Transform
+      pos: -4.5,28.5
       parent: 1
 - proto: BoxBodyBag
   entities:
@@ -5725,28 +5757,6 @@ entities:
     - type: Transform
       pos: -10.594801,5.7791753
       parent: 1
-- proto: Catwalk
-  entities:
-  - uid: 1156
-    components:
-    - type: Transform
-      pos: 7.5,29.5
-      parent: 1
-  - uid: 1163
-    components:
-    - type: Transform
-      pos: 6.5,30.5
-      parent: 1
-  - uid: 1604
-    components:
-    - type: Transform
-      pos: 5.5,30.5
-      parent: 1
-  - uid: 2387
-    components:
-    - type: Transform
-      pos: 4.5,30.5
-      parent: 1
 - proto: CarpetBlue
   entities:
   - uid: 12
@@ -6035,10 +6045,20 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 0.5,-10.5
       parent: 1
+  - uid: 1156
+    components:
+    - type: Transform
+      pos: 7.5,29.5
+      parent: 1
   - uid: 1160
     components:
     - type: Transform
       pos: -5.5,9.5
+      parent: 1
+  - uid: 1163
+    components:
+    - type: Transform
+      pos: 6.5,30.5
       parent: 1
   - uid: 1172
     components:
@@ -6424,6 +6444,11 @@ entities:
     - type: Transform
       pos: -5.5,25.5
       parent: 1
+  - uid: 1604
+    components:
+    - type: Transform
+      pos: 5.5,30.5
+      parent: 1
   - uid: 1617
     components:
     - type: Transform
@@ -6571,6 +6596,11 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 11.5,31.5
       parent: 1
+  - uid: 2387
+    components:
+    - type: Transform
+      pos: 4.5,30.5
+      parent: 1
   - uid: 2389
     components:
     - type: Transform
@@ -6668,14 +6698,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.625493,32.18197
-      parent: 1
-- proto: ChairOfficeDark
-  entities:
-  - uid: 2084
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -4.5,1.5
       parent: 1
 - proto: ChairPilotSeat
   entities:
@@ -7048,6 +7070,9 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 4.5,-1.5
       parent: 1
+    - type: Door
+      secondsUntilStateChange: -913.32477
+      state: Closing
 - proto: CurtainSpawner
   entities:
   - uid: 2294
@@ -7135,6 +7160,8 @@ entities:
     - type: Transform
       pos: -6.5,10.5
       parent: 1
+    - type: Openable
+      opened: True
   - uid: 106
     components:
     - type: Transform
@@ -8894,6 +8921,12 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#9955CCFF'
+  - uid: 2014
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,5.5
+      parent: 1
   - uid: 2031
     components:
     - type: Transform
@@ -10417,12 +10450,6 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1875
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -5.5,6.5
-      parent: 1
   - uid: 1879
     components:
     - type: Transform
@@ -10813,12 +10840,6 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2312
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -5.5,5.5
-      parent: 1
   - uid: 2349
     components:
     - type: Transform
@@ -11233,6 +11254,12 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#947507FF'
+  - uid: 1708
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,5.5
+      parent: 1
   - uid: 1710
     components:
     - type: Transform
@@ -11312,11 +11339,6 @@ entities:
     components:
     - type: Transform
       pos: -4.5,-1.5
-      parent: 1
-  - uid: 2305
-    components:
-    - type: Transform
-      pos: -5.5,7.5
       parent: 1
   - uid: 2485
     components:
@@ -11472,6 +11494,8 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 11.5,8.5
       parent: 1
+    - type: GasValve
+      open: False
     - type: AtmosPipeColor
       color: '#9955CCFF'
   - uid: 910
@@ -12829,14 +12853,7 @@ entities:
     - type: Transform
       pos: -9.5,29.5
       parent: 1
-- proto: PosterLegitSafetyMothHardhat
-  entities:
-  - uid: 2259
-    components:
-    - type: Transform
-      pos: 2.5,-10.5
-      parent: 1
-- proto: PosterLegitSMEpi
+- proto: PosterLegitSafetyMothEpi
   entities:
   - uid: 2274
     components:
@@ -12850,7 +12867,14 @@ entities:
     - type: Transform
       pos: -6.5,6.5
       parent: 1
-- proto: PosterLegitSMPiping
+- proto: PosterLegitSafetyMothHardhat
+  entities:
+  - uid: 2259
+    components:
+    - type: Transform
+      pos: 2.5,-10.5
+      parent: 1
+- proto: PosterLegitSafetyMothPiping
   entities:
   - uid: 2345
     components:
@@ -14186,6 +14210,8 @@ entities:
       rot: 3.141592653589793 rad
       pos: -1.5,8.5
       parent: 1
+    - type: SignalSwitch
+      state: True
     - type: DeviceLinkSource
       linkedPorts:
         1888:
@@ -17091,15 +17117,15 @@ entities:
       parent: 1
 - proto: WeldingFuelTankFull
   entities:
-  - uid: 1708
-    components:
-    - type: Transform
-      pos: -4.5,28.5
-      parent: 1
   - uid: 2002
     components:
     - type: Transform
       pos: -0.5,20.5
+      parent: 1
+  - uid: 2084
+    components:
+    - type: Transform
+      pos: -9.5,24.5
       parent: 1
 - proto: WetFloorSign
   entities:


### PR DESCRIPTION
## About the PR
This PR adds 2 cyborg recharge stations to Ambition, 3 to Anchor and 3 to Gourd


## Why / Balance
Considering that borgs are being worked on and are becoming popular, there is a need to add cyborg rechagers at ships, at least large ones, by default. 

Spectre, Crescend and Caduceus already have them, Wasp and Empress do not need them (no NFSD borgs), and Bison is a scrapyard ship, only the expedition ships remain without recharge stations, although cyborgs are actively being used by expedition crews. 

Prices wasnt changed, as it would be insignificant.

## Media
fuel tank has been moved to the left
![image](https://github.com/user-attachments/assets/bbbca5e3-8e00-4578-862f-0a20116e1738)


pipe with connector has been moved
![image](https://github.com/user-attachments/assets/05a57423-f700-4094-82ff-dc8076e0d783)


N2 closet has been moved to wall-mount state
![image](https://github.com/user-attachments/assets/aee802eb-e31b-4adb-bd0d-04db291a2157)


bookshelf sacrificed
![image](https://github.com/user-attachments/assets/4ac5274a-ff9b-4631-ac95-578bcbc2bed5)


peace grafitty saved
![image](https://github.com/user-attachments/assets/3373165d-4fd7-43fa-a475-7ab52a5a79a7)


rack moved to AME
![image](https://github.com/user-attachments/assets/23a07578-8eff-4b28-96a2-ca24c0a8e62b)


no sacrificed were made
![image](https://github.com/user-attachments/assets/cb3c15f9-0387-43d2-84a3-92cd763f32f4)


no sacrificed were made
![image](https://github.com/user-attachments/assets/3adf5d44-4756-4b9f-8b5e-a1d4b178dbe1)


## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.

**Changelog**
:cl:
- add: 2 cyborg recharge stations to Ambition
- add: 3 cyborg recharge stations to Anchor
- add: 3 cyborg recharge stations to Gourd
