### PR TITLE
[Fix] Make chair-vehicles non-recyclable

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Vehicles/vehicles.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Vehicles/vehicles.yml
@@ -244,10 +244,10 @@
     baseWalkSpeed: 2.5
   - type: StaticPrice
     price: 75
-  - type: PhysicalComposition
-    materialComposition:
-      Steel: 125
-      Plastic: 125
+  #- type: PhysicalComposition # Frontier
+    #materialComposition: # Frontier
+      #Steel: 125 # Frontier
+      #Plastic: 125 # Frontier
 
 - type: entity
   parent: VehicleWheelchair
@@ -287,9 +287,9 @@
     baseWalkSpeed: 2.5
   - type: StaticPrice
     price: 175
-  - type: PhysicalComposition
-    materialComposition:
-      Steel: 125
-      Plastic: 125
+  #- type: PhysicalComposition # Frontier
+    #materialComposition: # Frontier
+      #Steel: 125 # Frontier
+      #Plastic: 125 # Frontier
   - type: ItemSlots # Frontier
     slots: {} # Frontier: no keys required


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Comments out `PhysicalComposition` component for hover chair and wheel chair. A fix for [this issue](https://discord.com/channels/1123826877245694004/1366372491043405886/1366372491043405886).

## Why / Balance
Was funny. Was.

## Technical details
yml

## How to test
1. Spawn hover and wheel chairs, spawn material reclaimer.
2. Seat in chairs, try to ram material reclaimer.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [x] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:
- tweak: Hover chair and wheel chair are no longer recyclable.
