### PR TITLE
Shuttle (Update): Airtight flaps consistency

### DIFF
--- a/Resources/Maps/_NF/Shuttles/ambition.yml
+++ b/Resources/Maps/_NF/Shuttles/ambition.yml
@@ -2292,18 +2292,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 8.5,33.5
       parent: 1
-  - uid: 2089
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -1.5,34.5
-      parent: 1
-  - uid: 2098
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 2.5,34.5
-      parent: 1
 - proto: AtmosFixBlockerMarker
   entities:
   - uid: 35
@@ -12735,11 +12723,25 @@ entities:
       parent: 1
 - proto: PlasticFlapsAirtightClear
   entities:
+  - uid: 2089
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,34.5
+      parent: 1
+  - uid: 2098
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,34.5
+      parent: 1
+- proto: PlasticFlapClear
+  entities:
   - uid: 568
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 3.5,32.5
+      pos: 2.5,32.5
       parent: 1
   - uid: 1943
     components:

--- a/Resources/Maps/_NF/Shuttles/barge.yml
+++ b/Resources/Maps/_NF/Shuttles/barge.yml
@@ -633,12 +633,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 5.5,3.5
       parent: 70
-  - uid: 52
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 5.5,-0.5
-      parent: 70
   - uid: 81
     components:
     - type: Transform
@@ -662,12 +656,6 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,0.5
-      parent: 70
-  - uid: 601
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -4.5,1.5
       parent: 70
 - proto: AtmosFixBlockerMarker
   entities:

--- a/Resources/Maps/_NF/Shuttles/bazaar.yml
+++ b/Resources/Maps/_NF/Shuttles/bazaar.yml
@@ -1047,12 +1047,6 @@ entities:
       parent: 1
 - proto: AtmosDeviceFanDirectional
   entities:
-  - uid: 48
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 14.5,4.5
-      parent: 1
   - uid: 55
     components:
     - type: Transform
@@ -1159,12 +1153,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -13.5,3.5
-      parent: 1
-  - uid: 461
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -13.5,4.5
       parent: 1
 - proto: AtmosFixBlockerMarker
   entities:

--- a/Resources/Maps/_NF/Shuttles/bodkin.yml
+++ b/Resources/Maps/_NF/Shuttles/bodkin.yml
@@ -777,18 +777,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 7.5,-5.5
       parent: 2
-  - uid: 334
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 7.5,-8.5
-      parent: 2
-  - uid: 335
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -6.5,-8.5
-      parent: 2
   - uid: 336
     components:
     - type: Transform

--- a/Resources/Maps/_NF/Shuttles/bulker.yml
+++ b/Resources/Maps/_NF/Shuttles/bulker.yml
@@ -691,16 +691,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: -5.5,3.5
       parent: 1
-  - uid: 454
-    components:
-    - type: Transform
-      pos: -1.5,-7.5
-      parent: 1
-  - uid: 469
-    components:
-    - type: Transform
-      pos: 2.5,-7.5
-      parent: 1
   - uid: 504
     components:
     - type: Transform

--- a/Resources/Maps/_NF/Shuttles/chisel.yml
+++ b/Resources/Maps/_NF/Shuttles/chisel.yml
@@ -719,12 +719,6 @@ entities:
       parent: 1
 - proto: AtmosDeviceFanDirectional
   entities:
-  - uid: 306
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -6.5,-1.5
-      parent: 1
   - uid: 314
     components:
     - type: Transform
@@ -748,12 +742,6 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,4.5
-      parent: 1
-  - uid: 346
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,4.5
       parent: 1
 - proto: AtmosFixBlockerMarker
   entities:
@@ -2278,13 +2266,20 @@ entities:
       parent: 1
     - type: Physics
       bodyType: Static
-- proto: PlasticFlapsClear
+- proto: PlasticFlapsAirtightClear
   entities:
   - uid: 166
     components:
     - type: Transform
       pos: -6.5,-1.5
       parent: 1
+  - uid: 184
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 1
+- proto: PlasticFlapsClear
+  entities:
   - uid: 173
     components:
     - type: Transform
