### PR TITLE
Interview holograms: admin logging, spawn event

### DIFF
--- a/Content.Server/_NF/Roles/Systems/InterviewHologramSystem.cs
+++ b/Content.Server/_NF/Roles/Systems/InterviewHologramSystem.cs
@@ -1,14 +1,15 @@
 using Content.Server.Actions;
+using Content.Server.Administration.Logs;
 using Content.Server.Chat.Managers;
 using Content.Server.GameTicking;
 using Content.Server.PDA.Ringer;
 using Content.Server.Preferences.Managers;
 using Content.Server.Station.Systems;
-using Content.Server.StationRecords;
-using Content.Server.StationRecords.Systems;
 using Content.Shared._NF.Roles.Components;
 using Content.Shared._NF.Roles.Events;
 using Content.Shared.Chat;
+using Content.Shared.Database;
+using Content.Shared.GameTicking;
 using Content.Shared.Humanoid;
 using Content.Shared.Inventory;
 using Content.Shared.Mind;
@@ -16,7 +17,9 @@ using Content.Shared.Mind.Components;
 using Content.Shared.PDA;
 using Content.Shared.Preferences;
 using Content.Shared.Roles;
+using Content.Shared.Roles.Jobs;
 using Content.Shared.Verbs;
+using Robust.Server.Player;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
@@ -25,8 +28,10 @@ namespace Content.Server._NF.Roles.Systems;
 
 public sealed class InterviewHologramSystem : SharedInterviewHologramSystem
 {
+    [Dependency] private IAdminLogManager _adminLogger = default!;
     [Dependency] private IChatManager _chat = default!;
     [Dependency] private GameTicker _gameTicker = default!;
+    [Dependency] private IPlayerManager _playerManager = default!;
     [Dependency] private IPrototypeManager _proto = default!;
     [Dependency] private IServerPreferencesManager _prefs = default!;
     [Dependency] private ActionsSystem _actions = default!;
@@ -35,8 +40,8 @@ public sealed class InterviewHologramSystem : SharedInterviewHologramSystem
     [Dependency] private RingerSystem _ringer = default!;
     [Dependency] private SharedHumanoidAppearanceSystem _humanoid = default!;
     [Dependency] private SharedMindSystem _mind = default!;
+    [Dependency] private SharedRoleSystem _roles = default!;
     [Dependency] private StationJobsSystem _stationJobs = default!;
-    [Dependency] private StationRecordsSystem _stationRecords = default!;
     [Dependency] private StationSpawningSystem _stationSpawning = default!;
     [Dependency] private StationSystem _station = default!;
 
@@ -44,12 +49,18 @@ public sealed class InterviewHologramSystem : SharedInterviewHologramSystem
     {
         base.Initialize();
 
+        SubscribeLocalEvent<InterviewHologramComponent, PlayerSpawnCompleteEvent>(OnHologramPlayerSpawnComplete);
         SubscribeLocalEvent<InterviewHologramComponent, MapInitEvent>(OnHologramMapInit);
         SubscribeLocalEvent<InterviewHologramComponent, GetVerbsEvent<AlternativeVerb>>(OnAlternativeVerb);
         SubscribeLocalEvent<InterviewHologramComponent, MindRemovedMessage>(OnHologramMindRemoved);
         SubscribeLocalEvent<InterviewHologramComponent, MindAddedMessage>(OnHologramMindAdded);
         SubscribeLocalEvent<InterviewHologramComponent, CancelInterviewEvent>(OnHologramCancelInterview);
         SubscribeLocalEvent<InterviewHologramComponent, DismissInterviewEvent>(OnHologramDismissInterview);
+    }
+
+    private void OnHologramPlayerSpawnComplete(Entity<InterviewHologramComponent> ent, ref PlayerSpawnCompleteEvent ev)
+    {
+        ent.Comp.Station = ev.Station;
     }
 
     private void OnHologramMapInit(Entity<InterviewHologramComponent> ent, ref MapInitEvent ev)
@@ -195,28 +206,51 @@ public sealed class InterviewHologramSystem : SharedInterviewHologramSystem
         if (mindUid == null || !_mind.TryGetSession(mindUid, out var session))
             return;
 
-        HumanoidCharacterProfile? profile = null;
+        HumanoidCharacterProfile profile;
         if (_prefs.GetPreferences(session.UserId).SelectedCharacter is HumanoidCharacterProfile currentProfile)
             profile = currentProfile;
+        else
+            profile = HumanoidCharacterProfile.Random();
 
         // Prevent reopening the applicant's slot.
         RemComp<JobTrackingComponent>(ent);
 
-        // Spawn new entity.
-        var station = _station.GetOwningStation(ent);
+        // Spawn and inhabit new entity, tell them they got the job.
         var newEntity = _stationSpawning.SpawnPlayerMob(xform.Coordinates,
             ent.Comp.Job,
             profile,
-            station,
+            ent.Comp.Station,
             entity: null,
             session: session
             );
 
-        if (profile != null && TryComp<StationRecordsComponent>(station, out var stationRecords))
-            _stationRecords.CreateGeneralRecord(station.Value, newEntity, profile, ent.Comp.Job, stationRecords);
-
         _mind.TransferTo(mindUid.Value, newEntity);
         _chat.DispatchServerMessage(session, Loc.GetString("interview-hologram-message-accepted"), suppressLog: true);
+        _roles.MindTryRemoveRole<JobRoleComponent>(mindUid.Value);
+        _roles.MindAddJobRole(mindUid.Value, jobPrototype: ent.Comp.Job);
+
+        // Run spawn event for game rules, traits, etc.
+        _gameTicker.PlayersJoinedRoundNormally++;
+        var aev = new PlayerSpawnCompleteEvent(newEntity,
+            session,
+            ent.Comp.Job,
+            lateJoin: true,
+            silent: true,
+            joinOrder: _gameTicker.PlayersJoinedRoundNormally, // Increment regardless (unused as of writing)
+            ent.Comp.Station,
+            profile);
+        RaiseLocalEvent(newEntity, aev, true);
+
+        // Log the acceptance.
+        string stationName;
+        if (TryComp(ent.Comp.Station, out MetaDataComponent? meta))
+            stationName = $"station {meta.EntityName:stationName}";
+        else
+            stationName = "an unknown station";
+
+        _adminLogger.Add(LogType.LateJoin,
+            LogImpact.Medium,
+            $"Player {session.Name} controlling {ToPrettyString(ent):entity} has been spawned via interview on {stationName} as a {ent.Comp.Job:jobName}.");
 
         // Delete the old hologram.
         QueueDel(ent);
@@ -224,11 +258,49 @@ public sealed class InterviewHologramSystem : SharedInterviewHologramSystem
 
     private void OnHologramCancelInterview(Entity<InterviewHologramComponent> ent, ref CancelInterviewEvent ev)
     {
+        // Log cancellation
+        string player;
+        if (_playerManager.TryGetSessionByEntity(ent, out var session))
+            player = $"Player {session.Name}";
+        else
+            player = $"Someone";
+
+        var stationUid = _station.GetOwningStation(ent);
+        string station;
+        if (stationUid != null && TryComp(stationUid, out MetaDataComponent? meta))
+            station = $"station {meta.EntityName:stationName}";
+        else
+            station = "an unknown station";
+
+        _adminLogger.Add(LogType.LateJoin,
+            LogImpact.Medium,
+            $"{player} controlling {ToPrettyString(ent):entity} cancelled their interview on {station} for a {ent.Comp.Job:jobName} position.");
+
+        // Run dismissal
         DismissHologram(ent, message: Loc.GetString("interview-hologram-message-cancelled"));
     }
 
     private void OnHologramDismissInterview(Entity<InterviewHologramComponent> ent, ref DismissInterviewEvent ev)
     {
+        // Log cancellation
+        string player;
+        if (_playerManager.TryGetSessionByEntity(ent, out var session))
+            player = $"Player {session.Name}";
+        else
+            player = $"Someone";
+
+        var stationUid = _station.GetOwningStation(ent);
+        string station;
+        if (stationUid != null && TryComp(stationUid, out MetaDataComponent? meta))
+            station = $"station {meta.EntityName:stationName}";
+        else
+            station = "an unknown station";
+
+        _adminLogger.Add(LogType.LateJoin,
+            LogImpact.Medium,
+            $"{player} controlling {ToPrettyString(ev.Dismisser):entity} dismissed {ToPrettyString(ent):entity} from their interview on {station} for a {ent.Comp.Job:jobName} position.");
+
+        // Run dismissal
         DismissHologram(ent, ev.ReopenSlot, message: Loc.GetString("interview-hologram-message-dismissed"));
     }
 

--- a/Content.Server/_NF/Roles/Systems/InterviewHologramSystem.cs
+++ b/Content.Server/_NF/Roles/Systems/InterviewHologramSystem.cs
@@ -226,8 +226,7 @@ public sealed class InterviewHologramSystem : SharedInterviewHologramSystem
 
         _mind.TransferTo(mindUid.Value, newEntity);
         _chat.DispatchServerMessage(session, Loc.GetString("interview-hologram-message-accepted"), suppressLog: true);
-        _roles.MindTryRemoveRole<JobRoleComponent>(mindUid.Value);
-        _roles.MindAddJobRole(mindUid.Value, jobPrototype: ent.Comp.Job);
+        _roles.MindAddJobRole(mindUid.Value, jobPrototype: ent.Comp.Job); // Overwrites
 
         // Run spawn event for game rules, traits, etc.
         _gameTicker.PlayersJoinedRoundNormally++;

--- a/Content.Shared/_Goobstation/Vehicles/SharedVehicleSystem.cs
+++ b/Content.Shared/_Goobstation/Vehicles/SharedVehicleSystem.cs
@@ -271,7 +271,9 @@ public abstract partial class SharedVehicleSystem : EntitySystem
             grantedActions.Add(flashlight.ToggleActionEntity.Value);
             _flashlight.SetLight((vehicle, flashlight), flashlight.LightOn, quiet: true);
         }
