### PR TITLE
Prevent portals teleporting people off of protected grids

### DIFF
--- a/Content.Server/Xenoarchaeology/Artifact/XAE/XAEPortalSystem.cs
+++ b/Content.Server/Xenoarchaeology/Artifact/XAE/XAEPortalSystem.cs
@@ -3,13 +3,13 @@ using Content.Server.Xenoarchaeology.Artifact.XAE.Components;
 using Content.Shared.Mind.Components;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Teleportation.Systems;
-using Content.Shared.Tiles;
 using Content.Shared.Xenoarchaeology.Artifact;
 using Content.Shared.Xenoarchaeology.Artifact.XAE;
 using Robust.Shared.Collections;
 using Robust.Shared.Containers;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
+using Content.Shared.Tiles; // Frontier
 
 namespace Content.Server.Xenoarchaeology.Artifact.XAE;
 
@@ -46,7 +46,7 @@ public sealed class XAEPortalSystem : BaseXAESystem<XAEPortalComponent>
 
                 if (Vector2.Distance(_transform.GetMapCoordinates(uid, xform).Position, entPosition) > ent.Comp.MaxRange)
                     continue;
-                // End Frontier: ensure range check (don't teleport people from across the map)
+                // End Frontier: ensure range check (don't teleport people from across the map or off of protected grids)
 
                 validMinds.Add(uid);
             }

--- a/Content.Server/Xenoarchaeology/Artifact/XAE/XAEPortalSystem.cs
+++ b/Content.Server/Xenoarchaeology/Artifact/XAE/XAEPortalSystem.cs
@@ -3,6 +3,7 @@ using Content.Server.Xenoarchaeology.Artifact.XAE.Components;
 using Content.Shared.Mind.Components;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Teleportation.Systems;
+using Content.Shared.Tiles;
 using Content.Shared.Xenoarchaeology.Artifact;
 using Content.Shared.Xenoarchaeology.Artifact.XAE;
 using Robust.Shared.Collections;
@@ -39,7 +40,10 @@ public sealed class XAEPortalSystem : BaseXAESystem<XAEPortalComponent>
             // check if the MindContainer has a Mind and if the entity is not in a container (this also auto excludes AI) and if they are on the same map
             if (mc.HasMind && !_container.IsEntityOrParentInContainer(uid, meta: meta, xform: xform) && xform.MapID == map)
             {
-                // Frontier: ensure range check (don't teleport people from across the map)
+                // Frontier: ensure range check (don't teleport people from across the map or off of protected grids)
+                if (TryComp(xform.GridUid, out ProtectedGridComponent? grid) && grid.PreventArtifactTriggers)
+                    continue;
+
                 if (Vector2.Distance(_transform.GetMapCoordinates(uid, xform).Position, entPosition) > ent.Comp.MaxRange)
                     continue;
                 // End Frontier: ensure range check (don't teleport people from across the map)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

What it says on the tin.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

The PreventArtifactTriggers should really be a flag for "less effects from artifacts here, please", and I think this is in keeping with that.

## Technical details
<!-- Summary of code changes for easier review. -->

Adds a grid check in the portal activation node.  Should run (fairly) infrequently.

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->

Adjust the portal node weight to be much higher than the others.
Connect on two clients.
On client 1, move your character onto Frontier Outpost.
On client 2, purchase a science shuttle.
Spam artifacts and go through node activation until you get a portal.
All portals should move the character on client 2 and not client 1's character (on the protected grid).

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
ehhhhhh, maybe