### PR TITLE
Fix the issue with overfilling hidden stashes

### DIFF
--- a/Resources/Prototypes/_NF/Catalog/Fills/StorageFillTemplates/stashes.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/StorageFillTemplates/stashes.yml
@@ -1,152 +1,139 @@
 # Inventory template fills
+
 # The items here will be spawned inside a duffel bag
 # Currently duffel's inventory size is 8x5 (40),
 # so arbitrary total cap for spawned item footprint is ~30
 # (to account for item geometry)
+
 #region tables: valuables
 - type: entityTable # Max Inv. footprint: 2
   id: TableStorageFillStashCash
-  table: !type:AllSelector
+  table: !type:GroupSelector
     children:
-    - !type:GroupSelector
-      children:
-      - id: SpaceCash5000
-        weight: 70
-      - id: SpaceCash15000
-        weight: 27
-      - id: SpaceCash30000
-        weight: 3
+    - id: SpaceCash5000
+      weight: 70
+    - id: SpaceCash15000
+      weight: 27
+    - id: SpaceCash30000
+      weight: 3
 
 - type: entityTable # Max Inv. footprint: 1
   id: TableStorageFillStashCoins
   table: !type:GroupSelector
     children:
-      - !type:GroupSelector
-        children:
-        - id: TreasureCoinDiamond # 500 spesos for one
-        - id: TreasureCoinDiamond3
-        - id: TreasureCoinDiamond5
-        - id: TreasureCoinDiamond10
-      - !type:GroupSelector
-        children:
-        - id: TreasureCoinAdamantine # 250 spesos for one
-        - id: TreasureCoinAdamantine3
-        - id: TreasureCoinAdamantine5
-        - id: TreasureCoinAdamantine10
-      - !type:GroupSelector
-        children:
-        - id: TreasureCoinGold # 175 spesos for one
-        - id: TreasureCoinGold3
-        - id: TreasureCoinGold5
-        - id: TreasureCoinGold10
-      - !type:GroupSelector
-        children:
-        - id: TreasureCoinSilver # 135 spesos for one
-        - id: TreasureCoinSilver3
-        - id: TreasureCoinSilver5
-        - id: TreasureCoinSilver10
-      - !type:GroupSelector
-        children:
-        - id: TreasureCoinIron # 75 spesos for one
-        - id: TreasureCoinIron3
-        - id: TreasureCoinIron5
-        - id: TreasureCoinIron10
+    # Diamonds: 500 spesos for one
+    - id: TreasureCoinDiamond 
+    - id: TreasureCoinDiamond3
+    - id: TreasureCoinDiamond5
+    - id: TreasureCoinDiamond10
+    # Adamantine: 250 spesos for one
+    - id: TreasureCoinAdamantine
+    - id: TreasureCoinAdamantine3
+    - id: TreasureCoinAdamantine5
+    - id: TreasureCoinAdamantine10
+    # Gold: 175 spesos for one
+    - id: TreasureCoinGold
+    - id: TreasureCoinGold3
+    - id: TreasureCoinGold5
+    - id: TreasureCoinGold10
+    # Silver: 135 spesos for one
+    - id: TreasureCoinSilver
+    - id: TreasureCoinSilver3
+    - id: TreasureCoinSilver5
+    - id: TreasureCoinSilver10
+    # Iron: 75 spesos for one
+    - id: TreasureCoinIron
+    - id: TreasureCoinIron3
+    - id: TreasureCoinIron5
+    - id: TreasureCoinIron10
 
 - type: entityTable # Max Inv. footprint: 4
   id: TableStorageFillStashJewelry
-  table: !type:AllSelector
+  table: !type:GroupSelector
     children:
