### PR TITLE
Medical Dispatch's disposals tweak

### DIFF
--- a/Resources/Maps/_NF/POI/medical.yml
+++ b/Resources/Maps/_NF/POI/medical.yml
@@ -1,11 +1,11 @@
 meta:
   format: 7
   category: Grid
-  engineVersion: 247.2.0
+  engineVersion: 251.0.0
   forkId: ""
   forkVersion: ""
-  time: 03/22/2025 00:03:32
-  entityCount: 1768
+  time: 05/21/2025 05:29:18
+  entityCount: 1772
 maps: []
 grids:
 - 1
@@ -1815,7 +1815,6 @@ entities:
     - type: DeviceList
       devices:
       - 1222
-      - 1246
       - 1254
       - 1086
       - 1087
@@ -1870,7 +1869,6 @@ entities:
       - 983
       - 1096
       - 917
-      - 1118
       - 1119
       - 1071
       - 956
@@ -4965,6 +4963,12 @@ entities:
       rot: 3.141592653589793 rad
       pos: 2.5,-6.5
       parent: 1
+  - uid: 1118
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-14.5
+      parent: 1
 - proto: DisposalJunctionFlipped
   entities:
   - uid: 415
@@ -4978,6 +4982,12 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,12.5
+      parent: 1
+  - uid: 1205
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,9.5
       parent: 1
 - proto: DisposalPipe
   entities:
@@ -5016,6 +5026,18 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,8.5
+      parent: 1
+  - uid: 1149
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-14.5
+      parent: 1
+  - uid: 1255
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,9.5
       parent: 1
   - uid: 1514
     components:
@@ -5082,12 +5104,6 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-12.5
-      parent: 1
-  - uid: 1526
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 2.5,-14.5
       parent: 1
   - uid: 1527
     components:
@@ -5193,12 +5209,6 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,8.5
-      parent: 1
-  - uid: 1565
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 2.5,9.5
       parent: 1
   - uid: 1566
     components:
@@ -5350,6 +5360,12 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 9.5,-13.5
       parent: 1
+  - uid: 1246
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-14.5
+      parent: 1
   - uid: 1337
     components:
     - type: Transform
@@ -5361,6 +5377,12 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,17.5
+      parent: 1
+  - uid: 1565
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,9.5
       parent: 1
   - uid: 1670
     components:
@@ -5384,6 +5406,16 @@ entities:
     components:
     - type: Transform
       pos: -1.5,-5.5
+      parent: 1
+  - uid: 1769
+    components:
+    - type: Transform
+      pos: 4.5,-14.5
+      parent: 1
+  - uid: 1770
+    components:
+    - type: Transform
+      pos: 0.5,9.5
       parent: 1
 - proto: DresserChiefMedicalOfficerFilled
   entities:
@@ -6185,13 +6217,6 @@ entities:
     components:
     - type: Transform
       pos: 2.5,-2.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1205
-    components:
-    - type: Transform
-      pos: 2.5,9.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -7588,13 +7613,6 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1149
-    components:
-    - type: Transform
-      pos: 4.5,-15.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
   - uid: 1150
     components:
     - type: Transform
@@ -8108,14 +8126,6 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1255
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,9.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
   - uid: 1256
     components:
     - type: Transform
@@ -8322,6 +8332,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
+  - uid: 1526
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-16.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
 - proto: GasPipeTJunction
   entities:
   - uid: 687
@@ -8443,8 +8461,8 @@ entities:
   - uid: 1125
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 4.5,-16.5
+      rot: 1.5707963267948966 rad
+      pos: 2.5,9.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -9012,16 +9030,6 @@ entities:
       - 850
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1118
-    components:
-    - type: Transform
-      pos: 4.5,-14.5
-      parent: 1
-    - type: DeviceNetwork
-      deviceLists:
-      - 850
-    - type: AtmosPipeColor
-      color: '#990000FF'
   - uid: 1119
     components:
     - type: Transform
@@ -9159,17 +9167,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,18.5
-      parent: 1
-    - type: DeviceNetwork
-      deviceLists:
-      - 849
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1246
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 0.5,9.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
@@ -10043,6 +10040,14 @@ entities:
       rot: 3.141592653589793 rad
       pos: 11.698324,-6.049472
       parent: 1
+- proto: PosterLegitSafetyMothPills
+  entities:
+  - uid: 1672
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,8.5
+      parent: 1
 - proto: PosterLegitSafetyMothPiping
   entities:
   - uid: 1664
@@ -10050,14 +10055,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,8.5
-      parent: 1
-- proto: PosterLegitSMPills
-  entities:
-  - uid: 1672
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -1.5,8.5
       parent: 1
 - proto: PosterLegitWorkForAFuture
   entities:
@@ -10204,16 +10201,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 6.5,-23.5
       parent: 1
-- proto: PoweredlightUltraviolet
-  entities:
-  - uid: 1607
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -1.5,-8.5
-      parent: 1
-    - type: PoweredLight
-      on: False
 - proto: PoweredlightBlue
   entities:
   - uid: 902
@@ -10338,6 +10325,16 @@ entities:
     - type: Transform
       pos: 8.5,3.5
       parent: 1
+- proto: PoweredlightUltraviolet
+  entities:
+  - uid: 1607
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-8.5
+      parent: 1
+    - type: PoweredLight
+      on: False
 - proto: PoweredSmallLight
   entities:
   - uid: 134
@@ -13508,6 +13505,18 @@ entities:
     components:
     - type: Transform
       pos: 11.5,-6.5
+      parent: 1
+- proto: WindoorSecure
+  entities:
+  - uid: 1771
+    components:
+    - type: Transform
+      pos: 9.5,6.5
+      parent: 1
+  - uid: 1772
+    components:
+    - type: Transform
+      pos: 8.5,6.5
       parent: 1
 - proto: WindowReinforcedDirectional
   entities:


### PR DESCRIPTION
## About the PR
Super simple stuff. 
- Removes one air scrubber in the upper and lower lobbies and replaces it with a disposals chute.
- Places a secure windoor in front of the MD reclaimer's conveyor belt, preventing items from bouncing off the back wall and missing the conveyor.

## Why / Balance
Less trash on MD makes everyone happy!

## How to test
Load up MD, dispose of nearby trash in one of the new receptacles, watch it enter the janitor's room and land perfectly on the conveyor.

## Media
![image](https://github.com/user-attachments/assets/fe3596e2-c37a-443d-9e2f-b0a95927bcd6)
![image](https://github.com/user-attachments/assets/5c29706a-4ba3-49b3-8868-d701b1b51df3)
![image](https://github.com/user-attachments/assets/ca13c22a-7993-4d22-9b8c-a3d855160371)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I confirm that AI tools were not used in generating the material in this PR.

**Changelog**
:cl:
- tweak: Added extra disposals and a trash-catching door to Medical Dispatch
