### PR TITLE
Fix goblin recipes, allow using more trash for crafting

### DIFF
--- a/Content.Shared/_NF/Species/Components/GoblinComponent.cs
+++ b/Content.Shared/_NF/Species/Components/GoblinComponent.cs
@@ -14,3 +14,6 @@ public sealed partial class GoblinVehicleComponent : Component { }
 
 [RegisterComponent]
 public sealed partial class GoblinPreciousTrashComponent : Component { }
+
+[RegisterComponent]
+public sealed partial class GoblinPreciousTrashBagComponent : Component { }

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/tin.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/tin.yml
@@ -152,7 +152,7 @@
     - salty
     - cheap
   - type: Food
-    trash:
+    trash: 
     - FoodTinBeansTrash
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/tin.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/tin.yml
@@ -72,6 +72,7 @@
     - Trash
   - type: StaticPrice # Frontier
     price: 6 # Frontier
+  - type: GoblinPreciousTrash # Frontier
 
 # Tins
 
@@ -90,7 +91,7 @@
     - sweet
     - funny
   - type: Food
-    trash: 
+    trash:
     - FoodTinPeachesTrash
   - type: Tag
     tags:
@@ -113,7 +114,7 @@
   - type: Sprite
     sprite: Objects/Consumable/Food/Tins/maint_peaches.rsi
   - type: Food
-    trash: 
+    trash:
     - FoodTinPeachesMaintTrash
 
 # only exists for backwards compatibility with a few maps, nothing else uses it
@@ -151,7 +152,7 @@
     - salty
     - cheap
   - type: Food
-    trash: 
+    trash:
     - FoodTinBeansTrash
 
 - type: entity
@@ -181,7 +182,7 @@
     - salty
     - cheap
   - type: Food
-    trash: 
+    trash:
     - FoodTinMRETrash
   - type: Tag
     tags:

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/tin.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/tin.yml
@@ -195,3 +195,4 @@
   components:
   - type: Sprite
     sprite: Objects/Consumable/Food/Tins/meat.rsi
+

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/tin.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/tin.yml
@@ -114,7 +114,7 @@
   - type: Sprite
     sprite: Objects/Consumable/Food/Tins/maint_peaches.rsi
   - type: Food
-    trash:
+    trash: 
     - FoodTinPeachesMaintTrash
 
 # only exists for backwards compatibility with a few maps, nothing else uses it

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/tin.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/tin.yml
@@ -91,7 +91,7 @@
     - sweet
     - funny
   - type: Food
-    trash:
+    trash: 
     - FoodTinPeachesTrash
   - type: Tag
     tags:

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/tin.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/tin.yml
@@ -182,7 +182,7 @@
     - salty
     - cheap
   - type: Food
-    trash:
+    trash: 
     - FoodTinMRETrash
   - type: Tag
     tags:

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/frozen.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/frozen.yml
@@ -191,7 +191,7 @@
     - state: cone
     - state: berry
   - type: Food
-    trash:
+    trash: 
     - FoodFrozenSnowconeTrash
   - type: Tag
     tags:

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/frozen.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/frozen.yml
@@ -208,7 +208,7 @@
     - state: cone
     - state: fruitsalad
   - type: Food
-    trash:
+    trash: 
     - FoodFrozenSnowconeTrash
   - type: Tag
     tags:

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/frozen.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/frozen.yml
@@ -225,7 +225,7 @@
     - state: cone
     - state: clown
   - type: Food
-    trash:
+    trash: 
     - FoodFrozenSnowconeTrash
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/frozen.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/frozen.yml
@@ -121,7 +121,7 @@
     - state: stick
     - state: jumbo
   - type: Food
-    trash:
+    trash: 
     - FoodFrozenPopsicleTrash
   - type: SolutionContainerManager
     solutions:

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/frozen.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/frozen.yml
@@ -104,7 +104,7 @@
     - state: popsicle
       color: red
   - type: Food
-    trash:
+    trash: 
     - FoodFrozenPopsicleTrash
   - type: Tag
     tags:

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/frozen.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/frozen.yml
@@ -239,7 +239,7 @@
     - state: cone
     - state: mime
   - type: Food
-    trash:
+    trash: 
     - FoodFrozenSnowconeTrash
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/frozen.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/frozen.yml
@@ -253,7 +253,7 @@
     - state: cone
     - state: rainbow
   - type: Food
-    trash:
+    trash: 
     - FoodFrozenSnowconeTrash
 
 # Trash

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/frozen.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/frozen.yml
@@ -88,7 +88,7 @@
     - state: popsicle
       color: orange
   - type: Food
-    trash: 
+    trash:
     - FoodFrozenPopsicleTrash
 
 - type: entity
@@ -104,7 +104,7 @@
     - state: popsicle
       color: red
   - type: Food
-    trash: 
+    trash:
     - FoodFrozenPopsicleTrash
   - type: Tag
     tags:
@@ -121,7 +121,7 @@
     - state: stick
     - state: jumbo
   - type: Food
-    trash: 
+    trash:
     - FoodFrozenPopsicleTrash
   - type: SolutionContainerManager
     solutions:
