### PR TITLE
Hostile NPC speed and stamina adjustment

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_base.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_base.yml
@@ -164,6 +164,7 @@
     - type: Strippable
     - type: UserInterface
 
+#region Despawn timers
 - type: entity
   abstract: true
   id: NFMobTimedDespawn30
@@ -219,7 +220,9 @@
   components:
   - type: TimedDespawn
     lifetime: 3000
+#endregion
 
+#region Movement
 - type: entity
   save: false
   id: MobEnhancedMovement
@@ -244,8 +247,9 @@
 #  - type: Access
 #    groups:
 #    - AllAccess
+#endregion
 
-# Dungeon boss
+#region Dungeon boss
 - type: entity
   id: MobHostileBossBase
   abstract: true
@@ -265,8 +269,9 @@
     - DoorBumpOpener
     - CannotSuicide
   - type: FTLKnockdownImmune
+#endregion
 
-# Inventories
+#region Inventories
 - type: entity # All slots are fillable, most of them are "hidden"
   save: false
   id: MobHumanoidInvetory
@@ -284,8 +289,9 @@
   - type: Inventory
     templateId: hostilehumanoidsimplified # Does not support loadouts
   - type: InventorySlots
+#endregion
 
-# AI packages
+#region AI packages
 - type: entity
   id: MobHumanoidHostileAISimpleMelee
   abstract: true
@@ -336,6 +342,7 @@
         true
 #      NavSmash: !type:Bool # They use this option too much for my liking, but I'll keep it here as an option
 #        true
+#endregion
 
 # Human NPC, uses equipment, immune to vacuum/low pressure
 - type: entity

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_base.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_base.yml
@@ -27,6 +27,17 @@
 
 - type: entity
   save: false
+  id: MobLaserReflect
+  abstract: true
+  components:
+  - type: Reflect
+    reflectProb: 0.8
+    reflects:
+      - Energy
+
+# region Regeneration
+- type: entity
+  save: false
   id: MobPassiveRegenWeak
   abstract: true
   components:
@@ -72,17 +83,9 @@
         Brute: -0.5
         Burn: -0.5
         Airloss: -1
+#endregion
 
-- type: entity
-  save: false
-  id: MobLaserReflect
-  abstract: true
-  components:
-  - type: Reflect
-    reflectProb: 0.8
-    reflects:
-      - Energy
-
+#region Restrictions
 - type: entity
   abstract: true
   id: NFMobRestrictions
@@ -163,6 +166,7 @@
     removeComponentsOnRevival:
     - type: Strippable
     - type: UserInterface
+#endregion
 
 #region Despawn timers
 - type: entity
@@ -244,9 +248,71 @@
     speedModifier: 1.5
     useSound:
       path: /Audio/Items/crowbar.ogg
-#  - type: Access
-#    groups:
-#    - AllAccess
+  - type: Access
+    groups:
+    - AllAccess
+
+- type: entity # For reference 4.5 is the speed of unencombered humans
+  save: false
+  id: MobMovementSpeedModifierMelee
+  abstract: true
+  components:
+  - type: MovementSpeedModifier
+    baseWalkSpeed : 4.5
+    baseSprintSpeed : 4.5
+
+- type: entity
+  save: false
+  id: MobMovementSpeedModifierRanged
+  abstract: true
+  components:
+  - type: MovementSpeedModifier
+    baseWalkSpeed : 3.5
+    baseSprintSpeed : 3.5
+
+- type: entity
+  save: false
+  id: MobMovementSpeedModifierSpecial
+  abstract: true
+  components:
+  - type: MovementSpeedModifier
+    baseWalkSpeed : 5
+    baseSprintSpeed : 5
+
+- type: entity
+  save: false
+  id: MobMovementSpeedModifierBoss
+  abstract: true
+  components:
+  - type: MovementSpeedModifier
+    baseWalkSpeed : 4.5
+    baseSprintSpeed : 4.5
+#endregion
+
+#region Stamina
+- type: entity
+  save: false
+  id: MobStaminaFodder
+  abstract: true
+  components:
+  - type: Stamina
+    critThreshold: 100
+
+- type: entity
+  save: false
+  id: MobStaminaSpecial
+  abstract: true
+  components:
+  - type: Stamina
+    critThreshold: 300
+
+- type: entity
+  save: false
+  id: MobStaminaBoss
+  abstract: true
+  components:
+  - type: Stamina
+    critThreshold: 500
 #endregion
 
 #region Dungeon boss
