### PR TITLE
Remove contraband inventory from ChefVend

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chefvend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chefvend.yml
@@ -15,7 +15,7 @@
     FoodCondimentBottleKetchup: 2
     FoodCondimentBottleBBQ: 2
     FoodCondimentBottleVinegar: 5  # Frontier 2<5
-    FoodCondimentBottleSoysauce: 5 # Frontier    
+    FoodCondimentBottleSoysauce: 5 # Frontier
 #    ReagentContainerOliveoil: 2 # Frontier - Replaced with OilJarOlive
     ReagentContainerMayo: 2
     OilJarOlive: 1 # Frontier
@@ -32,9 +32,9 @@
     FoodButter: 3
     FoodCheese: 2 # Frontier: 1<2
     FoodMeat: 6
-  contrabandInventory:
-    EggBoxBroken: 1
-    FoodBoxDonkpocket: 1
-    FoodFrozenSandwich: 2
-    FoodFrozenSandwichStrawberry: 2
+  #contrabandInventory: # Frontier - no finished foods in ChefVend
+    #EggBoxBroken: 1 # Frontier
+    #FoodBoxDonkpocket: 1 # Frontier
+    #FoodFrozenSandwich: 2 # Frontier
+    #FoodFrozenSandwichStrawberry: 2 # Frontier
 


### PR DESCRIPTION
## About the PR
Removes `contrabandInventory` from the ChefVend.

## Why / Balance
The contraband inventory includes ice cream sandwiches and donk pockets, and we don't want finished foods in the vending machine. It also contains a box of broken eggs, for some reason, which we don't want people wasting spesos on.

This does remove the only source of ice cream sandwiches, but oh well!

## Technical details
YAML, innit.

## How to test
1. Get yourself a ChefVend
2. Cut the MNGR wire.
3. Behold, no extra stuff.

## Media
N/A

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [ ] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.

## Breaking changes

**Changelog**
:cl:
- fix: Ice cream sandwiches and donk pockets are no longer available in the ChefVend when hacked.