@@ -2294,11 +2289,6 @@ entities:
     components:
     - type: Transform
       pos: 1.5,2.5
-      parent: 1
-  - uid: 184
-    components:
-    - type: Transform
-      pos: 1.5,4.5
       parent: 1
 - proto: PortableGeneratorSuperPacmanShuttle
   entities:

--- a/Resources/Maps/_NF/Shuttles/comet.yml
+++ b/Resources/Maps/_NF/Shuttles/comet.yml
@@ -937,23 +937,11 @@ entities:
       rot: 3.141592653589793 rad
       pos: 1.5,18.5
       parent: 1
-  - uid: 245
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 2.5,18.5
-      parent: 1
   - uid: 246
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,9.5
-      parent: 1
-  - uid: 247
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -1.5,18.5
       parent: 1
   - uid: 248
     components:
@@ -3586,6 +3574,8 @@ entities:
     - type: Transform
       pos: -1.5,18.5
       parent: 1
+- proto: PlasticFlapsClear
+  entities:
   - uid: 444
     components:
     - type: Transform

--- a/Resources/Maps/_NF/Shuttles/crossroads.yml
+++ b/Resources/Maps/_NF/Shuttles/crossroads.yml
@@ -1396,12 +1396,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 1.5,15.5
       parent: 1
-  - uid: 56
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 2.5,15.5
-      parent: 1
 - proto: AtmosFixBlockerMarker
   entities:
   - uid: 57
@@ -6170,19 +6164,21 @@ entities:
       rot: 3.141592653589793 rad
       pos: 8.5,-5.5
       parent: 1
-- proto: PlasticFlapsAirtightClear
+- proto: PlasticFlapsClear
   entities:
   - uid: 741
     components:
     - type: Transform
       pos: 2.5,13.5
       parent: 1
+- proto: PlasticFlapsAirtightClear
+  entities:
   - uid: 742
     components:
     - type: Transform
       pos: 2.5,15.5
       parent: 1
-- proto: PlasticFlapsAirtightOpaque
+- proto: PlasticFlapsOpaque
   entities:
   - uid: 743
     components:

--- a/Resources/Maps/_NF/Shuttles/gasbender.yml
+++ b/Resources/Maps/_NF/Shuttles/gasbender.yml
@@ -1546,12 +1546,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -6.5,2.5
       parent: 1
-  - uid: 44
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -7.5,-9.5
-      parent: 1
   - uid: 111
     components:
     - type: Transform
@@ -1581,11 +1575,6 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,0.5
-      parent: 1
-  - uid: 193
-    components:
-    - type: Transform
-      pos: -3.5,-15.5
       parent: 1
   - uid: 210
     components:
@@ -7086,13 +7075,21 @@ entities:
     - type: Transform
       pos: 1.5,14.5
       parent: 1
-- proto: PlasticFlapsAirtightClear
+- proto: PlasticFlapsClear
   entities:
   - uid: 159
     components:
     - type: Transform
       pos: -3.5,-13.5
       parent: 1
+  - uid: 662
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-9.5
+      parent: 1
+- proto: PlasticFlapsAirtightClear
+  entities:
   - uid: 167
     components:
     - type: Transform
@@ -7103,12 +7100,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,-9.5
-      parent: 1
-  - uid: 662
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -5.5,-9.5
       parent: 1
 - proto: PortableGeneratorDKJrShuttle
   entities:

--- a/Resources/Maps/_NF/Shuttles/hauler.yml
+++ b/Resources/Maps/_NF/Shuttles/hauler.yml
@@ -825,23 +825,11 @@ entities:
       parent: 1
 - proto: AtmosDeviceFanDirectional
   entities:
-  - uid: 32
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 8.5,13.5
-      parent: 1
   - uid: 64
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 8.5,10.5
-      parent: 1
-  - uid: 91
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 8.5,9.5
       parent: 1
   - uid: 102
     components:
@@ -853,12 +841,6 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 8.5,12.5
-      parent: 1
-  - uid: 134
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -6.5,12.5
       parent: 1
   - uid: 162
     components:
