### PR TITLE
Trim flatpack kits in loot tables and vendomats

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -199,6 +199,7 @@
   name: R&D server machine board
   description: A machine printed circuit board for the R&D server.
   components:
+  - type: BindToStationExemption # Frontier
   - type: Sprite
     state: science
   - type: MachineBoard

--- a/Resources/Prototypes/Entities/Objects/Devices/flatpack.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/flatpack.yml
@@ -49,7 +49,7 @@
     layers:
     - state: solar-assembly-part
   - type: StaticPrice
-    price: 75
+    price: 25 # Frontier: 75<15
 
 - type: entity
   parent: BaseFlatpack

--- a/Resources/Prototypes/Entities/Objects/Devices/flatpack.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/flatpack.yml
@@ -49,7 +49,7 @@
     layers:
     - state: solar-assembly-part
   - type: StaticPrice
-    price: 25 # Frontier: 75<15
+    price: 25 # Frontier: 75<25
 
 - type: entity
   parent: BaseFlatpack

--- a/Resources/Prototypes/Entities/Structures/Machines/research.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/research.yml
@@ -4,6 +4,7 @@
   name: R&D server
   description: Contains the collective knowledge of the station's scientists. Destroying it would send them back to the stone age. You don't want that do you?
   components:
+  - type: BindToStationExemption # Frontier
   - type: Sprite
     sprite: Structures/Machines/server.rsi
     snapCardinals: true # Frontier

--- a/Resources/Prototypes/Recipes/Lathes/Packs/science.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/science.yml
@@ -95,6 +95,7 @@
   - APECircuitboard
   - ArtifactAnalyzerMachineCircuitboard
   - ArtifactCrusherMachineCircuitboard
+  - ResearchComputerCircuitboard # Frontier: add research computer
 
 - type: latheRecipePack
   id: CameraBoards

--- a/Resources/Prototypes/Research/experimental.yml
+++ b/Resources/Prototypes/Research/experimental.yml
@@ -43,6 +43,7 @@
   - BorgModuleArtifact
   - AnalysisComputerCircuitboard
   - ArtifactAnalyzerMachineCircuitboard
+  - ResearchComputerCircuitboard # Frontier: add research computer
 
 # Frontier: no tech disks
 # - type: technology

--- a/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/flatpackvend.yml
+++ b/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/flatpackvend.yml
@@ -24,6 +24,18 @@
     MachineFlatpackerFlatpack: 4294967295 # Infinite
     ExosuitFabricatorFlatpack: 4294967295 # Infinite
     CircuitImprinterFlatpack: 4294967295 # Infinite
+    GasThermoMachineFreezerFlatpack: 4294967295 # Infinite
+    PortableGeneratorJrPacmanFlatpack: 4294967295 # Infinite
+    PortableGeneratorPacmanFlatpack: 4294967295 # Infinite
+    PortableGeneratorSuperPacmanFlatpack: 4294967295 # Infinite
+    SolarAssemblyFlatpack: 4294967295 # Infinite
+    ComputerSolarControlFlatpack: 4294967295 # Infinite
+    GravityGeneratorMiniFlatpack: 4294967295 # Infinite
+    ThrusterFlatpack: 4294967295 # Infinite
+    GyroscopeFlatpack: 4294967295 # Infinite
+    SmallGyroscopeFlatpack: 4294967295 # Infinite
+    SmallThrusterFlatpack: 4294967295 # Infinite
+    SpaceHeaterFlatpack: 4294967295 # Infinite
     AirlockFlatpack: 4294967295 # Infinite
     AirlockGlassFlatpack: 4294967295 # Infinite
     AirlockShuttleFlatpack: 4294967295 # Infinite
@@ -32,3 +44,4 @@
     MachineArtifactAnalyzerFlatpack: 4294967295 # Infinite
     ResearchAndDevelopmentServerFlatpack: 4294967295 # Infinite
     BlueprintLithographFlatpack: 4294967295 # Infinite
+    TeslaGroundingRodFlatpack: 4294967295 # Infinite

--- a/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/flatpackvend.yml
+++ b/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/flatpackvend.yml
@@ -1,32 +1,34 @@
 - type: vendingMachineInventory
   id: FlatpackVendInventory
   startingInventory:
-    ShuttleGunKineticFlatpack: 4294967295 # Infinite
-    OreProcessorFlatpack: 4294967295 # Infinite
+    # General
     AutolatheFlatpack: 4294967295 # Infinite
-#    HydroponicsTrayEmptyFlatpack: 16 # Get a food ship, or an atmost ship
-    ExosuitFabricatorFlatpack: 4294967295 # Infinite
-    ProtolatheFlatpack: 4294967295 # Infinite
-    CircuitImprinterFlatpack: 4294967295 # Infinite
-    ResearchAndDevelopmentServerFlatpack: 4294967295 # Infinite
-    ComputerResearchAndDevelopmentFlatpack: 4294967295 # Infinite
-    BlueprintLithographFlatpack: 4294967295 # Infinite
-    EngineeringTechFabFlatpack: 4294967295 # Infinite
-    SalvageTechfabNFFlatpack: 4294967295 # Infinite
-    ScrapProcessorFlatpack: 4294967295 # Infinite
-    ServiceTechFabFlatpack: 4294967295 # Infinite
-#    MedicalTechFabFlatpack: 4294967295 # Infinite
-    MaterialReclaimerFlatpack: 4294967295 # Infinite
-#    UniformPrinterFlatpack: 6 # Loadouts are a thing
-    CutterMachineFlatpack: 4294967295 # Infinite
     PowerCellRechargerFlatpack: 4294967295 # Infinite
     WeaponCapacitorRechargerFlatpack: 4294967295 # Infinite
     BorgChargerFlatpack: 4294967295 # Infinite
-    MachineFlatpackerFlatpack: 4294967295 # Infinite
     NFHolopadShipFlatpack: 4294967295 # Infinite
+    # Salvage
+    SalvageTechfabNFFlatpack: 4294967295 # Infinite
+    OreProcessorFlatpack: 4294967295 # Infinite
+    MaterialReclaimerFlatpack: 4294967295 # Infinite
+    ScrapProcessorFlatpack: 4294967295 # Infinite
+    ShuttleGunKineticFlatpack: 4294967295 # Infinite
+    # Service
+    ServiceTechFabFlatpack: 4294967295 # Infinite
+    CutterMachineFlatpack: 4294967295 # Infinite
+    ComputerWithdrawBankATMFlatpack: 4294967295 # Infinite
+    TelevisionFlatpack: 4294967295 # Infinite
+#    UniformPrinterFlatpack: 6 # Loadouts are a thing
+    # Engineering
+    EngineeringTechFabFlatpack: 4294967295 # Infinite
+    MachineFlatpackerFlatpack: 4294967295 # Infinite
+    ExosuitFabricatorFlatpack: 4294967295 # Infinite
+    CircuitImprinterFlatpack: 4294967295 # Infinite
     AirlockFlatpack: 4294967295 # Infinite
     AirlockGlassFlatpack: 4294967295 # Infinite
     AirlockShuttleFlatpack: 4294967295 # Infinite
     AirlockGlassShuttleFlatpack: 4294967295 # Infinite
-    ComputerWithdrawBankATMFlatpack: 4294967295 # Infinite
-    TelevisionFlatpack: 4294967295 # Infinite
+    # Science
+    MachineArtifactAnalyzerFlatpack: 4294967295 # Infinite
+    ResearchAndDevelopmentServerFlatpack: 4294967295 # Infinite
+    BlueprintLithographFlatpack: 4294967295 # Infinite

--- a/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/flatpackvend.yml
+++ b/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/flatpackvend.yml
@@ -8,19 +8,19 @@
     BorgChargerFlatpack: 4294967295 # Infinite
     NFHolopadShipFlatpack: 4294967295 # Infinite
     # Salvage
-    SalvageTechfabNFFlatpack: 4294967295 # Infinite
+    #SalvageTechfabNFFlatpack: 4294967295 # Infinite
     OreProcessorFlatpack: 4294967295 # Infinite
     MaterialReclaimerFlatpack: 4294967295 # Infinite
     ScrapProcessorFlatpack: 4294967295 # Infinite
     ShuttleGunKineticFlatpack: 4294967295 # Infinite
     # Service