-        _actions.GrantActions(driver, grantedActions, vehicle);
+        // Only try to grant actions if the vehicle actually has them.
+        if (grantedActions.Count > 0)
+            _actions.GrantActions(driver, grantedActions, vehicle);
         // End Frontier
     }
 

--- a/Content.Shared/_NF/Roles/Components/InterviewHologramComponent.cs
+++ b/Content.Shared/_NF/Roles/Components/InterviewHologramComponent.cs
@@ -11,7 +11,7 @@ namespace Content.Shared._NF.Roles.Components;
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class InterviewHologramComponent : Component
 {
-    // Hologram parameters:
+    #region Hologram
     /// <summary>
     /// Name of the shader to use
     /// </summary>
@@ -59,8 +59,15 @@ public sealed partial class InterviewHologramComponent : Component
     /// </summary>
     [DataField(serverOnly: true)]
     public bool AppearanceApplied;
+    #endregion Hologram
 
-    // Application parameters:
+    #region Interview
+    /// <summary>
+    /// The job this user is applying for.
+    /// </summary>
+    [DataField]
+    public EntityUid Station;
+
     /// <summary>
     /// The job this user is applying for.
     /// </summary>
@@ -84,9 +91,9 @@ public sealed partial class InterviewHologramComponent : Component
     /// </summary>
     [DataField(serverOnly: true)]
     public bool NotificationsSent;
+    #endregion Interview
 
-    // Action parameters:
-
+    #region Actions
     [DataField]
     public EntProtoId ToggleApprovalAction = "ActionInterviewToggleApproval";
 
@@ -97,4 +104,5 @@ public sealed partial class InterviewHologramComponent : Component
 
     [DataField, AutoNetworkedField]
     public EntityUid? CancelApplicationActionEntity;
+    #endregion Actions
 }