@@ -4094,11 +4076,6 @@ entities:
     - type: Transform
       pos: -6.5,12.5
       parent: 1
-  - uid: 805
-    components:
-    - type: Transform
-      pos: -2.5,16.5
-      parent: 1
   - uid: 907
     components:
     - type: Transform
@@ -4108,6 +4085,13 @@ entities:
     components:
     - type: Transform
       pos: 8.5,13.5
+      parent: 1
+- proto: PlasticFlapsOpaque
+  entities:
+  - uid: 805
+    components:
+    - type: Transform
+      pos: -2.5,16.5
       parent: 1
 - proto: PlasticFlapsClear
   entities:

--- a/Resources/Maps/_NF/Shuttles/investigator.yml
+++ b/Resources/Maps/_NF/Shuttles/investigator.yml
@@ -723,18 +723,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 4.5,6.5
       parent: 2
-  - uid: 227
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 5.5,6.5
-      parent: 2
-  - uid: 232
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,6.5
-      parent: 2
   - uid: 233
     components:
     - type: Transform
@@ -3844,7 +3832,7 @@ entities:
     - type: Transform
       pos: -0.5,-4.5
       parent: 2
-- proto: PlasticFlapsAirtightClear
+- proto: PlasticFlapsClear
   entities:
   - uid: 375
     components:
@@ -3856,6 +3844,8 @@ entities:
     - type: Transform
       pos: 5.5,3.5
       parent: 2
+- proto: PlasticFlapsAirtightClear
+  entities:
   - uid: 455
     components:
     - type: Transform

--- a/Resources/Maps/_NF/Shuttles/izakaya.yml
+++ b/Resources/Maps/_NF/Shuttles/izakaya.yml
@@ -1708,11 +1708,6 @@ entities:
     - type: Transform
       pos: 14.5,-28.5
       parent: 1
-  - uid: 47
-    components:
-    - type: Transform
-      pos: 13.5,-28.5
-      parent: 1
   - uid: 48
     components:
     - type: Transform

--- a/Resources/Maps/_NF/Shuttles/liquidator.yml
+++ b/Resources/Maps/_NF/Shuttles/liquidator.yml
@@ -587,12 +587,6 @@ entities:
     - type: Transform
       pos: -3.5,-7.5
       parent: 1
-  - uid: 187
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 5.5,3.5
-      parent: 1
   - uid: 215
     components:
     - type: Transform
@@ -2355,7 +2349,7 @@ entities:
       parent: 1
     - type: Physics
       bodyType: Static
-- proto: PlasticFlapsClear
+- proto: PlasticFlapsAirtightClear
   entities:
   - uid: 161
     components:

--- a/Resources/Maps/_NF/Shuttles/loader.yml
+++ b/Resources/Maps/_NF/Shuttles/loader.yml
@@ -307,12 +307,6 @@ entities:
       parent: 1
 - proto: AtmosDeviceFanDirectional
   entities:
-  - uid: 177
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -3.5,3.5
-      parent: 1
   - uid: 221
     components:
     - type: Transform
@@ -1463,7 +1457,7 @@ entities:
     - type: Transform
       pos: 3.5458195,-1.807816
       parent: 1
-- proto: PlasticFlapsClear
+- proto: PlasticFlapsAirtightClear
   entities:
   - uid: 133
     components:

--- a/Resources/Maps/_NF/Shuttles/mccargo.yml
+++ b/Resources/Maps/_NF/Shuttles/mccargo.yml
@@ -1097,12 +1097,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 13.5,-1.5
       parent: 1
-  - uid: 410
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -0.5,12.5
-      parent: 1
   - uid: 411
     components:
     - type: Transform
@@ -1112,12 +1106,6 @@ entities:
     components:
     - type: Transform
       pos: -5.5,-8.5
-      parent: 1
-  - uid: 495
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -9.5,7.5
       parent: 1
   - uid: 542
     components:

