### PR TITLE
Proposal: up the starting balance to 50k

### DIFF
--- a/Content.Shared/Preferences/HumanoidCharacterProfile.cs
+++ b/Content.Shared/Preferences/HumanoidCharacterProfile.cs
@@ -34,7 +34,7 @@ namespace Content.Shared.Preferences
         public const int MaxLoadoutNameLength = 32;
         public const int MaxDescLength = 512;
 
-        public static readonly int DefaultBalance = NFCCVars.CompileTimeDefaultBalance; // Frontier
+        public const int DefaultBalance = 50000;
 
         //private readonly Dictionary<string, JobPriority> _jobPriorities; // Frontier: commented out during merge.
         //private readonly List<string> _antagPreferences; // Frontier: commented out during merge.
@@ -223,7 +223,7 @@ namespace Content.Shared.Preferences
         }
 
         // TODO: This should eventually not be a visual change only.
-        public static HumanoidCharacterProfile Random(HashSet<string>? ignoredSpecies = null, int balance = NFCCVars.CompileTimeDefaultBalance)
+        public static HumanoidCharacterProfile Random(HashSet<string>? ignoredSpecies = null, int balance = DefaultBalance)
         {
             var prototypeManager = IoCManager.Resolve<IPrototypeManager>();
             var random = IoCManager.Resolve<IRobustRandom>();
@@ -237,7 +237,7 @@ namespace Content.Shared.Preferences
             return RandomWithSpecies(species: species, balance: balance);
         }
 
-        public static HumanoidCharacterProfile RandomWithSpecies(string species = SharedHumanoidAppearanceSystem.DefaultSpecies, int balance = NFCCVars.CompileTimeDefaultBalance)
+        public static HumanoidCharacterProfile RandomWithSpecies(string species = SharedHumanoidAppearanceSystem.DefaultSpecies, int balance = DefaultBalance)
         {
             var prototypeManager = IoCManager.Resolve<IPrototypeManager>();
             var random = IoCManager.Resolve<IRobustRandom>();

--- a/Content.Shared/Preferences/HumanoidCharacterProfile.cs
+++ b/Content.Shared/Preferences/HumanoidCharacterProfile.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using System.Text.RegularExpressions;
-using Content.Shared._NF.Bank;
+using Content.Shared._NF.Bank; // Frontier
+using Content.Shared._NF.CCVar; // Frontier
 using Content.Shared.CCVar;
 using Content.Shared.GameTicking;
 using Content.Shared.Humanoid;
@@ -33,7 +34,7 @@ namespace Content.Shared.Preferences
         public const int MaxLoadoutNameLength = 32;
         public const int MaxDescLength = 512;
 
-        public const int DefaultBalance = 30000;
+        public static readonly int DefaultBalance = NFCCVars.CompileTimeDefaultBalance; // Frontier
 
         //private readonly Dictionary<string, JobPriority> _jobPriorities; // Frontier: commented out during merge.
         //private readonly List<string> _antagPreferences; // Frontier: commented out during merge.
@@ -222,7 +223,7 @@ namespace Content.Shared.Preferences
         }
 
         // TODO: This should eventually not be a visual change only.
-        public static HumanoidCharacterProfile Random(HashSet<string>? ignoredSpecies = null, int balance = DefaultBalance)
+        public static HumanoidCharacterProfile Random(HashSet<string>? ignoredSpecies = null, int balance = NFCCVars.CompileTimeDefaultBalance)
         {
             var prototypeManager = IoCManager.Resolve<IPrototypeManager>();
             var random = IoCManager.Resolve<IRobustRandom>();
@@ -236,7 +237,7 @@ namespace Content.Shared.Preferences
             return RandomWithSpecies(species: species, balance: balance);
         }
 
-        public static HumanoidCharacterProfile RandomWithSpecies(string species = SharedHumanoidAppearanceSystem.DefaultSpecies, int balance = DefaultBalance)
+        public static HumanoidCharacterProfile RandomWithSpecies(string species = SharedHumanoidAppearanceSystem.DefaultSpecies, int balance = NFCCVars.CompileTimeDefaultBalance)
         {
             var prototypeManager = IoCManager.Resolve<IPrototypeManager>();
             var random = IoCManager.Resolve<IRobustRandom>();

--- a/Content.Shared/_NF/CCVar/NFCCVars.Bank.cs
+++ b/Content.Shared/_NF/CCVar/NFCCVars.Bank.cs
@@ -6,8 +6,8 @@ public sealed partial class NFCCVars
 {
     /// <summary>
     /// Starting balance for a new character
+    /// TODO: Fix this to work in HumanoidCharacterProfile.cs
     /// </summary>
-    public const int CompileTimeDefaultBalance = 50000;
-    public static readonly CVarDef<int> DefaultBalance =
-        CVarDef.Create("nf14.default.balance", CompileTimeDefaultBalance, CVar.SERVERONLY);
+    //public static readonly CVarDef<int> DefaultBalance =
+    //    CVarDef.Create("nf14.bank.default_balance", 50000, CVar.SERVERONLY);
 }

--- a/Content.Shared/_NF/CCVar/NFCCVars.Bank.cs
+++ b/Content.Shared/_NF/CCVar/NFCCVars.Bank.cs
@@ -1,0 +1,13 @@
+using Robust.Shared.Configuration;
+
+namespace Content.Shared._NF.CCVar;
+
+public sealed partial class NFCCVars
+{
+    /// <summary>
+    /// Starting balance for a new character
+    /// </summary>
+    public const int CompileTimeDefaultBalance = 50000;
+    public static readonly CVarDef<int> DefaultBalance =
+        CVarDef.Create("nf14.default.balance", CompileTimeDefaultBalance, CVar.SERVERONLY);
+}

--- a/Content.Shared/_NF/CCVar/NFCCVars.cs
+++ b/Content.Shared/_NF/CCVar/NFCCVars.cs
@@ -3,7 +3,7 @@ using Robust.Shared.Configuration;
 namespace Content.Shared._NF.CCVar;
 
 [CVarDefs]
-public sealed class NFCCVars
+public sealed partial class NFCCVars
 {
     /*
      *  Respawn

--- a/Resources/ConfigPresets/Build/development.toml
+++ b/Resources/ConfigPresets/Build/development.toml
@@ -44,3 +44,8 @@ expedition_failed_cooldown = 10.0
 expedition_travel_time = 5.0
 expedition_proximity_check = false
 # End Frontier: expedition params
+
+# Frontier: bank
+# TODO: This currently not added in the code, please fix.
+#[nf14.bank]
+#default_balance = 1000000


### PR DESCRIPTION
## About the PR
With the server moving more to MRP and having changes to prices for gear, ships and overall market I will like to adjust the starting balance from 30k to a 50k, with the core idea that money always should be a drive force for MRP.

All and all while its not a massive boost its a good boost that should allow people to start new profiles with less "stress" about how to use the starting balance and a bit more breathing room for spending.

Or even more room for mistakes, extra spending on utility or just having the option to pay someone for a service when you just start up a new shift.

## Technical details
Changed 30k to 50k

## How to test
Start a new shift, look at your balance.

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [ ] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
:cl:
- tweak: Starting balance is up to 50k from 30k.
