### PR TITLE
Borg sight

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -296,6 +296,9 @@
 #  - type: AccessReader
 #    access: [["Command"], ["Research"]]
   - type: ShowJobIcons
+  - type: ShowHealthBars
+    damageContainers:
+    - Silicon
   - type: InteractionPopup
     interactSuccessSound:
       path: /Audio/Ambience/Objects/periodic_beep.ogg

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -296,7 +296,7 @@
 #  - type: AccessReader
 #    access: [["Command"], ["Research"]]
   - type: ShowJobIcons
-  - type: ShowHealthBars
+  - type: ShowHealthBars # Frontier | Shows other Silicons health
     damageContainers:
     - Silicon
   - type: InteractionPopup

--- a/Resources/Prototypes/borg_types.yml
+++ b/Resources/Prototypes/borg_types.yml
@@ -167,7 +167,7 @@
   - type: ShowHealthIcons
     damageContainers:
     - Biological
-    - Silicon
+    - Silicon # Frontier
 
   # Visual
   inventoryTemplateId: borgDutch

--- a/Resources/Prototypes/borg_types.yml
+++ b/Resources/Prototypes/borg_types.yml
@@ -167,6 +167,7 @@
   - type: ShowHealthIcons
     damageContainers:
     - Biological
+    - Silicon
 
   # Visual
   inventoryTemplateId: borgDutch


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Small change, gives all Borgs robotics Hud sight.

## Why / Balance
Silicons should be in tune with the status indicators of other borgs.
Alternatively, I could see only the Engineering borg having this. Given to all for now, thoughts welcome

## Technical details
Gave health icons for Silicon to BaseBorgChassisNT, added Silicon to Med borgs medhud to prevent parent overwriting.

## How to test
>Spawn Borg
>Control and see health bars

## Media
![image](https://github.com/user-attachments/assets/bb0efd1e-6832-43a6-84d1-f44684b1dd7c)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [x] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Cyborgs have been given visual diagnostics for robotic life.
-->
