### PR TITLE
Add soda recipes and category to the bio generator

### DIFF
--- a/Resources/Locale/en-US/_NF/lathe/lathe-categories.ftl
+++ b/Resources/Locale/en-US/_NF/lathe/lathe-categories.ftl
@@ -9,3 +9,4 @@ lathe-category-medical-nf = Medical
 # Biogen
 lathe-category-nf-animal-cubes = Animal Cubes
 lathe-category-seeds = Seeds
+lathe-category-soda = Soda

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -605,6 +605,7 @@
     - FriendlyCubesStatic # Frontier
     - NFBioGenIngredientsStatic # Frontier
     - NFBioGenMaterialsStatic # Frontier
+    - NFBioGenSodaStatic # Frontier
     - NFBioGenSeedsStatic # Frontier
     - NFBioGenSeedsMedicalStatic # Frontier
     - NFBioGenSoil # Frontier

--- a/Resources/Prototypes/_NF/Recipes/Lathes/Packs/biogen.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/Packs/biogen.yml
@@ -1,4 +1,23 @@
 - type: latheRecipePack
+  id: NFBioGenSodaStatic
+  recipes:
+  - NFBioGenCola
+  - NFBioGenChangelingSting
+  - NFBioGenDrGibb
+  - NFBioGenEnergyDrink
+  - NFBioGenGrapeSoda
+  - NFBioGenLemonLime
+  - NFBioGenLemonLimeCranberry
+  - NFBioGenPwrGame
+  - NFBioGenRootBeer
+  - NFBioGenSolDry
+  - NFBioGenSpaceMountainWind
+  - NFBioGenSpaceUp
+  - NFBioGenStarkist
+  - NFBioGenFourteenLoko
+  - NFBioGenShamblersJuice
+
+- type: latheRecipePack
   id: NFBioGenIngredientsStatic
   recipes:
   - BioGenAstrotame

--- a/Resources/Prototypes/_NF/Recipes/Lathes/biogen.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/biogen.yml
@@ -360,6 +360,203 @@
     sprite: Objects/Consumable/Food/condiments.rsi
     state: bottle-vinegar
 
