### PR TITLE
not needing t2 sec for RD hardsuit

### DIFF
--- a/Resources/Prototypes/_NF/Research/experimental.yml
+++ b/Resources/Prototypes/_NF/Research/experimental.yml
@@ -55,4 +55,3 @@
   - ClothingOuterHardsuitRd
   # technologyPrerequisites:
   # - HardsuitsArmored
-#Why does RD hardsuit need a t2 sec research to print?

--- a/Resources/Prototypes/_NF/Research/experimental.yml
+++ b/Resources/Prototypes/_NF/Research/experimental.yml
@@ -53,5 +53,5 @@
   cost: 15000
   recipeUnlocks:
   - ClothingOuterHardsuitRd
-  # technologyPrerequisites:
-  # - HardsuitsArmored
+# technologyPrerequisites:
+# - HardsuitsArmored

--- a/Resources/Prototypes/_NF/Research/experimental.yml
+++ b/Resources/Prototypes/_NF/Research/experimental.yml
@@ -53,5 +53,3 @@
   cost: 15000
   recipeUnlocks:
   - ClothingOuterHardsuitRd
-# technologyPrerequisites:
-# - HardsuitsArmored

--- a/Resources/Prototypes/_NF/Research/experimental.yml
+++ b/Resources/Prototypes/_NF/Research/experimental.yml
@@ -53,5 +53,6 @@
   cost: 15000
   recipeUnlocks:
   - ClothingOuterHardsuitRd
-  technologyPrerequisites:
-  - HardsuitsArmored
+  # technologyPrerequisites:
+  # - HardsuitsArmored
+#Why does RD hardsuit need a t2 sec research to print?


### PR DESCRIPTION
## About the PR
Yeah so apparently RD hardsuits are getting removed from sci ships
## Why / Balance

Removes the armored hardsuits prerequisite from RD hardsuit research, making it less of a hassle to get

it's not that useful for combat, just for the explosive and heat damage (okay so maybe silicon combat)
Also it just was always a hassle to print more RD suits
## Technical details

Pressed shift 3 on two lines in experimental .yml

## How to test
Open the guidebook, notice the rd tech no longer needs armored hardsuit
## Media
![image](https://github.com/user-attachments/assets/d14f5da5-e842-4f29-8011-f4f088b38600)


## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.

## Breaking changes
None?
**Changelog**
:cl:
- tweak: Research Director hardsuit research no longer needs armored hardsuit research.
