### PR TITLE
Fix shuttles missing BecomesStation components

### DIFF
--- a/Resources/Maps/_NF/Shuttles/Sr/duchess.yml
+++ b/Resources/Maps/_NF/Shuttles/Sr/duchess.yml
@@ -441,6 +441,8 @@ entities:
         chunkSize: 4
     - type: GasTileOverlay
     - type: RadiationGridResistance
+    - type: BecomesStation
+      id: Duchess
 - proto: AirAlarm
   entities:
   - uid: 231

--- a/Resources/Maps/_NF/Shuttles/ceres.yml
+++ b/Resources/Maps/_NF/Shuttles/ceres.yml
@@ -846,6 +846,8 @@ entities:
         chunkSize: 4
     - type: GasTileOverlay
     - type: RadiationGridResistance
+    - type: BecomesStation
+      id: Ceres
 - proto: AirAlarm
   entities:
   - uid: 1745

--- a/Resources/Maps/_NF/Shuttles/gasbender.yml
+++ b/Resources/Maps/_NF/Shuttles/gasbender.yml
@@ -1154,7 +1154,7 @@ entities:
     - type: GasTileOverlay
     - type: RadiationGridResistance
     - type: BecomesStation
-      id: gasbender
+      id: Gasbender
 - proto: AirAlarm
   entities:
   - uid: 77

--- a/Resources/Maps/_NF/Shuttles/kilderkin.yml
+++ b/Resources/Maps/_NF/Shuttles/kilderkin.yml
@@ -563,7 +563,7 @@ entities:
     - type: GasTileOverlay
     - type: RadiationGridResistance
     - type: BecomesStation
-      id: kilderkin
+      id: Kilderkin
 - proto: AirAlarm
   entities:
   - uid: 84


### PR DESCRIPTION
## About the PR
Title.
Adds BecomesStation components to the Duchess and Ceres, and fixes capitalization errors in Gasbender and Kilderkin.

## Why / Balance
Appease the MapRenderer.

## Technical details
6 lines of YML changes. Total.

## How to test
- Run Content.MapRenderer on any of the four shuttles.
- Realize you forgot to tell Robust to ignore that it isn't technically a map, fix that.
- Try again.
- See it complete.
- Go view your render(s).

## Media
![image](https://github.com/user-attachments/assets/a5ff8269-bcc4-40b2-a703-c9b0ae07e8dd)

## Requirements
- [x] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I confirm that AI tools were not used in generating the material in this PR.

**Changelog**
Nah