@@ -255,6 +321,8 @@
   abstract: true
   parent:
   - MobEnhancedMovement
+  - MobStaminaBoss
+  - MobMovementSpeedModifierBoss
   - MobPassiveRegenWeak
   - NFMobRestrictions
   components:
@@ -344,12 +412,15 @@
 #        true
 #endregion
 
+#region NPC types
 # Human NPC, uses equipment, immune to vacuum/low pressure
 - type: entity
   suffix: AI, Hostile
   abstract: true
   parent:
   - NFMobAtmos
+  - MobMovementSpeedModifierMelee
+  - MobStaminaFodder
   - MobBloodstream
   - MobFlammable
   - MobEnhancedMovement
@@ -369,8 +440,6 @@
       0: Alive
       80: Critical
       120: Dead
-  - type: Stamina
-    critThreshold: 100
   - type: SlowOnDamage
     speedModifierThresholds:
       40: 0.7
@@ -405,6 +474,8 @@
   abstract: true
   parent:
   - BaseMob
+  - MobMovementSpeedModifierMelee
+  - MobStaminaFodder
   - MobDamageable
   - MobCombat
   - NFMobAtmos
@@ -455,8 +526,6 @@
       0: Alive
       65: Critical
       100: Dead
-  - type: Stamina
-    critThreshold: 100
   - type: NpcFactionMember
     factions:
     - SimpleHostile
@@ -475,6 +544,8 @@
   abstract: true
   parent:
   - MobFlammable
+  - MobMovementSpeedModifierMelee
+  - MobStaminaFodder
   - MobEnhancedMovement
   - MobHumanoidHostileAISimpleMelee
   - BaseC3MobCreature
@@ -505,7 +576,9 @@
     - SimpleHostile
   - type: Carriable # Kept for consistency with other mobs
   - type: FTLKnockdownImmune
+#endregion
 
+#region Roadkill
 # Parent for consistent roadkill settings
 - type: entity
   abstract: true
@@ -516,3 +589,4 @@
     destroySpeed: 40 # yeehaw
     destroySound:
       collection: gib
+#endregion

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_bloodcultist.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_bloodcultist.yml
@@ -26,16 +26,15 @@
     deleteOrgans: true
     gib: false
     useArgumentEntity: true
-  - type: MovementSpeedModifier
-    baseWalkSpeed : 4.5
-    baseSprintSpeed : 4.5
 
-# Humans
+#region Humans
 # Blood Cult Priest, ranged mab, bolts deal 10 slash damage
 # Look for magic bolt here:\Resources\Prototypes\_NF\Entities\Objects\Weapons\Guns\Projectiles\magic.yml
 - type: entity
   name: blood cult priest
   parent:
+  - MobMovementSpeedModifierRanged
+  - MobStaminaFodder
   - MobBloodCultistBase
   - MobHumanoidHostileAISimpleRanged
   #- MobLaserReflect # Added to prevent laser abuse from players
@@ -72,6 +71,8 @@
 - type: entity
   name: blood cult janitor
   parent:
+  - MobMovementSpeedModifierRanged
+  - MobStaminaSpecial
   - MobBloodCultistBase
   - MobHumanoidHostileAISimpleRanged
   #- MobLaserReflect # Added to prevent laser abuse from players
@@ -84,8 +85,6 @@
   - type: Loadout
     prototypes:
     - BloodCultistJanitorGear
