### PR TITLE
Shuttle (Update): McCargo and biomass crate definitions

### DIFF
--- a/Resources/Maps/_NF/Shuttles/mccargo.yml
+++ b/Resources/Maps/_NF/Shuttles/mccargo.yml
@@ -1,10 +1,10 @@
 meta:
   format: 7
   category: Grid
-  engineVersion: 251.0.0
+  engineVersion: 255.0.0
   forkId: ""
   forkVersion: ""
-  time: 05/03/2025 22:40:51
+  time: 05/17/2025 11:10:41
   entityCount: 948
 maps: []
 grids:
@@ -2519,17 +2519,19 @@ entities:
     - type: Transform
       pos: -5.5,1.5
       parent: 1
-- proto: CrateMcCargoMaterialBiomass50
+- proto: CrateMaterialBiomassMcCargo
+  entities:
+  - uid: 476
+    components:
+    - type: Transform
+      pos: 9.5,9.5
+      parent: 1
+- proto: CrateServiceBoozeDispenser
   entities:
   - uid: 464
     components:
     - type: Transform
       pos: 9.5,10.5
-      parent: 1
-  - uid: 476
-    components:
-    - type: Transform
-      pos: 9.5,9.5
       parent: 1
 - proto: DefibrillatorCabinetFilled
   entities:
@@ -5515,9 +5517,11 @@ entities:
     - type: DeviceLinkSource
       linkedPorts:
         318:
-        - Pressed: Toggle
+        - - Pressed
+          - Toggle
         37:
-        - Pressed: Toggle
+        - - Pressed
+          - Toggle
   - uid: 173
     components:
     - type: Transform
@@ -5527,9 +5531,11 @@ entities:
     - type: DeviceLinkSource
       linkedPorts:
         151:
-        - Pressed: Toggle
+        - - Pressed
+          - Toggle
         193:
-        - Pressed: DoorBolt
+        - - Pressed
+          - DoorBolt
   - uid: 667
     components:
     - type: Transform
@@ -5538,9 +5544,11 @@ entities:
     - type: DeviceLinkSource
       linkedPorts:
         790:
-        - Pressed: Toggle
+        - - Pressed
+          - Toggle
         337:
-        - Pressed: Toggle
+        - - Pressed
+          - Toggle
   - uid: 669
     components:
     - type: Transform
@@ -5550,9 +5558,11 @@ entities:
     - type: DeviceLinkSource
       linkedPorts:
         412:
-        - Pressed: Toggle
+        - - Pressed
+          - Toggle
         281:
-        - Pressed: Toggle
+        - - Pressed
+          - Toggle
   - uid: 730
     components:
     - type: Transform
@@ -5562,9 +5572,11 @@ entities:
     - type: DeviceLinkSource
       linkedPorts:
         684:
-        - Pressed: Toggle
+        - - Pressed
+          - Toggle
         300:
-        - Pressed: DoorBolt
+        - - Pressed
+          - DoorBolt
   - uid: 859
     components:
     - type: Transform
@@ -5574,19 +5586,26 @@ entities:
     - type: DeviceLinkSource
       linkedPorts:
         676:
-        - Pressed: Toggle
+        - - Pressed
+          - Toggle
         677:
-        - Pressed: Toggle
+        - - Pressed
+          - Toggle
         678:
-        - Pressed: Toggle
+        - - Pressed
+          - Toggle
         679:
-        - Pressed: Toggle
+        - - Pressed
+          - Toggle
         680:
-        - Pressed: Toggle
+        - - Pressed
+          - Toggle
         681:
-        - Pressed: Toggle
+        - - Pressed
+          - Toggle
         682:
-        - Pressed: Toggle
+        - - Pressed
+          - Toggle
   - uid: 947
     components:
     - type: Transform
@@ -5595,13 +5614,17 @@ entities:
     - type: DeviceLinkSource
       linkedPorts:
         946:
-        - Pressed: DoorBolt
+        - - Pressed
+          - DoorBolt
         945:
-        - Pressed: DoorBolt
+        - - Pressed
+          - DoorBolt
         944:
-        - Pressed: DoorBolt
+        - - Pressed
+          - DoorBolt
         951:
-        - Pressed: Toggle
+        - - Pressed
+          - Toggle
   - uid: 948
     components:
     - type: Transform
@@ -5611,13 +5634,17 @@ entities:
     - type: DeviceLinkSource
       linkedPorts:
         937:
-        - Pressed: DoorBolt
+        - - Pressed
+          - DoorBolt
         936:
-        - Pressed: DoorBolt
+        - - Pressed
+          - DoorBolt
         935:
-        - Pressed: DoorBolt
+        - - Pressed
+          - DoorBolt
         954:
-        - Pressed: Toggle
+        - - Pressed
+          - Toggle
   - uid: 949
     components:
     - type: Transform
@@ -5626,13 +5653,17 @@ entities:
     - type: DeviceLinkSource
       linkedPorts:
         941:
-        - Pressed: DoorBolt
+        - - Pressed
+          - DoorBolt
         942:
-        - Pressed: DoorBolt
+        - - Pressed
+          - DoorBolt
         943:
-        - Pressed: DoorBolt
+        - - Pressed
+          - DoorBolt
         955:
-        - Pressed: Toggle
+        - - Pressed
+          - Toggle
   - uid: 950
     components:
     - type: Transform
