### PR TITLE
Syndie commander and cult janitor stamina changes

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_bloodcultist.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_bloodcultist.yml
@@ -83,7 +83,7 @@
     prototypes:
     - BloodCultistJanitorGear
   - type: Stamina
-    critThreshold: 500
+    critThreshold: 100
   - type: BasicEntityAmmoProvider
     proto: ShellSoapConjuredBloodCultCluster # SoapConjuredBloodCultCluster
     capacity: 1

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_syndicate.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_syndicate.yml
@@ -530,7 +530,7 @@
       prototypes:
         - SyndicateNavalCommanderGearA
     - type: Stamina
-      critThreshold: 500 # Extra hard to incapacitate and loot
+      critThreshold: 150 # Boss enemy can have a little extra stamina, but it's still just a regular guy
     - type: AutoImplant
       implants:
       - DeathRattleImplant


### PR DESCRIPTION


## About the PR
Reduces the stamina of the blood cult janitor and syndicate commander from 400/500 stamina to 100/200 respectively
## Why / Balance
in particular the commander, but also the cultist are literally just regular dudes in armor

If the armor they wear dosen't have stun resistance why should the enemy itself

Hopefully helps people using disablers (large exped crews, for example) have an easier time not getting robusted by janky AI with 500 stamina health
## Technical details
Adjusted the stamina of the Commander and cult janitor to 100 and 200 stamina
## How to test

Take a disabler/disabler SMG and shoot these enemies

they stamcrit noticably faster.

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.

## Breaking changes
None that I know of, it's two lines edited.
**Changelog**
:cl:
- tweak: the blood cult janitor and syndicate commander expedition enemies have less stamina health.