### PR TITLE
no using headsets when cuffed (DeltaV #2610)

### DIFF
--- a/Resources/Locale/en-US/_DV/radio/headset.ftl
+++ b/Resources/Locale/en-US/_DV/radio/headset.ftl
@@ -1,0 +1,1 @@
+headset-cant-reach = You can't reach your headset!


### PR DESCRIPTION
## About the PR
Mirror https://github.com/DeltaV-Station/Delta-v/pull/2610

you cant use headsets if you are cuffed or if someone (admins rn) cuts your hands off
the reasoning being that if you have to push to talk, you need usable hands to push it
doesnt affect generic or syndie radio implants making them much more useful, or listening for messages.

## Why / Balance
good for nfsd and valids alike:
* no more pesky prisoners calling for lawyers and claiming they "have rights"
* you can actually kidnap someone now without spending on a thing solely to force people to rp if you cuff someone now they have to actually do what you say instead of :c john smith evil help

## Technical details
### Feature Addition: Restrict headset usage based on player state

* **Dependency Injection for New Systems**: Added dependencies for `SharedCuffableSystem` and `SharedPopupSystem` to the `HeadsetSystem` class to support the new functionality. (`Content.Server/Radio/EntitySystems/HeadsetSystem.cs`, [Content.Server/Radio/EntitySystems/HeadsetSystem.csR21-R22](diffhunk://#diff-86a081ffd12db900f1f6382159d60ea38d75410e36a0c775793881a182c60becR21-R22))
* **Hand and Cuff Checks**: Implemented logic in the `OnSpeak` method to check if the player has at least one hand and is not cuffed before allowing headset usage. Displays a caution popup message if the conditions are not met. (`Content.Server/Radio/EntitySystems/HeadsetSystem.cs`, [Content.Server/Radio/EntitySystems/HeadsetSystem.csR61-R70](diffhunk://#diff-86a081ffd12db900f1f6382159d60ea38d75410e36a0c775793881a182c60becR61-R70))

### Localization Update

* **New Popup Message**: Added a localized string `"headset-cant-reach"` to notify players when they cannot use their headset due to missing or cuffed hands. (`Resources/Locale/en-US/_DV/radio/headset.ftl`, [Resources/Locale/en-US/_DV/radio/headset.ftlR1](diffhunk://#diff-712ddaba6803c70250e0067d9d60f4c568ce6dce56ba1eb17d4459906e1dbc15R1))

### Code Maintenance

* **Namespace Updates**: Added necessary `using` directives for components and systems related to cuffs, hands, and popups. (`Content.Server/Radio/EntitySystems/HeadsetSystem.cs`, [Content.Server/Radio/EntitySystems/HeadsetSystem.csR4-R8](diffhunk://#diff-86a081ffd12db900f1f6382159d60ea38d75410e36a0c775793881a182c60becR4-R8))

## How to test
Cuff yourself and talk on radio

## Media
![400089556-f74d4049-10be-4a40-b225-d9f036a0491d](https://github.com/user-attachments/assets/073fb011-8e97-49eb-8527-94889dd90f1b)
![400089615-d838bebf-f106-4c88-8531-29b2e7401e6e](https://github.com/user-attachments/assets/c75361bc-a4c0-4393-b15a-811d3905a0fa)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
:cl: deltanedas
- tweak: You can no longer use headsets when cuffed.