### PR TITLE
Hide Command Department

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/departments.yml
+++ b/Resources/Prototypes/Roles/Jobs/departments.yml
@@ -81,6 +81,7 @@
   - StationTrafficController # Frontier
   primary: false
   weight: 100
+  editorHidden: true # Frontier
 
 - type: department
   id: Engineering


### PR DESCRIPTION
## About the PR
This pull request introduces a small change to the `departments.yml` file. The change hides the `StationTrafficController` job from the editor by adding the `editorHidden: true` property.

## Why / Balance
It makes the list shorter to see and hide the 3 jobs that show up again anyway.

## How to test
Open game lobby, look on loadout.

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
N/A