-      - !type:GroupSelector
-        children:
-        - id: GoldRing # 300 spesos for one
-        - id: GoldRingDiamond # 1500 spesos for one
-        - id: GoldRingGem # 2100 spesos for one
-        - id: SilverRing # 275 spesos for one
-        - id: SilverRingDiamond # 1400 spesos for one
-        - id: SilverRingGem # 2000 spesos for one
-        - id: IngotGold # 600 per full stack
-        - id: IngotSilver # 450 per full stack
-        - id: TowelColorGold # 10 per one, but think of the PRESTIGE!
-        - id: ClothingNeckBling # 10 per one, but think of the PRESTIGE!
-        - id: WristwatchGold # 500 spesos for one
-          weight: 3
-        - id: ClothingMaskGoldenCursed # 5000 spesos for one
-          weight: 1
+    - id: GoldRing # 300 spesos for one
+    - id: GoldRingDiamond # 1500 spesos for one
+    - id: GoldRingGem # 2100 spesos for one
+    - id: SilverRing # 275 spesos for one
+    - id: SilverRingDiamond # 1400 spesos for one
+    - id: SilverRingGem # 2000 spesos for one
+    - id: IngotGold # 600 per full stack
+    - id: IngotSilver # 450 per full stack
+    - id: TowelColorGold # 10 per one, but think of the PRESTIGE!
+    - id: ClothingNeckBling # 10 per one, but think of the PRESTIGE!
+    - id: WristwatchGold # 500 spesos for one
+      weight: 3
+    - id: ClothingMaskGoldenCursed # 5000 spesos for one
+      weight: 1
 
 - type: entityTable # Max Inv. footprint: 10
   id: TableStorageFillStashTobacco
   table: !type:GroupSelector
     children:
-      - !type:AllSelector
-        children:
-        - id: FlippoEngravedLighter
-        - id: CigarGoldCase
-      - !type:AllSelector
-        children:
-        - id: SmokingPipe
-        - id: FlippoEngravedLighter
-        - id: TobaccoPouchBrownFilled
-        - id: TobaccoPouchPurpleFilled
-      - !type:AllSelector
-        children:
-        - id: SmokingPipe
-        - id: FlippoEngravedLighter
-        - id: TobaccoPouchPurpleFilled
-        - id: TobaccoPouchBlueFilled
-      - !type:AllSelector
-        children:
-        - id: SmokingPipe
-        - id: FlippoEngravedLighter
-        - id: TobaccoPouchBlueFilled
-        - id: TobaccoPouchRedFilled
-      - !type:AllSelector
-        children:
-        - id: SmokingPipe
-        - id: FlippoEngravedLighter
-        - id: TobaccoPouchRedFilled
-        - id: TobaccoPouchBrownFilled
+    - !type:AllSelector
+      children:
+      - id: FlippoEngravedLighter
+      - id: CigarGoldCase
+    - !type:AllSelector
+      children:
+      - id: SmokingPipe
+      - id: FlippoEngravedLighter
+      - id: TobaccoPouchBrownFilled
+      - id: TobaccoPouchPurpleFilled
+    - !type:AllSelector
+      children:
+      - id: SmokingPipe
+      - id: FlippoEngravedLighter
+      - id: TobaccoPouchPurpleFilled
+      - id: TobaccoPouchBlueFilled
+    - !type:AllSelector
+      children:
+      - id: SmokingPipe
+      - id: FlippoEngravedLighter
+      - id: TobaccoPouchBlueFilled
+      - id: TobaccoPouchRedFilled
+    - !type:AllSelector
+      children:
+      - id: SmokingPipe
+      - id: FlippoEngravedLighter
+      - id: TobaccoPouchRedFilled
+      - id: TobaccoPouchBrownFilled
 
 - type: entityTable # Max Inv. footprint: 12
   id: TableStorageFillStashBooze
   table: !type:GroupSelector
     children:
