### PR TITLE
Add a flatpack price calc

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/flatpack.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/flatpack.yml
@@ -33,8 +33,8 @@
       cpu_security: "#DE3A3A"
       cpu_science: "#D381C9"
       cpu_supply: "#A46106"
-  - type: StaticPrice
-    price: 250
+#  - type: StaticPrice # Frontier: Price match machine price
+#    price: 250 # Frontier: Price match machine price
   - type: Rotatable # Frontier
 
 - type: entity
@@ -48,8 +48,8 @@
   - type: Sprite
     layers:
     - state: solar-assembly-part
-  - type: StaticPrice
-    price: 25 # Frontier: 75<25
+#  - type: StaticPrice # Frontier: Price match machine price
+#    price: 75 # Frontier: Price match machine price
 
 - type: entity
   parent: BaseFlatpack
@@ -62,8 +62,8 @@
     - state: ame-part
   - type: Flatpack
     entity: AmeShielding
-  - type: StaticPrice
-    price: 500
+#  - type: StaticPrice # Frontier: Price match machine price
+#    price: 500 # Frontier: Price match machine price
   - type: GuideHelp
     guides:
     - AME

--- a/Resources/Prototypes/_NF/Entities/Objects/Devices/flatpack.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Devices/flatpack.yml
@@ -3,8 +3,6 @@
   parent: BaseFlatpack
   id: BaseNFFlatpack
   components:
-  - type: StaticPrice
-    price: 150
   - type: Sprite
     sprite: _NF/Objects/Devices/flatpack.rsi
     layers:
@@ -29,8 +27,6 @@
   components:
   - type: Flatpack
     entity: EngineeringTechFab
-  - type: StaticPrice
-    price: 250
 
 - type: entity
   parent: BaseNFFlatpack
@@ -40,8 +36,6 @@
   components:
   - type: Flatpack
     entity: GasThermoMachineFreezer
-  - type: StaticPrice
-    price: 250
 
 - type: entity
   parent: BaseNFFlatpack
@@ -51,8 +45,6 @@
   components:
   - type: Flatpack
     entity: MachineFlatpacker
-  - type: StaticPrice
-    price: 250
 
 - type: entity
   parent: BaseNFFlatpack
@@ -62,8 +54,6 @@
   components:
   - type: Flatpack
     entity: PowerCellRecharger
-  - type: StaticPrice
-    price: 15
   - type: Sprite
     layers:
     - state: power_charger
@@ -76,8 +66,6 @@
   components:
   - type: Flatpack
     entity: WeaponCapacitorRecharger
-  - type: StaticPrice
-    price: 55
 
 - type: entity
   parent: BaseNFFlatpack
@@ -87,8 +75,6 @@
   components:
   - type: Flatpack
     entity: BorgCharger
-  - type: StaticPrice
-    price: 55
   - type: Sprite
     layers:
     - state: power_charger
@@ -171,8 +157,6 @@
   components:
   - type: Flatpack
     entity: SmallGyroscope
-  - type: StaticPrice
-    price: 55
 
 - type: entity
   parent: BaseNFFlatpack
@@ -182,8 +166,6 @@
   components:
   - type: Flatpack
     entity: SmallThruster
-  - type: StaticPrice
-    price: 55
 
 - type: entity
   parent: BaseNFFlatpack
@@ -203,8 +185,6 @@
   components:
   - type: Flatpack
     entity: ExosuitFabricator
-  - type: StaticPrice
-    price: 250
 
 - type: entity
   parent: BaseNFFlatpack
@@ -214,8 +194,6 @@
   components:
   - type: Flatpack
     entity: CircuitImprinter
-  - type: StaticPrice
-    price: 250
 
 - type: entity
   parent: BaseNFFlatpack
@@ -225,8 +203,6 @@
   components:
   - type: Flatpack
     entity: Protolathe
-  - type: StaticPrice
-    price: 250
   - type: Sprite
     layers:
     - state: science_lathe
@@ -333,8 +309,6 @@
   components:
   - type: Flatpack
     entity: ServiceTechFab
-  - type: StaticPrice
-    price: 250
 
 - type: entity
   parent: UniformPrinterFlatpack
@@ -452,8 +426,6 @@
   components:
   - type: Flatpack
     entity: MedicalTechFab
-  - type: StaticPrice
-    price: 250
   - type: Sprite
     layers:
     - state: medical_lathe
@@ -551,8 +523,6 @@
   components:
   - type: Flatpack
     entity: ShuttleGunKinetic
-  - type: StaticPrice
-    price: 250
   - type: Sprite
     layers:
     - state: supply_gun
@@ -605,8 +575,6 @@
   components:
   - type: Flatpack
     entity: MercenaryTechFab
-  - type: StaticPrice
-    price: 600
 
 #region Consoles
 - type: entity
@@ -617,8 +585,6 @@
   components:
   - type: Flatpack
     entity: ComputerResearchAndDevelopment
-  - type: StaticPrice
-    price: 250
   - type: Sprite
     layers:
     - state: science_console
@@ -631,8 +597,6 @@
   components:
   - type: Flatpack
     entity: ComputerAnalysisConsole
-  - type: StaticPrice
-    price: 250
 
 - type: entity
   parent: BaseNFFlatpack
@@ -642,8 +606,6 @@
   components:
   - type: Flatpack
     entity: ComputerCrewMonitoring