-    ServiceTechFabFlatpack: 4294967295 # Infinite
+    #ServiceTechFabFlatpack: 4294967295 # Infinite
     CutterMachineFlatpack: 4294967295 # Infinite
     ComputerWithdrawBankATMFlatpack: 4294967295 # Infinite
     TelevisionFlatpack: 4294967295 # Infinite
 #    UniformPrinterFlatpack: 6 # Loadouts are a thing
     # Engineering
-    EngineeringTechFabFlatpack: 4294967295 # Infinite
+    #EngineeringTechFabFlatpack: 4294967295 # Infinite
     MachineFlatpackerFlatpack: 4294967295 # Infinite
     ExosuitFabricatorFlatpack: 4294967295 # Infinite
     CircuitImprinterFlatpack: 4294967295 # Infinite

--- a/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/dungeon_items_engineering.yml
+++ b/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/dungeon_items_engineering.yml
@@ -239,7 +239,7 @@
     offset: 0.0
     rarePrototypes:
     - SuitStorageNTSRA
-#    - SuitStorageCE 
+#    - SuitStorageCE
     rareChance: 0.05
 
 - type: entity
@@ -308,7 +308,7 @@
     # Filled crates
     - CrateEngineeringKitShipyardRcd
     - CrateEngineeringKitRtg
-    - CrateEngineeringKitFabrication
+    #- CrateEngineeringKitFabrication
     - CrateEngineerChiefHardsuit
     rareChance: 0.01
 

--- a/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/dungeon_items_hydroponics.yml
+++ b/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/dungeon_items_hydroponics.yml
@@ -102,7 +102,7 @@
     chance: 0.9
     offset: 0.0
     rarePrototypes:
-    - CrateServiceKitHydroponics
+    #- CrateServiceKitHydroponics
     rareChance: 0.005
 
 - type: entity

--- a/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/dungeon_items_hydroponics.yml
+++ b/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/dungeon_items_hydroponics.yml
@@ -101,9 +101,9 @@
     - CrateHydroponicsSeedsMedicinal
     chance: 0.9
     offset: 0.0
-    rarePrototypes:
+    #rarePrototypes:
     #- CrateServiceKitHydroponics
-    rareChance: 0.005
+    #rareChance: 0.005
 
 - type: entity
   name: random crate (restock)

--- a/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/dungeon_items_kitchen.yml
+++ b/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/dungeon_items_kitchen.yml
@@ -227,10 +227,10 @@
     - CrateServiceKitCleanades
     chance: 0.9
     offset: 0.0
-    rarePrototypes:
+    #rarePrototypes:
     #- CrateServiceKitKitchen
     #- CrateServiceKitHydroponics
-    rareChance: 0.005
+    #rareChance: 0.005
 
 - type: entity
   name: random crate (restock)

--- a/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/dungeon_items_kitchen.yml
+++ b/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/dungeon_items_kitchen.yml
@@ -228,8 +228,8 @@
     chance: 0.9
     offset: 0.0
     rarePrototypes:
-    - CrateServiceKitKitchen
-    - CrateServiceKitHydroponics
+    #- CrateServiceKitKitchen
+    #- CrateServiceKitHydroponics
     rareChance: 0.005
 
 - type: entity

--- a/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/dungeon_items_medical.yml
+++ b/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/dungeon_items_medical.yml
@@ -575,9 +575,9 @@
     chance: 0.9
     offset: 0.0
     rarePrototypes:
-    - CrateServiceKitMedbay
-    - CrateServiceKitChemLab
-    - CrateServiceKitMedbayCryo
+    #- CrateServiceKitMedbay
+    #- CrateServiceKitChemLab
+    #- CrateServiceKitMedbayCryo
     - CrateEvaKitCmo
     rareChance: 0.01
 

--- a/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/dungeon_items_research.yml
+++ b/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/dungeon_items_research.yml
@@ -186,11 +186,11 @@
     # Filled crates
     - CrateEngineeringKitShipyardRcd
     - CrateEngineeringKitRtg
-    - CrateEngineeringKitFabrication
+    #- CrateEngineeringKitFabrication
     - CrateEngineerChiefHardsuit
-    - CrateServiceKitMedbay
-    - CrateServiceKitChemLab
-    - CrateServiceKitMedbayCryo
+    #- CrateServiceKitMedbay
+    #- CrateServiceKitChemLab
+    #- CrateServiceKitMedbayCryo
     - CrateEvaKitCmo
     rareChance: 0.01
 

