### PR TITLE
Vault/Cache reward tweaks

### DIFF
--- a/Resources/Prototypes/_NF/Events/nf_bluespace_grids_events.yml
+++ b/Resources/Prototypes/_NF/Events/nf_bluespace_grids_events.yml
@@ -54,8 +54,6 @@
     duration: 1020
     maxDuration: 1350
     reoccurrenceDelay: 360 # 6 hours
-    requiredJobs:
-      Sheriff: 1
   - type: BluespaceErrorRule
     groups:
       grid: !type:GridSpawnGroup
@@ -77,7 +75,9 @@
         paths:
         - /Maps/_NF/Bluespace/vault.yml
     rewardAccounts:
-      Nfsd: 1.0
+      Nfsd: 0.33
+      Frontier: 0.33
+      Medical: 0.33
 
 - type: entity
   id: BluespaceVaultSmallError
@@ -95,8 +95,6 @@
     duration: 590
     maxDuration: 780
     reoccurrenceDelay: 360 # 6 hours
-    requiredJobs:
-      Sheriff: 1
   - type: BluespaceErrorRule
     groups:
       grid: !type:GridSpawnGroup
@@ -118,7 +116,9 @@
         paths:
         - /Maps/_NF/Bluespace/vaultsmall.yml
     rewardAccounts:
-      Nfsd: 1.0
+      Nfsd: 0.33
+      Frontier: 0.33
+      Medical: 0.33
 
 - type: entity
   id: BluespaceSyndicateFTLInterception


### PR DESCRIPTION

## About the PR
Changed the reward for vaults/caches to be a 33% split between NFSD/FO/MD accounts
## Why / Balance
Admin discussion on how to try and prevent negative RP interactions between NFSD and non NFSD jobs

Idea thread https://ptb.discord.com/channels/1123826877245694004/1377126872608931840

Note that this is not set in stone, open to discussions as to why this is not the best idea

## Technical details
Edited event rewards.yml


## How to test
Addgamerule a vault/cache
endgamerule a vault/cache

Notice all accounts get money for it

## Media
![image](https://github.com/user-attachments/assets/af7e3e41-a5da-4a16-9b67-fd4cd02b2fc2)
Before^

![image](https://github.com/user-attachments/assets/cdd29d04-009f-4c75-b1fa-b9f6cf20b33a)
After^
## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.

## Breaking changes
It... Might cause issues with how people pay bonuses, but would need monitoring to see
**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: vaults and caches now pay to all station accounts. Sheriffs are no longer required for them

