### PR TITLE
Remove trailing "!" in chatstack counter

### DIFF
--- a/Resources/Locale/en-US/_EE/chat/chatstack.ftl
+++ b/Resources/Locale/en-US/_EE/chat/chatstack.ftl
@@ -1,1 +1,3 @@
-chat-system-repeated-message-counter = {" "}[font size={$size}][color=#DD3333][bold]x{$count}![/bold][/color][/font]
+# Frontier: remove exclamation mark
+# chat-system-repeated-message-counter = {" "}[font size={$size}][color=#DD3333][bold]x{$count}![/bold][/color][/font]
+chat-system-repeated-message-counter = {" "}[font size={$size}][color=#DD3333][bold]x{$count}[/bold][/color][/font]


### PR DESCRIPTION
## About the PR
Remove the exclamation mark at the end of repeated messages.

## Why / Balance
At the tiny font size the stack thing is shown at, the exclamation mark is easily confused with the digit "1". It doesn't really add anything but noise.

## Technical details
.ftl

## How to test
1. Repeat yourself. Repeatedly.

## Media
N/A

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [ ] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.

## Breaking changes
No.

**Changelog**
N/A, too small to mention