### PR TITLE
Add Trade Mall spawn locations

### DIFF
--- a/Resources/Maps/_NF/POI/trademall.yml
+++ b/Resources/Maps/_NF/POI/trademall.yml
@@ -1,11 +1,11 @@
 meta:
   format: 7
   category: Grid
-  engineVersion: 247.2.0
+  engineVersion: 250.0.0
   forkId: ""
   forkVersion: ""
-  time: 03/22/2025 00:16:16
-  entityCount: 6307
+  time: 04/22/2025 11:11:45
+  entityCount: 6329
 maps: []
 grids:
 - 1
@@ -34980,6 +34980,10 @@ entities:
       rot: 3.141592653589793 rad
       pos: 10.5,26.5
       parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        5410:
+        - Pressed: DoorBolt
   - uid: 3439
     components:
     - type: Transform
@@ -36591,6 +36595,120 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 46.5,5.5
+      parent: 1
+  - uid: 6318
+    components:
+    - type: Transform
+      pos: 6.5,27.5
+      parent: 1
+  - uid: 6319
+    components:
+    - type: Transform
+      pos: 8.5,27.5
+      parent: 1
+- proto: SpawnPointMercenary
+  entities:
+  - uid: 6324
+    components:
+    - type: Transform
+      pos: -18.5,-1.5
+      parent: 1
+  - uid: 6306
+    components:
+    - type: Transform
+      pos: -20.5,-1.5
+      parent: 1
+  - uid: 6308
+    components:
+    - type: Transform
+      pos: -10.5,5.5
+      parent: 1
+  - uid: 6312
+    components:
+    - type: Transform
+      pos: -13.5,6.5
+      parent: 1
+  - uid: 6313
+    components:
+    - type: Transform
+      pos: -6.5,5.5
+      parent: 1
+  - uid: 6314
+    components:
+    - type: Transform
+      pos: -5.5,5.5
+      parent: 1
+  - uid: 6315
+    components:
+    - type: Transform
+      pos: -3.5,9.5
+      parent: 1
+  - uid: 6316
+    components:
+    - type: Transform
+      pos: 13.5,27.5
+      parent: 1
+  - uid: 6322
+    components:
+    - type: Transform
+      pos: -7.5,7.5
+      parent: 1
+  - uid: 6323
+    components:
+    - type: Transform
+      pos: -12.5,4.5
+      parent: 1
+- proto: SpawnPointPilot
+  entities:
+  - uid: 1888
+    components:
+    - type: Transform
+      pos: -19.5,-1.5
+      parent: 1
+  - uid: 6325
+    components:
+    - type: Transform
+      pos: -11.5,4.5
+      parent: 1
+  - uid: 6326
+    components:
+    - type: Transform
+      pos: -4.5,7.5
+      parent: 1
+  - uid: 6327
+    components:
+    - type: Transform
+      pos: -5.5,9.5
+      parent: 1
+  - uid: 6328
+    components:
+    - type: Transform
+      pos: -16.5,-1.5
+      parent: 1
+  - uid: 6329
+    components:
+    - type: Transform
+      pos: -13.5,5.5
+      parent: 1
+  - uid: 6330
+    components:
+    - type: Transform
+      pos: -7.5,6.5
+      parent: 1
+  - uid: 6317
+    components:
+    - type: Transform
+      pos: 4.5,30.5
+      parent: 1
+  - uid: 6320
+    components:
+    - type: Transform
+      pos: -10.5,6.5
+      parent: 1
+  - uid: 6321
+    components:
+    - type: Transform
+      pos: -4.5,9.5
       parent: 1
 - proto: SpawnPointSecurityGuard
   entities:


### PR DESCRIPTION
## About the PR
Adds Pilot & Mercenary spawn locations to Trade Mall, plus two latejoin spawns by cryo.
This does not actually add it as a latejoin location; that will be handled in a separate PR (#3284).

Also a minor bugfix (northern restroom wouldn't bolt).

## Why / Balance
Trade Mall has all the necessary amenities to serve as a spawn location; it's got deposit ATMs, shipyards, and plenty of space. It's outside the safezone, so no Contractors allowed, but I see no reason why not to allow mercs and pilots who accept the risk.

Also, no idea how the bathroom got messed up.

## Technical details
Map editing, YML changes. And some manual stitching (for some reason, `savemap`/`savegrid` _hate_ office chairs and seem to always remove them no matter what I do).

## How to test
N/A

## Media
![image](https://github.com/user-attachments/assets/2378421b-5022-4833-9460-b14018c06184)
![image](https://github.com/user-attachments/assets/dee7f48a-2138-40e6-818e-a44db4814f54)
![image](https://github.com/user-attachments/assets/f8dbdac6-272b-48c5-b77b-ee428c232a01)

## Requirements
- [x] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I confirm that AI tools were not used in generating the material in this PR.

**Changelog**
No changelog for you