### PR TITLE
FO Mail Bags replaced with NF variant

### DIFF
--- a/Resources/Maps/_NF/Outpost/frontier.yml
+++ b/Resources/Maps/_NF/Outpost/frontier.yml
@@ -1,16 +1,16 @@
 meta:
   format: 7
-  category: Grid
-  engineVersion: 255.0.0
+  category: Map
+  engineVersion: 247.2.0
   forkId: ""
   forkVersion: ""
-  time: 05/28/2025 05:58:20
-  entityCount: 5519
-maps: []
+  time: 03/22/2025 01:21:01
+  entityCount: 5522
+maps:
+- 5691
 grids:
 - 2173
-orphans:
-- 2173
+orphans: []
 nullspace: []
 tilemap:
   0: Space
@@ -48,7 +48,7 @@ entities:
     - type: MetaData
       name: Frontier Outpost
     - type: Transform
-      parent: invalid
+      parent: 5691
     - type: MapGrid
       chunks:
         0,0:
@@ -181,37 +181,43 @@ entities:
         path: /Audio/Effects/alert.ogg
     - type: WorldGenDistanceCarver
       distanceThresholds:
-      - prob: 0
-        maxDistance: 1000
-      - prob: 0.1
-        maxDistance: 1400
-      - prob: 0.2
-        maxDistance: 1800
-      - prob: 0.3
-        maxDistance: 2200
-      - prob: 0.4
-        maxDistance: 2600
-      - prob: 0.5
-        maxDistance: 3000
-      - prob: 0.6
-        maxDistance: 3400
-      - prob: 0.7
-        maxDistance: 3800
-      - prob: 0.8
-        maxDistance: 4200
-      - prob: 0.9
-        maxDistance: 4600
-      - maxDistance: 14000
-      - prob: 0.8
-        maxDistance: 14500
-      - prob: 0.6
-        maxDistance: 15000
-      - prob: 0.4
-        maxDistance: 15500
-      - prob: 0.2
-        maxDistance: 16000
-      - prob: 0
-        maxDistance: 100000000
+        # Dead zone
+        - maxDistance: 1000
+          prob: 0.0
+        # Sparse zone
+        - maxDistance: 1400
+          prob: 0.1
+        - maxDistance: 1800
+          prob: 0.2
+        - maxDistance: 2200
+          prob: 0.3
+        - maxDistance: 2600
+          prob: 0.4
+        - maxDistance: 3000
+          prob: 0.5
+        - maxDistance: 3400
+          prob: 0.6
+        - maxDistance: 3800
+          prob: 0.7
+        - maxDistance: 4200
+          prob: 0.8
+        - maxDistance: 4600
+          prob: 0.9
+        # Main world
+        - maxDistance: 14000
+          prob: 1.0
+        # Outer sparse zone
+        - maxDistance: 14500
+          prob: 0.8
+        - maxDistance: 15000
+          prob: 0.6
+        - maxDistance: 15500
+          prob: 0.4
+        - maxDistance: 16000
+          prob: 0.2
+        # Outer dead zone
+        - maxDistance: 99999999 # ~ 100 million
+          prob: 0.0
     - type: DecalGrid
       chunkCollection:
         version: 2
@@ -3599,7 +3605,7 @@ entities:
             0: 47903
           -9,3:
             0: 34831
-            2: 8704
+            3: 8704
           -8,4:
             0: 2187
             1: 768
@@ -3739,13 +3745,13 @@ entities:
             0: 63931
           -10,3:
             0: 13087
-            3: 34816
+            2: 34816
           -10,4:
             0: 3
-            3: 8
+            2: 8
             1: 3840
           -9,4:
-            2: 2
+            3: 2
             0: 8
             1: 3840
           -16,0:
@@ -3971,8 +3977,8 @@ entities:
         - volume: 2500
           temperature: 293.15
           moles:
-          - 6666.982
           - 0
+          - 6666.982
           - 0
           - 0
           - 0
@@ -3986,8 +3992,8 @@ entities:
         - volume: 2500
           temperature: 293.15
           moles:
-          - 0
           - 6666.982
+          - 0
           - 0
           - 0
           - 0