-  - type: StaticPrice
-    price: 250
   - type: Sprite
     layers:
     - state: medical_console
@@ -656,8 +618,6 @@
   components:
   - type: Flatpack
     entity: ComputerIFF
-  - type: StaticPrice
-    price: 400
   - type: Sprite
     layers:
     - state: supply_gun
@@ -670,8 +630,6 @@
   components:
   - type: Flatpack
     entity: ComputerSolarControl
-  - type: StaticPrice
-    price: 150
 
 #region Servers
 - type: entity
@@ -682,8 +640,6 @@
   components:
   - type: Flatpack
     entity: ResearchAndDevelopmentServer
-  - type: StaticPrice
-    price: 250
   - type: Sprite
     layers:
     - state: science_server
@@ -709,8 +665,6 @@
   components:
   - type: Flatpack
     entity: Airlock
-  - type: StaticPrice
-    price: 95
   - type: Sprite
     layers:
     - state: command_airlock
@@ -754,8 +708,6 @@
   components:
   - type: Flatpack
     entity: TubaInstrument
-  - type: StaticPrice
-    price: 400
   - type: Sprite
     layers:
     - state: service_music
@@ -786,8 +738,6 @@
   components:
   - type: Flatpack
     entity: VibraphoneInstrument
-  - type: StaticPrice
-    price: 400
 
 - type: entity
   parent: TubaInstrumentFlatpack
@@ -869,8 +819,6 @@
   components:
   - type: Flatpack
     entity: DawInstrument
-  - type: StaticPrice
-    price: 2000
 
 - type: entity
   parent: UniformPrinterFlatpack
@@ -880,8 +828,6 @@
   components:
   - type: Flatpack
     entity: NfsdTechFab
-  - type: StaticPrice
-    price: 250
   - type: Item
     shape:
     - 0,0,1,1
@@ -894,8 +840,6 @@
   components:
   - type: Flatpack
     entity: Jukebox
-  - type: StaticPrice
-    price: 250
 
 #region Hoverbikes
 - type: entity
@@ -906,8 +850,6 @@
   components:
   - type: Flatpack
     entity: NFVehicleHoverbikeKeys
-  - type: StaticPrice
-    price: 2000
   - type: Sprite
     layers:
     - state: command_airlock
@@ -920,8 +862,6 @@
   components:
   - type: Flatpack
     entity: VehicleHoverbikeMailcarrierKey
-  - type: StaticPrice
-    price: 75
 
 - type: entity
   parent: HoverbikeFlatpack
@@ -931,8 +871,6 @@
   components:
   - type: Flatpack
     entity: NFVehicleHoverbikeNfsdKey
-  - type: StaticPrice
-    price: 750
 
 - type: entity
   parent: HoverbikeFlatpack
@@ -942,8 +880,6 @@
   components:
   - type: Flatpack
     entity: VehicleHoverbikeSyndicateKey
-  - type: StaticPrice
-    price: 750
 
 - type: entity
   parent: BaseNFFlatpack
@@ -953,8 +889,6 @@
   components:
   - type: Flatpack
     entity: NFVehicleJanicartKey
-  - type: StaticPrice
-    price: 375 # 1.25 * base value of input materials
 
 #region Vendomats
 - type: entity
@@ -965,8 +899,6 @@
   components:
   - type: Flatpack
     entity: VendingMachineBooze
-  - type: StaticPrice
-    price: 1500
 
 - type: entity
   parent: VendingMachineBoozeFlatpack
@@ -1021,8 +953,6 @@
   components:
   - type: Flatpack
     entity: LockerBotanistFilled
-  - type: StaticPrice
-    price: 500
 
 - type: entity
   parent: VendingMachineBoozeFlatpack
@@ -1032,8 +962,6 @@
   components:
   - type: Flatpack
     entity: VendingMachineSyndieContraband
-  - type: StaticPrice
-    price: 2500
 
 - type: entity
   parent: VendingMachineBoozeFlatpack
@@ -1061,8 +989,6 @@
   components:
   - type: Flatpack
     entity: VendingMachineMedical
-  - type: StaticPrice
-    price: 2000
 
 - type: entity
   parent: VendingMachineBoozeFlatpack
@@ -1072,8 +998,6 @@
   components:
   - type: Flatpack
     entity: VendingMachineWallMedical
-  - type: StaticPrice
-    price: 2000
 
 - type: entity
   parent: VendingMachineBoozeFlatpack
@@ -1083,8 +1007,6 @@
   components:
   - type: Flatpack
     entity: VendingMachineChemicals
-  - type: StaticPrice
-    price: 2000
 
 #region DoC Console
 - type: entity
@@ -1098,8 +1020,6 @@
   - type: Sprite
     layers:
     - state: medical_console
-  - type: StaticPrice
-    price: 0
   - type: CargoSellBlacklist
   - type: Item
     shape:
@@ -1116,8 +1036,6 @@
   - type: Sprite
     layers:
     - state: medical_console
-  - type: StaticPrice
-    price: 0
   - type: CargoSellBlacklist
   - type: Item
     shape:


### PR DESCRIPTION
## About the PR
Auto calc the price of a flatpack so we can add them to market later.

This will also need a big edit for basic machines prices to allow us a factor if added income.

Leave as draft since vending machine code will need a update before we can use this.

## Why / Balance
Missing code

## Technical details
Added calc for flatpack entity.

## How to test
Spawn a flatpack and inspect its price, open and inspect price again.

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