-      - !type:GroupSelector
-        children:
-        - id: DrinkSakeBottleFull
-        - id: DrinkGinBottleFull
-        - id: DrinkRumBottleFull
-        - id: DrinkVodkaBottleFull
-        - id: DrinkTequilaBottleFull
-        - id: DrinkWhiskeyBottleFull
-        - id: DrinkAbsintheBottleFull
-        - id: DrinkCognacBottleFull
-        - id: DrinkMopwataBottleRandom
-      - !type:GroupSelector
-        children:
-        - id: DrinkAleBottleFull
-          amount: !type:RangeNumberSelector
-            range: 1, 6
-        - id: DrinkBeerBottleFull
-          amount: !type:RangeNumberSelector
-            range: 1, 6
+    - id: DrinkSakeBottleFull
+    - id: DrinkGinBottleFull
+    - id: DrinkRumBottleFull
+    - id: DrinkVodkaBottleFull
+    - id: DrinkTequilaBottleFull
+    - id: DrinkWhiskeyBottleFull
+    - id: DrinkAbsintheBottleFull
+    - id: DrinkCognacBottleFull
+    - id: DrinkMopwataBottleRandom
+    - id: DrinkAleBottleFull
+      amount: !type:RangeNumberSelector
+        range: 1, 6
+    - id: DrinkBeerBottleFull
+      amount: !type:RangeNumberSelector
+        range: 1, 6
 
 #region tables: spoiled food
 - type: entityTable # Max Inv. footprint: 2
   id: TableStorageFillStashFoodSpoiled
   table: !type:GroupSelector
     children:
-    - !type:GroupSelector
-      children:
-      - id: FoodBurgerBaconRotten
-      - id: FoodBurgerCheeseRotten
-      - id: FoodBurgerEmpoweredRotten
-      - id: FoodBurgerBigBiteRotten
-      - id: FoodBurgerPlainRotten
-      - id: FoodRiceEggMoldy
-      - id: FoodSoupMeatballMoldy
-      - id: FoodNoodlesMoldy
-      - id: FoodNoodlesMeatballMoldy
-      - id: FoodSaladCaesarMoldy
+    - id: FoodBurgerBaconRotten
+    - id: FoodBurgerCheeseRotten
+    - id: FoodBurgerEmpoweredRotten
+    - id: FoodBurgerBigBiteRotten
+    - id: FoodBurgerPlainRotten
+    - id: FoodRiceEggMoldy
+    - id: FoodSoupMeatballMoldy
+    - id: FoodNoodlesMoldy
+    - id: FoodNoodlesMeatballMoldy
+    - id: FoodSaladCaesarMoldy
 
 #region tables: weapons
 - type: entityTable # Max Inv. footprint: 16
@@ -247,7 +234,7 @@
   id: TableStorageFillStashPunk
   table: !type:AllSelector
     children:
-    # Jumpsuits
+    # Jumpsuits (max footprint: 4)
     - !type:GroupSelector
       children:
       - id: ClothingUniformRandomPunkCroptop
@@ -257,7 +244,7 @@
       - id: ClothingUniformRandomPunkTanktopShorts
       - id: ClothingUniformRandomPunkPantsOnly
       - id: ClothingUniformRandomPunkShortsOnly
-    # Outerclothing
+    # Outerclothing (max footprint: 4)
     - !type:GroupSelector
       children:
       - !type:GroupSelector
@@ -299,7 +286,7 @@
           range: 1, 2
       - id: GroundCannabis
         amount: !type:RangeNumberSelector
-          range: 0, 3
+          range: 1, 3
       - id: ClothingEyesPunkGoggles
       - id: ClothingEyesPunkInfoShades
 
@@ -337,14 +324,12 @@
   table: !type:AllSelector
     children:
     # Cash and Coins
-    - !type:AllSelector
-      children:
-      - !type:NestedSelector # Max Inv. footprint: 4
-        tableId: TableStorageFillStashJewelry # From 10 to 5000 spesos
-      - !type:NestedSelector # Max Inv. footprint: 2
-        tableId: TableStorageFillStashCash # From 5000 to 30000 spesos
-      - !type:NestedSelector # Max Inv. footprint: 1
-        tableId: TableStorageFillStashCoins # From 75 to ~5000 spesos
+    - !type:NestedSelector # Max Inv. footprint: 4
+      tableId: TableStorageFillStashJewelry # From 10 to 5000 spesos
+    - !type:NestedSelector # Max Inv. footprint: 2
+      tableId: TableStorageFillStashCash # From 5000 to 30000 spesos
+    - !type:NestedSelector # Max Inv. footprint: 1
+      tableId: TableStorageFillStashCoins # From 75 to ~5000 spesos
 
 - type: entityTable # Max Inv. footprint: 31
   id: TableStorageFillStashLoot
