### PR TITLE
Fix gyroscope thrust

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
+++ b/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
@@ -152,6 +152,7 @@
     baseThrust: 2000
     thrust: 2000
     machinePartThrust: Manipulator
+    thrustPerPartLevel: [2000, 2500, 3000, 3500] # Frontier: upgradable gyroscopes
   - type: Sprite
     # Listen I'm not the biggest fan of the sprite but it was the most appropriate thing I could find.
     sprite: _NF/Structures/Shuttles/gyroscope.rsi # Frontier: add _NF prefix

--- a/Resources/Prototypes/_NF/Entities/Structures/Shuttles/thrusters.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Shuttles/thrusters.yml
@@ -53,6 +53,7 @@
     requireSpace: false
     baseThrust: 250
     thrust: 250
+    thrustPerPartLevel: [250, 312.5, 375, 437.5]
   - type: ApcPowerReceiver
     powerLoad: 200
   - type: Sprite
@@ -186,6 +187,7 @@
   - type: Thruster
     baseThrust: 250
     thrust: 250
+    thrustPerPartLevel: [250, 312.5, 375, 437.5]
   - type: ApcPowerReceiver
     powerLoad: 200
   - type: Sprite


### PR DESCRIPTION
## About the PR
Defines `thrustPerPartLevel` on the various gyroscope entities, to ensure gyroscopes generate sufficent thrust to turn adequately.

## Why / Balance
With #3257, we added the new field `thrustPerPartLevel` instead of calculating upgraded thrust with a multiplier. Gyroscopes were not updated in that PR, however, and their base thrust is considerably higher than linear thrusters (2000 vs 100). As a result, when a gyro is initialised, it gets a thrust of 130, instead of the expected 2000.

This PR defines unique `thrustPerPartLevel` values for gyroscopes and small gyroscopes. Where linear thrusters get ~30% more per part level (relative to base), I gave gyroscopes exactly 25% more thrust per part level – 1, 1.25, 1.5, 1.75. Enough that you can feel the difference, not so much that your ship spins completely out of control at tier 3. As with linear thrusters, you still get more oomph from just building another machine than from T3ing everything.

## Technical details
.YML, my beloved

## How to test
1. Buy a ship with a full-size gyro.
2. VV the gyroscope, make sure its ThrusterComponent.Thrust is 2000.
3. Try to turn around, don't take an eternity.
4. Try to upgrade the gyro and verify that its thrust is increased correctly. Remember that gyros get their upgrades from the manipulator, of which it has two.
5. Repeat with a small gyro (buy e.g. a Pioneer).
6. Repeat with sec and NFSD ships, both full-size and small gyros.

## Media
N/A

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.

## Breaking changes

**Changelog**
:cl:
- fix: Gyroscopes once again provide the correct thrust.