### PR TITLE
Update EVA Suits Lockers

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
@@ -55,8 +55,8 @@
   - type: StorageFill
     contents:
 #        - id: OxygenTankFilled # Frontier
-        - id: NFTankO2N2EqualFilled # Frontier # Frontier
-        - id: ClothingOuterHardsuitEVAPrisoner
+        - id: NFTankO2N2EqualFilled # Frontier
+        - id: ClothingOuterEVASuitPrisoner # Frontier ClothingOuterHardsuitEVAPrisoner<ClothingOuterEVASuitPrisoner
         - id: ClothingHeadHelmetEVALarge
         - id: ClothingMaskBreath
 
@@ -87,7 +87,7 @@
 #        - id: NitrogenTankFilled
 #        - id: OxygenTankFilled
         - id: NFTankO2N2EqualFilled # Frontier
-        - id: ClothingOuterHardsuitPirateEVA
+        - id: ClothingOuterEVASuitPirate # Frontier ClothingOuterHardsuitPirateEVA<ClothingOuterEVASuitPirate
         - id: ClothingMaskGas
         - id: JetpackBlackFilled # Frontier
         - id: ClothingShoesBootsMagPirateFilled # Frontier

--- a/Resources/Prototypes/_NF/Catalog/pirate_uplink_catalog.yml
+++ b/Resources/Prototypes/_NF/Catalog/pirate_uplink_catalog.yml
@@ -2,7 +2,7 @@
   id: UplinkPirateHardsuit
   name:  uplink-pirate-hardsuit-name
   description: uplink-pirate-hardsuit-desc
-  productEntity: ClothingOuterHardsuitPirateEVA
+  productEntity: ClothingOuterEVASuitPirate
   icon: { sprite: Clothing/OuterClothing/Hardsuits/pirateeva.rsi, state: icon }
   cost:
     Doubloon: 2

--- a/Resources/Prototypes/_NF/Recipes/Lathes/Packs/Deprecated/nfsd_techfab.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/Packs/Deprecated/nfsd_techfab.yml
@@ -20,7 +20,7 @@
   - SmallThrusterMachineCircuitboard
   - GyroscopeNfsdMachineCircuitboard
   - SmallGyroscopeNfsdMachineCircuitboard
-  - ClothingOuterHardsuitEVAPrisoner
+  - ClothingOuterEVASuitPrisoner
   - NFWeaponEnergyPistolDisabler
   - ContrabandAppraisalTool
   - HoloprojectorNfsd

--- a/Resources/Prototypes/_NF/Recipes/Lathes/clothing-eva.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/clothing-eva.yml
@@ -77,6 +77,16 @@
   parent: NFBaseEVASuitRecipe
   result: ClothingOuterEVASuitMailman
 
+- type: latheRecipe
+  id: ClothingOuterEVASuitPrisoner
+  parent: NFBaseEVASuitRecipe
+  result: ClothingOuterEVASuitPrisoner
+
+- type: latheRecipe # EMAG
+  id: ClothingOuterEVASuitPirate
+  parent: NFBaseEVASuitRecipe
+  result: ClothingOuterEVASuitPirate
+
 # - type: latheRecipe
   # id: ClothingOuterHardsuitEVA
   # parent: NFBaseEVASuitRecipe
@@ -92,11 +102,6 @@
     Cloth: 300
     Durathread: 2500
     Silver: 1000
-
-- type: latheRecipe
-  id: ClothingOuterHardsuitEVAPrisoner
-  parent: NFBaseEVASuitRecipe
-  result: ClothingOuterHardsuitEVAPrisoner
 
 - type: latheRecipe # Probably should be available via T2-T3
   id: ClothingOuterHardsuitAncientEVA
@@ -283,11 +288,6 @@
   id: ClothingOuterHardsuitMime
   parent: NFBaseHardSuitRecipe
   result: ClothingOuterHardsuitMime
-
-- type: latheRecipe # EMAG (honestly, not particularly good stats on this one)
-  id: ClothingOuterEVASuitPirate
-  parent: NFBaseHardSuitRecipe
-  result: ClothingOuterEVASuitPirate
 
 - type: latheRecipe
   id: ClothingOuterHardsuitPilot

--- a/Resources/Prototypes/_NF/Recipes/Lathes/clothing-eva.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/clothing-eva.yml
@@ -285,9 +285,9 @@
   result: ClothingOuterHardsuitMime
 
 - type: latheRecipe # EMAG (honestly, not particularly good stats on this one)
-  id: ClothingOuterHardsuitPirateEVA
+  id: ClothingOuterEVASuitPirate
   parent: NFBaseHardSuitRecipe
-  result: ClothingOuterHardsuitPirateEVA
+  result: ClothingOuterEVASuitPirate
 
 - type: latheRecipe
   id: ClothingOuterHardsuitPilot


### PR DESCRIPTION
## About the PR
Swap the Pirate and Prisoners suits to frontier EVA

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
:cl:
- tweak: Prisoner and pirate EVA suit lockers now contain Frontier EVA suits.