@@ -4016,6 +4022,20 @@ entities:
     - type: SpreaderGrid
     - type: IFF
       readOnly: True
+  - uid: 5691
+    components:
+    - type: MetaData
+      name: map 1234
+    - type: Transform
+    - type: Map
+      mapPaused: True
+    - type: PhysicsMap
+    - type: GridTree
+    - type: MovedGrids
+    - type: Broadphase
+    - type: Parallax
+      parallax: FrontierStation
+    - type: OccluderTree
 - proto: ActionToggleLight
   entities:
   - uid: 2428
@@ -5134,11 +5154,9 @@ entities:
     - type: DeviceLinkSource
       linkedPorts:
         3746:
-        - - DoorStatus
-          - Close
+        - DoorStatus: Close
         3745:
-        - - DoorStatus
-          - Close
+        - DoorStatus: Close
   - uid: 2982
     components:
     - type: Transform
@@ -5150,11 +5168,9 @@ entities:
     - type: DeviceLinkSource
       linkedPorts:
         3746:
-        - - DoorStatus
-          - Close
+        - DoorStatus: Close
         3745:
-        - - DoorStatus
-          - Close
+        - DoorStatus: Close
   - uid: 3745
     components:
     - type: Transform
@@ -5166,11 +5182,9 @@ entities:
     - type: DeviceLinkSource
       linkedPorts:
         2976:
-        - - DoorStatus
-          - Close
+        - DoorStatus: Close
         2982:
-        - - DoorStatus
-          - Close
+        - DoorStatus: Close
   - uid: 3746
     components:
     - type: Transform
@@ -5182,11 +5196,9 @@ entities:
     - type: DeviceLinkSource
       linkedPorts:
         2976:
-        - - DoorStatus
-          - Close
+        - DoorStatus: Close
         2982:
-        - - DoorStatus
-          - Close
+        - DoorStatus: Close
 - proto: AirlockSeviceFrontierLocked
   entities:
   - uid: 389
@@ -18571,6 +18583,13 @@ entities:
       parent: 2173
     - type: AtmosPipeColor
       color: '#0055CCFF'
+  - uid: 4601
+    components:
+    - type: Transform
+      pos: -50.5,5.5
+      parent: 2173
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 4634
     components:
     - type: Transform
@@ -19405,13 +19424,6 @@ entities:
       parent: 2173
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2314
-    components:
-    - type: Transform
-      pos: -51.5,5.5
-      parent: 2173
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 2470
     components:
     - type: Transform
@@ -20415,6 +20427,14 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -49.5,4.5
+      parent: 2173
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 4598
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -50.5,4.5
       parent: 2173
     - type: AtmosPipeColor
       color: '#0055CCFF'
@@ -24097,14 +24117,6 @@ entities:
       parent: 2173
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2264
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -50.5,4.5
-      parent: 2173
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 2516
     components:
     - type: Transform
@@ -24256,6 +24268,14 @@ entities:
     components:
     - type: Transform
       pos: -42.5,4.5
+      parent: 2173
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 4600
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -51.5,5.5
       parent: 2173
     - type: AtmosPipeColor
       color: '#0055CCFF'
@@ -24829,13 +24849,6 @@ entities:
       parent: 2173
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2265
-    components:
-    - type: Transform
-      pos: -50.5,5.5
-      parent: 2173
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 2769
     components:
     - type: Transform
@@ -24919,6 +24932,14 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -29.5,-29.5
+      parent: 2173
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 4579
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -50.5,4.5
       parent: 2173
     - type: AtmosPipeColor
       color: '#0055CCFF'
@@ -27685,6 +27706,18 @@ entities:
     - type: Transform
       pos: -54.5,18.5
       parent: 2173
+- proto: NFMailBag
+  entities:
+  - uid: 805
+    components:
+    - type: Transform
+      pos: 29.810764,16.661615
+      parent: 2173
+  - uid: 807
+    components:
+    - type: Transform
+      pos: 29.342014,16.547031
+      parent: 2173
 - proto: MailingUnit
   entities:
   - uid: 207
@@ -27943,25 +27976,6 @@ entities:
     components:
     - type: Transform
       pos: 15.5,13.5