@@ -397,20 +382,18 @@
   table: !type:AllSelector
     children:
     # Cash and Coins
-    - !type:AllSelector
-      children:
-      - !type:NestedSelector # Max Inv. footprint: 12
-        tableId: TableStorageFillStashJewelry
-        rolls: !type:RangeNumberSelector
-          range: 1, 3 # From 10 to 15000 spesos
-      - !type:NestedSelector # Max Inv. footprint: 4
-        tableId: TableStorageFillStashCash
-        rolls: !type:RangeNumberSelector
-          range: 1, 2 # From 5 to 60000 spesos
-      - !type:NestedSelector # Max Inv. footprint: 3
-        tableId: TableStorageFillStashCoins
-        rolls: !type:RangeNumberSelector
-          range: 1, 3 # From 75 to 15000 spesos
+    - !type:NestedSelector # Max Inv. footprint: 12
+      tableId: TableStorageFillStashJewelry
+      rolls: !type:RangeNumberSelector
+        range: 1, 3 # From 10 to 15000 spesos
+    - !type:NestedSelector # Max Inv. footprint: 4
+      tableId: TableStorageFillStashCash
+      rolls: !type:RangeNumberSelector
+        range: 1, 2 # From 5 to 60000 spesos
+    - !type:NestedSelector # Max Inv. footprint: 3
+      tableId: TableStorageFillStashCoins
+      rolls: !type:RangeNumberSelector
+        range: 1, 3 # From 75 to 15000 spesos
 
 - type: entityTable # Max Inv. footprint: 31
   id: TableStorageFillStashPunkThreads

--- a/Resources/Prototypes/_NF/Catalog/Fills/StorageFillTemplates/stashes.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/StorageFillTemplates/stashes.yml
@@ -1,6 +1,10 @@
 # Inventory template fills
+# The items here will be spawned inside a duffel bag
+# Currently duffel's inventory size is 8x5 (40),
+# so arbitrary total cap for spawned item footprint is ~30
+# (to account for item geometry)
 #region tables: valuables
-- type: entityTable
+- type: entityTable # Max Inv. footprint: 2
   id: TableStorageFillStashCash
   table: !type:AllSelector
     children:
@@ -13,29 +17,42 @@
       - id: SpaceCash30000
         weight: 3
 
-- type: entityTable
+- type: entityTable # Max Inv. footprint: 1
   id: TableStorageFillStashCoins
-  table: !type:AllSelector
+  table: !type:GroupSelector
     children:
       - !type:GroupSelector
         children:
         - id: TreasureCoinDiamond # 500 spesos for one
-          amount: !type:RangeNumberSelector
-            range: 1, 10
+        - id: TreasureCoinDiamond3
+        - id: TreasureCoinDiamond5
+        - id: TreasureCoinDiamond10
+      - !type:GroupSelector
+        children:
         - id: TreasureCoinAdamantine # 250 spesos for one
-          amount: !type:RangeNumberSelector
-            range: 1, 10
+        - id: TreasureCoinAdamantine3
+        - id: TreasureCoinAdamantine5
+        - id: TreasureCoinAdamantine10
+      - !type:GroupSelector
+        children:
         - id: TreasureCoinGold # 175 spesos for one
-          amount: !type:RangeNumberSelector
-            range: 1, 10
+        - id: TreasureCoinGold3
+        - id: TreasureCoinGold5
+        - id: TreasureCoinGold10
+      - !type:GroupSelector
+        children:
         - id: TreasureCoinSilver # 135 spesos for one
-          amount: !type:RangeNumberSelector
-            range: 1, 10
+        - id: TreasureCoinSilver3
+        - id: TreasureCoinSilver5
+        - id: TreasureCoinSilver10
+      - !type:GroupSelector
+        children:
         - id: TreasureCoinIron # 75 spesos for one
