### PR TITLE
Add a proper fallback for GetPreferredJob

### DIFF
--- a/Content.Client/Lobby/LobbyUIController.cs
+++ b/Content.Client/Lobby/LobbyUIController.cs
@@ -352,7 +352,15 @@ public sealed class LobbyUIController : UIController, IOnStateEntered<LobbyState
     {
         var highPriorityJob = profile.JobPriorities.FirstOrDefault(p => p.Value == JobPriority.High).Key;
         // ReSharper disable once NullCoalescingConditionIsAlwaysNotNullAccordingToAPIContract (what is resharper smoking?)
-        return _prototypeManager.Index<JobPrototype>(highPriorityJob.Id ?? SharedGameTicker.FallbackOverflowJob);
+        // Frontier: Proper fallback for missing prototypes
+        //return _prototypeManager.Index<JobPrototype>(highPriorityJob.Id ?? SharedGameTicker.FallbackOverflowJob);
+        if (highPriorityJob.Id is { } highPriorityJobId &&
+            _prototypeManager.TryIndex<JobPrototype>(highPriorityJobId, out var job))
+        {
+            return job;
+        }
+        return _prototypeManager.Index<JobPrototype>(SharedGameTicker.FallbackOverflowJob);
+        // End Frontier
     }
 
     public void GiveDummyLoadout(EntityUid uid, RoleLoadout? roleLoadout)


### PR DESCRIPTION
## About the PR
Fixes the fallback in `GetPreferredJob()` to take missing job prototypes into account.

## Why / Balance
People's character UIs have stopped working after we renamed `PirateCaptain` to `NFPirateCaptain`.

## Technical details
The code still assumes `SharedGameTicker.FallbackOverflowJob` is a valid job prototype ID. If it isn't, we've got way more serious problems elsewhere.

## How to test
1. Set a high-priority job on one of your character slots. Not Contractor.
2. Close server, rename that job prototype to something else.
3. Start server again. Your character should fall back to Contractor; the UI should not crash.

## Media
N/A

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.

## Breaking changes
Sir, this is a fixing change, not a breaking change.

**Changelog**
:cl:
- fix: The lobby UI should once again load properly for all players.