--- a/Resources/Prototypes/_NF/Entities/Objects/Devices/flatpacks.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Devices/flatpacks.yml
@@ -190,6 +190,8 @@
   components:
   - type: Flatpack
     entity: ExosuitFabricator
+  - type: StaticPrice
+    price: 250
 
 - type: entity
   parent: BaseNFFlatpack
@@ -199,6 +201,8 @@
   components:
   - type: Flatpack
     entity: CircuitImprinter
+  - type: StaticPrice
+    price: 250
 
 - type: entity
   parent: BaseNFFlatpack

--- a/Resources/Prototypes/_NF/Entities/Objects/Devices/flatpacks.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Devices/flatpacks.yml
@@ -190,14 +190,9 @@
   components:
   - type: Flatpack
     entity: ExosuitFabricator
-  - type: StaticPrice
-    price: 250
-  - type: Sprite
-    layers:
-    - state: science_lathe
 
 - type: entity
-  parent: ExosuitFabricatorFlatpack
+  parent: BaseNFFlatpack
   id: CircuitImprinterFlatpack
   name: circuit imprinter flatpack
   description: A flatpack used for constructing a circuit imprinter.
@@ -206,16 +201,21 @@
     entity: CircuitImprinter
 
 - type: entity
-  parent: ExosuitFabricatorFlatpack
+  parent: BaseNFFlatpack
   id: ProtolatheFlatpack
   name: protolathe flatpack
   description: A flatpack used for constructing a protolathe.
   components:
   - type: Flatpack
     entity: Protolathe
+  - type: StaticPrice
+    price: 250
+  - type: Sprite
+    layers:
+    - state: science_lathe
 
 - type: entity
-  parent: ExosuitFabricatorFlatpack
+  parent: ProtolatheFlatpack
   id: MachineArtifactAnalyzerFlatpack
   name: artifact analyzer flatpack
   description: A flatpack used for constructing an artifact analyzer.
@@ -227,7 +227,7 @@
     - state: science_artifact_analyzer
 
 - type: entity
-  parent: ExosuitFabricatorFlatpack
+  parent: ProtolatheFlatpack
   id: MachineAnomalyVesselFlatpack
   name: anomaly vessel flatpack
   description: A flatpack used for constructing an anomaly vessel.
@@ -239,7 +239,7 @@
     - state: science_anomaly_vessel
 
 - type: entity
-  parent: ExosuitFabricatorFlatpack
+  parent: ProtolatheFlatpack
   id: MachineAPEFlatpack
   name: A.P.E. flatpack
   description: A flatpack used for constructing an A.P.E..
@@ -251,7 +251,7 @@
     - state: science_ape
 
 - type: entity
-  parent: ExosuitFabricatorFlatpack
+  parent: ProtolatheFlatpack
   id: MachineArtifactCrusherFlatpack
   name: artifact crusher flatpack
   description: A flatpack used for constructing an artifact crusher.
@@ -260,7 +260,7 @@
     entity: MachineArtifactCrusher
 
 - type: entity
-  parent: ExosuitFabricatorFlatpack
+  parent: ProtolatheFlatpack
   id: MachineAnomalyVesselExperimentalFlatpack
   name: experimental anomaly vessel flatpack
   description: A flatpack used for constructing an experimental anomaly vessel.
@@ -269,7 +269,7 @@
     entity: MachineAnomalyVesselExperimental
 
 - type: entity
-  parent: ExosuitFabricatorFlatpack
+  parent: ProtolatheFlatpack
   id: MachineAnomalyGeneratorFlatpack
   name: anomaly generator flatpack
   description: A flatpack used for constructing an anomaly generator.
@@ -278,7 +278,7 @@
     entity: MachineAnomalyGenerator
 
 - type: entity
-  parent: ExosuitFabricatorFlatpack
+  parent: ProtolatheFlatpack
   id: BlueprintLithographFlatpack
   name: blueprint lithograph flatpack
   description: A flatpack used for constructing a blueprint lithograph.
@@ -327,6 +327,9 @@
   components:
   - type: Flatpack
     entity: MaterialReclaimer
