### PR TITLE
Restore EVA softsuit 5% speed penalty

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/softsuits.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/softsuits.yml
@@ -7,6 +7,9 @@
   - ClothingOuterHardsuitBase
   id: NFClothingOuterEVASuitBase
   components:
+  - type: ClothingSpeedModifier
+    walkModifier: 0.95
+    sprintModifier: 0.95
   - type: Item
     shape:
     - 0,0,3,2


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Restored 5% speed penalty.

## Why / Balance
Unintended change

## Technical details
yml

## How to test
1. Get an EVA suit, examine, note the speed penalty

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [x] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:
- fix: Restore EVA softsuit 5% speed penalty.
