### PR TITLE
Increase auto-recharge rate for advanced laser pistol

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Battery/battery_pistols.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Battery/battery_pistols.yml
@@ -94,6 +94,9 @@
   - type: Battery # 26 shots
     maxCharge: 1560
     startingCharge: 1560
+  - type: BatterySelfRecharger # Recharges 1 shot per 3 seconds
+    autoRecharge: true
+    autoRechargeRate: 20
 
 # Frontier
 - type: entity


### PR DESCRIPTION
## About the PR
The title says it all, right? :)

## Why / Balance
This appears to have been missed in the mega gun rebalance PR. Upstream's advanced laser pistol recharges at 30 W, slower than the antique laser pistol's 40 W. Our rebalance antique laser pistol recharges at 30 W, so I made the advanced 20 W.

Without this change, it inherits from something else, which defaults it to a paaaaaainful 3 W.

## Technical details
YAML.

## How to test
1. Spawn an advanced laser pistol
2. pew pew
3. Behold the less painful recharge rate.

## Media
N/A

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [ ] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.

## Breaking changes
No.

**Changelog**
N/A, it's a fix for something that hasn't even been deployed yet.