### PR TITLE
Fix wield vs. fire mode ordering for energy guns

### DIFF
--- a/Content.Server/_DV/Weapons/Ranged/Systems/EnergyGunSystem.cs
+++ b/Content.Server/_DV/Weapons/Ranged/Systems/EnergyGunSystem.cs
@@ -25,7 +25,7 @@ public sealed class EnergyGunSystem : EntitySystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<EnergyGunComponent, UseInHandEvent>(OnInteractHandEvent, after: [typeof(SharedGunSystem)]); // Frontier: add after
+        SubscribeLocalEvent<EnergyGunComponent, UseInHandEvent>(OnInteractHandEvent, after: [typeof(SharedGunSystem)]); // Frontier: add after, swap to UseInHandEvent
         SubscribeLocalEvent<EnergyGunComponent, GetVerbsEvent<Verb>>(OnGetVerb);
         SubscribeLocalEvent<EnergyGunComponent, ExaminedEvent>(OnExamined);
     }

--- a/Content.Server/_DV/Weapons/Ranged/Systems/EnergyGunSystem.cs
+++ b/Content.Server/_DV/Weapons/Ranged/Systems/EnergyGunSystem.cs
@@ -84,7 +84,7 @@ public sealed class EnergyGunSystem : EntitySystem
         }
     }
 
-    private void OnInteractHandEvent(EntityUid uid, EnergyGunComponent component, UseInHandEvent args)
+    private void OnInteractHandEvent(EntityUid uid, EnergyGunComponent component, UseInHandEvent args) // Frontier: swap args to UseInHandEvent
     {
         if (args.Handled) // Frontier
             return; // Frontier

--- a/Content.Server/_DV/Weapons/Ranged/Systems/EnergyGunSystem.cs
+++ b/Content.Server/_DV/Weapons/Ranged/Systems/EnergyGunSystem.cs
@@ -2,13 +2,15 @@ using Content.Server.Popups;
 using Content.Server._DV.Weapons.Ranged.Components;
 using Content.Shared.Database;
 using Content.Shared.Examine;
-using Content.Shared.Interaction;
+// using Content.Shared.Interaction; // Frontier
 using Content.Shared.Verbs;
 using Content.Shared.Item;
 using Content.Shared._DV.Weapons.Ranged;
 using Content.Shared.Weapons.Ranged.Components;
 using Robust.Shared.Prototypes;
 using System.Linq;
+using Content.Shared.Interaction.Events; // Frontier
+using Content.Shared.Weapons.Ranged.Systems; // Frontier
 
 namespace Content.Server._DV.Weapons.Ranged.Systems;
 
@@ -23,7 +25,7 @@ public sealed class EnergyGunSystem : EntitySystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<EnergyGunComponent, ActivateInWorldEvent>(OnInteractHandEvent);
+        SubscribeLocalEvent<EnergyGunComponent, UseInHandEvent>(OnInteractHandEvent, after: [typeof(SharedGunSystem)]); // Frontier: add after
         SubscribeLocalEvent<EnergyGunComponent, GetVerbsEvent<Verb>>(OnGetVerb);
         SubscribeLocalEvent<EnergyGunComponent, ExaminedEvent>(OnExamined);
     }
@@ -82,8 +84,11 @@ public sealed class EnergyGunSystem : EntitySystem
         }
     }
 
-    private void OnInteractHandEvent(EntityUid uid, EnergyGunComponent component, ActivateInWorldEvent args)
+    private void OnInteractHandEvent(EntityUid uid, EnergyGunComponent component, UseInHandEvent args)
     {
+        if (args.Handled) // Frontier
+            return; // Frontier
+
         if (component.FireModes == null || component.FireModes.Count < 2)
             return;
 

--- a/Content.Shared/Weapons/Ranged/Systems/BatteryWeaponFireModesSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/BatteryWeaponFireModesSystem.cs
@@ -82,6 +82,11 @@ public sealed class BatteryWeaponFireModesSystem : EntitySystem
 
     private void OnUseInHandEvent(EntityUid uid, BatteryWeaponFireModesComponent component, UseInHandEvent args)
     {
+        // Frontier: check handled
+        if (args.Handled)
+            return;
+        // End Frontier
+
         TryCycleFireMode(uid, component, args.User);
     }
 

--- a/Content.Shared/Weapons/Ranged/Systems/BatteryWeaponFireModesSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/BatteryWeaponFireModesSystem.cs
@@ -82,10 +82,8 @@ public sealed class BatteryWeaponFireModesSystem : EntitySystem
 
     private void OnUseInHandEvent(EntityUid uid, BatteryWeaponFireModesComponent component, UseInHandEvent args)
     {
-        // Frontier: check handled
-        if (args.Handled)
-            return;
-        // End Frontier
+        if (args.Handled) // Frontier
+            return; // Frontier
 
         TryCycleFireMode(uid, component, args.User);
     }

--- a/Content.Shared/Wieldable/SharedWieldableSystem.cs
+++ b/Content.Shared/Wieldable/SharedWieldableSystem.cs
@@ -44,7 +44,7 @@ public abstract class SharedWieldableSystem : EntitySystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<WieldableComponent, UseInHandEvent>(OnUseInHand, before: [typeof(SharedGunSystem)]);
+        SubscribeLocalEvent<WieldableComponent, UseInHandEvent>(OnUseInHand, before: [typeof(SharedGunSystem), typeof(BatteryWeaponFireModesSystem)]); // Frontier: add BatteryWeaponFireModesSystem
         SubscribeLocalEvent<WieldableComponent, ItemUnwieldedEvent>(OnItemUnwielded);
         SubscribeLocalEvent<WieldableComponent, GotUnequippedHandEvent>(OnItemLeaveHand);
         SubscribeLocalEvent<WieldableComponent, VirtualItemDeletedEvent>(OnVirtualItemDeleted);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Ensures that wieldable energy guns with fire modes wield first, then toggle fire modes, and not both at the same time.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Annoying to use otherwise.

## Technical details
<!-- Summary of code changes for easier review. -->

Uses the Handled field in the UseInHandEvent.

Swaps EnergyGunSystem to use UseInHandEvent for consistency with other gun systems (prevents using the fire mode toggle when not holding it)

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->

1. Spawn energy submachine gun.
2. Pick it up.  Press Z, it should wield and not toggle fire modes.  Press Z, it should toggle fire modes (and break the visuals, this is expected, sadly)
3. Spawn laser carbine.
4. Pick it up.  Press Z, it should wield and not toggle fire modes.  Press Z, it should toggle fire modes.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
not sure the gun refactor has hit the live server, if not, no real point