### PR TITLE
AME fuel adjustements

### DIFF
--- a/Content.Shared/Ame/Components/AmeFuelContainerComponent.cs
+++ b/Content.Shared/Ame/Components/AmeFuelContainerComponent.cs
@@ -9,11 +9,11 @@ public sealed partial class AmeFuelContainerComponent : Component
     /// The amount of fuel in the container.
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
-    public int FuelAmount = 500;
+    public int FuelAmount = 800;
 
     /// <summary>
     /// The maximum fuel capacity of the container.
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
-    public int FuelCapacity = 500;
+    public int FuelCapacity = 800;
 }


### PR DESCRIPTION

## About the PR
increased the AME fuel per jar from 500 to 800

## Why / Balance
People always complain "AME suck, no magnet too little fuel" so figured I'd try my luck at giving em something to fix it

we don't use AME's to power 300 KW worth of station, out ships have 100 KW at maximum
## Technical details
Changed one number in AMEFuelComponent

## How to test
Spawn an AME can, observe it having more fuel

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.

## Breaking changes
Balancing? Somehow? Considering that AME fuel is not obtainable apart from fuelvendor, I think it balances out?
**Changelog**
:cl:
- tweak: AME jars have 800 fuel, up from 500, 30% increase