### PR TITLE
Fix duped name identifiers on spawn.

### DIFF
--- a/Content.Shared/Station/SharedStationSpawningSystem.cs
+++ b/Content.Shared/Station/SharedStationSpawningSystem.cs
@@ -112,14 +112,6 @@ public abstract class SharedStationSpawningSystem : EntitySystem
             name = Loc.GetString(_random.Pick(nameData.Values));
         }
 
-        // Frontier: apply name modifiers
-        if (TryComp<NameIdentifierComponent>(entity, out var nameIdentifier))
-        {
-            // Append our name identifier (why have a pseudonym for a role that has a complete name identifier group?)
-            name = $"{name} {nameIdentifier.FullIdentifier}";
-        }
-        // End Frontier
-
         if (!string.IsNullOrEmpty(name))
         {
             _metadata.SetEntityName(entity, name);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Removes a Frontier code addition that duplicated name identifiers on spawn.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Bug.

IIRC the NameIdentifierSystem changed in the last one or two upstream merges, should've removed this then.  My mistake.

## Technical details
<!-- Summary of code changes for easier review. -->

Removes a block of code that adds a name identifier to the entity's name proper.  When this was added, borgs would spawn without a specifier at all.  This has been resolved, so this is no longer needed.

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->

Spawn as a borg with a custom name, check your name, one specifier.
Spawn as a borg with a default name, check your name, one specifier.
Take Pun Pun's ghost role, one specifier.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Expected output from test procedure:
![image](https://github.com/user-attachments/assets/ef46bcd8-ec69-4cee-af95-5fc633a4d30f)
![image](https://github.com/user-attachments/assets/db532148-1d7c-4f65-8b0c-a26d2228d950)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Borgs now spawn with one numeric identifier, not two.