### PR TITLE
Lock NFSD Weapon Racks, make Wallmount Weapon Racks Directional.

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Structures/Furniture/Armory/base_weapon_rack.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Furniture/Armory/base_weapon_rack.yml
@@ -139,11 +139,9 @@
 
 - type: entity
   id: StructureGunRackWallmounted
-  parent: StructureGunRack
+  parent: [ BaseStructureWallmount, StructureGunRack ]
   suffix: Empty, Wallmount
   components:
-  - type: WallMount
-    arc: 360
   - type: Sprite
     layers:
     - state: base-gun-wall
@@ -234,11 +232,9 @@
 
 - type: entity
   id: StructureMeleeWeaponRackWallmounted
-  parent: StructureMeleeWeaponRack
+  parent: [ BaseStructureWallmount, StructureMeleeWeaponRack ]
   suffix: Empty, Wallmount
   components:
-  - type: WallMount
-    arc: 360
   - type: Sprite
     layers:
     - state: base-melee-wall
@@ -326,11 +322,9 @@
 
 - type: entity
   id: StructurePistolRackWallmounted
-  parent: StructurePistolRack
+  parent: [ BaseStructureWallmount, StructurePistolRack ]
   suffix: Empty, Wallmount
   components:
-  - type: WallMount
-    arc: 360
   - type: Sprite
     layers:
     - state: base-pistol-wall
@@ -391,11 +385,9 @@
 
 - type: entity
   id: StructurePistolRackLockWallmounted
-  parent: StructurePistolRackLock
+  parent: [ BaseStructureWallmount, StructurePistolRackLock]
   abstract: true
   components:
-  - type: WallMount
-    arc: 360
   - type: Sprite
     layers:
     - state: base-pistol-wall

--- a/Resources/Prototypes/_NF/Entities/Structures/Furniture/Armory/weapon_racks.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Furniture/Armory/weapon_racks.yml
@@ -256,8 +256,25 @@
     layers:
     - state: base-gun
       color: "#56422b"
+    - state: lock
+      color: "#1f6626"
     - state: base-gun-decal
       color: "#537045"
+    - state: locked
+      map: [ enum.LockVisualLayers.Lock ]
+      shader: unshaded
+  - type: AccessReader
+    access: [ ["Security"] ]
+  - type: LockVisuals
+  - type: Lock
+    locked: true
+  - type: ItemSlotsLock
+    slots:
+    - weapon1
+    - weapon2
+    - weapon3
+    - weapon4
+    - weapon5
 
 - type: entity
   id: StructureGunRackWallmountedNfsd
@@ -268,8 +285,25 @@
     layers:
     - state: base-gun-wall
       color: "#56422b"
+    - state: lock
+      color: "#1f6626"
     - state: base-gun-wall-decal
       color: "#537045"
+    - state: locked
+      map: [ enum.LockVisualLayers.Lock ]
+      shader: unshaded
+  - type: AccessReader
+    access: [ ["Security"] ]
+  - type: LockVisuals
+  - type: Lock
+    locked: true
+  - type: ItemSlotsLock
+    slots:
+    - weapon1
+    - weapon2
+    - weapon3
+    - weapon4
+    - weapon5
 
 # Melee weapon racks
 - type: entity
@@ -281,8 +315,25 @@
     layers:
     - state: base-melee
       color: "#56422b"
+    - state: lock
+      color: "#1f6626"
     - state: base-melee-decal
       color: "#537045"
+    - state: locked
+      map: [ enum.LockVisualLayers.Lock ]
+      shader: unshaded
+  - type: AccessReader
+    access: [ ["Security"] ]
+  - type: LockVisuals
+  - type: Lock
+    locked: true
+  - type: ItemSlotsLock
+    slots:
+    - weapon1
+    - weapon2
+    - weapon3
+    - weapon4
+    - weapon5
 
 - type: entity
   id: StructureMeleeWeaponRackWallmountedNfsd
@@ -293,8 +344,25 @@
     layers:
     - state: base-melee-wall
       color: "#56422b"
+    - state: lock
+      color: "#1f6626"
     - state: base-melee-wall-decal
       color: "#537045"
+    - state: locked
+      map: [ enum.LockVisualLayers.Lock ]
+      shader: unshaded
+  - type: AccessReader
+    access: [ ["Security"] ]
+  - type: LockVisuals
+  - type: Lock
+    locked: true
+  - type: ItemSlotsLock
+    slots:
+    - weapon1
+    - weapon2
+    - weapon3
+    - weapon4
+    - weapon5
 
 # Sidearm racks
 - type: entity
@@ -306,8 +374,24 @@
     layers:
     - state: base-pistol
       color: "#56422b"
+    - state: lock
+      color: "#1f6626"
     - state: base-pistol-decal
       color: "#537045"
+    - state: locked
+      map: [ enum.LockVisualLayers.Lock ]
+      shader: unshaded
+  - type: AccessReader
+    access: [ ["Security"] ]
+  - type: LockVisuals
+  - type: Lock
+    locked: true
+  - type: ItemSlotsLock
+    slots:
+    - weapon1
+    - weapon2
+    - weapon3
+    - weapon4
 
 - type: entity
   id: StructurePistolRackWallmountedNfsd
@@ -318,8 +402,24 @@
     layers:
     - state: base-pistol-wall
       color: "#56422b"
+    - state: lock
+      color: "#1f6626"
     - state: base-pistol-wall-decal
       color: "#537045"
+    - state: locked
+      map: [ enum.LockVisualLayers.Lock ]
+      shader: unshaded
+  - type: AccessReader
+    access: [ ["Security"] ]
+  - type: LockVisuals
+  - type: Lock
+    locked: true
+  - type: ItemSlotsLock
+    slots:
+    - weapon1
+    - weapon2
+    - weapon3
+    - weapon4
 
 ## Blood Cult
 # Melee weapon racks

--- a/Resources/Prototypes/_NF/Recipes/Construction/furniture_armory_construction.yml
+++ b/Resources/Prototypes/_NF/Recipes/Construction/furniture_armory_construction.yml
@@ -30,6 +30,7 @@
   objectType: Structure
   placementMode: SnapgridCenter
   canBuildInImpassable: true
+  canRotate: true
   conditions:
     - !type:WallmountCondition
 
@@ -64,6 +65,7 @@
   objectType: Structure
   placementMode: SnapgridCenter
   canBuildInImpassable: true
+  canRotate: true
   conditions:
     - !type:WallmountCondition
 
@@ -96,5 +98,6 @@
   objectType: Structure
   placementMode: SnapgridCenter
   canBuildInImpassable: true
+  canRotate: true
   conditions:
     - !type:WallmountCondition


### PR DESCRIPTION
## About the PR
This PR makes the following 2 changes:
1. The NFSD Weapon Racks (Pistol, Weapon, and Melee), are now locked to NFSD Access.
2. All wall-mount Weapon Rack variants now have a 175 degree wallmount access arc.

## Why / Balance
1. If the NFSD decides to store their weapons in the weapon racks that some ships have mapped, those should be secure.
2. If I put a weapon rack facing north on the bottom wall of my armory, I do not want somebody accessing it from outside that armory.

## Technical details
Just YAML changes, all within _NF directories.

## How to test
Spawn them in and check the locks/arcs, spawn them on ships and rotate those ships, all works.

## Media
Not much to show, looks how you would expect it to.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or **it does not require an ingame showcase**.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant. (It is not relevant)
- [X] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: BramvanZijp
- add: Added a lock to NFSD Weapon, Pistol, and Melee racks.
- fix: Wallmount Weapon/Pistol/Melee racks are now directional.