-          amount: !type:RangeNumberSelector
-            range: 1, 10
+        - id: TreasureCoinIron3
+        - id: TreasureCoinIron5
+        - id: TreasureCoinIron10
 
-- type: entityTable
+- type: entityTable # Max Inv. footprint: 4
   id: TableStorageFillStashJewelry
   table: !type:AllSelector
     children:
@@ -56,7 +73,7 @@
         - id: ClothingMaskGoldenCursed # 5000 spesos for one
           weight: 1
 
-- type: entityTable
+- type: entityTable # Max Inv. footprint: 10
   id: TableStorageFillStashTobacco
   table: !type:GroupSelector
     children:
@@ -89,7 +106,7 @@
         - id: TobaccoPouchRedFilled
         - id: TobaccoPouchBrownFilled
 
-- type: entityTable
+- type: entityTable # Max Inv. footprint: 12
   id: TableStorageFillStashBooze
   table: !type:GroupSelector
     children:
@@ -114,7 +131,7 @@
             range: 1, 6
 
 #region tables: spoiled food
-- type: entityTable
+- type: entityTable # Max Inv. footprint: 2
   id: TableStorageFillStashFoodSpoiled
   table: !type:GroupSelector
     children:
@@ -132,7 +149,7 @@
       - id: FoodSaladCaesarMoldy
 
 #region tables: weapons
-- type: entityTable
+- type: entityTable # Max Inv. footprint: 16
   id: TableStorageFillStashWeaponCasesGuns
   table: !type:GroupSelector
     children:
@@ -179,7 +196,7 @@
       - id: WeaponCaseShortLaserGunExpedition
 
 #region tables: clutter
-- type: entityTable
+- type: entityTable # Max Inv. footprint: 8
   id: MaintFluffTableTrimmed
   table: !type:GroupSelector
     children:
@@ -226,7 +243,7 @@
       - id: PonderingOrb
       - id: ClothingShoesSkates
 
-- type: entityTable
+- type: entityTable # Max Inv. footprint: 16
   id: TableStorageFillStashPunk
   table: !type:AllSelector
     children:
@@ -287,7 +304,7 @@
       - id: ClothingEyesPunkInfoShades
 
 #region tables: contraband
-- type: entityTable
+- type: entityTable # Max Inv. footprint: 21
   id: TableStorageFillStashContraband
   table: !type:AllSelector
     children:
@@ -315,98 +332,98 @@
        - id: WeaponCaseShortViper
 
 #region tables: combination
-- type: entityTable
+- type: entityTable # Max Inv. footprint: 7
   id: TableStorageFillStashValuables
   table: !type:AllSelector
     children:
     # Cash and Coins
     - !type:AllSelector
       children:
-      - !type:NestedSelector
-        tableId: TableStorageFillStashCash # From 5000 to 30000 spesos
-      - !type:NestedSelector
-        tableId: TableStorageFillStashCoins # From 750 to ~20000 spesos
-      - !type:NestedSelector
+      - !type:NestedSelector # Max Inv. footprint: 4
         tableId: TableStorageFillStashJewelry # From 10 to 5000 spesos
+      - !type:NestedSelector # Max Inv. footprint: 2
+        tableId: TableStorageFillStashCash # From 5000 to 30000 spesos
+      - !type:NestedSelector # Max Inv. footprint: 1
+        tableId: TableStorageFillStashCoins # From 75 to ~5000 spesos
 
-- type: entityTable
+- type: entityTable # Max Inv. footprint: 31
   id: TableStorageFillStashLoot
   table: !type:AllSelector
     children:
-    # Cash and Coins
-    - !type:NestedSelector
-      tableId: TableStorageFillStashValuables
     # Maint Fluff
-    - !type:NestedSelector
+    - !type:NestedSelector # Max Inv. footprint: 8x3
       tableId: MaintFluffTableTrimmed
       rolls: !type:RangeNumberSelector
-        range: 2, 6
+        range: 1, 3
+    # Cash and Coins
+    - !type:NestedSelector # Max Inv. footprint: 7
+      tableId: TableStorageFillStashValuables
 
