### PR TITLE
Adds DoC to Frontier Command on loadouts

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/departments.yml
+++ b/Resources/Prototypes/Roles/Jobs/departments.yml
@@ -78,6 +78,7 @@
   # - DeathSquad # Frontier
   - StationRepresentative # Frontier
   - Sheriff  # Frontier
+  - DirectorOfCare # Frontier
   - StationTrafficController # Frontier
   primary: false
   weight: 100


### PR DESCRIPTION
## About the PR
Title.

## Why / Balance
Definitely a command role. Should probably be with the other command roles also.

## Technical details
YML change.

## How to test
- Enter lobby.
- Open loadouts.
- See second DoC entry in roles under Frontier Command.

## Media
![image](https://github.com/user-attachments/assets/c446b0e7-8ac1-4c4f-94fd-21c4da884422)

## Requirements
- [x] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I confirm that AI tools were not used in generating the material in this PR.

**Changelog**
does this one really need a CL