### PR TITLE
Fix silo/turret machine part reqs, add machine part test

### DIFF
--- a/Content.IntegrationTests/Tests/MachineBoardTest.cs
+++ b/Content.IntegrationTests/Tests/MachineBoardTest.cs
@@ -141,7 +141,7 @@ public sealed class MachineBoardTest
         await pair.CleanReturnAsync();
     }
 
-    // Frontier: 
+    // Frontier: machine part tests
     /// <summary>
     /// Invalid stack types for MachineBoard components, should be listed as requirements.
     /// </summary>
@@ -241,4 +241,5 @@ public sealed class MachineBoardTest
 
         await pair.CleanReturnAsync();
     }
+    // End Frontier: machine part tests
 }

--- a/Content.IntegrationTests/Tests/MachineBoardTest.cs
+++ b/Content.IntegrationTests/Tests/MachineBoardTest.cs
@@ -2,10 +2,9 @@ using System.Collections.Generic;
 using System.Linq;
 using Content.Server.Construction.Components;
 using Content.Shared.Construction.Components;
-using Content.Shared.Construction.Prototypes;
-using Content.Shared.Stacks;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Prototypes;
+using Content.Shared.Construction.Prototypes; // Frontier
 
 namespace Content.IntegrationTests.Tests;
 
@@ -166,10 +165,10 @@ public sealed class MachineBoardTest
     };
 
     /// <summary>
-    /// Check machine requirements for stacks that are machine upgrades.
+    /// Check machine requirements for miscategorized machine part requirements.
     /// </summary>
     [Test]
-    public async Task TestValidateBoardStackRequirements()
+    public async Task TestValidateBoardMachinePartRequirements()
     {
         await using var pair = await PoolManager.GetServerClient();
         var server = pair.Server;
@@ -223,7 +222,7 @@ public sealed class MachineBoardTest
                     {
                         if (_invalidTags.Contains(tagReq))
                         {
-                            Assert.Fail($"Entity {p.ID} has a tagRequirement for {tagReq}, which should be listed into a machine part requirement.");
+                            Assert.Fail($"Entity {p.ID} has a tagRequirement for {tagReq}, which should be converted into a machine part requirement.");
                             continue;
                         }
                     }

--- a/Content.IntegrationTests/Tests/MachineBoardTest.cs
+++ b/Content.IntegrationTests/Tests/MachineBoardTest.cs
@@ -2,6 +2,8 @@ using System.Collections.Generic;
 using System.Linq;
 using Content.Server.Construction.Components;
 using Content.Shared.Construction.Components;
+using Content.Shared.Construction.Prototypes;
+using Content.Shared.Stacks;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Prototypes;
 
@@ -135,6 +137,107 @@ public sealed class MachineBoardTest
                     }
                 });
             }
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    // Frontier: 
+    /// <summary>
+    /// Invalid stack types for MachineBoard components, should be listed as requirements.
+    /// </summary>
+    private readonly HashSet<string> _invalidStackTypes = new()
+    {
+    };
+
+    /// <summary>
+    /// Invalid tags for MachineBoard components, should be listed as requirements.
+    /// </summary>
+    private readonly HashSet<string> _invalidTags = new()
+    {
+    };
+
+    /// <summary>
+    /// Invalid components for MachineBoard components, should be listed as requirements.
+    /// </summary>
+    private readonly HashSet<string> _invalidComponents = new()
+    {
+        "PowerCell"
+    };
+
+    /// <summary>
+    /// Check machine requirements for stacks that are machine upgrades.
+    /// </summary>
+    [Test]
+    public async Task TestValidateBoardStackRequirements()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var protoMan = server.ResolveDependency<IPrototypeManager>();
+        var compFact = server.ResolveDependency<IComponentFactory>();
+
+        await server.WaitAssertion(() =>
+        {
+            HashSet<EntProtoId> machinePartEntities = new();
+            foreach (var p in protoMan.EnumeratePrototypes<MachinePartPrototype>()
+                                .Where(p => !pair.IsTestPrototype(p))
+                                .Where(p => !_ignoredPrototypes.Contains(p.ID)))
+            {
+                machinePartEntities.Add(p.StockPartPrototype);
+            }
+
+            Assert.Multiple(() =>
+            {
+                foreach (var p in protoMan.EnumeratePrototypes<EntityPrototype>()
+                            .Where(p => !p.Abstract)
+                            .Where(p => !pair.IsTestPrototype(p))
+                            .Where(p => !_ignoredPrototypes.Contains(p.ID)))
+                {
+                    if (!p.TryGetComponent<MachineBoardComponent>(out var mbc, compFact))
+                        continue;
+
+                    foreach (var stackReq in mbc.StackRequirements.Keys)
+                    {
+                        if (_invalidStackTypes.Contains(stackReq))
+                        {
+                            Assert.Fail($"Entity {p.ID} has a stackRequirement for {stackReq}, which should be converted into a machine part requirement.");
+                            continue;
+                        }
+
+                        if (!protoMan.TryIndex(stackReq, out var stack))
+                        {
+                            Assert.Fail($"Entity {p.ID} has a stackRequirement for {stackReq}, which could not be resolved.");
+                            continue;
+                        }
+
+                        if (machinePartEntities.Contains(stack.Spawn))
+                        {
+                            Assert.Fail($"Entity {p.ID} has a stackRequirement for {stackReq}, which is a machine part, and should be in requirements.");
+                            continue;
+                        }
+                    }
+
+                    foreach (var tagReq in mbc.TagRequirements.Keys)
+                    {
+                        if (_invalidTags.Contains(tagReq))
+                        {
+                            Assert.Fail($"Entity {p.ID} has a tagRequirement for {tagReq}, which should be listed into a machine part requirement.");
+                            continue;
+                        }
+                    }
+
+                    foreach (var compReq in mbc.ComponentRequirements.Keys)
+                    {
+                        if (_invalidComponents.Contains(compReq))
+                        {
+                            Assert.Fail($"Entity {p.ID} has a componentRequirement for {compReq}, which should be converted into a machine part requirement.");
+                            continue;
+                        }
+                    }
+                }
+            });
         });
 
         await pair.CleanReturnAsync();

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -1057,8 +1057,9 @@
     state: supply
   - type: MachineBoard
     prototype: MachineMaterialSilo