-- type: entityTable
+- type: entityTable # Max Inv. footprint: 23
   id: TableStorageFillStashMercenary
   table: !type:AllSelector
     children:
-    # Cash and Coins
-    - !type:NestedSelector
-      tableId: TableStorageFillStashValuables
-    # Booze
-    - !type:NestedSelector
+    # Weapons
+    - !type:NestedSelector # Max Inv. footprint: 16
       tableId: TableStorageFillStashWeaponCasesGuns
+    # Cash and Coins
+    - !type:NestedSelector # Max Inv. footprint: 7
+      tableId: TableStorageFillStashValuables
 
-- type: entityTable
+- type: entityTable # Max Inv. footprint: 17
   id: TableStorageFillStashSmokes
   table: !type:AllSelector
     children:
-    # Cash and Coins
-    - !type:NestedSelector
-      tableId: TableStorageFillStashValuables
     # Smokes
-    - !type:NestedSelector
+    - !type:NestedSelector # Max Inv. footprint: 10
       tableId: TableStorageFillStashTobacco
+    # Cash and Coins
+    - !type:NestedSelector # Max Inv. footprint: 7
+      tableId: TableStorageFillStashValuables
 
-- type: entityTable
+- type: entityTable # Max Inv. footprint: 19
   id: TableStorageFillStashDrinks
   table: !type:AllSelector
     children:
-    # Cash and Coins
-    - !type:NestedSelector
-      tableId: TableStorageFillStashValuables
     # Booze
-    - !type:NestedSelector
+    - !type:NestedSelector # Max Inv. footprint: 12
       tableId: TableStorageFillStashBooze
+    # Cash and Coins
+    - !type:NestedSelector # Max Inv. footprint: 7
+      tableId: TableStorageFillStashValuables
 
-- type: entityTable
+- type: entityTable # Max Inv. footprint: 19
   id: TableStorageFillStashEmbezzled
   table: !type:AllSelector
     children:
     # Cash and Coins
     - !type:AllSelector
       children:
-      - !type:NestedSelector
-        tableId: TableStorageFillStashCash
-        rolls: !type:RangeNumberSelector
-          range: 1, 2 # From 10000 to 60000 spesos
-      - !type:NestedSelector
-        tableId: TableStorageFillStashCoins
-        rolls: !type:RangeNumberSelector
-          range: 1, 3 # From 2250 to ~60000 spesos
-      - !type:NestedSelector
+      - !type:NestedSelector # Max Inv. footprint: 12
         tableId: TableStorageFillStashJewelry
         rolls: !type:RangeNumberSelector
-          range: 1, 3 # From 30 to 15000 spesos
+          range: 1, 3 # From 10 to 15000 spesos
+      - !type:NestedSelector # Max Inv. footprint: 4
+        tableId: TableStorageFillStashCash
+        rolls: !type:RangeNumberSelector
+          range: 1, 2 # From 5 to 60000 spesos
+      - !type:NestedSelector # Max Inv. footprint: 3
+        tableId: TableStorageFillStashCoins
+        rolls: !type:RangeNumberSelector
+          range: 1, 3 # From 75 to 15000 spesos
 
-- type: entityTable
+- type: entityTable # Max Inv. footprint: 31
   id: TableStorageFillStashPunkThreads
   table: !type:AllSelector
     children:
     # Punk threads
-    - !type:NestedSelector
+    - !type:NestedSelector # Max Inv. footprint: 16
       tableId: TableStorageFillStashPunk
     # Booze
-    - !type:NestedSelector
+    - !type:NestedSelector # Max Inv. footprint: 12
       tableId: TableStorageFillStashBooze
     # Cash and Coins
-    - !type:NestedSelector
+    - !type:NestedSelector # Max Inv. footprint: 7
       tableId: TableStorageFillStashValuables
       rolls: !type:RangeNumberSelector
         range: 0, 1

--- a/Resources/Prototypes/_NF/Catalog/Fills/StorageFillTemplates/stashes.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/StorageFillTemplates/stashes.yml
@@ -82,7 +82,8 @@
           - id: TobaccoPouchBrownFilled
           - id: TobaccoPouchPurpleFilled
           - id: TobaccoPouchRedFilled
