### PR TITLE
Rewires the generator and SMES on the Apothecary to make more sense

### DIFF
--- a/Resources/Maps/_NF/Shuttles/apothecary.yml
+++ b/Resources/Maps/_NF/Shuttles/apothecary.yml
@@ -1,11 +1,11 @@
 meta:
   format: 7
   category: Grid
-  engineVersion: 248.0.2
+  engineVersion: 251.0.0
   forkId: ""
   forkVersion: ""
-  time: 04/18/2025 03:35:30
-  entityCount: 428
+  time: 05/16/2025 08:03:07
+  entityCount: 427
 maps: []
 grids:
 - 1
@@ -1412,27 +1412,22 @@ entities:
   - uid: 12
     components:
     - type: Transform
-      pos: -3.5,-0.5
+      pos: -3.5,-2.5
       parent: 1
   - uid: 13
     components:
     - type: Transform
       pos: -2.5,0.5
       parent: 1
-  - uid: 22
+  - uid: 199
     components:
     - type: Transform
-      pos: -3.5,-1.5
+      pos: -2.5,-1.5
       parent: 1
   - uid: 223
     components:
     - type: Transform
       pos: -2.5,-2.5
-      parent: 1
-  - uid: 235
-    components:
-    - type: Transform
-      pos: -3.5,-2.5
       parent: 1
 - proto: CableMV
   entities:
@@ -1453,11 +1448,11 @@ entities:
       parent: 1
 - proto: CableTerminal
   entities:
-  - uid: 199
+  - uid: 22
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,-2.5
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-2.5
       parent: 1
 - proto: Catwalk
   entities:
@@ -1568,7 +1563,7 @@ entities:
   - uid: 335
     components:
     - type: Transform
-      pos: -3.5210888,-2.1972485
+      pos: -2.53125,-2.296875
       parent: 1
 - proto: ComputerTabletopCrewMonitoring
   entities:
@@ -2601,7 +2596,7 @@ entities:
   - uid: 234
     components:
     - type: Transform
-      pos: -2.5,-2.5
+      pos: -3.5,-2.5
       parent: 1
     - type: FuelGenerator
       targetPower: 26000
@@ -3105,7 +3100,7 @@ entities:
   - uid: 157
     components:
     - type: Transform
-      pos: -3.5,-2.5
+      pos: -2.5,-2.5
       parent: 1
 - proto: SpawnPointLatejoin
   entities:


### PR DESCRIPTION
## About the PR
Literally just swaps the placement of the SMES and generator on the Apothecary

## Why / Balance
The wiring  right now makes a weird loop to go around the generator, presumably for the sole purpose of having the uranium wall closet be above the generator itself. This weird loop makes any rewiring a huge pain for arguably very little benefit. With this change, the wiring opens up for better options. You can wire out to the side to install extra generators/RTGs/solars, you can move the generator itself, etc, without having to lift the SMES and shuffle things around. Also uses precisely 1 less HV cable.

## How to test
Load it up, grab a t-ray/toggle subfloor, enjoy

## Media
![apoth change](https://github.com/user-attachments/assets/579c2843-b8c9-4379-915f-165c76351e2a)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I confirm that AI tools were not used in generating the material in this PR.
- 
**Changelog**
:cl:
- tweak: Swapped placement of Apothecary SMES and generator to improve wiring situation
