### PR TITLE
Science rebalance

### DIFF
--- a/Content.Client/Xenoarchaeology/Ui/AnalysisConsoleMenu.xaml.cs
+++ b/Content.Client/Xenoarchaeology/Ui/AnalysisConsoleMenu.xaml.cs
@@ -243,7 +243,7 @@ public sealed partial class AnalysisConsoleMenu : FancyWindow
         }
 
         ClassValueLabel.SetMarkup(Loc.GetString("analysis-console-info-class-value",
-            ("class", Loc.GetString($"artifact-node-class-{Math.Min(6, predecessorNodes.Count + 1)}"))));
+            ("class", Loc.GetString($"artifact-node-nf-class-{Math.Min(8, predecessorNodes.Count + 1)}")))); // Frontier: add nf-, 6<8
     }
 }
 

--- a/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.Node.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.Node.cs
@@ -404,14 +404,11 @@ public abstract partial class SharedXenoArtifactSystem
             : 1f + durabilityEffect;
 
         var predecessorNodes = GetPredecessorNodes((artifact, artifact), node);
-        nodeComponent.ResearchValue = (int)(Math.Pow(1.25, Math.Pow(predecessorNodes.Count, 1.5f)) * nodeComponent.BasePointValue * durabilityMultiplier);
-        // Frontier: remove value from using artifexium
+        nodeComponent.ResearchValue = (int)(Math.Pow(1.4, Math.Pow(predecessorNodes.Count + 1, 1.2f)) * nodeComponent.BasePointValue * durabilityMultiplier); // Frontier: 
+        // Frontier: remove value from using artifexium, different value sets
         if (node.Comp.ArtifexiumUsed)
-        {
-            nodeComponent.ResearchValue -= 500;
-            nodeComponent.ResearchValue /= 2;
-        }
-        // End Frontier: remove value from using artifexium
+            nodeComponent.ResearchValue = (int)Math.Pow(nodeComponent.ResearchValue - 700, 0.9);
+        // End Frontier: remove value from using artifexium, different value sets
 
     }
 

--- a/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.Node.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.Node.cs
@@ -404,7 +404,7 @@ public abstract partial class SharedXenoArtifactSystem
             : 1f + durabilityEffect;
 
         var predecessorNodes = GetPredecessorNodes((artifact, artifact), node);
-        nodeComponent.ResearchValue = (int)(Math.Pow(1.4, Math.Pow(predecessorNodes.Count + 1, 1.2f)) * nodeComponent.BasePointValue * durabilityMultiplier); // Frontier: 
+        nodeComponent.ResearchValue = (int)(Math.Pow(1.4, Math.Pow(predecessorNodes.Count + 1, 1.2f)) * nodeComponent.BasePointValue * durabilityMultiplier); // Frontier: add one to count, 1.25<1.4, 1.5<1.2
         // Frontier: remove value from using artifexium, different value sets
         if (node.Comp.ArtifexiumUsed)
             nodeComponent.ResearchValue = (int)Math.Pow(nodeComponent.ResearchValue - 700, 0.9);

--- a/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.Unlock.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.Unlock.cs
@@ -74,10 +74,6 @@ public abstract partial class SharedXenoArtifactSystem
         SoundSpecifier? soundEffect;
         if (TryGetNodeFromUnlockState(ent, out var node))
         {
-            SetNodeUnlocked((ent, artifactComponent), node.Value);
-            ActivateNode((ent, ent), (node.Value, node.Value), null, null, Transform(ent).Coordinates, true); // Frontier: false<true
-            unlockAttemptResultMsg = "artifact-unlock-state-end-success";
-
             // Frontier: remove value if artifexium used
             if (ent.Comp1.ArtifexiumApplied)
             {
@@ -86,6 +82,10 @@ public abstract partial class SharedXenoArtifactSystem
                 Dirty(node.Value);
             }
             // End Frontier
+
+            SetNodeUnlocked((ent, artifactComponent), node.Value);
+            ActivateNode((ent, ent), (node.Value, node.Value), null, null, Transform(ent).Coordinates, true); // Frontier: false<true
+            unlockAttemptResultMsg = "artifact-unlock-state-end-success";
 
             // as an experiment - unlocking node doesn't activate it, activation is left for player to decide.
             // var activated = ActivateNode((ent, artifactComponent), node.Value, null, null, Transform(ent).Coordinates, false);

--- a/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.XAE.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.XAE.cs
@@ -130,6 +130,9 @@ public abstract partial class SharedXenoArtifactSystem
             AdjustNodeDurability((node, node.Comp), -1);
         }
 
