### PR TITLE
Gaslock Flatpack V2

### DIFF
--- a/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/flatpackvend.yml
+++ b/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/flatpackvend.yml
@@ -30,3 +30,4 @@
     AirlockGlassShuttleFlatpack: 4294967295 # Infinite
     ComputerWithdrawBankATMFlatpack: 4294967295 # Infinite
     TelevisionFlatpack: 4294967295 # Infinite
+    GaslockFlatpack: 4294967295 # Infinite

--- a/Resources/Prototypes/_NF/Entities/Objects/Devices/flatpacks.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Devices/flatpacks.yml
@@ -705,6 +705,18 @@
     - state: command_airlock_directional
 
 - type: entity
+  parent: AirlockFlatpack
+  id: GaslockFlatpack
+  name: gaslock flatpack
+  description: A flatpack used for constructing a gaslock.
+  components:
+  - type: Flatpack
+    entity: Gaslock
+  - type: Sprite
+    layers:
+    - state: command_airlock_directional
+
+- type: entity
   parent: AirlockShuttleFlatpack
   id: AirlockGlassShuttleFlatpack
   name: docking glass airlock flatpack


### PR DESCRIPTION

## About the PR
Gaslock flatpacks are now a thing, featuring orange markings to indicate which way they will unpack
## Why / Balance
Frequent request from DIY atmos enjoyers

## Technical details
Added a graslock flatpack entry to Flatpacks.yml and Flatpackvendor.yml
## How to test
pay a flatpackvend 4k
recieve your flatpack
unpack
cry because it was facing the wrong way

## Media
![image](https://github.com/user-attachments/assets/6da625e1-ce2c-4b11-b535-3a9cef62a668)

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.

## Breaking changes
None I hope
**Changelog**
:cl:
- add: Added gaslock flatpacks (Make sure they are facing the right way before unpacking)