### PR TITLE
Make bullets (including the emitter bolt) hit emitters

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/emitter.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/emitter.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: Emitter
   name: emitter
-  parent: SmallConstructibleMachine
+  parent: ConstructibleMachine # Frontier: SmallConstructibleMachine<ConstructibleMachine (remove RequireProjectileTarget)
   description: A heavy duty industrial laser. Shoots non-stop when turned on.
   placement:
     mode: SnapgridCenter


### PR DESCRIPTION
## About the PR
Reparents the emitter, from `SmallConstructibleMachine` to `ConstructibleMachine`. This has the single effect of removing the `RequireProjectileTarget` component, which means projectiles, including the emitter bolt, can hit emitters without being explicitly targeted.

## Why / Balance
Unfortunately, people have discovered that they can make looooong rows of emitters, one behind the other, to fire off volleys of incredible destructive potential. This is distinctly uncool. It turns out it's the `RequireProjectileTarget` component that stops emitter bolts (and indeed other 'stray' projectiles) from hitting emitters. On upstream, this probably makes sense, as emitter sabotage is almost invariably round-ending and must be done deliberately. Here on Frontier, it leads to lame powergaming bullshit.

## Technical details
YAML change, reparent, whee

## How to test
1. Set up a long line of emitters.
2. Make sure they have MV power.
3. Turn them on.
4. Watch as they destroy each other in a funny way.
5. Try shooting emitters with other bullets too! Pew pew machine breaks.

## Media
https://github.com/user-attachments/assets/d0594365-e555-48b2-bda7-add000568d95


## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.

## Breaking changes
It might break someone's meta >:P

**Changelog**
:cl:
- fix: Emitter bolts will now collide with other emitters, potentially destroying them.