-          amount: 2
+          rolls: !type:ConstantNumberSelector
+            value: 2
     - id: FlippoEngravedLighter
 
 - type: entityTable # Max Inv. footprint: 12

--- a/Resources/Prototypes/_NF/Catalog/Fills/StorageFillTemplates/stashes.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/StorageFillTemplates/stashes.yml
@@ -61,43 +61,29 @@
     - id: IngotSilver # 450 per full stack
     - id: TowelColorGold # 10 per one, but think of the PRESTIGE!
     - id: ClothingNeckBling # 10 per one, but think of the PRESTIGE!
-    - id: WristwatchGold # 500 spesos for one
+    - id: WristwatchGold # 500 spesos for one (footprint: 4)
       weight: 3
-    - id: ClothingMaskGoldenCursed # 5000 spesos for one
+    - id: ClothingMaskGoldenCursed # 5000 spesos for one (footprint: 4?)
       weight: 1
 
-- type: entityTable # Max Inv. footprint: 10
+- type: entityTable # Max Inv. footprint: 9
   id: TableStorageFillStashTobacco
-  table: !type:GroupSelector
+  table: !type:AllSelector
     children:
-    - !type:AllSelector
+    - !type:GroupSelector
       children:
-      - id: FlippoEngravedLighter
       - id: CigarGoldCase
-    - !type:AllSelector
-      children:
-      - id: SmokingPipe
-      - id: FlippoEngravedLighter
-      - id: TobaccoPouchBrownFilled
-      - id: TobaccoPouchPurpleFilled
-    - !type:AllSelector
-      children:
-      - id: SmokingPipe
-      - id: FlippoEngravedLighter
-      - id: TobaccoPouchPurpleFilled
-      - id: TobaccoPouchBlueFilled
-    - !type:AllSelector
-      children:
-      - id: SmokingPipe
-      - id: FlippoEngravedLighter
-      - id: TobaccoPouchBlueFilled
-      - id: TobaccoPouchRedFilled
-    - !type:AllSelector
-      children:
-      - id: SmokingPipe
-      - id: FlippoEngravedLighter
-      - id: TobaccoPouchRedFilled
-      - id: TobaccoPouchBrownFilled
+      - !type:AllSelector
+        children:
+        - id: SmokingPipe
+        - !type:GroupSelector
+          children:
+          - id: TobaccoPouchBlueFilled
+          - id: TobaccoPouchBrownFilled
+          - id: TobaccoPouchPurpleFilled
+          - id: TobaccoPouchRedFilled
+          amount: 2
+    - id: FlippoEngravedLighter
 
 - type: entityTable # Max Inv. footprint: 12
   id: TableStorageFillStashBooze
@@ -295,10 +281,21 @@
   id: TableStorageFillStashContraband
   table: !type:AllSelector
     children:
-    - id: SyndicateBusinessCard
-    - id: BoxID
+    - id: BoxID # (footprint: 9)
       prob: 0.2
-    - !type:GroupSelector # Cash
+    - !type:GroupSelector # Weapons (footprint: 4)
+       children:
+       - id: WeaponCaseShortCobra
+       - id: WeaponCaseShortViper
+    - !type:GroupSelector # Tools (footprint: 2)
+      children:
+      - id: CameraBug
+      - id: ClothingMaskGasVoiceChameleon
+      - id: Emag
+      - id: StorageImplanter
+      - id: RadioJammer
+    - id: SyndicateBusinessCard # (footprint: 1)
+    - !type:GroupSelector # Cash (footprint: 1)
       children:
       - id: Telecrystal1
         weight: 80
@@ -306,17 +303,6 @@
         weight: 18
       - id: Telecrystal10
         weight: 2
-    - !type:GroupSelector # Tools
-      children:
-      - id: CameraBug
-      - id: ClothingMaskGasVoiceChameleon
-      - id: Emag
-      - id: StorageImplanter
-      - id: RadioJammer
-    - !type:GroupSelector # Weapons
-       children:
-       - id: WeaponCaseShortCobra
-       - id: WeaponCaseShortViper
 
 #region tables: combination
 - type: entityTable # Max Inv. footprint: 7

