### PR TITLE
ourple pipe

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/spray_painter.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/spray_painter.yml
@@ -30,5 +30,6 @@
       distro: '#0055cc'
       air: '#03fcd3'
       mix: '#947507'
+      external: '#9955cc' # Frontier
   - type: StaticPrice
     price: 20 # Frontier 40<20


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds an "external" purple color for pipes to the Spray Painter. As seen with gaslocks.

## Why / Balance
As one of maybe 2 spray painter users in existence, non-replicable pipe colors irk me. This makes it so you can set up your own network in purple.

## Technical details
Single-line YML change

## How to test
- Have pipe.
- Have spray painter.
- Paint pipe.
- ourple

## Media
![image](https://github.com/user-attachments/assets/c189c2ac-b5b6-4fbb-b23f-cb12c6bf380f)

## Requirements
- [x] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I confirm that AI tools were not used in generating the material in this PR.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: The spray painter can now color pipes purple.