-  - type: Stamina
-    critThreshold: 500
   - type: BasicEntityAmmoProvider
     proto: ShellSoapConjuredBloodCultCluster # SoapConjuredBloodCultCluster
     capacity: 1
@@ -109,6 +108,8 @@
 - type: entity
   name: blood cult acolyte
   parent:
+  - MobMovementSpeedModifierMelee
+  - MobStaminaFodder
   - MobBloodCultistBase
   - MobHumanoidHostileAISimpleMelee
   #- MobLaserReflect # Added to prevent laser abuse from players
@@ -125,6 +126,8 @@
 - type: entity
   name: blood cult zealot
   parent:
+  - MobMovementSpeedModifierMelee
+  - MobStaminaFodder
   - MobBloodCultistBase
   - MobHumanoidHostileAISimpleMelee
   id: MobBloodCultistZealotMelee
@@ -140,6 +143,8 @@
 - type: entity
   name: blood cult zealot
   parent:
+  - MobMovementSpeedModifierRanged
+  - MobStaminaFodder
   - MobBloodCultistBase
   - MobHumanoidHostileAISimpleRanged
   id: MobBloodCultistZealotRanged
@@ -174,6 +179,8 @@
 - type: entity
   name: blood cult zealot
   parent:
+  - MobMovementSpeedModifierRanged
+  - MobStaminaFodder
   - MobBloodCultistBase
   - MobHumanoidHostileAISimpleRanged
   id: MobBloodCultistCaster
@@ -201,11 +208,14 @@
       path: /Audio/_NF/Effects/silence.ogg
 
 # Non-human mobs
+#region Leech
 # Blood Leech, melee, fast, has moderate health regen
 - type: entity
   name: blood leech
   categories: [ HideSpawnMenu ]
   parent:
+  - MobMovementSpeedModifierSpecial
+  - MobStaminaFodder
   - MobNonHumanHostileBase
   - MobPassiveRegen
   - MobHumanoidHostileAISimpleMelee
@@ -237,11 +247,6 @@
       0: Alive
       60: Critical
       120: Dead
-  - type: Stamina
-    critThreshold: 80
-  - type: MovementSpeedModifier
-    baseWalkSpeed: 4
-    baseSprintSpeed: 6
   - type: MeleeWeapon
     soundHit:
       path: /Audio/Effects/bite.ogg
@@ -251,12 +256,15 @@
         Structural: 20
     animation: WeaponArcBite
 
+#region Boss
 # Ascended Cultist, spawns 2 Drained Ones
 - type: entity
   name: ascended cultist
   description: Elevated above their mortal forms by Nar'Sie herself as a reward for their devotion.
   categories: [ HideSpawnMenu ]
   parent:
+  - MobMovementSpeedModifierBoss
+  - MobStaminaBoss
   - MobNonHumanHostileBase
   - MobHumanoidHostileAIComplex
   #- MobLaserReflect # Added to prevent laser abuse from players
@@ -309,8 +317,6 @@
       0: Alive
       240: Critical
       320: Dead
-  - type: Stamina
-    critThreshold: 320
   - type: BasicEntityAmmoProvider
     proto: SpawnMobBloodCultistAscendedSummons # MobBloodCultDrainedOne
     capacity: 2
@@ -351,15 +357,14 @@
     spawned:
     - id: ClothingNeckAmuletBloodCult
       amount: 1
-  - type: MovementSpeedModifier
-    baseWalkSpeed : 4.5
-    baseSprintSpeed : 4.5
 
-# Drained One, melee
+#region Drained One, melee
 - type: entity
   name: drained one
   categories: [ HideSpawnMenu ]
   parent:
+  - MobStaminaSpecial
+  - MobMovementSpeedModifierMelee
   - MobNonHumanHostileBase
   - FlyingMobBase
   - MobPassiveRegen
@@ -407,8 +412,6 @@
       0: Alive
       80: Critical
       100: Dead
