### PR TITLE
Add power to Trade Outpost conference room

### DIFF
--- a/Resources/Maps/_NF/POI/trade.yml
+++ b/Resources/Maps/_NF/POI/trade.yml
@@ -1,11 +1,11 @@
 meta:
   format: 7
   category: Grid
-  engineVersion: 247.2.0
+  engineVersion: 251.0.0
   forkId: ""
   forkVersion: ""
-  time: 03/22/2025 00:14:13
-  entityCount: 6429
+  time: 04/23/2025 15:17:34
+  entityCount: 6438
 maps: []
 grids:
 - 1
@@ -7308,6 +7308,51 @@ entities:
     components:
     - type: Transform
       pos: 26.5,0.5
+      parent: 1
+  - uid: 6431
+    components:
+    - type: Transform
+      pos: 59.5,-5.5
+      parent: 1
+  - uid: 6432
+    components:
+    - type: Transform
+      pos: 59.5,-2.5
+      parent: 1
+  - uid: 6433
+    components:
+    - type: Transform
+      pos: 60.5,-5.5
+      parent: 1
+  - uid: 6434
+    components:
+    - type: Transform
+      pos: 61.5,-5.5
+      parent: 1
+  - uid: 6435
+    components:
+    - type: Transform
+      pos: 62.5,-5.5
+      parent: 1
+  - uid: 6436
+    components:
+    - type: Transform
+      pos: 63.5,-5.5
+      parent: 1
+  - uid: 6437
+    components:
+    - type: Transform
+      pos: 59.5,-1.5
+      parent: 1
+  - uid: 6438
+    components:
+    - type: Transform
+      pos: 59.5,-3.5
+      parent: 1
+  - uid: 6439
+    components:
+    - type: Transform
+      pos: 59.5,-4.5
       parent: 1
 - proto: CableHV
   entities:


### PR DESCRIPTION
## About the PR
Adds power to the Trade Outpost conference room.

## Why / Balance
⚡

Vent and scrubber not work. Power make work. Feel refresh.

## Technical details
Due to a hilarious bug around saving office chairs – that being that they _don't_ save at present – I had to manually edit the YAML. It should still work, I hope.

## How to test
1. Go to the Trade Outpost
2. Behold the conference room
3. The vent does a thing. The scrubber does a thing. The fax machine does a thing.

## Media
These LV cables are new:
![image](https://github.com/user-attachments/assets/90955de3-fc5e-485d-95d3-0ac489f064b9)

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.

## Breaking changes
No.

**Changelog**
- fix: The Trade Outpost conference room has power cables under it now. The air vent and scrubber now work, hurrah!