+# region Soda
+
+- type: latheRecipe
+  id: NFBioGenCola
+  resultReagents:
+    Cola: 10
+  categories:
+  - Soda
+  icon:
+    sprite: Objects/Consumable/Drinks/cola.rsi
+    state: icon
+  completetime: 1
+  materials:
+    Biomass: 12
+
+- type: latheRecipe
+  id: NFBioGenChangelingSting
+  resultReagents:
+    ChangelingSting: 10
+  categories:
+  - Soda
+  icon:
+    sprite: Objects/Consumable/Drinks/changelingsting.rsi
+    state: icon
+  completetime: 1
+  materials:
+    Biomass: 12
+
+- type: latheRecipe
+  id: NFBioGenDrGibb
+  resultReagents:
+    DrGibb: 10
+  categories:
+  - Soda
+  icon:
+    sprite: Objects/Consumable/Drinks/dr_gibb.rsi
+    state: icon
+  completetime: 1
+  materials:
+    Biomass: 12
+
+- type: latheRecipe
+  id: NFBioGenEnergyDrink
+  resultReagents:
+    EnergyDrink: 10
+  categories:
+  - Soda
+  icon:
+    sprite: Objects/Consumable/Drinks/energy_drink.rsi
+    state: icon
+  completetime: 1
+  materials:
+    Biomass: 12
+
+- type: latheRecipe
+  id: NFBioGenGrapeSoda
+  resultReagents:
+    GrapeSoda: 10
+  categories:
+  - Soda
+  icon:
+    sprite: Objects/Consumable/Drinks/purple_can.rsi
+    state: icon
+  completetime: 1
+  materials:
+    Biomass: 12
+
+- type: latheRecipe
+  id: NFBioGenLemonLime
+  resultReagents:
+    LemonLime: 10
+  categories:
+  - Soda
+  icon:
+    sprite: Objects/Consumable/Drinks/lemon-lime.rsi
+    state: icon
+  completetime: 1
+  materials:
+    Biomass: 12
+
+- type: latheRecipe
+  id: NFBioGenLemonLimeCranberry
+  resultReagents:
+    LemonLimeCranberry: 10
+  categories:
+  - Soda
+  icon:
+    sprite: Objects/Consumable/Drinks/lemon-lime-cranberry.rsi
+    state: icon
+  completetime: 1
+  materials:
+    Biomass: 12
+
+- type: latheRecipe
+  id: NFBioGenPwrGame
+  resultReagents:
+    PwrGame: 10
+  categories:
+  - Soda
+  icon:
+    sprite: Objects/Consumable/Drinks/pwrgame.rsi
+    state: icon
+  completetime: 1
+  materials:
+    Biomass: 12
+
+- type: latheRecipe
+  id: NFBioGenRootBeer
+  resultReagents:
+    RootBeer: 10
+  categories:
+  - Soda
+  icon:
+    sprite: Objects/Consumable/Drinks/rootbeer.rsi
+    state: icon
+  completetime: 1
+  materials:
+    Biomass: 12
+
+- type: latheRecipe
+  id: NFBioGenSolDry
+  resultReagents:
+    SolDry: 10
+  categories:
+  - Soda
+  icon:
+    sprite: Objects/Consumable/Drinks/sol_dry.rsi
+    state: icon
+  completetime: 1
+  materials:
+    Biomass: 12
+
+- type: latheRecipe
+  id: NFBioGenSpaceMountainWind
+  resultReagents:
+    SpaceMountainWind: 10
+  categories:
+  - Soda
+  icon:
+    sprite: Objects/Consumable/Drinks/space_mountain_wind.rsi
+    state: icon
+  completetime: 1
+  materials:
+    Biomass: 12
+
+- type: latheRecipe
+  id: NFBioGenSpaceUp
+  resultReagents:
+    SpaceUp: 10
+  categories:
+  - Soda
+  icon:
+    sprite: Objects/Consumable/Drinks/space-up.rsi
+    state: icon
+  completetime: 1
+  materials:
+    Biomass: 12
+
+- type: latheRecipe
+  id: NFBioGenStarkist
+  resultReagents:
+    Starkist: 10
+  categories:
+  - Soda
+  icon:
+    sprite: Objects/Consumable/Drinks/starkist.rsi
+    state: icon
+  completetime: 1
+  materials:
+    Biomass: 12
+
+- type: latheRecipe
+  id: NFBioGenFourteenLoko
+  resultReagents:
+    FourteenLoko: 10
+  categories:
+  - Soda
+  icon:
+    sprite: Objects/Consumable/Drinks/fourteen_loko.rsi
+    state: icon
+  completetime: 1
+  materials:
+    Biomass: 12
+
+- type: latheRecipe
+  id: NFBioGenShamblersJuice
+  resultReagents:
+    ShamblersJuice: 10
+  categories:
+  - Soda
+  icon:
+    sprite: Objects/Consumable/Drinks/shamblersjuice.rsi
+    state: icon
+  completetime: 1
+  materials:
+    Biomass: 12
+
 # region Seeds
 
 - type: latheRecipe

--- a/Resources/Prototypes/_NF/Recipes/Lathes/categories.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/categories.yml
@@ -28,5 +28,9 @@
   name: lathe-category-seeds
 
 - type: latheCategory
+  id: Soda
+  name: lathe-category-soda
+
+- type: latheCategory
   id: NFAnimalCubes
   name: lathe-category-nf-animal-cubes


### PR DESCRIPTION
## About the PR
I dont want to map a soda machine or a soda refills on a food ship.
This is a fair fix.

## Why / Balance
For the RP option of selling soda in food meals.

## Technical details
Added soda making in bio generator, that's about it.

## How to test
Print some soda from the ``BiogeneratorFill``

## Media
![image](https://github.com/user-attachments/assets/7dd94cb9-7880-4b0f-94fc-9b6b398fae91)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
:cl:
- tweak: The Biogenerator can now print soda.