@@ -5642,13 +5673,17 @@ entities:
     - type: DeviceLinkSource
       linkedPorts:
         940:
-        - Pressed: DoorBolt
+        - - Pressed
+          - DoorBolt
         939:
-        - Pressed: DoorBolt
+        - - Pressed
+          - DoorBolt
         938:
-        - Pressed: DoorBolt
+        - - Pressed
+          - DoorBolt
         958:
-        - Pressed: Toggle
+        - - Pressed
+          - Toggle
 - proto: SignalButtonDirectional
   entities:
   - uid: 362
@@ -5660,11 +5695,14 @@ entities:
     - type: DeviceLinkSource
       linkedPorts:
         685:
-        - Pressed: Toggle
+        - - Pressed
+          - Toggle
         9:
-        - Pressed: Toggle
+        - - Pressed
+          - Toggle
         529:
-        - Pressed: Toggle
+        - - Pressed
+          - Toggle
   - uid: 482
     components:
     - type: Transform
@@ -5674,11 +5712,14 @@ entities:
     - type: DeviceLinkSource
       linkedPorts:
         265:
-        - Pressed: Toggle
+        - - Pressed
+          - Toggle
         414:
-        - Pressed: Toggle
+        - - Pressed
+          - Toggle
         413:
-        - Pressed: Toggle
+        - - Pressed
+          - Toggle
   - uid: 562
     components:
     - type: Transform
@@ -5688,7 +5729,8 @@ entities:
     - type: DeviceLinkSource
       linkedPorts:
         1069:
-        - Pressed: Toggle
+        - - Pressed
+          - Toggle
   - uid: 750
     components:
     - type: Transform
@@ -5698,7 +5740,8 @@ entities:
     - type: DeviceLinkSource
       linkedPorts:
         344:
-        - Pressed: Toggle
+        - - Pressed
+          - Toggle
 - proto: SignCargo
   entities:
   - uid: 874
@@ -6817,7 +6860,8 @@ entities:
     - type: DeviceLinkSource
       linkedPorts:
         44:
-        - DoorStatus: Close
+        - - DoorStatus
+          - Close
   - uid: 44
     components:
     - type: Transform
@@ -6829,7 +6873,8 @@ entities:
     - type: DeviceLinkSource
       linkedPorts:
         32:
-        - DoorStatus: Close
+        - - DoorStatus
+          - Close
   - uid: 631
     components:
     - type: Transform

--- a/Resources/Prototypes/_NF/Catalog/Fills/Crates/materials.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/Crates/materials.yml
@@ -10,16 +10,28 @@
       amount: 3
 
 - type: entity
+  id: CrateMaterialBiomass50
+  parent: CrateMaterialBiomass
+  suffix: 50 biomass
+  components:
+  - type: StorageFill
+    contents:
+    - id: MaterialBiomass50
+      amount: 1
+
+- type: entity
   id: CrateMaterialBiomass
   parent: CrateFreezer
-  name: biomass crate
-  suffix: 300 # Frontier label for distinction
-  description: 300 units of biomass. Yum.
+  suffix: 300 biomass
   components:
   - type: StorageFill
     contents:
     - id: MaterialBiomass
       amount: 3
+
+- type: entity
+  id: CrateMaterialBiomassMcCargo
+  parent: [CrateFreezerMcCargo, CrateMaterialBiomass]
 
 # region Materials
 - type: entity

--- a/Resources/Prototypes/_NF/Entities/Materials/materials.yml
+++ b/Resources/Prototypes/_NF/Entities/Materials/materials.yml
@@ -18,27 +18,3 @@
   components:
   - type: Stack
     count: 50
-
-- type: entity
-  id: CrateMaterialBiomass50
-  parent: CrateMaterialBiomass
-  name: biomass crate
-  suffix: 50
-  description: 50 units of biomass. Yum.
-  components:
-  - type: StorageFill
-    contents:
-    - id: MaterialBiomass50
-      amount: 1
-
-- type: entity
-  id: CrateMcCargoMaterialBiomass50
-  parent: CrateFreezerMcCargo
-  name: mcbiomass crate
-  suffix: 50
-  description: 50 units of biomass. Not for grilling.
-  components:
-  - type: StorageFill
-    contents:
-    - id: MaterialBiomass50
-      amount: 1


### PR DESCRIPTION
## About the PR
Tiny update to the McCargo freezer to make it give it biomass boost since it was still an issue for starting players on the shuttle.
Added a booze refill crate (same as booze dispenser fill, but minus the machine)

## Why / Balance
Was told people need a bigger boost for machine lost, and alcohol options.

## Technical details
### Map File Updates:
* Replaced `CrateMcCargoMaterialBiomass50` with `CrateMaterialBiomassMcCargo` in entity definitions, and adjusted associated `uid` and position values.
### Prototype Adjustments:
* Added a new `CrateMaterialBiomassMcCargo` prototype in `Resources/Prototypes/_NF/Catalog/Fills/Crates/materials.yml` for better modularity.
* Removed redundant definitions for `CrateMaterialBiomass50` and `CrateMcCargoMaterialBiomass50` from `Resources/Prototypes/_NF/Entities/Materials/materials.yml` as they are now consolidated into the new prototype structure.

## How to test
Open mapping on mccargo.yml

## Media
![image](https://github.com/user-attachments/assets/9f5420f4-5085-4098-8550-69ee0a9ef779)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
Small change, no need.