-  - type: Stamina
-    critThreshold: 320
   - type: MeleeWeapon
     soundHit:
       collection: MetalThud
@@ -429,9 +432,6 @@
     speechVerb: Ghost
   - type: Ammo
     muzzleFlash: null
-  - type: MovementSpeedModifier
-    baseWalkSpeed : 4.5
-    baseSprintSpeed : 4.5
 
 - type: entity
   name: cultist shade
@@ -478,6 +478,7 @@
 - type: entity
   categories: [ HideSpawnMenu ]
   parent:
+  - MobStaminaFodder
   - BaseC3MobCreatureNoValue
   - MobBloodCultDrainedOne
   - NFMobTimedDespawn180
@@ -501,7 +502,7 @@
     factions:
     - NanoTrasen
 
-# Turrets
+#region Turrets
 # blood pylon, ranged, magic bolt deals 5 slash and 2 bloodloss
 # Look for magic bolt here:\Resources\Prototypes\_NF\Entities\Objects\Weapons\Guns\Projectiles\magic.yml
 - type: entity

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_expeditions_aberrant_flesh.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_expeditions_aberrant_flesh.yml
@@ -1,6 +1,8 @@
-# BASE
+#region BASE
 - type: entity
   parent:
+  - MobMovementSpeedModifierMelee
+  - MobStaminaFodder
   - MobNonHumanHostileBase
   - MobHumanoidHostileAISimpleMelee
   - NFMobRestrictions
@@ -27,8 +29,6 @@
     speedModifierThresholds:
       34: 0.7
       45: 0.5
-  - type: Stamina
-    critThreshold: 64
   - type: Butcherable
     spawned:
     - id: FoodMeat
@@ -47,11 +47,8 @@
         Structural: 20
   - type: ReplacementAccent
     accent: genericAggressive
-  - type: MovementSpeedModifier
-    baseWalkSpeed : 4.5
-    baseSprintSpeed : 4.5
 
-# MOBS
+#region MOBS
 - type: entity
   parent: BaseMobFleshExpeditions
   id: MobFleshJaredExpeditions
@@ -179,8 +176,6 @@
     speedModifierThresholds:
       48: 0.7
       64: 0.5
-  - type: Stamina
-    critThreshold: 100
   - type: DamageStateVisuals
     states:
       Alive:
@@ -195,15 +190,13 @@
 
 - type: entity
   parent:
+  - MobMovementSpeedModifierRanged
   - BaseMobFleshExpeditions
   - MobHumanoidHostileAISimpleRanged
   id: MobFleshClampExpeditions
   description: A flying flesh monster that can shoot spikes or toothy creatures that can latch on.
   #categories: [ HideSpawnMenu ]
   components:
-  - type: MovementSpeedModifier
-    baseWalkSpeed : 4
-    baseSprintSpeed : 4
   - type: CanMoveInAir
   - type: Fixtures
     fixtures:
@@ -293,14 +286,13 @@
       collection: BulletMiss
 
 - type: entity
-  parent: BaseMobFleshExpeditions
+  parent:
+  - MobMovementSpeedModifierSpecial
+  - BaseMobFleshExpeditions
   id: MobFleshLoverExpeditions
   description: The Lover's light frame makes it fragile, but capable of flight.
   #categories: [ HideSpawnMenu ]
   components:
-  - type: MovementSpeedModifier
-    baseWalkSpeed : 5
-    baseSprintSpeed : 5
   - type: CanMoveInAir
   - type: Fixtures
     fixtures:
@@ -346,17 +338,17 @@
       types:
         Blunt: 4
 
-# EXPEDITION BOSS
+#region BOSS
 - type: entity
-  parent: [ BaseMobFleshExpeditions, MobHostileBossBase, NFMobBossRestrictions ]
+  parent:
+  - NFMobBossRestrictions
+  - MobHostileBossBase
+  - BaseMobFleshExpeditions
   id: MobHorrorExpeditions
   name: aberrant flesh horror
   description: Tougher and more resilient than most aberrant flesh monsters. Has sharp, bony protrusions and highly developed musculature.
   #categories: [ HideSpawnMenu ]
   components:
-  - type: MovementSpeedModifier
-    baseWalkSpeed : 4.6
-    baseSprintSpeed : 4.6
   - type: Sprite
     layers:
     - map: ["enum.DamageStateVisualLayers.Base"]
@@ -445,7 +437,7 @@
     range: 0
     itemIconStyle: BigAction
 
-# FUNNY LITTLE GUY
+#region FUNNY LITTLE GUY
 # embedable projectile that bites you until you either kill it or detach it or die (or it despawns)
 - type: entity
   parent: [ BaseMobFleshExpeditions, NFMobTimedDespawn60 ]
@@ -494,7 +486,8 @@
       types:
         Slash: 3
 
-# Newborns (spawned from assimilation sack)
+#region Newborns
+# spawned from assimilation sack
 - type: entity
   id: BaseMobFleshExpeditionsNewborn
   parent: BaseMobFleshExpeditions

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_expeditions_argocyte.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_expeditions_argocyte.yml
@@ -1,6 +1,10 @@
-# BASE
+#region BASE
 - type: entity
-  parent: [ MobNonHumanHostileBase, NFMobRestrictions ]
+  parent:
+  - MobMovementSpeedModifierRanged
+  - MobStaminaFodder
+  - NFMobRestrictions
+  - MobNonHumanHostileBase
   id: BaseMobArgocyteExpeditions
   name: argocyte
   description: |-
@@ -55,9 +59,6 @@
         Structural: 20
   - type: Body
     prototype: Animal
-  - type: MovementSpeedModifier
-    baseSprintSpeed : 3.5
-    baseWalkSpeed : 3
   - type: TypingIndicator
     proto: alien
   - type: ReplacementAccent
@@ -79,7 +80,7 @@
       amount: 3
 
 # VARIANTS
-## Stalkers morphotype
+#region Stalkers morphotype
 - type: entity
   parent: BaseMobArgocyteExpeditions
   id: MobArgocyteSlurvaExpeditions
@@ -120,9 +121,6 @@
       types:
         Slash: 3
         Structural: 20
-  - type: MovementSpeedModifier
-    baseSprintSpeed : 3
-    baseWalkSpeed : 3
 
 - type: entity
   parent: BaseMobArgocyteExpeditions
@@ -164,12 +162,11 @@
       types:
         Slash: 6
         Structural: 20
-  - type: MovementSpeedModifier
-    baseSprintSpeed : 3.5
-    baseWalkSpeed : 3.5
 
 - type: entity
-  parent: BaseMobArgocyteExpeditions
+  parent:
+  - MobMovementSpeedModifierMelee
+  - BaseMobArgocyteExpeditions
   id: MobArgocyteSwiperExpeditions
   name: swiper
   description: The third lifecycle stage of the Stalker morphotype. Roaming scavengers, usually out on reconnaisance or gathering materials.
@@ -197,12 +194,11 @@
       types:
         Slash: 8
         Structural: 20
-  - type: MovementSpeedModifier
-    baseSprintSpeed : 4
-    baseWalkSpeed: 4
 
 - type: entity
-  parent: BaseMobArgocyteExpeditions
+  parent:
+  - MobMovementSpeedModifierMelee
+  - BaseMobArgocyteExpeditions
   id: MobArgocyteGliderExpeditions
   name: glider
   description: The fourth lifecycle stage of the Stalker morphotype. Born and bred hunters, these stalk and prey upon smaller wildlife.
@@ -230,12 +226,11 @@
       types:
         Slash: 10
         Structural: 20
-  - type: MovementSpeedModifier
-    baseSprintSpeed : 4.5
-    baseWalkSpeed: 4.5
 
 - type: entity
