### PR TITLE
Shuttle (Update): McDelivery

### DIFF
--- a/Resources/Maps/_NF/Shuttles/mcdelivery.yml
+++ b/Resources/Maps/_NF/Shuttles/mcdelivery.yml
@@ -1,6 +1,17 @@
 meta:
-  format: 6
-  postmapinit: false
+  format: 7
+  category: Grid
+  engineVersion: 255.0.0
+  forkId: ""
+  forkVersion: ""
+  time: 05/17/2025 11:22:36
+  entityCount: 101
+maps: []
+grids:
+- 1
+orphans:
+- 1
+nullspace: []
 tilemap:
   0: Space
   88: FloorShuttleWhite
@@ -284,6 +295,14 @@ entities:
     - type: Transform
       pos: 0.5,3.5
       parent: 1
+- proto: ComputerWallmountStationRecords
+  entities:
+  - uid: 61
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,2.5
+      parent: 1
 - proto: ComputerWallmountWithdrawBankATM
   entities:
   - uid: 68
@@ -534,14 +553,6 @@ entities:
       parent: 1
     - type: Physics
       bodyType: Static
-- proto: NoticeBoardNF
-  entities:
-  - uid: 61
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,2.5
-      parent: 1
 - proto: OxygenCanister
   entities:
   - uid: 98
@@ -672,7 +683,8 @@ entities:
     - type: DeviceLinkSource
       linkedPorts:
         79:
-        - Pressed: Toggle
+        - - Pressed
+          - Toggle
 - proto: SignCargoDock
   entities:
   - uid: 30


### PR DESCRIPTION
## About the PR
Swapped the notice board to a wallmount records computer so you can actually find out who is the ship owner.

## Why / Balance
I think its needed, it was removed with holo update when there was no space for it, but it can now be moved to a wall.

## Technical details
### Entity modifications:
* Added a new entity `ComputerWallmountStationRecords` with specific components, and removed the `NoticeBoardNF` entity. [[1]](diffhunk://#diff-0b13036b29ee56d500d853d4c5f48a7a40d400796c7fff29140877dfdac66d9aR298-R305) [[2]](diffhunk://#diff-0b13036b29ee56d500d853d4c5f48a7a40d400796c7fff29140877dfdac66d9aL537-L544)

## How to test
Look at map, confirm.

## Media
![image](https://github.com/user-attachments/assets/973d011a-d3cb-4543-b240-1776753a9adc)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
Too small of a change.