### PR TITLE
Fix Remove access lock on LVHI Adder captain airlock

### DIFF
--- a/Resources/Maps/_NF/Shuttles/adder.yml
+++ b/Resources/Maps/_NF/Shuttles/adder.yml
@@ -345,7 +345,7 @@ entities:
       - 109
       - 144
       - 145
-- proto: AirlockCaptainLocked
+- proto: AirlockCommand
   entities:
   - uid: 20
     components:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Replaced captain access-locked airlock with an airlock without an access lock.

## Why / Balance
Fix unintended hurdle

## Technical details
yml

## How to test
1. Buy Adder, loose your ID, walk in the cockpit.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [x] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:
- tweak: Replaced captain access-locked airlock with an airlock without an access lock.
