### PR TITLE
Sheleg change damage modifiers

### DIFF
--- a/Resources/Prototypes/_NF/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_NF/Damage/modifier_sets.yml
@@ -11,11 +11,11 @@
   id: Sheleg
   coefficients:
     Cold: 0.0
-    Blunt: 0.75
-    Slash: 0.75
-    Piercing: 0.75
+    Blunt: 0.80
+    Slash: 0.80
+    Piercing: 0.80
     Heat: 1.65
-    Shock: 1.2
+    Shock: 1.25
 
 - type: damageModifierSet
   id: MobHostileDamageModifierSetLow

--- a/Resources/ServerInfo/_NF/Guidebook/Mobs/Sheleg.xml
+++ b/Resources/ServerInfo/_NF/Guidebook/Mobs/Sheleg.xml
@@ -11,7 +11,7 @@
   - Normal medical chemicals has no effects, however cryo chemicals works with thier cold body temperature.
 
   ## Benefits
-  - Takes no Cold damage and 25% less Blunt, Slash and Piercing damage.
+  - Takes no Cold damage and 20% less Blunt, Slash and Piercing damage.
   - Due to their big size, they can easily carry, shove and pull any other morphotypes.
   - They are harder to shove.
   - Being cold has no walking and running speed reductions.
@@ -28,7 +28,7 @@
   ## Drawbacks
   - They are harder to carry and pull.
   - They are bigger than Humans, making them easier to hit.
-  - Takes 65% more Heat and 20% more Shock damage.
+  - Takes 65% more Heat and 25% more Shock damage.
   - They take high heat damage above 0 degrees celsius body temperature.
   - Cannot be syringed, hypo or darted due to harden skin
   - Slow food and chemical mobilization, can only processes one chemical at a time.


### PR DESCRIPTION
## About the PR
Changed 25% to 20% overall protection, added 5% more electric damage.

## Why / Balance
25% is a bit too much

## Technical details
This pull request updates the damage modifiers and guidebook descriptions for the Sheleg morphotype, ensuring consistency between the gameplay mechanics and documentation. The changes primarily involve adjustments to damage resistance and vulnerability values.

### Gameplay Mechanics Adjustments:

* Updated the Sheleg morphotype's damage resistance values for Blunt, Slash, and Piercing damage from 0.75 to 0.80 in `modifier_sets.yml`.
* Increased the Sheleg morphotype's vulnerability to Shock damage from 1.2 to 1.25 in `modifier_sets.yml`.

### Documentation Updates:

* Adjusted the Sheleg morphotype's description in `Guidebook/Mobs/Sheleg.xml` to reflect the updated resistance values, changing "25% less Blunt, Slash and Piercing damage" to "20% less Blunt, Slash and Piercing damage."
* Updated the vulnerability description in `Guidebook/Mobs/Sheleg.xml` to match the new Shock damage value, changing "20% more Shock damage" to "25% more Shock damage."

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
:cl:
- tweak: Adjusted Sheleg damage modifiers.