--- a/Resources/Maps/_NF/Shuttles/phoenix.yml
+++ b/Resources/Maps/_NF/Shuttles/phoenix.yml
@@ -1461,16 +1461,6 @@ entities:
     - type: Transform
       pos: 1.5,-8.5
       parent: 1
-  - uid: 34
-    components:
-    - type: Transform
-      pos: -1.5,-8.5
-      parent: 1
-  - uid: 35
-    components:
-    - type: Transform
-      pos: 2.5,-8.5
-      parent: 1
 - proto: AtmosFixBlockerMarker
   entities:
   - uid: 36
@@ -4510,7 +4500,7 @@ entities:
     - type: Transform
       pos: -5.998787,10.62704
       parent: 1
-- proto: PlasticFlapsAirtightClear
+- proto: PlasticFlapsClear
   entities:
   - uid: 504
     components:
@@ -4524,6 +4514,8 @@ entities:
       rot: 3.141592653589793 rad
       pos: 2.5,-6.5
       parent: 1
+- proto: PlasticFlapsAirtightClear
+  entities:
   - uid: 506
     components:
     - type: Transform

--- a/Resources/Maps/_NF/Shuttles/prospector.yml
+++ b/Resources/Maps/_NF/Shuttles/prospector.yml
@@ -449,12 +449,6 @@ entities:
       parent: 201
 - proto: AtmosDeviceFanDirectional
   entities:
-  - uid: 21
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -6.5,-2.5
-      parent: 201
   - uid: 27
     components:
     - type: Transform
@@ -1492,6 +1486,8 @@ entities:
     - type: Transform
       pos: -6.5,-2.5
       parent: 201
+- proto: PlasticFlapsClear
+  entities:
   - uid: 134
     components:
     - type: Transform

--- a/Resources/Maps/_NF/Shuttles/vagabond.yml
+++ b/Resources/Maps/_NF/Shuttles/vagabond.yml
@@ -973,12 +973,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 3.5,1.5
       parent: 1
-  - uid: 259
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -10.5,-7.5
-      parent: 1
   - uid: 260
     components:
     - type: Transform
@@ -1011,11 +1005,6 @@ entities:
     components:
     - type: Transform
       pos: -5.5,-14.5
-      parent: 1
-  - uid: 660
-    components:
-    - type: Transform
-      pos: -4.5,-14.5
       parent: 1
 - proto: AtmosFixBlockerMarker
   entities:

--- a/Resources/Prototypes/Entities/Structures/plastic_flaps.yml
+++ b/Resources/Prototypes/Entities/Structures/plastic_flaps.yml
@@ -44,9 +44,9 @@
 - type: entity
   id: PlasticFlapsClear
   parent: PlasticFlapsBase
-  name: plastic flaps
+  name: leaky plastic flaps
   suffix: Clear
-  description: Heavy duty, plastic flaps. Definitely can't get past those. No way.
+  description: A pale imitation of the real thing. Gas will get through these but you still can't. No way.
   components:
   - type: Construction
     graph: PlasticFlapsGraph
@@ -55,9 +55,9 @@
 - type: entity
   id: PlasticFlapsOpaque
   parent: PlasticFlapsBase
-  name: plastic flaps
+  name: leaky plastic flaps
   suffix: Opaque
-  description: Heavy duty, plastic flaps. Definitely can't get past those. No way.
+  description: A pale imitation of the real thing. Gas will get through these but you still can't. No way.
   components:
   - type: Fixtures
     fixtures:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Removed redundant directional fans, made all external flaps airtight and all internal flaps regular ones on every shuttle. 

## Why / Balance
I found the usage of flaps, airtight flaps and directional fans inconsistent and that led me to believe that regular flaps were airtight when they were not during a round. 

## How to test
Check for directional fans on the same tile as airtight flaps. Checking for internal flaps would be a good bit more complicated though you might be able to get away with checking for atmos diffs on the tiles vertically and horizontally adjacent.

## Media
The tweaks only affect specific tiles and their appearance is identical due to the directional fans being covered.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [x] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- fix: Fixed airtight flaps, regular flaps and directional fans to be consistent