-      parent: 2173
-- proto: NFMailBag
-  entities:
-  - uid: 805
-    components:
-    - type: Transform
-      pos: 29.810764,16.661615
-      parent: 2173
-  - uid: 807
-    components:
-    - type: Transform
-      pos: 29.342014,16.547031
-      parent: 2173
-- proto: NFRandomBook
-  entities:
-  - uid: 2063
-    components:
-    - type: Transform
-      pos: 51.5,10.5
       parent: 2173
 - proto: NFSignBus
   entities:
@@ -28365,7 +28379,7 @@ entities:
     - type: Transform
       pos: 42.5,17.5
       parent: 2173
-- proto: PosterLegitSafetyMothEpi
+- proto: PosterLegitSMEpi
   entities:
   - uid: 4839
     components:
@@ -28373,7 +28387,7 @@ entities:
       rot: 3.141592653589793 rad
       pos: -54.5,9.5
       parent: 2173
-- proto: PosterLegitSafetyMothPills
+- proto: PosterLegitSMPills
   entities:
   - uid: 4838
     components:
@@ -28381,7 +28395,7 @@ entities:
       rot: 3.141592653589793 rad
       pos: -46.5,15.5
       parent: 2173
-- proto: PosterLegitSafetyMothPoisoning
+- proto: PosterLegitSMPoisoning
   entities:
   - uid: 765
     components:
@@ -29087,6 +29101,13 @@ entities:
       rot: 3.141592653589793 rad
       pos: 39.5,22.5
       parent: 2173
+- proto: PoweredlightUltraviolet
+  entities:
+  - uid: 2064
+    components:
+    - type: Transform
+      pos: 51.5,10.5
+      parent: 2173
 - proto: PoweredlightLED
   entities:
   - uid: 4191
@@ -29097,13 +29118,6 @@ entities:
       parent: 2173
     - type: ApcPowerReceiver
       powerLoad: 0
-- proto: PoweredlightUltraviolet
-  entities:
-  - uid: 2064
-    components:
-    - type: Transform
-      pos: 51.5,10.5
-      parent: 2173
 - proto: PoweredSmallLight
   entities:
   - uid: 269
@@ -29550,6 +29564,13 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -49.5,11.5
+      parent: 2173
+- proto: NFRandomBook
+  entities:
+  - uid: 2063
+    components:
+    - type: Transform
+      pos: 51.5,10.5
       parent: 2173
 - proto: RandomFoodMeal
   entities:
@@ -31815,7 +31836,7 @@ entities:
     - type: Transform
       pos: 42.5,19.5
       parent: 2173
-- proto: SignSecurity
+- proto: SignSec
   entities:
   - uid: 2154
     components:
@@ -33180,12 +33201,9 @@ entities:
     - type: DeviceLinkSource
       linkedPorts:
         6083:
-        - - Left
-          - Forward
-        - - Right
-          - Forward
-        - - Middle
-          - Off
+        - Left: Forward
+        - Right: Forward
+        - Middle: Off
 - proto: UniformPrinterStaff
   entities:
   - uid: 2042
@@ -36892,8 +36910,7 @@ entities:
     - type: DeviceLinkSource
       linkedPorts:
         2642:
-        - - DoorStatus
-          - Close
+        - DoorStatus: Close
   - uid: 2803
     components:
     - type: Transform
@@ -36910,8 +36927,7 @@ entities:
     - type: DeviceLinkSource
       linkedPorts:
         2643:
-        - - DoorStatus
-          - Close
+        - DoorStatus: Close
   - uid: 3726
     components:
     - type: Transform


### PR DESCRIPTION
## About the PR
Replaces the mail bags in the Frontier Outpost mailroom with New Frontiers version mail bags.

## Why / Balance
The mail bags currently in there (item: MailBag) are presently an old variety. They're smaller, don't have a magnet, and most important CANNOT HOLD MAIL. The new ones (item: NFMailBag), which is the one mail carriers usually have anyways, work as intended.

## How to test
- Start as a mail carrier
- Notice your spiffy new mail bags
- Succesfully put mail inside of them

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I confirm that AI tools were not used in generating the material in this PR.