+        if (node.Comp.ArtifexiumUsed) // Frontier
+            return true; // Frontier
+
         var ev = new XenoArtifactNodeActivatedEvent(artifact, node, user, target, coordinates);
         RaiseLocalEvent(node, ref ev);
         return true;

--- a/Resources/Locale/en-US/_NF/xenoarchaeology/artifact-component.ftl
+++ b/Resources/Locale/en-US/_NF/xenoarchaeology/artifact-component.ftl
@@ -1,4 +1,3 @@
-
 artifact-node-nf-class-1 = [color=#ff2bb1]Hylic[/color]
 artifact-node-nf-class-2 = [color=#ff8b2b]Psychic[/color]
 artifact-node-nf-class-3 = [color=#a9ff38]Noumenal[/color]

--- a/Resources/Locale/en-US/_NF/xenoarchaeology/artifact-component.ftl
+++ b/Resources/Locale/en-US/_NF/xenoarchaeology/artifact-component.ftl
@@ -1,0 +1,9 @@
+
+artifact-node-nf-class-1 = [color=#ff2bb1]Hylic[/color]
+artifact-node-nf-class-2 = [color=#ff8b2b]Psychic[/color]
+artifact-node-nf-class-3 = [color=#a9ff38]Noumenal[/color]
+artifact-node-nf-class-4 = [color=#2bfff8]Archon[/color]
+artifact-node-nf-class-5 = [color=#7883ff]Luminary[/color]
+artifact-node-nf-class-6 = [color=#be78ff]Demiurge[/color]
+artifact-node-nf-class-7 = [color=#ffda8a]Aeonic[/color]
+artifact-node-nf-class-8 = [color=#ffffff]Monadic[/color]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Rebalances science.  Nodes tend to give more points compared to what was.

Artifexium is now prevents artifact effects from triggering on unlocking a node, and changes a node's value more severely at higher nodes.

Added a few extra classes for higher nodes that can occasionally spawn.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Playtesting & feedback.

Artifexium: unlocking two nodes with the exact same triggers should not give more points the second time around compared to the first.  This also provides a safer way to activate nodes for those that want it, but at a reduced point income.

## Technical details
<!-- Summary of code changes for easier review. -->

A group of 40 artifacts was spawned, and each of their node counts was observed

| Trigger Count | Number of nodes | Average per Artifact |
| - | - | - |
| 1 | 163 | 4.08 |
| 2 | 97 | 2.42 |
| 3 | 97 | 2.42 |
| 4 | 53 | 1.33 |
| 5 | 28 | 0.70 |
| 6 | 13 | 0.33 |
| 7 | 10 | 0.25 |
| **Total** | **461** | **11.52** |

With these changes, the average number of available points goes from ~30.6k to ~48.4k.

Points per node change as follows:

| Trigger Count | New points | Old points | Relative Ratio |
| - | - | - | - |
| 1 | 1400 | 1000 | **1.4** |
| 2 | 2166 | 1250 | **1.73** |
| 3 | 3516 | 1879 | **1.87** |
| 4 | 5905 | 3188 | **1.85** |
| 5 | 10187 | 5960 | **1.71** |
| 6 | 17973 | 12119 | **1.48** |
| 7 | 32326 | 26563 | **1.22** |
| 8 | 59143 | 62344 | **0.95** |

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

![image](https://github.com/user-attachments/assets/dcd57011-2e7a-4ea4-b8c5-305fb148d134)

![image](https://github.com/user-attachments/assets/00b909c2-c002-435e-aa0c-e7b03b4395a6)

![image](https://github.com/user-attachments/assets/75f98837-1754-4b6a-a344-f968103faea3)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Artifacts now generally give more points per node.
- tweak: Artifexium unlocks a node, but does not trigger a node's effects.