### PR TITLE
Accidental Guns Discharges (DeltaV #3869)

### DIFF
--- a/Content.Server/_DV/Weapons/Ranged/Components/FireOnLandComponent.cs
+++ b/Content.Server/_DV/Weapons/Ranged/Components/FireOnLandComponent.cs
@@ -1,0 +1,11 @@
+namespace Content.Server._DV.Weapons.Ranged.Components;
+
+[RegisterComponent]
+public sealed partial class FireOnLandComponent : Component
+{
+    /// <summary>
+    /// Chance to trigger.
+    /// </summary>
+    [DataField]
+    public float Probability = 0.1f;
+}

--- a/Content.Server/_DV/Weapons/Ranged/Systems/FireOnLandSystem.cs
+++ b/Content.Server/_DV/Weapons/Ranged/Systems/FireOnLandSystem.cs
@@ -1,0 +1,31 @@
+using System.Numerics;
+using Content.Server._DV.Weapons.Ranged.Components;
+using Content.Server.Weapons.Ranged.Systems;
+using Content.Shared.Throwing;
+using Content.Shared.Weapons.Ranged.Components;
+using Robust.Shared.Map;
+using Robust.Shared.Random;
+
+namespace Content.Server._DV.Weapons.Ranged.Systems;
+
+public sealed class FireOnLandSystem : EntitySystem
+{
+    [Dependency] private readonly GunSystem _gunSystem = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<FireOnLandComponent, LandEvent>(FireOnLand);
+    }
+
+    private void FireOnLand(Entity<FireOnLandComponent> ent, ref LandEvent args)
+    {
+        if (!_random.Prob(ent.Comp.Probability) || !TryComp(ent, out GunComponent? gc))
+            return;
+
+        var dir = gc.DefaultDirection;
+        dir = new Vector2(-dir.Y, dir.X); // 90 degrees counter-clockwise, guns shoot down by default
+        _gunSystem.AttemptShoot(ent, ent, gc, new EntityCoordinates(ent, dir));
+    }
+}

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -67,6 +67,7 @@
   - type: Appearance
   - type: StaticPrice
     price: 500
+  - type: FireOnLand # DeltaV - gun safety
 
 - type: entity
   name: viper


### PR DESCRIPTION
## About the PR
Mirror https://github.com/DeltaV-Station/Delta-v/pull/3869
"Whenever a pistol hits the ground (via throwing, tripping, or any physics-based method) there is a small chance for it to fire."

## Why / Balance
It's funny, and also slightly discourages nfsd from open-carrying magazine-fed pistols 24/7.
This currently applies only to ballistic, magazine-fed pistols- no revolvers or energy weapons. The chance of it happening is 10%, which felt pretty reasonable in testing, but might be worth adjusting.

## Technical details
Adds a ``FireOnLandComponent`` which does about what it says on the tin. Any gun inheriting from ``BaseWeaponPistol`` gets the component.

## How to test
Run with your pistol, slip on soap.

## Media
Inside https://github.com/DeltaV-Station/Delta-v/pull/3869

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
:cl: kotobdev
- tweak: Pistols now have a small chance to fire upon hitting the ground.