-  parent: BaseMobArgocyteExpeditions
+  parent:
+  - MobMovementSpeedModifierSpecial
+  - BaseMobArgocyteExpeditions
   id: MobArgocyteCrawlerExpeditions
   name: crawler
   description: The fifth lifecycle stage of the Stalker morphotype. These deadly pack animals ambush and maul unsuspecting travelers.
@@ -263,9 +258,6 @@
       types:
         Slash: 12
         Structural: 20
-  - type: MovementSpeedModifier
-    baseSprintSpeed : 5
-    baseWalkSpeed: 5
   - type: Butcherable
     spawned:
     - id: SpawnDungeonLootMaterialsBasicSingle
@@ -274,7 +266,9 @@
       amount: 5
 
 - type: entity
-  parent: BaseMobArgocyteExpeditions
+  parent:
+  - MobMovementSpeedModifierMelee
+  - BaseMobArgocyteExpeditions
   id: MobArgocyteFounderExpeditions
   name: founder
   description: The last known lifecycle stage of the Stalker morphotype. Most often seen in mature hives preparing for an expansion.
@@ -303,9 +297,6 @@
       types:
         Slash: 14
         Structural: 25
-  - type: MovementSpeedModifier
-    baseSprintSpeed : 4.5
-    baseWalkSpeed: 4.5
   - type: Butcherable
     spawned:
     - id: SpawnDungeonLootMaterialsBasicFull
@@ -313,7 +304,7 @@
     - id: FoodMeatXeno
       amount: 7
 
-## Guardian morphotype
+#region Guardian morphotype
 - type: entity
   parent: BaseMobArgocyteExpeditions
   id: MobArgocyteBarrierExpeditions
@@ -384,9 +375,6 @@
       types:
         Blunt: 8
         Structural: 20
-  - type: MovementSpeedModifier
-    baseSprintSpeed : 3.5
-    baseWalkSpeed : 3.5
 
 - type: entity
   parent: BaseMobArgocyteExpeditions
@@ -416,9 +404,6 @@
     damage:
       types:
         Blunt: 10
-  - type: MovementSpeedModifier
-    baseSprintSpeed : 3.5
-    baseWalkSpeed : 3.5
   - type: Butcherable
     spawned:
     - id: SpawnDungeonLootMaterialsBasicSingle
@@ -498,8 +483,12 @@
     - id: FoodMeatXeno
       amount: 7
 
+#region boss
 - type: entity
-  parent: [ BaseMobArgocyteExpeditions, NFMobBossRestrictions ]
+  parent:
+  - NFMobBossRestrictions
+  - MobHostileBossBase
+  - BaseMobArgocyteExpeditions
   id: MobArgocyteLeviathingExpeditions
   name: leviathing
   description: The final known lifecycle stage of the Guardian morphotype. These hulking beasts lead attacks on the hive's enemies.

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_expeditions_carp.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_expeditions_carp.yml
@@ -1,6 +1,20 @@
+#region base
+- type: entity
+  id: NFMobCarpBase
+  abstract: true
+  parent:
+  - MobStaminaFodder
+  - MobMovementSpeedModifierMelee
+  - NFMobRestrictions
+  - NFMobSimpleHostileBase
+  - NFMobRoadkillable
+
+#region Carps
 - type: entity
   id: NFMobCarp
-  parent: [NFMobRestrictions, NFMobSimpleHostileBase, MobCarp, NFMobRoadkillable]
+  parent:
+  - NFMobCarpBase
+  - MobCarp
   suffix: "Frontier"
   categories: [ HideSpawnMenu ]
   components:
@@ -12,15 +26,12 @@
     speedModifierThresholds:
       19: 0.7
       26: 0.5
-  - type: Stamina
-    critThreshold: 50
-  - type: MovementSpeedModifier
-    baseWalkSpeed : 4.5
-    baseSprintSpeed : 4.5
 
 - type: entity
   id: NFMobCarpMagic
-  parent: [NFMobRestrictions, NFMobSimpleHostileBase, NFMobCarp, MobCarpMagic]
+  parent:
+  - NFMobCarpBase
+  - MobCarpMagic
   suffix: "Frontier"
   categories: [ HideSpawnMenu ]
   components:
