### PR TITLE
Damage crates on impacts, only while on moving belts

### DIFF
--- a/Content.Shared/Conveyor/ConveyorComponent.cs
+++ b/Content.Shared/Conveyor/ConveyorComponent.cs
@@ -1,4 +1,5 @@
 using Content.Shared.DeviceLinking;
+using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;

--- a/Content.Shared/Damage/Components/DamageOnHighSpeedImpactComponent.cs
+++ b/Content.Shared/Damage/Components/DamageOnHighSpeedImpactComponent.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Damage.Systems;
+using Content.Shared.Physics.Controllers; // Frontier
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
@@ -8,7 +9,7 @@ namespace Content.Shared.Damage.Components;
 /// <summary>
 /// Should the entity take damage / be stunned if colliding at a speed above MinimumSpeed?
 /// </summary>
-[RegisterComponent, NetworkedComponent, Access(typeof(DamageOnHighSpeedImpactSystem))]
+[RegisterComponent, NetworkedComponent, Access(typeof(DamageOnHighSpeedImpactSystem), typeof(SharedConveyorController))] // Frontier: Added SharedConveyorController
 public sealed partial class DamageOnHighSpeedImpactComponent : Component
 {
     [DataField("minimumSpeed"), ViewVariables(VVAccess.ReadWrite)]


### PR DESCRIPTION
## About the PR
Add a tiny bit of damage and a visual effect on the crates taking it when they are jammed into one another, while only on moving crates.

## Why / Balance
Help lower some lags that might come from over loading crates into belts smash by showing players its not a good thing.

## Technical details
### New functionality for trade crates:

* [`Content.Shared/Physics/Controllers/SharedConveyorController.cs`](diffhunk://#diff-f81607979c82968a141a385542043bbce29f8848f922526fad472b53d840411bR116-R130): Added logic to apply damage to trade crates on high-speed collisions by ensuring they have a `DamageOnHighSpeedImpactComponent`, setting its `MinimumSpeed`, and applying structural damage.
* [`Content.Shared/Physics/Controllers/SharedConveyorController.cs`](diffhunk://#diff-f81607979c82968a141a385542043bbce29f8848f922526fad472b53d840411bR193-R197): Updated the `UpdateBeforeSolve` method to remove the `DamageOnHighSpeedImpactComponent` from trade crates when they are no longer conveyed.

### Supporting changes:

* [`Content.Shared/Damage/Components/DamageOnHighSpeedImpactComponent.cs`](diffhunk://#diff-7492d06130a1c4d038979f477fb99e0f9239dcb54754c85a13deced9fc155d47L11-R12): Updated the `Access` attribute to include `SharedConveyorController`, enabling it to interact with the component.
* [`Content.Shared/Physics/Controllers/SharedConveyorController.cs`](diffhunk://#diff-f81607979c82968a141a385542043bbce29f8848f922526fad472b53d840411bL1-R4): Added necessary `using` directives for the `Damage` and `Trade` namespaces to support the new functionality. [[1]](diffhunk://#diff-f81607979c82968a141a385542043bbce29f8848f922526fad472b53d840411bL1-R4) [[2]](diffhunk://#diff-f81607979c82968a141a385542043bbce29f8848f922526fad472b53d840411bR17)

## How to test
Put few trade crates on moving belts and smash them into a wall.

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
:cl:
- tweak: Trade crates slightly get damaged when hitting one another while on moving conveyor belts.