@@ -152,7 +152,7 @@
         - state: alpha-filling
     #      color: foo
     - type: Food
-      trash: 
+      trash:
       - FoodFrozenSnowconeTrash
     - type: SolutionContainerManager
       solutions:
@@ -191,7 +191,7 @@
     - state: cone
     - state: berry
   - type: Food
-    trash: 
+    trash:
     - FoodFrozenSnowconeTrash
   - type: Tag
     tags:
@@ -208,7 +208,7 @@
     - state: cone
     - state: fruitsalad
   - type: Food
-    trash: 
+    trash:
     - FoodFrozenSnowconeTrash
   - type: Tag
     tags:
@@ -225,7 +225,7 @@
     - state: cone
     - state: clown
   - type: Food
-    trash: 
+    trash:
     - FoodFrozenSnowconeTrash
 
 - type: entity
@@ -239,7 +239,7 @@
     - state: cone
     - state: mime
   - type: Food
-    trash: 
+    trash:
     - FoodFrozenSnowconeTrash
 
 - type: entity
@@ -253,7 +253,7 @@
     - state: cone
     - state: rainbow
   - type: Food
-    trash: 
+    trash:
     - FoodFrozenSnowconeTrash
 
 # Trash
@@ -270,6 +270,7 @@
   - type: Tag
     tags:
     - Trash
+  - type: GoblinPreciousTrash # Frontier
 
 - type: entity
   name: popsicle stick
@@ -291,3 +292,4 @@
     tags:
     - Trash
   - type: SpaceGarbage
+  - type: GoblinPreciousTrash # Frontier

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/frozen.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/frozen.yml
@@ -152,7 +152,7 @@
         - state: alpha-filling
     #      color: foo
     - type: Food
-      trash:
+      trash: 
       - FoodFrozenSnowconeTrash
     - type: SolutionContainerManager
       solutions:

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/frozen.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/frozen.yml
@@ -88,7 +88,7 @@
     - state: popsicle
       color: orange
   - type: Food
-    trash:
+    trash: 
     - FoodFrozenPopsicleTrash
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/trashbag.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/trashbag.yml
@@ -41,6 +41,7 @@
     size: Normal
   - type: MagnetPickup # Frontier
     magnetEnabled: false # Frontier
+  - type: GoblinPreciousTrashBag # Frontier
 
 - type: entity
   name: trash bag


### PR DESCRIPTION
## About the PR
- Added missing component to trash bags.
- Distributed goblin craft related component through more trash items.

## Why / Balance
Goblins now able to craft bags from trash bags and can utilize more trash items in crafting.

## Technical details
This pull request introduces a new `GoblinPreciousTrash` tag and a corresponding `GoblinPreciousTrashBag` component, updating several entity prototypes to include these additions. These changes enhance the goblin-related mechanics by categorizing specific items as "precious trash" for goblins.

### New Components and Tags:

* Added a new `GoblinPreciousTrashBagComponent` in `GoblinComponent.cs` to represent a specialized trash bag for goblins. (`[Content.Shared/_NF/Species/Components/GoblinComponent.csR17-R19](diffhunk://#diff-ab77990984df2f01f32a04d4fcb4b5f4a85f37e0cadb98180fdd852289a96520R17-R19)`)
* Introduced the `GoblinPreciousTrash` tag in multiple entity prototype files to classify certain items as "precious trash" for goblins. (`[[1]](diffhunk://#diff-46e4bbe5ba89e12891a9779f330128faf51ba27583a6ad7098cdef994297d41cR75)`, `[[2]](diffhunk://#diff-abc5d414f42e0f04fe46de0d6aa9ebbc3a5914155640e7dc23e067de1affc988R273)`, `[[3]](diffhunk://#diff-abc5d414f42e0f04fe46de0d6aa9ebbc3a5914155640e7dc23e067de1affc988R295)`)

### Entity Prototype Updates:

* Updated `tin.yml` to include the `GoblinPreciousTrash` tag for specific consumable items. (`[Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/tin.ymlR75](diffhunk://#diff-46e4bbe5ba89e12891a9779f330128faf51ba27583a6ad7098cdef994297d41cR75)`)
* Updated `frozen.yml` to add the `GoblinPreciousTrash` tag to frozen food-related entities. (`[[1]](diffhunk://#diff-abc5d414f42e0f04fe46de0d6aa9ebbc3a5914155640e7dc23e067de1affc988R273)`, `[[2]](diffhunk://#diff-abc5d414f42e0f04fe46de0d6aa9ebbc3a5914155640e7dc23e067de1affc988R295)`)
* Updated `trashbag.yml` to include the `GoblinPreciousTrashBag` type for janitorial trash bags. (`[Resources/Prototypes/Entities/Objects/Specific/Janitorial/trashbag.ymlR44](diffhunk://#diff-24987f44df7db8c81144ce4ad2742a9bb42a4747587cd3f531ab42df66cd297dR44)`)

## How to test
Spawn as a goblin, get some trash bags, craft backpack, duffel and pouch.
Spawn assortment of trash items, craft goblin tools.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [x] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:
- fix: Fixed the bug that prevented goblins from crafting bags from trash bags; allowed to use more trash items in crafting.
