### PR TITLE
Fixed the missing contra label on the pirate ship cannon

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Shuttles/cannons.yml
+++ b/Resources/Prototypes/Entities/Structures/Shuttles/cannons.yml
@@ -275,7 +275,7 @@
 
 - type: entity
   id: ShuttleGunPirateCannon
-  parent: [BaseStructureDisableToolUse, ShuttleGunBase] # Frontier: Added BaseStructureDisableToolUse
+  parent: [BaseStructureDisableToolUse, ShuttleGunBase, BaseC3PirateContraband] # Frontier: Added BaseStructureDisableToolUse
   name: pirate ship cannon
   description: Kaboom!
   components:


### PR DESCRIPTION

## About the PR
Fixed the missing contra label on the pirate ship cannon

## Why / Balance
Despite spacelaw defining these as c3 contra, the ship mounted pirate cannon was lacking a c3 tag.

## Technical details
Added BaseC3PirateContra to pirate ship cannon
## How to test
spawn a pirate cannon

See red lock
## Media
![image](https://github.com/user-attachments/assets/d44acf01-cb15-4dd0-9d0a-80c1a191b9e4)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.

## Breaking changes
None?
**Changelog**
:cl:
- fix: The Pirate cannon (ship) now displays as C3 contraband