--- a/Resources/Prototypes/_NF/Entities/Objects/Misc/treasure.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Misc/treasure.yml
@@ -1,0 +1,139 @@
+# iron
+- type: entity
+  id: TreasureCoinIron3
+  parent: TreasureCoinIron
+  suffix: 3
+  components:
+  - type: Stack
+    stackType: TreasureCoinIron
+    count: 3
+
+- type: entity
+  id: TreasureCoinIron5
+  parent: TreasureCoinIron
+  suffix: 5
+  components:
+  - type: Stack
+    stackType: TreasureCoinIron
+    count: 5
+
+- type: entity
+  id: TreasureCoinIron10
+  parent: TreasureCoinIron
+  suffix: 10
+  components:
+  - type: Stack
+    stackType: TreasureCoinIron
+    count: 10
+
+# silver
+- type: entity
+  id: TreasureCoinSilver3
+  parent: TreasureCoinSilver
+  suffix: 3
+  components:
+  - type: Stack
+    stackType: TreasureCoinSilver
+    count: 3
+
+- type: entity
+  id: TreasureCoinSilver5
+  parent: TreasureCoinSilver
+  suffix: 5
+  components:
+  - type: Stack
+    stackType: TreasureCoinSilver
+    count: 5
+
+- type: entity
+  id: TreasureCoinSilver10
+  parent: TreasureCoinSilver
+  suffix: 10
+  components:
+  - type: Stack
+    stackType: TreasureCoinSilver
+    count: 10
+
+# Gold
+- type: entity
+  id: TreasureCoinGold3
+  parent: TreasureCoinGold
+  suffix: 3
+  components:
+  - type: Stack
+    stackType: TreasureCoinGold
+    count: 3
+
+- type: entity
+  id: TreasureCoinGold5
+  parent: TreasureCoinGold
+  suffix: 5
+  components:
+  - type: Stack
+    stackType: TreasureCoinGold
+    count: 5
+
+- type: entity
+  id: TreasureCoinGold10
+  parent: TreasureCoinGold
+  suffix: 10
+  components:
+  - type: Stack
+    stackType: TreasureCoinGold
+    count: 10
+
+# Adamantine
+- type: entity
+  id: TreasureCoinAdamantine3
+  parent: TreasureCoinAdamantine
+  suffix: 3
+  components:
+  - type: Stack
+    stackType: TreasureCoinAdamantine
+    count: 3
+
+- type: entity
+  id: TreasureCoinAdamantine5
+  parent: TreasureCoinAdamantine
+  suffix: 5
+  components:
+  - type: Stack
+    stackType: TreasureCoinAdamantine
+    count: 5
+
+- type: entity
+  id: TreasureCoinAdamantine10
+  parent: TreasureCoinAdamantine
+  suffix: 10
+  components:
+  - type: Stack
+    stackType: TreasureCoinAdamantine
+    count: 10
+
+# Diamond
+- type: entity
+  id: TreasureCoinDiamond3
+  parent: TreasureCoinDiamond
+  suffix: 3
+  components:
+  - type: Stack
+    stackType: TreasureCoinDiamond
+    count: 3
+
+- type: entity
+  id: TreasureCoinDiamond5
+  parent: TreasureCoinDiamond
+  suffix: 5
+  components:
+  - type: Stack
+    stackType: TreasureCoinDiamond
+    count: 5
+
+- type: entity
+  id: TreasureCoinDiamond10
+  parent: TreasureCoinDiamond
+  suffix: 10
+  components:
+  - type: Stack
+    stackType: TreasureCoinDiamond
+    count: 10


### PR DESCRIPTION
## About the PR
Making sure that max fill volume of random tables for hidden stashes doesn't exceed the duffel volume.

## Why / Balance
Bug fix

## Technical details
yml

## How to test
1. Spam spawn stashes.

## Media
not needed
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [x] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
not needed
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