--- a/Content.Shared/_NF/Roles/Events/DismissInterviewEvent.cs
+++ b/Content.Shared/_NF/Roles/Events/DismissInterviewEvent.cs
@@ -3,8 +3,15 @@ namespace Content.Shared._NF.Roles.Events;
 /// <summary>
 /// Tries to dismiss a given interview.
 /// </summary>
-public sealed class DismissInterviewEvent(EntityUid captain, bool reopenSlot) : EntityEventArgs
+public sealed class DismissInterviewEvent(EntityUid dismisser, bool reopenSlot) : EntityEventArgs
 {
-    public readonly EntityUid Captain = captain;
+    /// <summary>
+    /// The person requesting the dismissal.
+    /// </summary>
+    public readonly EntityUid Dismisser = dismisser;
+
+    /// <summary>
+    /// If true, the slot for the job should be reopened.
+    /// </summary>
     public readonly bool ReopenSlot = reopenSlot;
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

A touchup to the interview hologram system.

Adds admin logging, fixes mind roles, and creates a spawn complete event (for station records, traits, etc.)

Pork barrels a vehicle action bugfix that I missed.

Note: job acceptance log currently isn't showing up, unsure why (client-side action?).

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Traits, mind roles: unintentional, oversight.  Fixes #3326.

Admin logging: admin sanity.

## Technical details
<!-- Summary of code changes for easier review. -->

Added a Station field to the InterviewHologramComponent that's set on player spawning (lookup could be buggy if the player moved to space).

I'd like for the code path taken to be reduced, this copies more of GameTicker's spawn logic, but using the action is better than adjusting the station record.

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->

1. Open two clients.
2. On the first client, spawn in, purchase a ship, take your ID out of the computer, and open a contractor job slot on the ship.
3. On the second client, set up a character with traits including wheelchair-bound and blindness and spawn in on the job.
4. Try to move on the second client, it shouldn't work.
5. Cancel the interview on the second client.  Open the admin logs, the dismissal should show under the LateJoin key.
6. Rejoin the interview slot on the second client.  Dismiss client 2's character on the client 1.  Open the admin logs, the dismissal should show under the LateJoin key.
7. Rejoin the interview slot on the second client.  Use the ACCEPT action on client 2, and right-click and accept the character on client 1.  Client 2's character should join, have a wheelchair and blindness, and should get a "Your role is: Contractor" message after "You got the job!".
8. On client 1, aghost and open the Ghost Warps menu.  Client 2's character should be listed as "Contractor", not "Contractor Applicant".
9. Check the console for errors on client 2.  There should be none about the ActionContainerComponent on the wheelchair.
10. Open the admin log, there should be a log for accepting the job offer.  **NOTE: This currently doesn't exist, unsure why.**

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

None, no API changes.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Interview slots now apply traits to the character when the job is accepted.