+  - type: Sprite
+    layers:
+    - state: supply_lathe
 
 - type: entity
   parent: UniformPrinterFlatpack

--- a/Resources/Prototypes/_NF/Entities/Objects/Devices/flatpacks.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Devices/flatpacks.yml
@@ -181,6 +181,15 @@
   - type: Flatpack
     entity: SmallThruster
 
+- type: entity
+  parent: BaseNFFlatpack
+  id: GravityGeneratorMiniFlatpack
+  name: mini gravity generator flatpack
+  description: A flatpack used for constructing a mini gravity generator.
+  components:
+  - type: Flatpack
+    entity: GravityGeneratorMini
+
 #region Science
 - type: entity
   parent: BaseNFFlatpack
@@ -648,6 +657,17 @@
   - type: Sprite
     layers:
     - state: supply_gun
+
+- type: entity
+  parent: BaseNFFlatpack
+  id: ComputerSolarControlFlatpack
+  name: solar control computer flatpack
+  description: A flatpack used for constructing a solar control computer.
+  components:
+  - type: Flatpack
+    entity: ComputerSolarControl
+  - type: StaticPrice
+    price: 150
 
 #region Servers
 - type: entity

--- a/Resources/Prototypes/_NF/Entities/Objects/Devices/flatpacks.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Devices/flatpacks.yml
@@ -171,6 +171,8 @@
   components:
   - type: Flatpack
     entity: SmallGyroscope
+  - type: StaticPrice
+    price: 55
 
 - type: entity
   parent: BaseNFFlatpack
@@ -180,6 +182,8 @@
   components:
   - type: Flatpack
     entity: SmallThruster
+  - type: StaticPrice
+    price: 55
 
 - type: entity
   parent: BaseNFFlatpack

--- a/Resources/Prototypes/_NF/Recipes/Lathes/electronics.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/electronics.yml
@@ -94,6 +94,12 @@
     Steel: 800
     Glass: 900
 
+# region Consoles
+- type: latheRecipe
+  id: ResearchComputerCircuitboard
+  parent: [BaseGoldCircuitboardRecipe, BaseResearchComputerRecipeCategory]
+  result: ResearchComputerCircuitboard
+
 # region Thrusters
 - type: latheRecipe
   id: ThrusterSecurityMachineCircuitboard


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- Commented out kitchen, chemical, medical, science, and engineering flatpack kits from expedition loot tables;
- Removed science consoles from flatpack vendomat;
- Removed salvage, engineering and service techfabs;
- Added artifact analyzer pad flatpack to vendomat;
- Added thrusters, gyros, generators, solar, freezer, heater and grounding rods to vendomat;
- Slightly rearranged order of items in flatpack vendomat.
- Added R&D computer board to Basic Xenoarch Research.

## Why / Balance
The problem with the wide availability of science kits stems from science being a superdepartment (which is a separate issue) that allows a player to obtain every machine and technology upgrade other departments have to offer, and the kit itself allows a player to bypass at least 2 intended game loops: seeking out scientists to buy stuff from them and seeking out food shuttles to buy food from them (because you can unlock kitchen/botany machines).

Reasoning behind only partial removal of SciKit from vendomat:
- Analyzer was added, because it tends to disappear after explosions;
- Blueprint lithograph was kept, because it's not mapped on some of the shuttles;
- Circuit imprinter was kept, because imo it's more of an engineering fab than a science fab;
- Exosuit fabricator was kept, because imo it's more of an engineering fab than a science fab;
- R&D Server was kept, so scientists could fill it and sell it;
- R&D computer consoles were removed so the remaining science machines couldn't be used for setting up a functioning science lab on non-science shuttles.

## Technical details
yml

## How to test
1. Peruse the FlatpackVend menu.

## Media
![image](https://github.com/user-attachments/assets/dac93201-de6c-4c18-bf41-0c802dcff0b7) 
![image](https://github.com/user-attachments/assets/df9b3caf-c782-44f5-9ebd-c93370286526)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [x] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:
- add: Added artifact analyzer pad, thrusters, gyros, generators, solar, freezer, heater and grounding rods flatpacks to vendomat.
- tweak: R&D computer board can be unlocked (included in "Basic Xenoarcheology" tech) and printed.
- remove: Removed science consoles, salvage, engineering and service techfabs from flatpack vendomat.