+    requirements: # Frontier
+      MatterBin: 4 # Frontier: stackRequirements<requirements
     stackRequirements:
-      MatterBin: 4
       Cable: 1
 
 - type: entity
@@ -1296,8 +1297,9 @@
     state: supply
   - type: MachineBoard
     prototype: CargoMailTeleporter
+    requirements: # Frontier
+      Capacitor: 2 # Frontier: stackRequirements<requirements
     stackRequirements:
-      Capacitor: 2
       Steel: 5
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/turrets.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/turrets.yml
@@ -17,7 +17,7 @@
       ProximitySensor:
         amount: 1
         defaultPrototype: ProximitySensor
-    componentRequirements:
+    requirements: # Frontier: componentRequirements<requirements
       PowerCell:
         amount: 1
         defaultPrototype: PowerCellMedium


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Fix ore silo & sentry turret machine part requirements, add a machine part test.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

reqs: Bug.

test: Fewer future bugs.

## Technical details
<!-- Summary of code changes for easier review. -->

Threw the test in the existing MachineBoardTests - not a huge deal, could move it to _NF tests if needed, but it's marked as ours.

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->

You can edit the existing requirements back out to stackRequirements on a machine board with capacitor/matter bin/manipulator reqs and it'll fail.

Here was the output of a test that failed: https://github.com/whatston3/frontier-station-14/actions/runs/15256921701/job/42906667488?pr=22

```
  Failed TestValidateBoardStackRequirements [43 ms]
  Error Message:
   Multiple failures or warnings in test:
  1) Entity MailTeleporterMachineCircuitboard has a stackRequirement for Capacitor, which is a machine part, and should be in requirements.
  2) Entity WeaponEnergyTurretStationMachineCircuitboard has a componentRequirement for PowerCell, which should be converted into a machine part requirement.
  3) Entity WeaponEnergyTurretAIMachineCircuitboard has a componentRequirement for PowerCell, which should be converted into a machine part requirement.
  4) Entity MaterialSiloMachineCircuitboard has a stackRequirement for MatterBin, which is a machine part, and should be in requirements.
```

Test printouts have changed slightly, but all entities will be checked for failure at once.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Material silos should now be constructible.