@@ -43,7 +54,9 @@
 
 - type: entity
   id: NFMobCarpHolo
-  parent: [NFMobRestrictions, NFMobSimpleHostileBase, MobCarpHolo, NFMobRoadkillable]
+  parent:
+  - NFMobCarpBase
+  - MobCarpHolo
   suffix: "Frontier"
   categories: [ HideSpawnMenu ]
   components:
@@ -63,13 +76,12 @@
     - map: [ "enum.DamageStateVisualLayers.BaseUnshaded" ]
       state: mouth
       shader: unshaded
-  - type: MovementSpeedModifier
-    baseWalkSpeed : 4.5
-    baseSprintSpeed : 4.5
 
 - type: entity
   id: NFMobCarpRainbow
-  parent: [NFMobRestrictions, NFMobSimpleHostileBase, NFMobCarp, MobCarpRainbow]
+  parent:
+  - NFMobCarpBase
+  - MobCarpRainbow
   suffix: "Frontier"
   categories: [ HideSpawnMenu ]
   components:
@@ -84,7 +96,9 @@
 
 - type: entity
   id: NFMobShark
-  parent: [NFMobRestrictions, NFMobSimpleHostileBase, MobShark, NFMobRoadkillable]
+  parent:
+  - NFMobCarpBase
+  - MobShark
   suffix: "Frontier"
 #  categories: [ HideSpawnMenu ] # No spawner
   components:
@@ -96,19 +110,17 @@
     speedModifierThresholds:
       38: 0.7
       52: 0.5
-  - type: Stamina
-    critThreshold: 80
-  - type: MovementSpeedModifier
-    baseWalkSpeed : 4.5
-    baseSprintSpeed : 4.5
   - type: MeleeWeapon
     damage:
       types:
         Slash: 7
         Bloodloss: 7
 
+#region Snakes
 - type: entity
-  parent: [NFMobRestrictions, NFMobSimpleHostileBase, MobSmallPurpleSnake, NFMobRoadkillable]
+  parent:
+  - NFMobCarpBase
+  - NFMobRoadkillable
   id: NFMobSmallRainbowSnake
   suffix: Frontier, Rainbow
   #categories: [ HideSpawnMenu ] # No spawner
@@ -167,8 +179,12 @@
         Slash: 3
         Structural: 20
 
+#region Wyverns
 - type: entity
-  parent: [NFMobRestrictions, NFMobSimpleHostileBase, MobCarp, NFMobRoadkillable]
+  parent:
+  - MobMovementSpeedModifierRanged
+  - NFMobCarpBase
+  - MobCarp
   id: NFMobRainbowWyvernIce
   name: wyvern
   description: A smaller relative of a space dragon known for its hunting provess and ability to conjure magical progectiles.
@@ -314,8 +330,13 @@
     capacity: 1
     count: 1
 
+#region boss
 - type: entity
-  parent: [NFMobRestrictions, NFMobSimpleHostileBase, MobDragonDungeon, NFMobBossRestrictions ]
+  parent:
+  - NFMobBossRestrictions
+  - MobHostileBossBase
+  - NFMobSimpleHostileBase
+  - MobDragonDungeon
   id: NFMobDragonDungeon
   suffix: Dungeon, Frontier
   components:


### PR DESCRIPTION
## About the PR
Made new parents so it'd be easier to adjust speed and stamina for all mobs by changing numbers in one file.
In general
- Melee mobs kept their speed (4.5);
- Special melee mobs kept their speed (5);
- Bosses kept their speed (4.5);
- Ranged mobs now move slower (3.5);
- Standardized stamina values for mobs: fodder - 80, special mobs - 200, bosses - 500.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
yml

## How to test
1. Spawn mobs or visit expeds/vgroids.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [x] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:
- tweak: Ranged mobs now move slightly slower.
