### PR TITLE
CentComm Outpost - A mini-CentComm station for Admeme purposes

### DIFF
--- a/Resources/Maps/_NF/Admin/minicentcomm.yml
+++ b/Resources/Maps/_NF/Admin/minicentcomm.yml
@@ -1,0 +1,10276 @@
+meta:
+  format: 7
+  category: Grid
+  engineVersion: 255.1.0
+  forkId: ""
+  forkVersion: ""
+  time: 06/14/2025 06:49:31
+  entityCount: 1486
+maps: []
+grids:
+- 1
+orphans:
+- 1
+nullspace: []
+tilemap:
+  3: Space
+  21: FloorAstroGrass
+  6: FloorBlueCircuit
+  0: FloorDark
+  5: FloorDarkMono
+  16: FloorGlass
+  18: FloorLino
+  23: FloorMowedAstroGrass
+  22: FloorRGlass
+  11: FloorReinforced
+  20: FloorShuttleBlack
+  8: FloorShuttleBlue
+  2: FloorSteel
+  7: FloorSteelCheckerLight
+  17: FloorSteelMini
+  12: FloorSteelMono
+  1: FloorTechMaint
+  13: FloorTechMaint2
+  19: FloorTechMaint3
+  10: FloorWhite
+  14: FloorWood
+  9: FloorWoodLarge
+  15: Lattice
+  4: Plating
+entities:
+- proto: ""
+  entities:
+  - uid: 1
+    components:
+    - type: MetaData
+      name: CentComm Outpost
+    - type: Transform
+      pos: -0.515625,-0.4375
+      parent: invalid
+    - type: MapGrid
+      chunks:
+        0,0:
+          ind: 0,0
+          tiles: AAAAAAAAAAAAAAADAAAAAAADAAAAAAADAAAAAAAAAQAAAAAAAgAAAAAAAgAAAAABAgAAAAABAQAAAAAACgAAAAABCgAAAAAACgAAAAACBAAAAAAAAwAAAAAAAwAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAADAAAAAAACBAAAAAAAAgAAAAACAgAAAAACAgAAAAAABAAAAAAAAAAAAAACAAAAAAABAAAAAAACBAAAAAAABAAAAAAABAAAAAAAAAAAAAABAAAAAAACAAAAAAACAAAAAAACAAAAAAAABAAAAAAAAgAAAAACAgAAAAACAgAAAAAABAAAAAAACgAAAAACCgAAAAAACgAAAAACBAAAAAAACwAAAAAACwAAAAAAAAAAAAACAAAAAAAAAAAAAAABAAAAAAAAAAAAAAABBAAAAAAAAgAAAAAAAgAAAAADAgAAAAAABAAAAAAACgAAAAADCgAAAAACCgAAAAAABAAAAAAACwAAAAAACwAAAAAABAAAAAAABAAAAAAABQAAAAADBAAAAAAABAAAAAAAFQAAAAADAgAAAAAAFgAAAAADAgAAAAABFgAAAAACBAAAAAAABAAAAAAABAAAAAAABAAAAAAACwAAAAAACwAAAAAAAgAAAAADAgAAAAAAAgAAAAADAgAAAAAAAgAAAAAAAgAAAAACAgAAAAACAgAAAAAAAgAAAAACFgAAAAADBAAAAAAAAAAAAAADAAAAAAADAAAAAAACAAAAAAAAAAAAAAACFgAAAAADFgAAAAABAgAAAAACAgAAAAACAgAAAAABFgAAAAAAAgAAAAACAgAAAAAAAgAAAAAAFgAAAAAABAAAAAAAAAAAAAAAAAAAAAACAAAAAAABAAAAAAAAAAAAAAABAgAAAAAAAgAAAAADAgAAAAAAAgAAAAADAgAAAAACAgAAAAADAgAAAAACAgAAAAADAgAAAAADFgAAAAABBAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAADAAAAAAACFwAAAAAAFwAAAAAAAgAAAAACAgAAAAADBAAAAAAAFQAAAAACAgAAAAADFgAAAAABAgAAAAADFgAAAAADBAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAADgAAAAAADgAAAAADDgAAAAADDgAAAAABDgAAAAADBAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAADgAAAAABDgAAAAACDgAAAAACDgAAAAACDgAAAAAABAAAAAAADwAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAADgAAAAACDgAAAAABEgAAAAAAEgAAAAAAEgAAAAAABAAAAAAADwAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAADgAAAAAADgAAAAABEgAAAAAAEgAAAAAAEgAAAAAABAAAAAAADwAAAAAADwAAAAAADwAAAAAADwAAAAAAAQAAAAAAEgAAAAAAEgAAAAAABAAAAAAAAwAAAAAAAwAAAAAADgAAAAABDgAAAAAAEgAAAAAAEgAAAAAAEgAAAAAABAAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABAAAAAAAEgAAAAAAEgAAAAAABAAAAAAAAwAAAAAAAwAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAAEAAAAAADAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAEAAAAAAABAAAAAAABAAAAAAAEAAAAAACAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAA
+          version: 6
+        0,-1:
+          ind: 0,-1
+          tiles: AwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAADwAAAAAADwAAAAAADwAAAAAADwAAAAAADwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAADwAAAAAAAwAAAAAAAwAAAAAADwAAAAAADwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABAAAAAAABAAAAAAABAAAAAAAAwAAAAAADwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAFAAAAAAAFAAAAAADBAAAAAAADwAAAAAADwAAAAAADwAAAAAADwAAAAAADwAAAAAADwAAAAAADwAAAAAADwAAAAAADwAAAAAADwAAAAAADwAAAAAADwAAAAAADwAAAAAAFAAAAAAAFAAAAAACBAAAAAAAAwAAAAAADwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAADwAAAAAAAwAAAAAAAwAAAAAADwAAAAAAAwAAAAAAAwAAAAAADwAAAAAADwAAAAAAAQAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAAAwAAAAAADwAAAAAABQAAAAADBQAAAAAABQAAAAABAAAAAAADAAAAAAAABAAAAAAAAAAAAAABAAAAAAACAAAAAAAAAQAAAAAAEQAAAAABEQAAAAABEQAAAAACBAAAAAAAAwAAAAAADwAAAAAABQAAAAAABQAAAAADBQAAAAADAAAAAAADAAAAAAABBAAAAAAAAAAAAAAAAAAAAAABAAAAAAADBAAAAAAAEQAAAAADEQAAAAABEQAAAAACBAAAAAAADwAAAAAADwAAAAAAAAAAAAABAAAAAAAAAAAAAAACAAAAAAADAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAABAAAAAAADBAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAAAwAAAAAADwAAAAAAAAAAAAABAAAAAAABAAAAAAAAAAAAAAACAAAAAAACBAAAAAAAAAAAAAACAAAAAAADAAAAAAAABAAAAAAAEQAAAAACEQAAAAAAEQAAAAABBAAAAAAAAwAAAAAADwAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABQAAAAABAAAAAAACBQAAAAABAQAAAAAAEQAAAAADEQAAAAACEQAAAAABBAAAAAAAAwAAAAAADwAAAAAABAAAAAAABgAAAAAABAAAAAAABwAAAAABBwAAAAAABAAAAAAAAQAAAAAABAAAAAAAAQAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAADwAAAAAADwAAAAAACAAAAAADBgAAAAAABAAAAAAABwAAAAADBwAAAAAABAAAAAAABQAAAAADBAAAAAAABQAAAAACBAAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABAAAAAAAAwAAAAAADwAAAAAACAAAAAAABgAAAAAABAAAAAAAAQAAAAAABAAAAAAABAAAAAAAAQAAAAAABAAAAAAAAQAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAAAwAAAAAAAwAAAAAAAQAAAAAABAAAAAAABAAAAAAAAAAAAAADAAAAAAADBAAAAAAABQAAAAACFgAAAAAABQAAAAAABAAAAAAACgAAAAACCgAAAAAACgAAAAAABAAAAAAAAwAAAAAAAwAAAAAA
+          version: 6
+        -1,0:
+          ind: -1,0
+          tiles: AwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABAAAAAAAAgAAAAADAgAAAAADAgAAAAAAAQAAAAAAAAAAAAAAAAAAAAABAAAAAAABAAAAAAADAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABAAAAAAAAgAAAAABAgAAAAADAgAAAAACBAAAAAAAAAAAAAAAAAAAAAABAAAAAAACAAAAAAACAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABAAAAAAAAgAAAAAAAgAAAAADAgAAAAAABAAAAAAAAAAAAAADAAAAAAAAAAAAAAABAAAAAAADAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAEAAAAAACBAAAAAAAAgAAAAACAgAAAAAAAgAAAAACBAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAABAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABAAAAAAAFgAAAAAAAgAAAAACFgAAAAADAgAAAAABFQAAAAACBAAAAAAABAAAAAAABAAAAAAABAAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABAAAAAAAFgAAAAACAgAAAAABAgAAAAABAgAAAAABAgAAAAABAgAAAAABAgAAAAADAgAAAAADAgAAAAADAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABAAAAAAAFgAAAAADAgAAAAAAAgAAAAADAgAAAAACFgAAAAAAAgAAAAABAgAAAAADAgAAAAAAFgAAAAACAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABAAAAAAAFgAAAAACAgAAAAADAgAAAAABAgAAAAABAgAAAAABAgAAAAACAgAAAAAAAgAAAAABAgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABAAAAAAAFgAAAAACAgAAAAAAFgAAAAABAgAAAAAAFQAAAAABBAAAAAAAAgAAAAACAgAAAAADFwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAEAAAAAABBAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAAADgAAAAADDgAAAAADDgAAAAABDgAAAAABAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABAAAAAAAAgAAAAACAgAAAAABAgAAAAADAQAAAAAADgAAAAADDgAAAAACDgAAAAACDgAAAAABAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABAAAAAAAAgAAAAADAgAAAAADAgAAAAACAQAAAAAADgAAAAADDgAAAAADDgAAAAADDgAAAAABAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABAAAAAAAAgAAAAABFgAAAAACAgAAAAAABAAAAAAADgAAAAAADgAAAAADDgAAAAADDgAAAAACAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABAAAAAAAAgAAAAABAgAAAAADAgAAAAADBAAAAAAADgAAAAADDgAAAAABDgAAAAAADgAAAAADAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABAAAAAAAAgAAAAACAgAAAAADAgAAAAADBAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAA
+          version: 6
+        -1,-1:
+          ind: -1,-1
+          tiles: AwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAADwAAAAAABAAAAAAABAAAAAAABAAAAAAADwAAAAAADwAAAAAADwAAAAAADwAAAAAADwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABAAAAAAABQAAAAAABgAAAAAABQAAAAABBAAAAAAADwAAAAAADwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABAAAAAAABgAAAAAABQAAAAADBgAAAAAABAAAAAAADwAAAAAAAwAAAAAABAAAAAAABAAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABAAAAAAABgAAAAAABQAAAAADBgAAAAAABAAAAAAADwAAAAAADwAAAAAABAAAAAAAFAAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABAAAAAAABAAAAAAAAQAAAAAABAAAAAAABAAAAAAADwAAAAAAAwAAAAAABAAAAAAAFAAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAAFgAAAAABAgAAAAABFgAAAAAAAgAAAAABBAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAgAAAAAAAgAAAAABAQAAAAAAFgAAAAADAgAAAAAAAgAAAAACAgAAAAABBAAAAAAAAAAAAAABAAAAAAAABQAAAAADBQAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAgAAAAADAgAAAAAAAQAAAAAAFgAAAAACAgAAAAABAgAAAAADAgAAAAAABAAAAAAAAAAAAAAAAAAAAAADBQAAAAABBQAAAAADAwAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAgAAAAADAgAAAAADAQAAAAAAFgAAAAADAgAAAAACAgAAAAABAgAAAAACAQAAAAAAAAAAAAADAAAAAAACAAAAAAAAAAAAAAABAwAAAAAAAwAAAAAAAwAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAAFgAAAAAAAgAAAAADFgAAAAABAgAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAACAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABAAAAAAAAgAAAAABAgAAAAAAAgAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABAAAAAAAAgAAAAADAgAAAAABAgAAAAABBAAAAAAACQAAAAACCQAAAAAABAAAAAAABgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABAAAAAAAAgAAAAAAAgAAAAADAgAAAAABBAAAAAAACQAAAAABCQAAAAACBAAAAAAABgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABAAAAAAAAgAAAAAAAgAAAAAAAgAAAAABBAAAAAAABAAAAAAAAQAAAAAABAAAAAAABgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABAAAAAAAAgAAAAACFgAAAAADAgAAAAACBAAAAAAAAAAAAAAAAAAAAAADBAAAAAAABAAAAAAA
+          version: 6
+        1,0:
+          ind: 1,0
+          tiles: AwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABAAAAAAAEAAAAAABAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAACwAAAAAABAAAAAAADwAAAAAADwAAAAAADwAAAAAADwAAAAAADwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAACwAAAAAABAAAAAAADwAAAAAAAwAAAAAADwAAAAAAAwAAAAAADwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAACwAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAADwAAAAAADwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAAAAAAADAAAAAAAAAAAAAAACAAAAAAACBAAAAAAAAwAAAAAADwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAAAAAAACAAAAAAABAAAAAAAAAAAAAAADBAAAAAAADwAAAAAADwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAAAAAAADAAAAAAABAAAAAAABAAAAAAABBAAAAAAAAwAAAAAADwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABAAAAAAABAAAAAAAAQAAAAAABAAAAAAABAAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABAAAAAAACwAAAAAACwAAAAAACwAAAAAABAAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABAAAAAAACwAAAAAACwAAAAAACwAAAAAABAAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAAEAAAAAABAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAA
+          version: 6
+        -1,1:
+          ind: -1,1
+          tiles: AwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABAAAAAAAAgAAAAABAgAAAAADAgAAAAACBAAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABAAAAAAAAgAAAAACAgAAAAAAAgAAAAABBAAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAA
+          version: 6
+    - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      fixedRotation: False
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures: {}
+    - type: OccluderTree
+    - type: SpreaderGrid
+    - type: Shuttle
+      dampingModifier: 0.25
+    - type: GridPathfinding
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+    - type: DecalGrid
+      chunkCollection:
+        version: 2
+        nodes:
+        - node:
+            color: '#FFFFFFFF'
+            id: Arrows
+          decals:
+            245: 8,-1
+        - node:
+            angle: 3.141592653589793 rad
+            color: '#FFFFFFFF'
+            id: Arrows
+          decals:
+            133: 6,-5
+        - node:
+            color: '#FFFFFFFF'
+            id: Bot
+          decals:
+            129: 6,-3
+            130: 8,-3
+        - node:
+            color: '#951710FF'
+            id: BotGreyscale
+          decals:
+            284: -2,-9
+            285: 2,-9
+        - node:
+            color: '#FFFFFFFF'
+            id: BotLeft
+          decals:
+            788: -2,5
+            789: -1,5
+            790: 0,5
+            791: 1,5
+            792: 2,5
+        - node:
+            color: '#52B4E9FF'
+            id: BoxGreyscale
+          decals:
+            325: 14,9
+        - node:
+            color: '#DE3A3AFF'
+            id: BoxGreyscale
+          decals:
+            324: 12,9
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileDarkBox
+          decals:
+            187: -7,-14
+            188: -6,-13
+            189: -8,-13
+            190: -8,-12
+            191: -6,-12
+            901: 7,-1
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileDarkCornerNe
+          decals:
+            193: 1,8
+            338: 4,13
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileDarkCornerNw
+          decals:
+            194: -1,8
+            337: 2,13
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileDarkCornerSe
+          decals:
+            335: 4,11
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileDarkCornerSw
+          decals:
+            336: 2,11
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileDarkEndS
+          decals:
+            966: -7,-13
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileDarkLineE
+          decals:
+            342: 4,12
+            968: -7,-12
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileDarkLineN
+          decals:
+            195: 0,8
+            339: 3,13
+            962: 6,-1
+            963: 8,-1
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileDarkLineS
+          decals:
+            340: 3,11
+            964: 6,-5
+            965: 8,-5
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileDarkLineW
+          decals:
+            341: 2,12
+            967: -7,-12
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileSteelBox
+          decals:
+            892: -7,-6
+            893: -7,-1
+            894: -7,4
+            895: -5,6
+            899: 5,6
+            900: 7,4
+            906: -7,-10
+            907: -7,8
+            953: -7,12
+            954: 7,8
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileSteelEndE
+          decals:
+            903: 1,6
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileSteelEndW
+          decals:
+            902: -1,6
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileSteelLineN
+          decals:
+            905: 0,6
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileSteelLineS
+          decals:
+            904: 0,6
+        - node:
+            color: '#446326FF'
+            id: CheckerNESW
+          decals:
+            265: 3,-3
+            266: 4,-3
+            267: 3,-4
+            268: 4,-4
+        - node:
+            color: '#F1B2237F'
+            id: CheckerNESW
+          decals:
+            756: -9,8
+            757: -9,7
+            758: -9,6
+            759: -9,5
+            760: -9,4
+            761: 9,8
+            762: 9,7
+            763: 9,6
+            764: 9,5
+            766: -9,-6
+            767: -9,-7
+            769: -9,-9
+            770: -9,-10
+            840: -9,-8
+            961: 9,4
+        - node:
+            color: '#1F66267F'
+            id: CheckerNWSE
+          decals:
+            960: 9,4
+        - node:
+            color: '#2E99357F'
+            id: CheckerNWSE
+          decals:
+            771: -9,4
+            772: -9,5
+            773: -9,6
+            774: -9,7
+            775: -9,8
+            776: 9,8
+            777: 9,7
+            778: 9,6
+            779: 9,5
+            781: -9,-6
+            782: -9,-7
+            784: -9,-9
+            785: -9,-10
+            839: -9,-8
+        - node:
+            color: '#639137FF'
+            id: CheckerNWSE
+          decals:
+            83: 0,1
+        - node:
+            color: '#C6FF91FF'
+            id: CheckerNWSE
+          decals:
+            261: 3,-4
+            262: 3,-3
+            263: 4,-3
+            264: 4,-4
+        - node:
+            color: '#FFFFFFFF'
+            id: Flowersy3
+          decals:
+            797: -5,4
+            799: 5,8
+            800: 5,4
+            911: 1,8
+        - node:
+            color: '#FFFFFFFF'
+            id: Flowersy4
+          decals:
+            842: -5,8
+            910: -1,8
+        - node:
+            color: '#446326FF'
+            id: HalfTileOverlayGreyscale
+          decals:
+            91: 4,3
+            92: 3,3
+            93: 2,3
+            94: 1,3
+            95: 0,3
+            96: -1,3
+            97: -2,3
+            98: -4,3
+            99: -3,3
+        - node:
+            color: '#52B4E996'
+            id: HalfTileOverlayGreyscale
+          decals:
+            250: 10,3
+            251: 11,3
+            252: 12,3
+        - node:
+            color: '#DE3A3A96'
+            id: HalfTileOverlayGreyscale
+          decals:
+            232: -4,-6
+            233: -3,-6
+            234: -2,-6
+            235: -1,-6
+            236: 0,-6
+            237: 1,-6
+            238: 2,-6
+            239: 3,-6
+            240: 4,-6
+            241: 7,-5
+        - node:
+            color: '#EFB34196'
+            id: HalfTileOverlayGreyscale
+          decals:
+            315: 11,7
+            316: 12,7
+            317: 13,7
+            318: 14,7
+            319: 15,7
+            320: 16,7
+            321: 17,7
+            322: 18,7
+            323: 19,7
+        - node:
+            color: '#446326FF'
+            id: HalfTileOverlayGreyscale180
+          decals:
+            100: -4,-1
+            101: -3,-1
+            102: 3,-1
+            103: 4,-1
+        - node:
+            color: '#52B4E996'
+            id: HalfTileOverlayGreyscale180
+          decals:
+            247: 10,-1
+            248: 11,-1
+            249: 12,-1
+        - node:
+            color: '#DE3A3A96'
+            id: HalfTileOverlayGreyscale180
+          decals:
+            222: 10,1
+            223: 11,1
+            224: 12,1
+            225: 6,-9
+            226: 7,-9
+            227: 8,-9
+            228: -4,-9
+            229: -3,-9
+            230: 3,-9
+            231: 4,-9
+        - node:
+            color: '#EFB34196'
+            id: HalfTileOverlayGreyscale180
+          decals:
+            306: 11,5
+            307: 12,5
+            308: 13,5
+            309: 14,5
+            310: 15,5
+            311: 16,5
+            312: 17,5
+            313: 18,5
+            314: 19,5
+        - node:
+            color: '#639137FF'
+            id: HalfTileOverlayGreyscale270
+          decals:
+            82: 1,1
+        - node:
+            color: '#639137FF'
+            id: HalfTileOverlayGreyscale90
+          decals:
+            81: -1,1
+        - node:
+            color: '#951710FF'
+            id: MiniTileCornerOverlayNE
+          decals:
+            294: 1,-11
+        - node:
+            color: '#951710FF'
+            id: MiniTileCornerOverlayNW
+          decals:
+            293: -1,-11
+        - node:
+            color: '#951710FF'
+            id: MiniTileCornerOverlaySE
+          decals:
+            292: 1,-12
+        - node:
+            color: '#951710FF'
+            id: MiniTileCornerOverlaySW
+          decals:
+            291: -1,-12
+        - node:
+            color: '#FFFFFFFF'
+            id: MiniTileDarkCornerNe
+          decals:
+            298: 2,-8
+            445: 12,13
+        - node:
+            color: '#FFFFFFFF'
+            id: MiniTileDarkCornerNw
+          decals:
+            297: -2,-8
+            444: 11,13
+        - node:
+            color: '#FFFFFFFF'
+            id: MiniTileDarkCornerSe
+          decals:
+            446: 12,12
+        - node:
+            color: '#FFFFFFFF'
+            id: MiniTileDarkCornerSw
+          decals:
+            447: 11,12
+        - node:
+            color: '#FFFFFFFF'
+            id: MiniTileDarkInnerSe
+          decals:
+            305: -2,-7
+        - node:
+            color: '#FFFFFFFF'
+            id: MiniTileDarkInnerSw
+          decals:
+            304: 2,-7
+        - node:
+            color: '#FFFFFFFF'
+            id: MiniTileDarkLineE
+          decals:
+            299: 2,-9
+        - node:
+            color: '#FFFFFFFF'
+            id: MiniTileDarkLineS
+          decals:
+            301: 1,-7
+            302: 0,-7
+            303: -1,-7
+        - node:
+            color: '#FFFFFFFF'
+            id: MiniTileDarkLineW
+          decals:
+            300: -2,-9
+        - node:
+            color: '#951710FF'
+            id: MiniTileLineOverlayN
+          decals:
+            295: 0,-11
+        - node:
+            color: '#D58C18FF'
+            id: MiniTileLineOverlayN
+          decals:
+            269: 10,-5
+            270: 11,-5
+            271: 12,-5
+            272: 10,-8
+            273: 11,-8
+            274: 12,-8
+        - node:
+            color: '#951710FF'
+            id: MiniTileLineOverlayS
+          decals:
+            296: 0,-12
+        - node:
+            color: '#D58C18FF'
+            id: MiniTileLineOverlayS
+          decals:
+            275: 10,-9
+            276: 11,-9
+            277: 12,-9
+            278: 12,-6
+            279: 11,-6
+            280: 10,-6
+        - node:
+            color: '#639137FF'
+            id: QuarterTileOverlayGreyscale
+          decals:
+            78: 1,0
+            79: 2,0
+        - node:
+            color: '#446326FF'
+            id: QuarterTileOverlayGreyscale180
+          decals:
+            87: -1,0
+        - node:
+            color: '#639137FF'
+            id: QuarterTileOverlayGreyscale180
+          decals:
+            77: -1,2
+            80: -2,2
+        - node:
+            color: '#446326FF'
+            id: QuarterTileOverlayGreyscale270
+          decals:
+            85: 0,1
+            86: 1,0
+            88: 2,0
+        - node:
+            color: '#639137FF'
+            id: QuarterTileOverlayGreyscale270
+          decals:
+            76: 1,2
+        - node:
+            color: '#446326FF'
+            id: QuarterTileOverlayGreyscale90
+          decals:
+            84: 0,0
+            89: -2,1
+        - node:
+            color: '#639137FF'
+            id: QuarterTileOverlayGreyscale90
+          decals:
+            75: -1,0
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnCornerNE
+          decals:
+            181: -8,-14
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnCornerNW
+          decals:
+            180: -6,-14
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnCornerSmallSE
+          decals:
+            288: -1,-9
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnCornerSmallSW
+          decals:
+            289: 1,-9
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnLineE
+          decals:
+            977: -5,11
+            978: -5,10
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnLineN
+          decals:
+            246: 6,-1
+            287: 0,-9
+            787: -9,-10
+            909: -7,-10
+            952: -8,-10
+            969: -8,9
+            970: -7,9
+            971: -6,9
+        - node:
+            zIndex: 1
+            color: '#FFFFFFFF'
+            id: WarnLineN
+          decals:
+            944: -6,-10
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnLineS
+          decals:
+            972: -5,10
+            973: -5,11
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnLineW
+          decals:
+            136: 8,-5
+            974: -8,9
+            975: -7,9
+            976: -6,9
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinCornerNe
+          decals:
+            253: -3,-3
+            327: 1,13
+            332: 4,10
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinCornerNw
+          decals:
+            210: -4,13
+            256: -4,-3
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinCornerSe
+          decals:
+            205: 4,9
+            254: -3,-4
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinCornerSw
+          decals:
+            206: -4,9
+            255: -4,-4
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinInnerNe
+          decals:
+            328: 1,10
+            851: -6,7
+            854: 4,7
+            859: -6,3
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinInnerNw
+          decals:
+            852: 6,7
+            853: -4,7
+            860: 6,3
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinInnerSe
+          decals:
+            855: -6,5
+            856: 4,5
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinInnerSw
+          decals:
+            857: -4,5
+            858: 6,5
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinLineE
+          decals:
+            333: 1,12
+            334: 1,11
+            849: -6,8
+            850: -6,4
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinLineN
+          decals:
+            211: -3,13
+            212: -2,13
+            213: -1,13
+            214: 0,13
+            329: 2,10
+            330: 3,10
+            843: -5,7
+            844: 5,7
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinLineS
+          decals:
+            196: -2,9
+            197: -1,9
+            198: 0,9
+            199: 1,9
+            200: 2,9
+            201: 3,9
+            203: -3,9
+            845: -5,5
+            846: 5,5
+            912: -1,8
+            913: 0,8
+            914: 1,8
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinLineW
+          decals:
+            207: -4,10
+            208: -4,11
+            209: -4,12
+            847: 6,8
+            848: 6,4
+        - node:
+            cleanable: True
+            color: '#DE3A3A96'
+            id: heart
+          decals:
+            326: 15.078187,1.8530874
+    - type: GridAtmosphere
+      version: 2
+      data:
+        tiles:
+          0,0:
+            0: 65535
+          -1,0:
+            0: 65535
+          0,1:
+            0: 65524
+          -1,1:
+            0: 65520
+          0,2:
+            0: 65535
+          -1,2:
+            0: 65534
+          0,3:
+            0: 255
+          -1,3:
+            0: 255
+          0,-1:
+            0: 35771
+          1,0:
+            0: 56799
+          1,1:
+            0: 65534
+          1,2:
+            0: 4382
+            1: 17408
+          1,3:
+            0: 17
+            2: 512
+            1: 12
+          1,-1:
+            0: 54357
+          2,0:
+            0: 56799
+          2,1:
+            0: 49075
+          2,2:
+            0: 4883
+            3: 2176
+          2,3:
+            1: 3
+            0: 140
+            2: 1024
+          2,-1:
+            0: 53521
+          3,0:
+            0: 56593
+          3,1:
+            0: 65532
+          3,2:
+            3: 272
+            4: 3264
+          3,3:
+            0: 17
+            2: 512
+          3,-1:
+            0: 4096
+            1: 140
+          4,0:
+            0: 4352
+            2: 32
+            1: 19456
+          4,1:
+            0: 65521
+          0,-4:
+            1: 2544
+          -1,-4:
+            1: 5104
+          0,-3:
+            0: 61491
+            1: 8
+          -1,-3:
+            0: 61576
+            1: 19
+          0,-2:
+            0: 4095
+          -1,-2:
+            0: 4095
+          -1,-1:
+            0: 15035
+          1,-4:
+            1: 4368
+          1,-3:
+            1: 31
+            0: 53248
+          1,-2:
+            0: 52733
+          2,-3:
+            1: 159
+            0: 61440
+          2,-2:
+            0: 64797
+          3,-3:
+            1: 35023
+            0: 4096
+          3,-2:
+            0: 4353
+            1: 34956
+          -3,0:
+            2: 16384
+          -3,1:
+            0: 34952
+          -3,2:
+            2: 64
+            0: 8
+          -2,0:
+            0: 30591
+          -2,1:
+            0: 65535
+          -2,2:
+            0: 65407
+          -2,3:
+            0: 30583
+          -2,-1:
+            0: 30583
+          -2,4:
+            0: 1911
+          -4,-3:
+            0: 32768
+          -4,-2:
+            0: 136
+          -3,-3:
+            0: 63488
+          -3,-2:
+            0: 2303
+          -3,-4:
+            1: 128
+          -2,-4:
+            0: 30464
+            1: 128
+          -2,-3:
+            0: 30471
+          -2,-2:
+            0: 30711
+          4,2:
+            0: 3808
+          5,0:
+            1: 22272
+          5,2:
+            2: 4096
+          5,1:
+            1: 17990
+        uniqueMixes:
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 21.824879
+          - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          immutable: True
+          moles:
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 0
+          - 6666.982
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 6666.982
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        chunkSize: 4
+    - type: GasTileOverlay
+    - type: RadiationGridResistance
+    - type: BecomesStation
+      id: CentcommOutpost
+    - type: ForceAnchor
+    - type: PreventGridAnchorChanges
+    - type: IFF
+      readOnly: True
+      color: '#00DD00FF'
+- proto: AirAlarm
+  entities:
+  - uid: 152
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-1.5
+      parent: 1
+  - uid: 1305
+    components:
+    - type: Transform
+      pos: 13.5,8.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 1153
+      - 1152
+      - 1032
+      - 1079
+      - 973
+      - 1078
+      - 1031
+      - 1112
+      - 1046
+      - 1034
+      - 1045
+      - 1035
+      - 1047
+      - 1033
+      - 1037
+      - 1036
+      - 1137
+      - 1111
+      - 1038
+      - 1092
+      - 1098
+      - 1039
+      - 1040
+      - 1100
+      - 1101
+      - 1155
+      - 1158
+      - 1129
+      - 1154
+- proto: AirlockBrigGlassLocked
+  entities:
+  - uid: 204
+    components:
+    - type: Transform
+      pos: 9.5,-4.5
+      parent: 1
+  - uid: 219
+    components:
+    - type: Transform
+      pos: 9.5,-8.5
+      parent: 1
+- proto: AirlockBrigmedicGlassLocked
+  entities:
+  - uid: 763
+    components:
+    - type: Transform
+      pos: 9.5,0.5
+      parent: 1
+- proto: AirlockCentralCommandGlassLocked
+  entities:
+  - uid: 100
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,0.5
+      parent: 1
+  - uid: 102
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,0.5
+      parent: 1
+- proto: AirlockCentralCommandLocked
+  entities:
+  - uid: 103
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-1.5
+      parent: 1
+  - uid: 104
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-1.5
+      parent: 1
+  - uid: 416
+    components:
+    - type: Transform
+      pos: 10.5,6.5
+      parent: 1
+- proto: AirlockExternalGlass
+  entities:
+  - uid: 702
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,15.5
+      parent: 1
+  - uid: 703
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,15.5
+      parent: 1
+  - uid: 704
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,15.5
+      parent: 1
+  - uid: 1185
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,12.5
+      parent: 1
+- proto: AirlockExternalGlassCommandLocked
+  entities:
+  - uid: 408
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,-7.5
+      parent: 1
+  - uid: 614
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,-6.5
+      parent: 1
+  - uid: 619
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,-8.5
+      parent: 1
+- proto: AirlockExternalGlassLocked
+  entities:
+  - uid: 360
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,9.5
+      parent: 1
+  - uid: 375
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,11.5
+      parent: 1
+- proto: AirlockGlassShuttle
+  entities:
+  - uid: 308
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,18.5
+      parent: 1
+  - uid: 403
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -12.5,-7.5
+      parent: 1
+  - uid: 617
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -12.5,-8.5
+      parent: 1
+  - uid: 625
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -12.5,-6.5
+      parent: 1
+  - uid: 656
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,18.5
+      parent: 1
+  - uid: 657
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,18.5
+      parent: 1
+- proto: AirlockSecurityGlassLocked
+  entities:
+  - uid: 227
+    components:
+    - type: Transform
+      pos: 6.5,-3.5
+      parent: 1
+  - uid: 228
+    components:
+    - type: Transform
+      pos: 8.5,-1.5
+      parent: 1
+  - uid: 229
+    components:
+    - type: Transform
+      pos: 5.5,-6.5
+      parent: 1
+- proto: AirlockSecurityLocked
+  entities:
+  - uid: 151
+    components:
+    - type: Transform
+      pos: -4.5,-6.5
+      parent: 1
+- proto: AlwaysPoweredlightCyan
+  entities:
+  - uid: 640
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,-13.5
+      parent: 1
+- proto: APCBasic
+  entities:
+  - uid: 129
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-0.5
+      parent: 1
+  - uid: 180
+    components:
+    - type: Transform
+      pos: -2.5,-4.5
+      parent: 1
+  - uid: 467
+    components:
+    - type: Transform
+      pos: 16.5,8.5
+      parent: 1
+  - uid: 764
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-9.5
+      parent: 1
+  - uid: 765
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,3.5
+      parent: 1
+  - uid: 766
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,3.5
+      parent: 1
+  - uid: 767
+    components:
+    - type: Transform
+      pos: 7.5,9.5
+      parent: 1
+- proto: AtmosDeviceFanDirectional
+  entities:
+  - uid: 310
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,18.5
+      parent: 1
+  - uid: 317
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,18.5
+      parent: 1
+  - uid: 374
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,18.5
+      parent: 1
+  - uid: 376
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,11.5
+      parent: 1
+  - uid: 616
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -12.5,-8.5
+      parent: 1
+  - uid: 626
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -12.5,-7.5
+      parent: 1
+  - uid: 631
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -12.5,-6.5
+      parent: 1
+  - uid: 1184
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,12.5
+      parent: 1
+- proto: AtmosFixBlockerMarker
+  entities:
+  - uid: 31
+    components:
+    - type: Transform
+      pos: -3.5,-10.5
+      parent: 1
+  - uid: 1342
+    components:
+    - type: Transform
+      pos: -3.5,-11.5
+      parent: 1
+  - uid: 1397
+    components:
+    - type: Transform
+      pos: -2.5,-11.5
+      parent: 1
+  - uid: 1398
+    components:
+    - type: Transform
+      pos: -3.5,-12.5
+      parent: 1
+  - uid: 1399
+    components:
+    - type: Transform
+      pos: -3.5,-13.5
+      parent: 1
+  - uid: 1400
+    components:
+    - type: Transform
+      pos: -2.5,-13.5
+      parent: 1
+  - uid: 1401
+    components:
+    - type: Transform
+      pos: -4.5,-14.5
+      parent: 1
+  - uid: 1402
+    components:
+    - type: Transform
+      pos: -8.5,-14.5
+      parent: 1
+  - uid: 1403
+    components:
+    - type: Transform
+      pos: -3.5,-14.5
+      parent: 1
+  - uid: 1404
+    components:
+    - type: Transform
+      pos: -2.5,-14.5
+      parent: 1
+  - uid: 1405
+    components:
+    - type: Transform
+      pos: -1.5,-14.5
+      parent: 1
+  - uid: 1406
+    components:
+    - type: Transform
+      pos: -0.5,-14.5
+      parent: 1
+  - uid: 1407
+    components:
+    - type: Transform
+      pos: 0.5,-13.5
+      parent: 1
+  - uid: 1408
+    components:
+    - type: Transform
+      pos: 0.5,-14.5
+      parent: 1
+  - uid: 1409
+    components:
+    - type: Transform
+      pos: 1.5,-14.5
+      parent: 1
+  - uid: 1410
+    components:
+    - type: Transform
+      pos: 3.5,-14.5
+      parent: 1
+  - uid: 1411
+    components:
+    - type: Transform
+      pos: 2.5,-14.5
+      parent: 1
+  - uid: 1412
+    components:
+    - type: Transform
+      pos: 3.5,-13.5
+      parent: 1
+  - uid: 1413
+    components:
+    - type: Transform
+      pos: 4.5,-14.5
+      parent: 1
+  - uid: 1414
+    components:
+    - type: Transform
+      pos: 4.5,-13.5
+      parent: 1
+  - uid: 1415
+    components:
+    - type: Transform
+      pos: 4.5,-12.5
+      parent: 1
+  - uid: 1416
+    components:
+    - type: Transform
+      pos: 4.5,-11.5
+      parent: 1
+  - uid: 1417
+    components:
+    - type: Transform
+      pos: 4.5,-10.5
+      parent: 1
+  - uid: 1418
+    components:
+    - type: Transform
+      pos: 3.5,-11.5
+      parent: 1
+  - uid: 1419
+    components:
+    - type: Transform
+      pos: 5.5,-11.5
+      parent: 1
+  - uid: 1420
+    components:
+    - type: Transform
+      pos: 6.5,-11.5
+      parent: 1
+  - uid: 1421
+    components:
+    - type: Transform
+      pos: 7.5,-11.5
+      parent: 1
+  - uid: 1422
+    components:
+    - type: Transform
+      pos: 8.5,-11.5
+      parent: 1
+  - uid: 1423
+    components:
+    - type: Transform
+      pos: 9.5,-11.5
+      parent: 1
+  - uid: 1424
+    components:
+    - type: Transform
+      pos: 10.5,-11.5
+      parent: 1
+  - uid: 1425
+    components:
+    - type: Transform
+      pos: 11.5,-11.5
+      parent: 1
+  - uid: 1426
+    components:
+    - type: Transform
+      pos: 12.5,-11.5
+      parent: 1
+  - uid: 1427
+    components:
+    - type: Transform
+      pos: 13.5,-11.5
+      parent: 1
+  - uid: 1428
+    components:
+    - type: Transform
+      pos: 14.5,-11.5
+      parent: 1
+  - uid: 1429
+    components:
+    - type: Transform
+      pos: 15.5,-11.5
+      parent: 1
+  - uid: 1430
+    components:
+    - type: Transform
+      pos: 8.5,-10.5
+      parent: 1
+  - uid: 1431
+    components:
+    - type: Transform
+      pos: 11.5,-10.5
+      parent: 1
+  - uid: 1432
+    components:
+    - type: Transform
+      pos: 14.5,-10.5
+      parent: 1
+  - uid: 1433
+    components:
+    - type: Transform
+      pos: 15.5,-10.5
+      parent: 1
+  - uid: 1434
+    components:
+    - type: Transform
+      pos: 15.5,-9.5
+      parent: 1
+  - uid: 1435
+    components:
+    - type: Transform
+      pos: 15.5,-8.5
+      parent: 1
+  - uid: 1436
+    components:
+    - type: Transform
+      pos: 15.5,-7.5
+      parent: 1
+  - uid: 1437
+    components:
+    - type: Transform
+      pos: 15.5,-6.5
+      parent: 1
+  - uid: 1438
+    components:
+    - type: Transform
+      pos: 15.5,-3.5
+      parent: 1
+  - uid: 1439
+    components:
+    - type: Transform
+      pos: 15.5,-4.5
+      parent: 1
+  - uid: 1440
+    components:
+    - type: Transform
+      pos: 15.5,-2.5
+      parent: 1
+  - uid: 1441
+    components:
+    - type: Transform
+      pos: 15.5,-5.5
+      parent: 1
+  - uid: 1442
+    components:
+    - type: Transform
+      pos: 14.5,-3.5
+      parent: 1
+  - uid: 1443
+    components:
+    - type: Transform
+      pos: 14.5,-7.5
+      parent: 1
+  - uid: 1444
+    components:
+    - type: Transform
+      pos: 17.5,1.5
+      parent: 1
+  - uid: 1445
+    components:
+    - type: Transform
+      pos: 18.5,3.5
+      parent: 1
+  - uid: 1446
+    components:
+    - type: Transform
+      pos: 18.5,2.5
+      parent: 1
+  - uid: 1447
+    components:
+    - type: Transform
+      pos: 19.5,2.5
+      parent: 1
+  - uid: 1448
+    components:
+    - type: Transform
+      pos: 20.5,2.5
+      parent: 1
+  - uid: 1449
+    components:
+    - type: Transform
+      pos: 21.5,2.5
+      parent: 1
+  - uid: 1450
+    components:
+    - type: Transform
+      pos: 22.5,2.5
+      parent: 1
+  - uid: 1451
+    components:
+    - type: Transform
+      pos: 22.5,3.5
+      parent: 1
+  - uid: 1452
+    components:
+    - type: Transform
+      pos: 20.5,3.5
+      parent: 1
+  - uid: 1453
+    components:
+    - type: Transform
+      pos: 21.5,4.5
+      parent: 1
+  - uid: 1454
+    components:
+    - type: Transform
+      pos: 22.5,4.5
+      parent: 1
+  - uid: 1455
+    components:
+    - type: Transform
+      pos: 22.5,5.5
+      parent: 1
+  - uid: 1456
+    components:
+    - type: Transform
+      pos: 22.5,6.5
+      parent: 1
+  - uid: 1457
+    components:
+    - type: Transform
+      pos: 22.5,7.5
+      parent: 1
+  - uid: 1458
+    components:
+    - type: Transform
+      pos: 21.5,6.5
+      parent: 1
+  - uid: 1459
+    components:
+    - type: Transform
+      pos: 20.5,11.5
+      parent: 1
+  - uid: 1460
+    components:
+    - type: Transform
+      pos: 13.5,14.5
+      parent: 1
+  - uid: 1461
+    components:
+    - type: Transform
+      pos: 10.5,14.5
+      parent: 1
+  - uid: 1462
+    components:
+    - type: Transform
+      pos: 9.5,12.5
+      parent: 1
+  - uid: 1463
+    components:
+    - type: Transform
+      pos: 8.5,12.5
+      parent: 1
+  - uid: 1464
+    components:
+    - type: Transform
+      pos: 7.5,12.5
+      parent: 1
+  - uid: 1465
+    components:
+    - type: Transform
+      pos: 6.5,12.5
+      parent: 1
+  - uid: 1466
+    components:
+    - type: Transform
+      pos: 6.5,11.5
+      parent: 1
+  - uid: 1467
+    components:
+    - type: Transform
+      pos: 6.5,10.5
+      parent: 1
+  - uid: 1468
+    components:
+    - type: Transform
+      pos: 5.5,14.5
+      parent: 1
+  - uid: 1469
+    components:
+    - type: Transform
+      pos: -9.5,9.5
+      parent: 1
+  - uid: 1470
+    components:
+    - type: Transform
+      pos: -9.5,3.5
+      parent: 1
+- proto: AtmosFixNitrogenMarker
+  entities:
+  - uid: 388
+    components:
+    - type: Transform
+      pos: 11.5,10.5
+      parent: 1
+  - uid: 389
+    components:
+    - type: Transform
+      pos: 11.5,9.5
+      parent: 1
+  - uid: 390
+    components:
+    - type: Transform
+      pos: 12.5,10.5
+      parent: 1
+  - uid: 391
+    components:
+    - type: Transform
+      pos: 12.5,9.5
+      parent: 1
+- proto: AtmosFixOxygenMarker
+  entities:
+  - uid: 384
+    components:
+    - type: Transform
+      pos: 14.5,10.5
+      parent: 1
+  - uid: 385
+    components:
+    - type: Transform
+      pos: 15.5,9.5
+      parent: 1
+  - uid: 386
+    components:
+    - type: Transform
+      pos: 15.5,10.5
+      parent: 1
+  - uid: 387
+    components:
+    - type: Transform
+      pos: 14.5,9.5
+      parent: 1
+- proto: BannerNanotrasen
+  entities:
+  - uid: 1350
+    components:
+    - type: Transform
+      pos: -8.5,6.5
+      parent: 1
+- proto: BarSpoon
+  entities:
+  - uid: 1293
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.7965863,11.443083
+      parent: 1
+- proto: Bed
+  entities:
+  - uid: 87
+    components:
+    - type: Transform
+      pos: -3.5,-3.5
+      parent: 1
+  - uid: 265
+    components:
+    - type: Transform
+      pos: 12.5,-4.5
+      parent: 1
+  - uid: 266
+    components:
+    - type: Transform
+      pos: 12.5,-8.5
+      parent: 1
+- proto: BedsheetBrigmedic
+  entities:
+  - uid: 277
+    components:
+    - type: Transform
+      pos: 12.5,-0.5
+      parent: 1
+  - uid: 278
+    components:
+    - type: Transform
+      pos: 10.5,-0.5
+      parent: 1
+- proto: BedsheetCentcom
+  entities:
+  - uid: 88
+    components:
+    - type: Transform
+      pos: -3.5,-3.5
+      parent: 1
+- proto: BedsheetOrange
+  entities:
+  - uid: 271
+    components:
+    - type: Transform
+      pos: 12.5,-4.5
+      parent: 1
+  - uid: 272
+    components:
+    - type: Transform
+      pos: 12.5,-8.5
+      parent: 1
+- proto: BenchBlueComfy
+  entities:
+  - uid: 247
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,7.5
+      parent: 1
+  - uid: 1159
+    components:
+    - type: Transform
+      pos: 6.5,8.5
+      parent: 1
+  - uid: 1318
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,5.5
+      parent: 1
+  - uid: 1320
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,5.5
+      parent: 1
+  - uid: 1349
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,7.5
+      parent: 1
+- proto: BookshelfFilled
+  entities:
+  - uid: 1278
+    components:
+    - type: Transform
+      pos: -3.5,13.5
+      parent: 1
+- proto: BoozeDispenser
+  entities:
+  - uid: 1253
+    components:
+    - type: Transform
+      pos: 3.5,13.5
+      parent: 1
+- proto: BoxBodyBag
+  entities:
+  - uid: 300
+    components:
+    - type: Transform
+      pos: 10.339466,1.8083065
+      parent: 1
+- proto: BoxFolderCentComClipboard
+  entities:
+  - uid: 112
+    components:
+    - type: Transform
+      pos: -3.5307064,2.4822583
+      parent: 1
+- proto: BrbSign
+  entities:
+  - uid: 1392
+    components:
+    - type: Transform
+      pos: 4.453079,2.7788117
+      parent: 1
+- proto: ButtonFrameCaution
+  entities:
+  - uid: 182
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-7.5
+      parent: 1
+  - uid: 299
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-5.5
+      parent: 1
+- proto: ButtonFrameCautionSecurity
+  entities:
+  - uid: 1487
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-0.5
+      parent: 1
+- proto: CableApcExtension
+  entities:
+  - uid: 447
+    components:
+    - type: Transform
+      pos: 15.5,7.5
+      parent: 1
+  - uid: 451
+    components:
+    - type: Transform
+      pos: 14.5,7.5
+      parent: 1
+  - uid: 768
+    components:
+    - type: Transform
+      pos: 9.5,3.5
+      parent: 1
+  - uid: 769
+    components:
+    - type: Transform
+      pos: 11.5,3.5
+      parent: 1
+  - uid: 770
+    components:
+    - type: Transform
+      pos: 10.5,3.5
+      parent: 1
+  - uid: 771
+    components:
+    - type: Transform
+      pos: 11.5,2.5
+      parent: 1
+  - uid: 772
+    components:
+    - type: Transform
+      pos: 11.5,1.5
+      parent: 1
+  - uid: 773
+    components:
+    - type: Transform
+      pos: 11.5,0.5
+      parent: 1
+  - uid: 774
+    components:
+    - type: Transform
+      pos: 11.5,-0.5
+      parent: 1
+  - uid: 775
+    components:
+    - type: Transform
+      pos: 16.5,8.5
+      parent: 1
+  - uid: 776
+    components:
+    - type: Transform
+      pos: 16.5,7.5
+      parent: 1
+  - uid: 777
+    components:
+    - type: Transform
+      pos: 16.5,6.5
+      parent: 1
+  - uid: 778
+    components:
+    - type: Transform
+      pos: 16.5,5.5
+      parent: 1
+  - uid: 779
+    components:
+    - type: Transform
+      pos: 16.5,4.5
+      parent: 1
+  - uid: 780
+    components:
+    - type: Transform
+      pos: 16.5,3.5
+      parent: 1
+  - uid: 781
+    components:
+    - type: Transform
+      pos: 16.5,6.5
+      parent: 1
+  - uid: 782
+    components:
+    - type: Transform
+      pos: 12.5,7.5
+      parent: 1
+  - uid: 783
+    components:
+    - type: Transform
+      pos: 13.5,7.5
+      parent: 1
+  - uid: 786
+    components:
+    - type: Transform
+      pos: 17.5,6.5
+      parent: 1
+  - uid: 787
+    components:
+    - type: Transform
+      pos: 18.5,6.5
+      parent: 1
+  - uid: 788
+    components:
+    - type: Transform
+      pos: 19.5,6.5
+      parent: 1
+  - uid: 789
+    components:
+    - type: Transform
+      pos: 18.5,7.5
+      parent: 1
+  - uid: 790
+    components:
+    - type: Transform
+      pos: 18.5,8.5
+      parent: 1
+  - uid: 791
+    components:
+    - type: Transform
+      pos: 7.5,9.5
+      parent: 1
+  - uid: 792
+    components:
+    - type: Transform
+      pos: 8.5,9.5
+      parent: 1
+  - uid: 793
+    components:
+    - type: Transform
+      pos: 8.5,10.5
+      parent: 1
+  - uid: 794
+    components:
+    - type: Transform
+      pos: 8.5,11.5
+      parent: 1
+  - uid: 795
+    components:
+    - type: Transform
+      pos: 7.5,8.5
+      parent: 1
+  - uid: 796
+    components:
+    - type: Transform
+      pos: 7.5,7.5
+      parent: 1
+  - uid: 797
+    components:
+    - type: Transform
+      pos: 7.5,6.5
+      parent: 1
+  - uid: 798
+    components:
+    - type: Transform
+      pos: 7.5,5.5
+      parent: 1
+  - uid: 799
+    components:
+    - type: Transform
+      pos: 7.5,2.5
+      parent: 1
+  - uid: 800
+    components:
+    - type: Transform
+      pos: 7.5,3.5
+      parent: 1
+  - uid: 801
+    components:
+    - type: Transform
+      pos: 7.5,1.5
+      parent: 1
+  - uid: 802
+    components:
+    - type: Transform
+      pos: 7.5,0.5
+      parent: 1
+  - uid: 803
+    components:
+    - type: Transform
+      pos: 7.5,-0.5
+      parent: 1
+  - uid: 804
+    components:
+    - type: Transform
+      pos: 7.5,4.5
+      parent: 1
+  - uid: 805
+    components:
+    - type: Transform
+      pos: 6.5,6.5
+      parent: 1
+  - uid: 806
+    components:
+    - type: Transform
+      pos: 5.5,6.5
+      parent: 1
+  - uid: 807
+    components:
+    - type: Transform
+      pos: 4.5,6.5
+      parent: 1
+  - uid: 808
+    components:
+    - type: Transform
+      pos: 3.5,6.5
+      parent: 1
+  - uid: 809
+    components:
+    - type: Transform
+      pos: 2.5,6.5
+      parent: 1
+  - uid: 810
+    components:
+    - type: Transform
+      pos: 1.5,6.5
+      parent: 1
+  - uid: 811
+    components:
+    - type: Transform
+      pos: -8.5,3.5
+      parent: 1
+  - uid: 812
+    components:
+    - type: Transform
+      pos: -7.5,3.5
+      parent: 1
+  - uid: 813
+    components:
+    - type: Transform
+      pos: -6.5,3.5
+      parent: 1
+  - uid: 814
+    components:
+    - type: Transform
+      pos: -6.5,4.5
+      parent: 1
+  - uid: 815
+    components:
+    - type: Transform
+      pos: -6.5,5.5
+      parent: 1
+  - uid: 816
+    components:
+    - type: Transform
+      pos: -6.5,6.5
+      parent: 1
+  - uid: 817
+    components:
+    - type: Transform
+      pos: -6.5,7.5
+      parent: 1
+  - uid: 818
+    components:
+    - type: Transform
+      pos: -6.5,8.5
+      parent: 1
+  - uid: 819
+    components:
+    - type: Transform
+      pos: -6.5,9.5
+      parent: 1
+  - uid: 820
+    components:
+    - type: Transform
+      pos: -6.5,10.5
+      parent: 1
+  - uid: 821
+    components:
+    - type: Transform
+      pos: -6.5,11.5
+      parent: 1
+  - uid: 822
+    components:
+    - type: Transform
+      pos: -6.5,12.5
+      parent: 1
+  - uid: 823
+    components:
+    - type: Transform
+      pos: -6.5,13.5
+      parent: 1
+  - uid: 824
+    components:
+    - type: Transform
+      pos: -6.5,14.5
+      parent: 1
+  - uid: 825
+    components:
+    - type: Transform
+      pos: -6.5,15.5
+      parent: 1
+  - uid: 826
+    components:
+    - type: Transform
+      pos: -6.5,16.5
+      parent: 1
+  - uid: 827
+    components:
+    - type: Transform
+      pos: -6.5,17.5
+      parent: 1
+  - uid: 828
+    components:
+    - type: Transform
+      pos: -4.5,-9.5
+      parent: 1
+  - uid: 829
+    components:
+    - type: Transform
+      pos: -5.5,-9.5
+      parent: 1
+  - uid: 830
+    components:
+    - type: Transform
+      pos: -6.5,-9.5
+      parent: 1
+  - uid: 831
+    components:
+    - type: Transform
+      pos: -6.5,-10.5
+      parent: 1
+  - uid: 832
+    components:
+    - type: Transform
+      pos: -6.5,-11.5
+      parent: 1
+  - uid: 833
+    components:
+    - type: Transform
+      pos: -6.5,-12.5
+      parent: 1
+  - uid: 834
+    components:
+    - type: Transform
+      pos: -6.5,-8.5
+      parent: 1
+  - uid: 835
+    components:
+    - type: Transform
+      pos: -6.5,-7.5
+      parent: 1
+  - uid: 836
+    components:
+    - type: Transform
+      pos: -7.5,-7.5
+      parent: 1
+  - uid: 837
+    components:
+    - type: Transform
+      pos: -8.5,-7.5
+      parent: 1
+  - uid: 838
+    components:
+    - type: Transform
+      pos: -9.5,-7.5
+      parent: 1
+  - uid: 839
+    components:
+    - type: Transform
+      pos: -10.5,-7.5
+      parent: 1
+  - uid: 840
+    components:
+    - type: Transform
+      pos: -11.5,-7.5
+      parent: 1
+  - uid: 841
+    components:
+    - type: Transform
+      pos: -12.5,-7.5
+      parent: 1
+  - uid: 842
+    components:
+    - type: Transform
+      pos: -6.5,-6.5
+      parent: 1
+  - uid: 843
+    components:
+    - type: Transform
+      pos: -6.5,-5.5
+      parent: 1
+  - uid: 844
+    components:
+    - type: Transform
+      pos: -6.5,-4.5
+      parent: 1
+  - uid: 845
+    components:
+    - type: Transform
+      pos: -6.5,-3.5
+      parent: 1
+  - uid: 846
+    components:
+    - type: Transform
+      pos: -6.5,-2.5
+      parent: 1
+  - uid: 847
+    components:
+    - type: Transform
+      pos: -6.5,-1.5
+      parent: 1
+  - uid: 848
+    components:
+    - type: Transform
+      pos: -6.5,-0.5
+      parent: 1
+  - uid: 849
+    components:
+    - type: Transform
+      pos: -6.5,0.5
+      parent: 1
+  - uid: 850
+    components:
+    - type: Transform
+      pos: -6.5,1.5
+      parent: 1
+  - uid: 851
+    components:
+    - type: Transform
+      pos: -2.5,-4.5
+      parent: 1
+  - uid: 852
+    components:
+    - type: Transform
+      pos: -2.5,-5.5
+      parent: 1
+  - uid: 853
+    components:
+    - type: Transform
+      pos: -2.5,-6.5
+      parent: 1
+  - uid: 854
+    components:
+    - type: Transform
+      pos: -3.5,-6.5
+      parent: 1
+  - uid: 855
+    components:
+    - type: Transform
+      pos: -1.5,-6.5
+      parent: 1
+  - uid: 856
+    components:
+    - type: Transform
+      pos: -0.5,-6.5
+      parent: 1
+  - uid: 857
+    components:
+    - type: Transform
+      pos: 0.5,-6.5
+      parent: 1
+  - uid: 858
+    components:
+    - type: Transform
+      pos: 1.5,-6.5
+      parent: 1
+  - uid: 859
+    components:
+    - type: Transform
+      pos: 2.5,-6.5
+      parent: 1
+  - uid: 860
+    components:
+    - type: Transform
+      pos: 3.5,-6.5
+      parent: 1
+  - uid: 861
+    components:
+    - type: Transform
+      pos: 4.5,-6.5
+      parent: 1
+  - uid: 862
+    components:
+    - type: Transform
+      pos: 0.5,-7.5
+      parent: 1
+  - uid: 863
+    components:
+    - type: Transform
+      pos: 0.5,-8.5
+      parent: 1
+  - uid: 864
+    components:
+    - type: Transform
+      pos: 0.5,-9.5
+      parent: 1
+  - uid: 865
+    components:
+    - type: Transform
+      pos: 0.5,-10.5
+      parent: 1
+  - uid: 866
+    components:
+    - type: Transform
+      pos: 0.5,-11.5
+      parent: 1
+  - uid: 867
+    components:
+    - type: Transform
+      pos: 2.5,-0.5
+      parent: 1
+  - uid: 868
+    components:
+    - type: Transform
+      pos: 3.5,-0.5
+      parent: 1
+  - uid: 869
+    components:
+    - type: Transform
+      pos: 3.5,-1.5
+      parent: 1
+  - uid: 870
+    components:
+    - type: Transform
+      pos: 3.5,-2.5
+      parent: 1
+  - uid: 871
+    components:
+    - type: Transform
+      pos: 3.5,-3.5
+      parent: 1
+  - uid: 872
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 1
+  - uid: 873
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 1
+  - uid: 874
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 1
+  - uid: 875
+    components:
+    - type: Transform
+      pos: -0.5,0.5
+      parent: 1
+  - uid: 876
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 1
+  - uid: 877
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 1
+  - uid: 878
+    components:
+    - type: Transform
+      pos: -2.5,-0.5
+      parent: 1
+  - uid: 879
+    components:
+    - type: Transform
+      pos: -2.5,-1.5
+      parent: 1
+  - uid: 880
+    components:
+    - type: Transform
+      pos: -2.5,-2.5
+      parent: 1
+  - uid: 881
+    components:
+    - type: Transform
+      pos: -2.5,-3.5
+      parent: 1
+  - uid: 882
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 1
+  - uid: 883
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 1
+  - uid: 884
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 1
+  - uid: 885
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 1
+  - uid: 886
+    components:
+    - type: Transform
+      pos: -2.5,1.5
+      parent: 1
+  - uid: 887
+    components:
+    - type: Transform
+      pos: -2.5,2.5
+      parent: 1
+  - uid: 888
+    components:
+    - type: Transform
+      pos: -2.5,3.5
+      parent: 1
+  - uid: 889
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 1
+  - uid: 890
+    components:
+    - type: Transform
+      pos: 2.5,2.5
+      parent: 1
+  - uid: 891
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 892
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 1
+  - uid: 893
+    components:
+    - type: Transform
+      pos: -0.5,3.5
+      parent: 1
+  - uid: 894
+    components:
+    - type: Transform
+      pos: 3.5,3.5
+      parent: 1
+  - uid: 895
+    components:
+    - type: Transform
+      pos: 4.5,3.5
+      parent: 1
+  - uid: 896
+    components:
+    - type: Transform
+      pos: 4.5,-0.5
+      parent: 1
+  - uid: 897
+    components:
+    - type: Transform
+      pos: -3.5,-0.5
+      parent: 1
+  - uid: 898
+    components:
+    - type: Transform
+      pos: 5.5,-6.5
+      parent: 1
+  - uid: 899
+    components:
+    - type: Transform
+      pos: 7.5,-6.5
+      parent: 1
+  - uid: 900
+    components:
+    - type: Transform
+      pos: 6.5,-6.5
+      parent: 1
+  - uid: 901
+    components:
+    - type: Transform
+      pos: 8.5,-6.5
+      parent: 1
+  - uid: 902
+    components:
+    - type: Transform
+      pos: 9.5,-6.5
+      parent: 1
+  - uid: 903
+    components:
+    - type: Transform
+      pos: 9.5,-5.5
+      parent: 1
+  - uid: 904
+    components:
+    - type: Transform
+      pos: 9.5,-4.5
+      parent: 1
+  - uid: 905
+    components:
+    - type: Transform
+      pos: 10.5,-4.5
+      parent: 1
+  - uid: 906
+    components:
+    - type: Transform
+      pos: 11.5,-4.5
+      parent: 1
+  - uid: 907
+    components:
+    - type: Transform
+      pos: 9.5,-7.5
+      parent: 1
+  - uid: 908
+    components:
+    - type: Transform
+      pos: 9.5,-8.5
+      parent: 1
+  - uid: 909
+    components:
+    - type: Transform
+      pos: 10.5,-8.5
+      parent: 1
+  - uid: 910
+    components:
+    - type: Transform
+      pos: 11.5,-8.5
+      parent: 1
+  - uid: 911
+    components:
+    - type: Transform
+      pos: 7.5,-5.5
+      parent: 1
+  - uid: 912
+    components:
+    - type: Transform
+      pos: 7.5,-4.5
+      parent: 1
+  - uid: 913
+    components:
+    - type: Transform
+      pos: 7.5,-3.5
+      parent: 1
+  - uid: 914
+    components:
+    - type: Transform
+      pos: 7.5,-2.5
+      parent: 1
+  - uid: 915
+    components:
+    - type: Transform
+      pos: -5.5,6.5
+      parent: 1
+  - uid: 916
+    components:
+    - type: Transform
+      pos: -0.5,6.5
+      parent: 1
+  - uid: 917
+    components:
+    - type: Transform
+      pos: -2.5,6.5
+      parent: 1
+  - uid: 918
+    components:
+    - type: Transform
+      pos: -3.5,6.5
+      parent: 1
+  - uid: 919
+    components:
+    - type: Transform
+      pos: -4.5,6.5
+      parent: 1
+  - uid: 920
+    components:
+    - type: Transform
+      pos: -1.5,6.5
+      parent: 1
+  - uid: 921
+    components:
+    - type: Transform
+      pos: -5.5,12.5
+      parent: 1
+  - uid: 922
+    components:
+    - type: Transform
+      pos: -4.5,12.5
+      parent: 1
+  - uid: 923
+    components:
+    - type: Transform
+      pos: -3.5,12.5
+      parent: 1
+  - uid: 924
+    components:
+    - type: Transform
+      pos: -2.5,12.5
+      parent: 1
+  - uid: 925
+    components:
+    - type: Transform
+      pos: -1.5,12.5
+      parent: 1
+  - uid: 926
+    components:
+    - type: Transform
+      pos: -0.5,12.5
+      parent: 1
+  - uid: 927
+    components:
+    - type: Transform
+      pos: 0.5,12.5
+      parent: 1
+  - uid: 928
+    components:
+    - type: Transform
+      pos: 3.5,12.5
+      parent: 1
+  - uid: 929
+    components:
+    - type: Transform
+      pos: 2.5,12.5
+      parent: 1
+  - uid: 930
+    components:
+    - type: Transform
+      pos: 1.5,12.5
+      parent: 1
+  - uid: 931
+    components:
+    - type: Transform
+      pos: 3.5,11.5
+      parent: 1
+  - uid: 932
+    components:
+    - type: Transform
+      pos: 3.5,10.5
+      parent: 1
+  - uid: 933
+    components:
+    - type: Transform
+      pos: 2.5,10.5
+      parent: 1
+  - uid: 934
+    components:
+    - type: Transform
+      pos: 2.5,9.5
+      parent: 1
+  - uid: 935
+    components:
+    - type: Transform
+      pos: -2.5,10.5
+      parent: 1
+  - uid: 936
+    components:
+    - type: Transform
+      pos: -1.5,9.5
+      parent: 1
+  - uid: 937
+    components:
+    - type: Transform
+      pos: -1.5,10.5
+      parent: 1
+  - uid: 938
+    components:
+    - type: Transform
+      pos: 1.5,10.5
+      parent: 1
+  - uid: 939
+    components:
+    - type: Transform
+      pos: 0.5,10.5
+      parent: 1
+  - uid: 940
+    components:
+    - type: Transform
+      pos: -0.5,10.5
+      parent: 1
+  - uid: 941
+    components:
+    - type: Transform
+      pos: -1.5,13.5
+      parent: 1
+  - uid: 942
+    components:
+    - type: Transform
+      pos: 2.5,13.5
+      parent: 1
+  - uid: 943
+    components:
+    - type: Transform
+      pos: 4.5,11.5
+      parent: 1
+  - uid: 1352
+    components:
+    - type: Transform
+      pos: 8.5,12.5
+      parent: 1
+  - uid: 1353
+    components:
+    - type: Transform
+      pos: 9.5,12.5
+      parent: 1
+  - uid: 1354
+    components:
+    - type: Transform
+      pos: 10.5,12.5
+      parent: 1
+  - uid: 1355
+    components:
+    - type: Transform
+      pos: 11.5,12.5
+      parent: 1
+  - uid: 1356
+    components:
+    - type: Transform
+      pos: 11.5,13.5
+      parent: 1
+  - uid: 1490
+    components:
+    - type: Transform
+      pos: 11.5,7.5
+      parent: 1
+- proto: CableHV
+  entities:
+  - uid: 427
+    components:
+    - type: Transform
+      pos: 15.5,6.5
+      parent: 1
+  - uid: 428
+    components:
+    - type: Transform
+      pos: 15.5,5.5
+      parent: 1
+  - uid: 431
+    components:
+    - type: Transform
+      pos: 17.5,5.5
+      parent: 1
+  - uid: 432
+    components:
+    - type: Transform
+      pos: 18.5,6.5
+      parent: 1
+  - uid: 442
+    components:
+    - type: Transform
+      pos: 16.5,5.5
+      parent: 1
+  - uid: 443
+    components:
+    - type: Transform
+      pos: 17.5,6.5
+      parent: 1
+  - uid: 444
+    components:
+    - type: Transform
+      pos: 16.5,6.5
+      parent: 1
+  - uid: 445
+    components:
+    - type: Transform
+      pos: 18.5,5.5
+      parent: 1
+  - uid: 446
+    components:
+    - type: Transform
+      pos: 19.5,6.5
+      parent: 1
+  - uid: 448
+    components:
+    - type: Transform
+      pos: 13.5,5.5
+      parent: 1
+  - uid: 452
+    components:
+    - type: Transform
+      pos: 13.5,6.5
+      parent: 1
+  - uid: 454
+    components:
+    - type: Transform
+      pos: 14.5,6.5
+      parent: 1
+  - uid: 455
+    components:
+    - type: Transform
+      pos: 19.5,5.5
+      parent: 1
+  - uid: 456
+    components:
+    - type: Transform
+      pos: 14.5,5.5
+      parent: 1
+  - uid: 457
+    components:
+    - type: Transform
+      pos: 11.5,5.5
+      parent: 1
+  - uid: 464
+    components:
+    - type: Transform
+      pos: 12.5,5.5
+      parent: 1
+- proto: CableMV
+  entities:
+  - uid: 465
+    components:
+    - type: Transform
+      pos: 11.5,5.5
+      parent: 1
+  - uid: 466
+    components:
+    - type: Transform
+      pos: 10.5,5.5
+      parent: 1
+  - uid: 468
+    components:
+    - type: Transform
+      pos: 10.5,6.5
+      parent: 1
+  - uid: 469
+    components:
+    - type: Transform
+      pos: 10.5,7.5
+      parent: 1
+  - uid: 470
+    components:
+    - type: Transform
+      pos: 10.5,8.5
+      parent: 1
+  - uid: 471
+    components:
+    - type: Transform
+      pos: 11.5,8.5
+      parent: 1
+  - uid: 472
+    components:
+    - type: Transform
+      pos: 12.5,8.5
+      parent: 1
+  - uid: 473
+    components:
+    - type: Transform
+      pos: 13.5,8.5
+      parent: 1
+  - uid: 474
+    components:
+    - type: Transform
+      pos: 14.5,8.5
+      parent: 1
+  - uid: 475
+    components:
+    - type: Transform
+      pos: 15.5,8.5
+      parent: 1
+  - uid: 476
+    components:
+    - type: Transform
+      pos: 16.5,8.5
+      parent: 1
+  - uid: 477
+    components:
+    - type: Transform
+      pos: 17.5,8.5
+      parent: 1
+  - uid: 478
+    components:
+    - type: Transform
+      pos: 18.5,8.5
+      parent: 1
+  - uid: 479
+    components:
+    - type: Transform
+      pos: 19.5,8.5
+      parent: 1
+  - uid: 480
+    components:
+    - type: Transform
+      pos: 20.5,8.5
+      parent: 1
+  - uid: 481
+    components:
+    - type: Transform
+      pos: 20.5,7.5
+      parent: 1
+  - uid: 482
+    components:
+    - type: Transform
+      pos: 20.5,6.5
+      parent: 1
+  - uid: 483
+    components:
+    - type: Transform
+      pos: 20.5,5.5
+      parent: 1
+  - uid: 484
+    components:
+    - type: Transform
+      pos: 20.5,4.5
+      parent: 1
+  - uid: 485
+    components:
+    - type: Transform
+      pos: 19.5,4.5
+      parent: 1
+  - uid: 486
+    components:
+    - type: Transform
+      pos: 18.5,4.5
+      parent: 1
+  - uid: 487
+    components:
+    - type: Transform
+      pos: 9.5,5.5
+      parent: 1
+  - uid: 488
+    components:
+    - type: Transform
+      pos: 9.5,4.5
+      parent: 1
+  - uid: 489
+    components:
+    - type: Transform
+      pos: 9.5,3.5
+      parent: 1
+  - uid: 490
+    components:
+    - type: Transform
+      pos: 9.5,2.5
+      parent: 1
+  - uid: 491
+    components:
+    - type: Transform
+      pos: 9.5,1.5
+      parent: 1
+  - uid: 492
+    components:
+    - type: Transform
+      pos: 9.5,0.5
+      parent: 1
+  - uid: 493
+    components:
+    - type: Transform
+      pos: 9.5,-0.5
+      parent: 1
+  - uid: 494
+    components:
+    - type: Transform
+      pos: 9.5,-1.5
+      parent: 1
+  - uid: 495
+    components:
+    - type: Transform
+      pos: 10.5,-1.5
+      parent: 1
+  - uid: 496
+    components:
+    - type: Transform
+      pos: 11.5,-1.5
+      parent: 1
+  - uid: 497
+    components:
+    - type: Transform
+      pos: 9.5,-2.5
+      parent: 1
+  - uid: 498
+    components:
+    - type: Transform
+      pos: 9.5,-3.5
+      parent: 1
+  - uid: 499
+    components:
+    - type: Transform
+      pos: 10.5,-3.5
+      parent: 1
+  - uid: 500
+    components:
+    - type: Transform
+      pos: 11.5,-3.5
+      parent: 1
+  - uid: 501
+    components:
+    - type: Transform
+      pos: 9.5,-4.5
+      parent: 1
+  - uid: 502
+    components:
+    - type: Transform
+      pos: 9.5,-5.5
+      parent: 1
+  - uid: 503
+    components:
+    - type: Transform
+      pos: 9.5,-6.5
+      parent: 1
+  - uid: 504
+    components:
+    - type: Transform
+      pos: 9.5,-7.5
+      parent: 1
+  - uid: 505
+    components:
+    - type: Transform
+      pos: 9.5,-8.5
+      parent: 1
+  - uid: 506
+    components:
+    - type: Transform
+      pos: 9.5,-9.5
+      parent: 1
+  - uid: 507
+    components:
+    - type: Transform
+      pos: 10.5,-9.5
+      parent: 1
+  - uid: 508
+    components:
+    - type: Transform
+      pos: 11.5,-9.5
+      parent: 1
+  - uid: 509
+    components:
+    - type: Transform
+      pos: 2.5,-0.5
+      parent: 1
+  - uid: 510
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 1
+  - uid: 511
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 1
+  - uid: 512
+    components:
+    - type: Transform
+      pos: 4.5,0.5
+      parent: 1
+  - uid: 513
+    components:
+    - type: Transform
+      pos: 5.5,0.5
+      parent: 1
+  - uid: 514
+    components:
+    - type: Transform
+      pos: 6.5,0.5
+      parent: 1
+  - uid: 515
+    components:
+    - type: Transform
+      pos: 7.5,0.5
+      parent: 1
+  - uid: 516
+    components:
+    - type: Transform
+      pos: 8.5,0.5
+      parent: 1
+  - uid: 517
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 1
+  - uid: 518
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 1
+  - uid: 519
+    components:
+    - type: Transform
+      pos: -0.5,0.5
+      parent: 1
+  - uid: 520
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 1
+  - uid: 521
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 1
+  - uid: 522
+    components:
+    - type: Transform
+      pos: -2.5,-0.5
+      parent: 1
+  - uid: 523
+    components:
+    - type: Transform
+      pos: -2.5,-1.5
+      parent: 1
+  - uid: 524
+    components:
+    - type: Transform
+      pos: -2.5,-2.5
+      parent: 1
+  - uid: 525
+    components:
+    - type: Transform
+      pos: -2.5,-3.5
+      parent: 1
+  - uid: 526
+    components:
+    - type: Transform
+      pos: -2.5,-4.5
+      parent: 1
+  - uid: 564
+    components:
+    - type: Transform
+      pos: 8.5,-9.5
+      parent: 1
+  - uid: 565
+    components:
+    - type: Transform
+      pos: 7.5,-9.5
+      parent: 1
+  - uid: 566
+    components:
+    - type: Transform
+      pos: 6.5,-9.5
+      parent: 1
+  - uid: 567
+    components:
+    - type: Transform
+      pos: 5.5,-9.5
+      parent: 1
+  - uid: 568
+    components:
+    - type: Transform
+      pos: 4.5,-9.5
+      parent: 1
+  - uid: 569
+    components:
+    - type: Transform
+      pos: 3.5,-9.5
+      parent: 1
+  - uid: 570
+    components:
+    - type: Transform
+      pos: 4.5,-10.5
+      parent: 1
+  - uid: 571
+    components:
+    - type: Transform
+      pos: 4.5,-11.5
+      parent: 1
+  - uid: 572
+    components:
+    - type: Transform
+      pos: 4.5,-12.5
+      parent: 1
+  - uid: 573
+    components:
+    - type: Transform
+      pos: 4.5,-13.5
+      parent: 1
+  - uid: 576
+    components:
+    - type: Transform
+      pos: 1.5,-14.5
+      parent: 1
+  - uid: 577
+    components:
+    - type: Transform
+      pos: 0.5,-14.5
+      parent: 1
+  - uid: 578
+    components:
+    - type: Transform
+      pos: 2.5,-14.5
+      parent: 1
+  - uid: 579
+    components:
+    - type: Transform
+      pos: -0.5,-14.5
+      parent: 1
+  - uid: 580
+    components:
+    - type: Transform
+      pos: -1.5,-14.5
+      parent: 1
+  - uid: 581
+    components:
+    - type: Transform
+      pos: -2.5,-14.5
+      parent: 1
+  - uid: 582
+    components:
+    - type: Transform
+      pos: -3.5,-14.5
+      parent: 1
+  - uid: 583
+    components:
+    - type: Transform
+      pos: 3.5,-14.5
+      parent: 1
+  - uid: 584
+    components:
+    - type: Transform
+      pos: -3.5,-14.5
+      parent: 1
+  - uid: 585
+    components:
+    - type: Transform
+      pos: -4.5,-14.5
+      parent: 1
+  - uid: 586
+    components:
+    - type: Transform
+      pos: -4.5,-13.5
+      parent: 1
+  - uid: 587
+    components:
+    - type: Transform
+      pos: -4.5,-12.5
+      parent: 1
+  - uid: 588
+    components:
+    - type: Transform
+      pos: -4.5,-11.5
+      parent: 1
+  - uid: 589
+    components:
+    - type: Transform
+      pos: -3.5,-9.5
+      parent: 1
+  - uid: 590
+    components:
+    - type: Transform
+      pos: -2.5,-9.5
+      parent: 1
+  - uid: 591
+    components:
+    - type: Transform
+      pos: -4.5,-9.5
+      parent: 1
+  - uid: 592
+    components:
+    - type: Transform
+      pos: -4.5,-8.5
+      parent: 1
+  - uid: 593
+    components:
+    - type: Transform
+      pos: -4.5,-7.5
+      parent: 1
+  - uid: 594
+    components:
+    - type: Transform
+      pos: 5.5,-8.5
+      parent: 1
+  - uid: 595
+    components:
+    - type: Transform
+      pos: 5.5,-7.5
+      parent: 1
+  - uid: 596
+    components:
+    - type: Transform
+      pos: 5.5,-6.5
+      parent: 1
+  - uid: 597
+    components:
+    - type: Transform
+      pos: 5.5,-5.5
+      parent: 1
+  - uid: 624
+    components:
+    - type: Transform
+      pos: -4.5,-10.5
+      parent: 1
+  - uid: 658
+    components:
+    - type: Transform
+      pos: 3.5,-13.5
+      parent: 1
+  - uid: 692
+    components:
+    - type: Transform
+      pos: 5.5,-11.5
+      parent: 1
+  - uid: 736
+    components:
+    - type: Transform
+      pos: 6.5,-11.5
+      parent: 1
+  - uid: 737
+    components:
+    - type: Transform
+      pos: 7.5,-11.5
+      parent: 1
+  - uid: 738
+    components:
+    - type: Transform
+      pos: 8.5,-11.5
+      parent: 1
+  - uid: 739
+    components:
+    - type: Transform
+      pos: 9.5,-11.5
+      parent: 1
+  - uid: 740
+    components:
+    - type: Transform
+      pos: 10.5,-11.5
+      parent: 1
+  - uid: 741
+    components:
+    - type: Transform
+      pos: 11.5,-11.5
+      parent: 1
+  - uid: 742
+    components:
+    - type: Transform
+      pos: 12.5,-11.5
+      parent: 1
+  - uid: 743
+    components:
+    - type: Transform
+      pos: 13.5,-11.5
+      parent: 1
+  - uid: 744
+    components:
+    - type: Transform
+      pos: 14.5,-11.5
+      parent: 1
+  - uid: 745
+    components:
+    - type: Transform
+      pos: 14.5,-10.5
+      parent: 1
+  - uid: 747
+    components:
+    - type: Transform
+      pos: 15.5,-10.5
+      parent: 1
+  - uid: 748
+    components:
+    - type: Transform
+      pos: 15.5,-9.5
+      parent: 1
+  - uid: 749
+    components:
+    - type: Transform
+      pos: 15.5,-8.5
+      parent: 1
+  - uid: 750
+    components:
+    - type: Transform
+      pos: 15.5,-7.5
+      parent: 1
+  - uid: 751
+    components:
+    - type: Transform
+      pos: 15.5,-6.5
+      parent: 1
+  - uid: 752
+    components:
+    - type: Transform
+      pos: 15.5,-5.5
+      parent: 1
+  - uid: 753
+    components:
+    - type: Transform
+      pos: 15.5,-4.5
+      parent: 1
+  - uid: 754
+    components:
+    - type: Transform
+      pos: 15.5,-3.5
+      parent: 1
+  - uid: 755
+    components:
+    - type: Transform
+      pos: 15.5,-2.5
+      parent: 1
+  - uid: 1393
+    components:
+    - type: Transform
+      pos: 10.5,9.5
+      parent: 1
+  - uid: 1394
+    components:
+    - type: Transform
+      pos: 9.5,9.5
+      parent: 1
+  - uid: 1395
+    components:
+    - type: Transform
+      pos: 8.5,9.5
+      parent: 1
+  - uid: 1396
+    components:
+    - type: Transform
+      pos: 7.5,9.5
+      parent: 1
+  - uid: 1491
+    components:
+    - type: Transform
+      pos: -3.5,0.5
+      parent: 1
+  - uid: 1492
+    components:
+    - type: Transform
+      pos: -4.5,0.5
+      parent: 1
+  - uid: 1493
+    components:
+    - type: Transform
+      pos: -5.5,0.5
+      parent: 1
+  - uid: 1494
+    components:
+    - type: Transform
+      pos: -6.5,0.5
+      parent: 1
+  - uid: 1495
+    components:
+    - type: Transform
+      pos: -6.5,1.5
+      parent: 1
+  - uid: 1496
+    components:
+    - type: Transform
+      pos: -6.5,3.5
+      parent: 1
+  - uid: 1497
+    components:
+    - type: Transform
+      pos: -6.5,2.5
+      parent: 1
+  - uid: 1498
+    components:
+    - type: Transform
+      pos: -7.5,3.5
+      parent: 1
+  - uid: 1499
+    components:
+    - type: Transform
+      pos: -8.5,3.5
+      parent: 1
+- proto: CableTerminal
+  entities:
+  - uid: 450
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 14.5,5.5
+      parent: 1
+  - uid: 453
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 14.5,6.5
+      parent: 1
+- proto: CardBoxNanotrasen
+  entities:
+  - uid: 1301
+    components:
+    - type: Transform
+      pos: -1.4497089,11.713941
+      parent: 1
+- proto: CarpetGreen
+  entities:
+  - uid: 91
+    components:
+    - type: Transform
+      pos: -3.5,-3.5
+      parent: 1
+  - uid: 92
+    components:
+    - type: Transform
+      pos: -3.5,-2.5
+      parent: 1
+- proto: CarpetSBlue
+  entities:
+  - uid: 761
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,11.5
+      parent: 1
+  - uid: 1248
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,13.5
+      parent: 1
+  - uid: 1249
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,10.5
+      parent: 1
+  - uid: 1255
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,13.5
+      parent: 1
+  - uid: 1267
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,13.5
+      parent: 1
+  - uid: 1272
+    components:
+    - type: Transform
+      pos: -1.5,12.5
+      parent: 1
+  - uid: 1273
+    components:
+    - type: Transform
+      pos: -1.5,11.5
+      parent: 1
+  - uid: 1274
+    components:
+    - type: Transform
+      pos: -0.5,12.5
+      parent: 1
+  - uid: 1275
+    components:
+    - type: Transform
+      pos: -0.5,11.5
+      parent: 1
+  - uid: 1276
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,10.5
+      parent: 1
+  - uid: 1279
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,13.5
+      parent: 1
+  - uid: 1282
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,12.5
+      parent: 1
+  - uid: 1283
+    components:
+    - type: Transform
+      pos: -1.5,12.5
+      parent: 1
+  - uid: 1284
+    components:
+    - type: Transform
+      pos: -1.5,11.5
+      parent: 1
+  - uid: 1286
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,11.5
+      parent: 1
+  - uid: 1287
+    components:
+    - type: Transform
+      pos: -0.5,12.5
+      parent: 1
+  - uid: 1288
+    components:
+    - type: Transform
+      pos: -0.5,11.5
+      parent: 1
+  - uid: 1289
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,10.5
+      parent: 1
+  - uid: 1290
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,12.5
+      parent: 1
+  - uid: 1291
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,10.5
+      parent: 1
+- proto: Catwalk
+  entities:
+  - uid: 2
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 1
+  - uid: 705
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,10.5
+      parent: 1
+  - uid: 706
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,12.5
+      parent: 1
+  - uid: 707
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,12.5
+      parent: 1
+  - uid: 708
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,12.5
+      parent: 1
+  - uid: 1176
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,10.5
+      parent: 1
+- proto: ChairOfficeDark
+  entities:
+  - uid: 127
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5445282,2.4686832
+      parent: 1
+  - uid: 128
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5804718,3.4686832
+      parent: 1
+  - uid: 547
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.6467302,-7.814904
+      parent: 1
+  - uid: 548
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5876448,-7.830529
+      parent: 1
+- proto: ChairWoodFancyGreen
+  entities:
+  - uid: 1270
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,10.5
+      parent: 1
+  - uid: 1271
+    components:
+    - type: Transform
+      pos: -0.5,13.5
+      parent: 1
+  - uid: 1277
+    components:
+    - type: Transform
+      pos: -1.5,13.5
+      parent: 1
+  - uid: 1280
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,10.5
+      parent: 1
+- proto: ChemMaster
+  entities:
+  - uid: 283
+    components:
+    - type: Transform
+      pos: 12.5,3.5
+      parent: 1
+- proto: CigarCase
+  entities:
+  - uid: 1265
+    components:
+    - type: Transform
+      pos: -0.40066457,12.271481
+      parent: 1
+- proto: CigPackRed
+  entities:
+  - uid: 602
+    components:
+    - type: Transform
+      pos: -3.6820374,-7.2516036
+      parent: 1
+- proto: ClosetWallO2N2FilledRandom
+  entities:
+  - uid: 1317
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,0.5
+      parent: 1
+- proto: ClothingEyesGlassesSunglasses
+  entities:
+  - uid: 600
+    components:
+    - type: Transform
+      pos: 4.4273376,-7.735979
+      parent: 1
+- proto: ClothingHeadHatCentcomcap
+  entities:
+  - uid: 163
+    components:
+    - type: Transform
+      pos: 1.5040406,3.673563
+      parent: 1
+- proto: ClothingShoesBootsWinterCentCom
+  entities:
+  - uid: 122
+    components:
+    - type: Transform
+      pos: -3.5972033,-2.3509061
+      parent: 1
+- proto: ComputerFrame
+  entities:
+  - uid: 1391
+    components:
+    - type: Transform
+      pos: -3.5,-5.5
+      parent: 1
+- proto: ComputerTabletopCriminalRecords
+  entities:
+  - uid: 546
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-8.5
+      parent: 1
+- proto: ComputerTabletopId
+  entities:
+  - uid: 30
+    components:
+    - type: Transform
+      pos: 3.5,3.5
+      parent: 1
+- proto: ComputerTabletopSurveillanceCameraMonitor
+  entities:
+  - uid: 113
+    components:
+    - type: Transform
+      pos: -2.5,3.5
+      parent: 1
+- proto: ConveyorBelt
+  entities:
+  - uid: 1182
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,12.5
+      parent: 1
+- proto: CrateSecure
+  entities:
+  - uid: 598
+    components:
+    - type: Transform
+      pos: -0.5,-10.5
+      parent: 1
+    - type: Lock
+      locked: False
+    - type: Fixtures
+      fixtures:
+        fix1:
+          shape: !type:PolygonShape
+            radius: 0.01
+            vertices:
+            - -0.4,-0.4
+            - 0.4,-0.4
+            - 0.4,0.29
+            - -0.4,0.29
+          mask:
+          - Impassable
+          - HighImpassable
+          - LowImpassable
+          layer:
+          - BulletImpassable
+          - Opaque
+          density: 50
+          hard: True
+          restitution: 0
+          friction: 0.4
+    - type: EntityStorage
+      open: True
+      removedMasks: 20
+    - type: PlaceableSurface
+      isPlaceable: True
+  - uid: 599
+    components:
+    - type: Transform
+      pos: -0.5,-11.5
+      parent: 1
+    - type: Lock
+      locked: False
+    - type: Fixtures
+      fixtures:
+        fix1:
+          shape: !type:PolygonShape
+            radius: 0.01
+            vertices:
+            - -0.4,-0.4
+            - 0.4,-0.4
+            - 0.4,0.29
+            - -0.4,0.29
+          mask:
+          - Impassable
+          - HighImpassable
+          - LowImpassable
+          layer:
+          - BulletImpassable
+          - Opaque
+          density: 50
+          hard: True
+          restitution: 0
+          friction: 0.4
+    - type: EntityStorage
+      open: True
+      removedMasks: 20
+    - type: PlaceableSurface
+      isPlaceable: True
+- proto: CurtainsGreenOpen
+  entities:
+  - uid: 90
+    components:
+    - type: Transform
+      pos: -3.5,-3.5
+      parent: 1
+- proto: CurtainsWhiteOpen
+  entities:
+  - uid: 17
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-3.5
+      parent: 1
+- proto: DefaultStationBeaconFrontierEvaAccess
+  entities:
+  - uid: 1333
+    components:
+    - type: Transform
+      pos: 8.5,10.5
+      parent: 1
+- proto: DefibrillatorCabinetFilled
+  entities:
+  - uid: 292
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,0.5
+      parent: 1
+  - uid: 293
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,3.5
+      parent: 1
+- proto: DisposalBend
+  entities:
+  - uid: 1189
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,12.5
+      parent: 1
+  - uid: 1190
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,12.5
+      parent: 1
+  - uid: 1230
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-5.5
+      parent: 1
+- proto: DisposalJunctionFlipped
+  entities:
+  - uid: 1197
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,8.5
+      parent: 1
+  - uid: 1208
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-5.5
+      parent: 1
+  - uid: 1229
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-0.5
+      parent: 1
+- proto: DisposalPipe
+  entities:
+  - uid: 1191
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 11.5,12.5
+      parent: 1
+  - uid: 1192
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,12.5
+      parent: 1
+  - uid: 1193
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,12.5
+      parent: 1
+  - uid: 1194
+    components:
+    - type: Transform
+      pos: 8.5,11.5
+      parent: 1
+  - uid: 1195
+    components:
+    - type: Transform
+      pos: 8.5,10.5
+      parent: 1
+  - uid: 1196
+    components:
+    - type: Transform
+      pos: 8.5,9.5
+      parent: 1
+  - uid: 1202
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-5.5
+      parent: 1
+  - uid: 1203
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-5.5
+      parent: 1
+  - uid: 1204
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,-5.5
+      parent: 1
+  - uid: 1205
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-5.5
+      parent: 1
+  - uid: 1206
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-5.5
+      parent: 1
+  - uid: 1207
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-5.5
+      parent: 1
+  - uid: 1209
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,-5.5
+      parent: 1
+  - uid: 1210
+    components:
+    - type: Transform
+      pos: 8.5,7.5
+      parent: 1
+  - uid: 1211
+    components:
+    - type: Transform
+      pos: 8.5,6.5
+      parent: 1
+  - uid: 1212
+    components:
+    - type: Transform
+      pos: 8.5,5.5
+      parent: 1
+  - uid: 1213
+    components:
+    - type: Transform
+      pos: 8.5,4.5
+      parent: 1
+  - uid: 1214
+    components:
+    - type: Transform
+      pos: 8.5,3.5
+      parent: 1
+  - uid: 1215
+    components:
+    - type: Transform
+      pos: 8.5,2.5
+      parent: 1
+  - uid: 1216
+    components:
+    - type: Transform
+      pos: 8.5,1.5
+      parent: 1
+  - uid: 1217
+    components:
+    - type: Transform
+      pos: 8.5,0.5
+      parent: 1
+  - uid: 1218
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,8.5
+      parent: 1
+  - uid: 1219
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,8.5
+      parent: 1
+  - uid: 1220
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,8.5
+      parent: 1
+  - uid: 1221
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,8.5
+      parent: 1
+  - uid: 1222
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,8.5
+      parent: 1
+  - uid: 1223
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,8.5
+      parent: 1
+  - uid: 1224
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,8.5
+      parent: 1
+  - uid: 1225
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-1.5
+      parent: 1
+  - uid: 1226
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-2.5
+      parent: 1
+  - uid: 1227
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-3.5
+      parent: 1
+  - uid: 1228
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-4.5
+      parent: 1
+  - uid: 1231
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-5.5
+      parent: 1
+  - uid: 1232
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-5.5
+      parent: 1
+  - uid: 1233
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-0.5
+      parent: 1
+  - uid: 1234
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-0.5
+      parent: 1
+  - uid: 1235
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-0.5
+      parent: 1
+  - uid: 1237
+    components:
+    - type: Transform
+      pos: 4.5,-4.5
+      parent: 1
+- proto: DisposalTrunk
+  entities:
+  - uid: 1188
+    components:
+    - type: Transform
+      pos: 12.5,13.5
+      parent: 1
+  - uid: 1199
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,8.5
+      parent: 1
+  - uid: 1200
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-0.5
+      parent: 1
+  - uid: 1201
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-5.5
+      parent: 1
+  - uid: 1236
+    components:
+    - type: Transform
+      pos: 4.5,-3.5
+      parent: 1
+- proto: DisposalUnit
+  entities:
+  - uid: 463
+    components:
+    - type: Transform
+      pos: 4.5,-0.5
+      parent: 1
+  - uid: 1175
+    components:
+    - type: Transform
+      pos: 0.5,8.5
+      parent: 1
+  - uid: 1198
+    components:
+    - type: Transform
+      pos: -2.5,-5.5
+      parent: 1
+- proto: DresserStationRepresentativeFilled
+  entities:
+  - uid: 89
+    components:
+    - type: Transform
+      pos: -2.5,-3.5
+      parent: 1
+- proto: DrinkBlueCuracaoGlass
+  entities:
+  - uid: 1472
+    components:
+    - type: Transform
+      pos: 3.1383395,11.784244
+      parent: 1
+- proto: DrinkGlass
+  entities:
+  - uid: 1245
+    components:
+    - type: Transform
+      pos: 4.603674,11.86307
+      parent: 1
+  - uid: 1252
+    components:
+    - type: Transform
+      pos: 4.416174,11.628695
+      parent: 1
+  - uid: 1261
+    components:
+    - type: Transform
+      pos: 4.197424,11.76932
+      parent: 1
+- proto: DrinkMugGreen
+  entities:
+  - uid: 1471
+    components:
+    - type: Transform
+      pos: -3.3023617,1.6196568
+      parent: 1
+- proto: DrinkShaker
+  entities:
+  - uid: 1285
+    components:
+    - type: Transform
+      pos: 3.9059613,11.708708
+      parent: 1
+- proto: EmergencyLight
+  entities:
+  - uid: 1360
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 19.5,7.5
+      parent: 1
+- proto: ExtinguisherCabinetFilled
+  entities:
+  - uid: 294
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,3.5
+      parent: 1
+- proto: FaxMachineCentcom
+  entities:
+  - uid: 12
+    components:
+    - type: Transform
+      pos: 4.5,3.5
+      parent: 1
+- proto: filingCabinetDrawerRandom
+  entities:
+  - uid: 120
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 1
+- proto: FireAlarm
+  entities:
+  - uid: 130
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-0.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 72
+      - 1341
+      - 74
+      - 86
+      - 82
+  - uid: 1473
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,12.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 1337
+      - 1335
+      - 1348
+      - 1347
+      - 1346
+      - 1338
+      - 1339
+      - 366
+      - 426
+      - 377
+      - 689
+      - 690
+- proto: FireAxeCabinetCommand
+  entities:
+  - uid: 85
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-0.5
+      parent: 1
+- proto: FirelockEdge
+  entities:
+  - uid: 74
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,3.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 130
+  - uid: 1346
+    components:
+    - type: Transform
+      pos: -0.5,9.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 1473
+  - uid: 1347
+    components:
+    - type: Transform
+      pos: 0.5,9.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 1473
+  - uid: 1348
+    components:
+    - type: Transform
+      pos: 1.5,9.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 1473
+- proto: FirelockGlass
+  entities:
+  - uid: 72
+    components:
+    - type: Transform
+      pos: -4.5,0.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 130
+  - uid: 82
+    components:
+    - type: Transform
+      pos: 3.5,-1.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 130
+  - uid: 86
+    components:
+    - type: Transform
+      pos: -2.5,-1.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 130
+  - uid: 366
+    components:
+    - type: Transform
+      pos: -4.5,10.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 1473
+  - uid: 377
+    components:
+    - type: Transform
+      pos: -5.5,9.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 1473
+  - uid: 426
+    components:
+    - type: Transform
+      pos: -4.5,11.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 1473
+  - uid: 689
+    components:
+    - type: Transform
+      pos: -6.5,9.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 1473
+  - uid: 690
+    components:
+    - type: Transform
+      pos: -7.5,9.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 1473
+  - uid: 1335
+    components:
+    - type: Transform
+      pos: 3.5,8.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 1473
+  - uid: 1337
+    components:
+    - type: Transform
+      pos: 2.5,8.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 1473
+  - uid: 1338
+    components:
+    - type: Transform
+      pos: -1.5,8.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 1473
+  - uid: 1339
+    components:
+    - type: Transform
+      pos: -2.5,8.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 1473
+  - uid: 1340
+    components:
+    - type: Transform
+      pos: 10.5,6.5
+      parent: 1
+  - uid: 1341
+    components:
+    - type: Transform
+      pos: 5.5,0.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 130
+  - uid: 1343
+    components:
+    - type: Transform
+      pos: -4.5,-6.5
+      parent: 1
+  - uid: 1344
+    components:
+    - type: Transform
+      pos: 5.5,-6.5
+      parent: 1
+  - uid: 1345
+    components:
+    - type: Transform
+      pos: 9.5,0.5
+      parent: 1
+- proto: FlippoEngravedLighter
+  entities:
+  - uid: 1266
+    components:
+    - type: Transform
+      pos: -0.30691457,11.802731
+      parent: 1
+- proto: FloorDrain
+  entities:
+  - uid: 1314
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,12.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: GasMixerOn
+  entities:
+  - uid: 528
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,7.5
+      parent: 1
+    - type: GasMixer
+      inletTwoConcentration: 0.79
+      inletOneConcentration: 0.21
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasPassiveVent
+  entities:
+  - uid: 944
+    components:
+    - type: Transform
+      pos: 12.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 945
+    components:
+    - type: Transform
+      pos: 14.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1144
+    components:
+    - type: Transform
+      pos: 6.5,12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPipeBend
+  entities:
+  - uid: 691
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 946
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 14.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 992
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1016
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1030
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,17.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1059
+    components:
+    - type: Transform
+      pos: 0.5,12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1099
+    components:
+    - type: Transform
+      pos: 8.5,-6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1102
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,-8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1123
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1134
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,-8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1143
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1146
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1157
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasPipeFourway
+  entities:
+  - uid: 955
+    components:
+    - type: Transform
+      pos: 2.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasPipeStraight
+  entities:
+  - uid: 947
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 948
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 14.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 949
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 951
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 953
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 956
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 957
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 958
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 959
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 961
+    components:
+    - type: Transform
+      pos: 2.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 962
+    components:
+    - type: Transform
+      pos: 2.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 963
+    components:
+    - type: Transform
+      pos: 2.5,10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 964
+    components:
+    - type: Transform
+      pos: 2.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 965
+    components:
+    - type: Transform
+      pos: 2.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 966
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 968
+    components:
+    - type: Transform
+      pos: 6.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 969
+    components:
+    - type: Transform
+      pos: 6.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 970
+    components:
+    - type: Transform
+      pos: 6.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 971
+    components:
+    - type: Transform
+      pos: 6.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 972
+    components:
+    - type: Transform
+      pos: 6.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 974
+    components:
+    - type: Transform
+      pos: 6.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 975
+    components:
+    - type: Transform
+      pos: 6.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 976
+    components:
+    - type: Transform
+      pos: 6.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 977
+    components:
+    - type: Transform
+      pos: 6.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 980
+    components:
+    - type: Transform
+      pos: 7.5,-6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 981
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,-6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 983
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,-7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 984
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,-7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 985
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 986
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 987
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 988
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 989
+    components:
+    - type: Transform
+      pos: 6.5,-5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 990
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 991
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 993
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 994
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 995
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 996
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 997
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 998
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 999
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1002
+    components:
+    - type: Transform
+      pos: -5.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1003
+    components:
+    - type: Transform
+      pos: -5.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1004
+    components:
+    - type: Transform
+      pos: -5.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1005
+    components:
+    - type: Transform
+      pos: -5.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1006
+    components:
+    - type: Transform
+      pos: -5.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1007
+    components:
+    - type: Transform
+      pos: -5.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1008
+    components:
+    - type: Transform
+      pos: -5.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1009
+    components:
+    - type: Transform
+      pos: -5.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1010
+    components:
+    - type: Transform
+      pos: -5.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1012
+    components:
+    - type: Transform
+      pos: -5.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1013
+    components:
+    - type: Transform
+      pos: -5.5,-5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1014
+    components:
+    - type: Transform
+      pos: -5.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1017
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1018
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,-6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1019
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -8.5,-6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1020
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,-6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1021
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1022
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1023
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1025
+    components:
+    - type: Transform
+      pos: -6.5,12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1026
+    components:
+    - type: Transform
+      pos: -6.5,13.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1027
+    components:
+    - type: Transform
+      pos: -6.5,14.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1028
+    components:
+    - type: Transform
+      pos: -6.5,15.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1029
+    components:
+    - type: Transform
+      pos: -6.5,16.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1041
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1042
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1043
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1048
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,16.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1049
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,15.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1050
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,14.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1051
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,13.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1053
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1054
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1055
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1056
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1057
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1060
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1061
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1063
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1064
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1065
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1066
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1068
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1069
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1070
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1071
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1072
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1073
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1074
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1080
+    components:
+    - type: Transform
+      pos: 8.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1081
+    components:
+    - type: Transform
+      pos: 8.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1082
+    components:
+    - type: Transform
+      pos: 8.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1083
+    components:
+    - type: Transform
+      pos: 7.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1084
+    components:
+    - type: Transform
+      pos: 7.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1085
+    components:
+    - type: Transform
+      pos: 7.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1086
+    components:
+    - type: Transform
+      pos: 7.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1087
+    components:
+    - type: Transform
+      pos: 7.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1088
+    components:
+    - type: Transform
+      pos: 7.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1093
+    components:
+    - type: Transform
+      pos: 7.5,-7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1094
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1095
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1096
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1097
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1103
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1104
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1105
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1106
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1107
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1108
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1109
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1110
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1114
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1116
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1117
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1118
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1119
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1120
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1121
+    components:
+    - type: Transform
+      pos: -7.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1122
+    components:
+    - type: Transform
+      pos: -7.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1124
+    components:
+    - type: Transform
+      pos: -7.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1125
+    components:
+    - type: Transform
+      pos: -7.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1126
+    components:
+    - type: Transform
+      pos: -7.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1127
+    components:
+    - type: Transform
+      pos: -7.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1128
+    components:
+    - type: Transform
+      pos: -7.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1130
+    components:
+    - type: Transform
+      pos: -7.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1131
+    components:
+    - type: Transform
+      pos: -7.5,-5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1132
+    components:
+    - type: Transform
+      pos: -7.5,-6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1133
+    components:
+    - type: Transform
+      pos: -7.5,-7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1135
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -8.5,-8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1136
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,-8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1138
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1139
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1140
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1141
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1142
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1147
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1148
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 11.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1149
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1150
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1151
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 11.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1156
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1306
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1311
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1312
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1313
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasPipeTJunction
+  entities:
+  - uid: 952
+    components:
+    - type: Transform
+      pos: 8.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 954
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 960
+    components:
+    - type: Transform
+      pos: 6.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 967
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 978
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 979
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 982
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1000
+    components:
+    - type: Transform
+      pos: -5.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1001
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1011
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1015
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1024
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1044
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1052
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1058
+    components:
+    - type: Transform
+      pos: -1.5,12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1062
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1067
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1075
+    components:
+    - type: Transform
+      pos: 9.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1076
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1077
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1089
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,-5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1090
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1091
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1113
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1115
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPressurePumpOn
+  entities:
+  - uid: 950
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasPressurePumpOnMax
+  entities:
+  - uid: 1145
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasVentPump
+  entities:
+  - uid: 973
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,0.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 1305
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1031
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,6.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 1305
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1032
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,6.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 1305
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1033
+    components:
+    - type: Transform
+      pos: 2.5,11.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 1305
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1034
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,11.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 1305
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1035
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,17.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 1305
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1036
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,-6.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 1305
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1037
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-7.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 1305
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1038
+    components:
+    - type: Transform
+      pos: 3.5,-5.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 1305
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1039
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,-7.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 1305
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1040
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,-4.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 1305
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1098
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,-7.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 1305
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1153
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,6.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 1305
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1154
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,3.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 1305
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1155
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-2.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 1305
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasVentScrubber
+  entities:
+  - uid: 1045
+    components:
+    - type: Transform
+      pos: -7.5,17.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 1305
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1046
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,11.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 1305
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1047
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,11.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 1305
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1078
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,0.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 1305
+  - uid: 1079
+    components:
+    - type: Transform
+      pos: 7.5,2.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 1305
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1092
+    components:
+    - type: Transform
+      pos: 6.5,-7.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 1305
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1100
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,-5.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 1305
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1101
+    components:
+    - type: Transform
+      pos: 10.5,-7.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 1305
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1111
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-8.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 1305
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1112
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,2.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 1305
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1129
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,3.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 1305
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1137
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,-8.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 1305
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1152
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,5.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 1305
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1158
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-3.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 1305
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GeneratorBasic15kW
+  entities:
+  - uid: 458
+    components:
+    - type: Transform
+      pos: 19.5,6.5
+      parent: 1
+  - uid: 459
+    components:
+    - type: Transform
+      pos: 18.5,6.5
+      parent: 1
+  - uid: 461
+    components:
+    - type: Transform
+      pos: 18.5,5.5
+      parent: 1
+  - uid: 696
+    components:
+    - type: Transform
+      pos: 19.5,5.5
+      parent: 1
+  - uid: 700
+    components:
+    - type: Transform
+      pos: 17.5,6.5
+      parent: 1
+  - uid: 701
+    components:
+    - type: Transform
+      pos: 17.5,5.5
+      parent: 1
+  - uid: 1160
+    components:
+    - type: Transform
+      pos: 16.5,6.5
+      parent: 1
+  - uid: 1161
+    components:
+    - type: Transform
+      pos: 16.5,5.5
+      parent: 1
+- proto: GravityGenerator
+  entities:
+  - uid: 421
+    components:
+    - type: Transform
+      pos: 18.5,10.5
+      parent: 1
+- proto: Grille
+  entities:
+  - uid: 6
+    components:
+    - type: Transform
+      pos: 5.5,1.5
+      parent: 1
+  - uid: 8
+    components:
+    - type: Transform
+      pos: -4.5,2.5
+      parent: 1
+  - uid: 24
+    components:
+    - type: Transform
+      pos: -2.5,4.5
+      parent: 1
+  - uid: 25
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,4.5
+      parent: 1
+  - uid: 32
+    components:
+    - type: Transform
+      pos: 5.5,-0.5
+      parent: 1
+  - uid: 40
+    components:
+    - type: Transform
+      pos: -4.5,1.5
+      parent: 1
+  - uid: 43
+    components:
+    - type: Transform
+      pos: -0.5,4.5
+      parent: 1
+  - uid: 59
+    components:
+    - type: Transform
+      pos: 5.5,2.5
+      parent: 1
+  - uid: 60
+    components:
+    - type: Transform
+      pos: -4.5,-0.5
+      parent: 1
+  - uid: 64
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,4.5
+      parent: 1
+  - uid: 106
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,4.5
+      parent: 1
+  - uid: 115
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 1
+  - uid: 118
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,4.5
+      parent: 1
+  - uid: 123
+    components:
+    - type: Transform
+      pos: -5.5,-10.5
+      parent: 1
+  - uid: 155
+    components:
+    - type: Transform
+      pos: -4.5,-7.5
+      parent: 1
+  - uid: 156
+    components:
+    - type: Transform
+      pos: -4.5,-8.5
+      parent: 1
+  - uid: 167
+    components:
+    - type: Transform
+      pos: -3.5,-9.5
+      parent: 1
+  - uid: 168
+    components:
+    - type: Transform
+      pos: -2.5,-9.5
+      parent: 1
+  - uid: 169
+    components:
+    - type: Transform
+      pos: 3.5,-9.5
+      parent: 1
+  - uid: 174
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-5.5
+      parent: 1
+  - uid: 175
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-7.5
+      parent: 1
+  - uid: 183
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-3.5
+      parent: 1
+  - uid: 213
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-2.5
+      parent: 1
+  - uid: 214
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-1.5
+      parent: 1
+  - uid: 217
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,-3.5
+      parent: 1
+  - uid: 218
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,-9.5
+      parent: 1
+  - uid: 222
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-5.5
+      parent: 1
+  - uid: 223
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-7.5
+      parent: 1
+  - uid: 255
+    components:
+    - type: Transform
+      pos: 9.5,2.5
+      parent: 1
+  - uid: 256
+    components:
+    - type: Transform
+      pos: 9.5,1.5
+      parent: 1
+  - uid: 257
+    components:
+    - type: Transform
+      pos: 9.5,-0.5
+      parent: 1
+  - uid: 258
+    components:
+    - type: Transform
+      pos: 11.5,-1.5
+      parent: 1
+  - uid: 295
+    components:
+    - type: Transform
+      pos: 4.5,-9.5
+      parent: 1
+  - uid: 347
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,5.5
+      parent: 1
+  - uid: 348
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,7.5
+      parent: 1
+  - uid: 349
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,8.5
+      parent: 1
+  - uid: 350
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 11.5,8.5
+      parent: 1
+  - uid: 351
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 14.5,8.5
+      parent: 1
+  - uid: 352
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 15.5,8.5
+      parent: 1
+  - uid: 362
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,10.5
+      parent: 1
+  - uid: 363
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,9.5
+      parent: 1
+  - uid: 378
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,11.5
+      parent: 1
+  - uid: 380
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,10.5
+      parent: 1
+  - uid: 393
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,6.5
+      parent: 1
+  - uid: 394
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,7.5
+      parent: 1
+  - uid: 398
+    components:
+    - type: Transform
+      pos: -3.5,-14.5
+      parent: 1
+  - uid: 411
+    components:
+    - type: Transform
+      pos: -7.5,-10.5
+      parent: 1
+  - uid: 412
+    components:
+    - type: Transform
+      pos: -8.5,-11.5
+      parent: 1
+  - uid: 413
+    components:
+    - type: Transform
+      pos: -8.5,-12.5
+      parent: 1
+  - uid: 436
+    components:
+    - type: Transform
+      pos: 18.5,4.5
+      parent: 1
+  - uid: 437
+    components:
+    - type: Transform
+      pos: 19.5,4.5
+      parent: 1
+  - uid: 438
+    components:
+    - type: Transform
+      pos: 20.5,5.5
+      parent: 1
+  - uid: 439
+    components:
+    - type: Transform
+      pos: 20.5,6.5
+      parent: 1
+  - uid: 440
+    components:
+    - type: Transform
+      pos: 19.5,8.5
+      parent: 1
+  - uid: 441
+    components:
+    - type: Transform
+      pos: 17.5,8.5
+      parent: 1
+  - uid: 544
+    components:
+    - type: Transform
+      pos: -0.5,-14.5
+      parent: 1
+  - uid: 545
+    components:
+    - type: Transform
+      pos: -1.5,-14.5
+      parent: 1
+  - uid: 552
+    components:
+    - type: Transform
+      pos: -2.5,-14.5
+      parent: 1
+  - uid: 553
+    components:
+    - type: Transform
+      pos: 1.5,-14.5
+      parent: 1
+  - uid: 554
+    components:
+    - type: Transform
+      pos: 2.5,-14.5
+      parent: 1
+  - uid: 555
+    components:
+    - type: Transform
+      pos: 3.5,-14.5
+      parent: 1
+  - uid: 556
+    components:
+    - type: Transform
+      pos: 4.5,-12.5
+      parent: 1
+  - uid: 557
+    components:
+    - type: Transform
+      pos: 4.5,-11.5
+      parent: 1
+  - uid: 561
+    components:
+    - type: Transform
+      pos: 4.5,-13.5
+      parent: 1
+  - uid: 638
+    components:
+    - type: Transform
+      pos: -4.5,-11.5
+      parent: 1
+  - uid: 639
+    components:
+    - type: Transform
+      pos: -4.5,-12.5
+      parent: 1
+  - uid: 648
+    components:
+    - type: Transform
+      pos: -11.5,-5.5
+      parent: 1
+  - uid: 649
+    components:
+    - type: Transform
+      pos: -10.5,-5.5
+      parent: 1
+  - uid: 650
+    components:
+    - type: Transform
+      pos: -11.5,-9.5
+      parent: 1
+  - uid: 651
+    components:
+    - type: Transform
+      pos: -10.5,-9.5
+      parent: 1
+  - uid: 652
+    components:
+    - type: Transform
+      pos: -8.5,-3.5
+      parent: 1
+  - uid: 653
+    components:
+    - type: Transform
+      pos: -8.5,-2.5
+      parent: 1
+  - uid: 654
+    components:
+    - type: Transform
+      pos: -8.5,1.5
+      parent: 1
+  - uid: 655
+    components:
+    - type: Transform
+      pos: -8.5,2.5
+      parent: 1
+  - uid: 668
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,17.5
+      parent: 1
+  - uid: 669
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -8.5,16.5
+      parent: 1
+  - uid: 670
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -8.5,17.5
+      parent: 1
+  - uid: 673
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,11.5
+      parent: 1
+  - uid: 674
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,14.5
+      parent: 1
+  - uid: 675
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,14.5
+      parent: 1
+  - uid: 676
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,14.5
+      parent: 1
+  - uid: 677
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,14.5
+      parent: 1
+  - uid: 678
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,14.5
+      parent: 1
+  - uid: 679
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,14.5
+      parent: 1
+  - uid: 680
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,14.5
+      parent: 1
+  - uid: 684
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,16.5
+      parent: 1
+  - uid: 693
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -8.5,12.5
+      parent: 1
+  - uid: 694
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -8.5,11.5
+      parent: 1
+  - uid: 695
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -8.5,10.5
+      parent: 1
+  - uid: 709
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 22.5,7.5
+      parent: 1
+  - uid: 710
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 22.5,6.5
+      parent: 1
+  - uid: 711
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 22.5,5.5
+      parent: 1
+  - uid: 712
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 18.5,2.5
+      parent: 1
+  - uid: 713
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 19.5,2.5
+      parent: 1
+  - uid: 714
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 20.5,2.5
+      parent: 1
+  - uid: 715
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 22.5,2.5
+      parent: 1
+  - uid: 716
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 22.5,3.5
+      parent: 1
+  - uid: 717
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 15.5,-9.5
+      parent: 1
+  - uid: 718
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 14.5,-11.5
+      parent: 1
+  - uid: 719
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 15.5,-10.5
+      parent: 1
+  - uid: 720
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 15.5,-8.5
+      parent: 1
+  - uid: 721
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-11.5
+      parent: 1
+  - uid: 722
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,-11.5
+      parent: 1
+  - uid: 723
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-11.5
+      parent: 1
+  - uid: 724
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 13.5,-11.5
+      parent: 1
+  - uid: 725
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 15.5,-7.5
+      parent: 1
+  - uid: 726
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-11.5
+      parent: 1
+  - uid: 727
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-11.5
+      parent: 1
+  - uid: 728
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-11.5
+      parent: 1
+  - uid: 729
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 15.5,-4.5
+      parent: 1
+  - uid: 730
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,-11.5
+      parent: 1
+  - uid: 731
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-11.5
+      parent: 1
+  - uid: 732
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 15.5,-5.5
+      parent: 1
+  - uid: 733
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 15.5,-6.5
+      parent: 1
+  - uid: 734
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 15.5,-3.5
+      parent: 1
+  - uid: 735
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 15.5,-2.5
+      parent: 1
+  - uid: 1174
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,13.5
+      parent: 1
+- proto: GrilleDiagonal
+  entities:
+  - uid: 406
+    components:
+    - type: Transform
+      pos: -4.5,-14.5
+      parent: 1
+- proto: GunSafeShuttleCaptain
+  entities:
+  - uid: 33
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 1
+- proto: HighSecCentralCommandLocked
+  entities:
+  - uid: 62
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 1
+  - uid: 203
+    components:
+    - type: Transform
+      pos: 18.5,8.5
+      parent: 1
+  - uid: 537
+    components:
+    - type: Transform
+      pos: 0.5,-9.5
+      parent: 1
+- proto: HighSecDoor
+  entities:
+  - uid: 645
+    components:
+    - type: Transform
+      pos: -6.5,-10.5
+      parent: 1
+- proto: HospitalCurtainsOpen
+  entities:
+  - uid: 279
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-0.5
+      parent: 1
+  - uid: 280
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,-0.5
+      parent: 1
+- proto: Jukebox
+  entities:
+  - uid: 1269
+    components:
+    - type: Transform
+      pos: -3.5,9.5
+      parent: 1
+- proto: LockableButtonCentcomm
+  entities:
+  - uid: 159
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-5.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        160:
+        - - Pressed
+          - Toggle
+        161:
+        - - Pressed
+          - Toggle
+        179:
+        - - Pressed
+          - Toggle
+        177:
+        - - Pressed
+          - Toggle
+        603:
+        - - Pressed
+          - Toggle
+        604:
+        - - Pressed
+          - Toggle
+        605:
+        - - Pressed
+          - Toggle
+        606:
+        - - Pressed
+          - Toggle
+        151:
+        - - Pressed
+          - DoorBolt
+        229:
+        - - Pressed
+          - DoorBolt
+  - uid: 172
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-7.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        179:
+        - - Pressed
+          - Toggle
+        177:
+        - - Pressed
+          - Toggle
+        204:
+        - - Pressed
+          - DoorBolt
+        219:
+        - - Pressed
+          - DoorBolt
+        227:
+        - - Pressed
+          - DoorBolt
+        228:
+        - - Pressed
+          - DoorBolt
+  - uid: 1486
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-0.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        1483:
+        - - Pressed
+          - Toggle
+        1484:
+        - - Pressed
+          - Toggle
+        1485:
+        - - Pressed
+          - Toggle
+        50:
+        - - Pressed
+          - Toggle
+        1474:
+        - - Pressed
+          - Toggle
+        1475:
+        - - Pressed
+          - Toggle
+        1476:
+        - - Pressed
+          - Toggle
+        1477:
+        - - Pressed
+          - Toggle
+        1478:
+        - - Pressed
+          - Toggle
+        1479:
+        - - Pressed
+          - Toggle
+        1480:
+        - - Pressed
+          - Toggle
+        1481:
+        - - Pressed
+          - Toggle
+        1482:
+        - - Pressed
+          - Toggle
+        100:
+        - - Pressed
+          - DoorBolt
+        102:
+        - - Pressed
+          - DoorBolt
+        107:
+        - - Pressed
+          - DoorBolt
+        98:
+        - - Pressed
+          - DoorBolt
+- proto: LockerElectricalSuppliesFilled
+  entities:
+  - uid: 1165
+    components:
+    - type: Transform
+      pos: 14.5,5.5
+      parent: 1
+- proto: LockerEvidence
+  entities:
+  - uid: 187
+    components:
+    - type: Transform
+      pos: 7.5,-8.5
+      parent: 1
+  - uid: 202
+    components:
+    - type: Transform
+      pos: 7.5,-4.5
+      parent: 1
+- proto: LockerJanitorFilled
+  entities:
+  - uid: 1315
+    components:
+    - type: Transform
+      pos: 11.5,13.5
+      parent: 1
+- proto: LockerMedicineFilled
+  entities:
+  - uid: 282
+    components:
+    - type: Transform
+      pos: 10.5,3.5
+      parent: 1
+  - uid: 284
+    components:
+    - type: Transform
+      pos: 11.5,3.5
+      parent: 1
+- proto: LockerRepresentative
+  entities:
+  - uid: 131
+    components:
+    - type: Transform
+      pos: -0.5,3.5
+      parent: 1
+- proto: LockerSecurity
+  entities:
+  - uid: 533
+    components:
+    - type: Transform
+      pos: 2.5,-8.5
+      parent: 1
+  - uid: 535
+    components:
+    - type: Transform
+      pos: -1.5,-8.5
+      parent: 1
+- proto: LockerWallEVAColorEmergencyFilled
+  entities:
+  - uid: 1379
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,-1.5
+      parent: 1
+- proto: MaterialReclaimer
+  entities:
+  - uid: 1177
+    components:
+    - type: Transform
+      pos: 12.5,13.5
+      parent: 1
+- proto: MedicalBed
+  entities:
+  - uid: 275
+    components:
+    - type: Transform
+      pos: 10.5,-0.5
+      parent: 1
+  - uid: 276
+    components:
+    - type: Transform
+      pos: 12.5,-0.5
+      parent: 1
+- proto: MedkitAdvancedFilled
+  entities:
+  - uid: 290
+    components:
+    - type: Transform
+      pos: 10.730091,1.5426815
+      parent: 1
+- proto: Mirror
+  entities:
+  - uid: 3
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-2.5
+      parent: 1
+- proto: NFAshtray
+  entities:
+  - uid: 601
+    components:
+    - type: Transform
+      pos: -3.2914124,-7.3609786
+      parent: 1
+- proto: NFHolopadShipAntag
+  entities:
+  - uid: 126
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 1
+- proto: NFPlushieSharkMinnow
+  entities:
+  - uid: 1186
+    components:
+    - type: Transform
+      pos: 14.546937,2.4468374
+      parent: 1
+- proto: NFPrisonerClosetWallOrangeFilled
+  entities:
+  - uid: 230
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,-9.5
+      parent: 1
+  - uid: 231
+    components:
+    - type: Transform
+      pos: 12.5,-3.5
+      parent: 1
+- proto: NFSignDock
+  entities:
+  - uid: 1307
+    components:
+    - type: Transform
+      pos: -8.5,18.5
+      parent: 1
+  - uid: 1308
+    components:
+    - type: Transform
+      pos: -4.5,18.5
+      parent: 1
+  - uid: 1309
+    components:
+    - type: Transform
+      pos: -12.5,-5.5
+      parent: 1
+  - uid: 1310
+    components:
+    - type: Transform
+      pos: -12.5,-9.5
+      parent: 1
+- proto: NFTelecomServerFilled
+  entities:
+  - uid: 63
+    components:
+    - type: Transform
+      pos: -0.5,-3.5
+      parent: 1
+- proto: NuclearBomb
+  entities:
+  - uid: 71
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-3.5
+      parent: 1
+- proto: PaperBin10
+  entities:
+  - uid: 549
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-8.5
+      parent: 1
+- proto: PaperBin20
+  entities:
+  - uid: 22
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,1.5
+      parent: 1
+- proto: Pen
+  entities:
+  - uid: 550
+    components:
+    - type: Transform
+      pos: -3.7132874,-7.845354
+      parent: 1
+- proto: PlasmaReinforcedWindowDirectional
+  entities:
+  - uid: 699
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 14.5,4.5
+      parent: 1
+  - uid: 1162
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 16.5,5.5
+      parent: 1
+  - uid: 1163
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 16.5,6.5
+      parent: 1
+  - uid: 1164
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 16.5,4.5
+      parent: 1
+- proto: PlastitaniumWindow
+  entities:
+  - uid: 51
+    components:
+    - type: Transform
+      pos: -0.5,4.5
+      parent: 1
+  - uid: 53
+    components:
+    - type: Transform
+      pos: -2.5,4.5
+      parent: 1
+  - uid: 54
+    components:
+    - type: Transform
+      pos: -4.5,1.5
+      parent: 1
+  - uid: 57
+    components:
+    - type: Transform
+      pos: -4.5,-0.5
+      parent: 1
+  - uid: 58
+    components:
+    - type: Transform
+      pos: 5.5,-0.5
+      parent: 1
+  - uid: 70
+    components:
+    - type: Transform
+      pos: 5.5,1.5
+      parent: 1
+  - uid: 76
+    components:
+    - type: Transform
+      pos: -4.5,2.5
+      parent: 1
+  - uid: 78
+    components:
+    - type: Transform
+      pos: 5.5,2.5
+      parent: 1
+  - uid: 79
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,4.5
+      parent: 1
+  - uid: 105
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,4.5
+      parent: 1
+  - uid: 109
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 1
+  - uid: 114
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,4.5
+      parent: 1
+  - uid: 116
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,4.5
+      parent: 1
+  - uid: 138
+    components:
+    - type: Transform
+      pos: -3.5,-9.5
+      parent: 1
+  - uid: 139
+    components:
+    - type: Transform
+      pos: -2.5,-9.5
+      parent: 1
+  - uid: 148
+    components:
+    - type: Transform
+      pos: 3.5,-9.5
+      parent: 1
+  - uid: 150
+    components:
+    - type: Transform
+      pos: 4.5,-9.5
+      parent: 1
+  - uid: 153
+    components:
+    - type: Transform
+      pos: -4.5,-7.5
+      parent: 1
+  - uid: 154
+    components:
+    - type: Transform
+      pos: -4.5,-8.5
+      parent: 1
+  - uid: 184
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-1.5
+      parent: 1
+  - uid: 193
+    components:
+    - type: Transform
+      pos: 11.5,-9.5
+      parent: 1
+  - uid: 196
+    components:
+    - type: Transform
+      pos: 11.5,-3.5
+      parent: 1
+  - uid: 215
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-3.5
+      parent: 1
+  - uid: 216
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-2.5
+      parent: 1
+  - uid: 220
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-7.5
+      parent: 1
+  - uid: 221
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-5.5
+      parent: 1
+  - uid: 224
+    components:
+    - type: Transform
+      pos: 5.5,-5.5
+      parent: 1
+  - uid: 226
+    components:
+    - type: Transform
+      pos: 5.5,-7.5
+      parent: 1
+  - uid: 236
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,-1.5
+      parent: 1
+  - uid: 243
+    components:
+    - type: Transform
+      pos: 9.5,-0.5
+      parent: 1
+  - uid: 244
+    components:
+    - type: Transform
+      pos: 9.5,1.5
+      parent: 1
+  - uid: 245
+    components:
+    - type: Transform
+      pos: 9.5,2.5
+      parent: 1
+  - uid: 248
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,10.5
+      parent: 1
+  - uid: 316
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,7.5
+      parent: 1
+  - uid: 353
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,16.5
+      parent: 1
+  - uid: 354
+    components:
+    - type: Transform
+      pos: 19.5,8.5
+      parent: 1
+  - uid: 355
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,10.5
+      parent: 1
+  - uid: 356
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,9.5
+      parent: 1
+  - uid: 357
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,11.5
+      parent: 1
+  - uid: 358
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,11.5
+      parent: 1
+  - uid: 364
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,14.5
+      parent: 1
+  - uid: 365
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,14.5
+      parent: 1
+  - uid: 369
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,14.5
+      parent: 1
+  - uid: 371
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,14.5
+      parent: 1
+  - uid: 372
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,14.5
+      parent: 1
+  - uid: 373
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,14.5
+      parent: 1
+  - uid: 379
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,14.5
+      parent: 1
+  - uid: 399
+    components:
+    - type: Transform
+      pos: -5.5,-10.5
+      parent: 1
+  - uid: 401
+    components:
+    - type: Transform
+      pos: -8.5,-11.5
+      parent: 1
+  - uid: 402
+    components:
+    - type: Transform
+      pos: -4.5,-12.5
+      parent: 1
+  - uid: 414
+    components:
+    - type: Transform
+      pos: 17.5,8.5
+      parent: 1
+  - uid: 415
+    components:
+    - type: Transform
+      pos: 18.5,4.5
+      parent: 1
+  - uid: 418
+    components:
+    - type: Transform
+      pos: 19.5,4.5
+      parent: 1
+  - uid: 419
+    components:
+    - type: Transform
+      pos: 20.5,5.5
+      parent: 1
+  - uid: 424
+    components:
+    - type: Transform
+      pos: 20.5,6.5
+      parent: 1
+  - uid: 435
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,12.5
+      parent: 1
+  - uid: 563
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,10.5
+      parent: 1
+  - uid: 575
+    components:
+    - type: Transform
+      pos: -9.5,6.5
+      parent: 1
+  - uid: 611
+    components:
+    - type: Transform
+      pos: -10.5,-9.5
+      parent: 1
+  - uid: 613
+    components:
+    - type: Transform
+      pos: -8.5,-12.5
+      parent: 1
+  - uid: 615
+    components:
+    - type: Transform
+      pos: -4.5,-11.5
+      parent: 1
+  - uid: 618
+    components:
+    - type: Transform
+      pos: -7.5,-10.5
+      parent: 1
+  - uid: 621
+    components:
+    - type: Transform
+      pos: -10.5,-5.5
+      parent: 1
+  - uid: 622
+    components:
+    - type: Transform
+      pos: -11.5,-5.5
+      parent: 1
+  - uid: 623
+    components:
+    - type: Transform
+      pos: -11.5,-9.5
+      parent: 1
+  - uid: 633
+    components:
+    - type: Transform
+      pos: -8.5,1.5
+      parent: 1
+  - uid: 634
+    components:
+    - type: Transform
+      pos: -8.5,-3.5
+      parent: 1
+  - uid: 635
+    components:
+    - type: Transform
+      pos: -8.5,-2.5
+      parent: 1
+  - uid: 637
+    components:
+    - type: Transform
+      pos: -8.5,2.5
+      parent: 1
+  - uid: 660
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,16.5
+      parent: 1
+  - uid: 661
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,17.5
+      parent: 1
+  - uid: 663
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,11.5
+      parent: 1
+  - uid: 666
+    components:
+    - type: Transform
+      pos: -9.5,5.5
+      parent: 1
+  - uid: 667
+    components:
+    - type: Transform
+      pos: -9.5,7.5
+      parent: 1
+  - uid: 685
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,17.5
+      parent: 1
+  - uid: 1168
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,13.5
+      parent: 1
+- proto: PlastitaniumWindowIndestructible
+  entities:
+  - uid: 321
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,8.5
+      parent: 1
+  - uid: 323
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 11.5,8.5
+      parent: 1
+  - uid: 327
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 15.5,8.5
+      parent: 1
+  - uid: 328
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 14.5,8.5
+      parent: 1
+- proto: PlushieCarp
+  entities:
+  - uid: 1181
+    components:
+    - type: Transform
+      pos: 16.531311,2.4155874
+      parent: 1
+- proto: PlushieLizard
+  entities:
+  - uid: 1295
+    components:
+    - type: Transform
+      pos: -0.52724886,13.646208
+      parent: 1
+- proto: PlushieLizardInversed
+  entities:
+  - uid: 1180
+    components:
+    - type: Transform
+      pos: 6.4647846,12.6659
+      parent: 1
+    - type: CollisionWake
+      enabled: False
+    - type: Conveyed
+- proto: PlushieLizardMirrored
+  entities:
+  - uid: 1296
+    components:
+    - type: Transform
+      pos: -1.5428739,13.630583
+      parent: 1
+- proto: PosterLegitEnlist
+  entities:
+  - uid: 641
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-9.5
+      parent: 1
+- proto: PosterLegitNanotrasenLogo
+  entities:
+  - uid: 296
+    components:
+    - type: Transform
+      pos: -1.5,4.5
+      parent: 1
+  - uid: 298
+    components:
+    - type: Transform
+      pos: -4.5,-1.5
+      parent: 1
+  - uid: 1297
+    components:
+    - type: Transform
+      pos: -8.5,14.5
+      parent: 1
+  - uid: 1298
+    components:
+    - type: Transform
+      pos: -4.5,14.5
+      parent: 1
+  - uid: 1299
+    components:
+    - type: Transform
+      pos: -9.5,-5.5
+      parent: 1
+  - uid: 1300
+    components:
+    - type: Transform
+      pos: -9.5,-9.5
+      parent: 1
+- proto: PosterLegitNTTGC
+  entities:
+  - uid: 643
+    components:
+    - type: Transform
+      pos: 4.5,8.5
+      parent: 1
+- proto: PosterLegitObey
+  entities:
+  - uid: 644
+    components:
+    - type: Transform
+      pos: 5.5,-8.5
+      parent: 1
+- proto: PosterLegitSecWatch
+  entities:
+  - uid: 176
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-6.5
+      parent: 1
+- proto: PosterLegitVacation
+  entities:
+  - uid: 642
+    components:
+    - type: Transform
+      pos: -3.5,8.5
+      parent: 1
+- proto: PottedPlant18
+  entities:
+  - uid: 1264
+    components:
+    - type: Transform
+      pos: -1.0100396,12.146481
+      parent: 1
+- proto: PottedPlantRandom
+  entities:
+  - uid: 101
+    components:
+    - type: Transform
+      pos: -3.5,-0.5
+      parent: 1
+  - uid: 551
+    components:
+    - type: Transform
+      pos: 4.5,-5.5
+      parent: 1
+- proto: PottedPlantRandomPlastic
+  entities:
+  - uid: 44
+    components:
+    - type: Transform
+      pos: -3.5,3.5
+      parent: 1
+- proto: PowerCellRecharger
+  entities:
+  - uid: 291
+    components:
+    - type: Transform
+      pos: 12.5,1.5
+      parent: 1
+- proto: Poweredlight
+  entities:
+  - uid: 1316
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,1.5
+      parent: 1
+  - uid: 1357
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,5.5
+      parent: 1
+  - uid: 1358
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 18.5,5.5
+      parent: 1
+  - uid: 1359
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 15.5,2.5
+      parent: 1
+  - uid: 1361
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,13.5
+      parent: 1
+  - uid: 1363
+    components:
+    - type: Transform
+      pos: -2.5,-5.5
+      parent: 1
+  - uid: 1364
+    components:
+    - type: Transform
+      pos: 3.5,-5.5
+      parent: 1
+  - uid: 1366
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-5.5
+      parent: 1
+  - uid: 1367
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-7.5
+      parent: 1
+  - uid: 1368
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-0.5
+      parent: 1
+  - uid: 1369
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,1.5
+      parent: 1
+  - uid: 1370
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-7.5
+      parent: 1
+  - uid: 1371
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -10.5,-8.5
+      parent: 1
+  - uid: 1372
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,6.5
+      parent: 1
+  - uid: 1375
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,-0.5
+      parent: 1
+  - uid: 1376
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,5.5
+      parent: 1
+  - uid: 1378
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 1381
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,17.5
+      parent: 1
+- proto: PoweredlightLED
+  entities:
+  - uid: 95
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-3.5
+      parent: 1
+- proto: PoweredlightRed
+  entities:
+  - uid: 1365
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-11.5
+      parent: 1
+- proto: PoweredlightSodium
+  entities:
+  - uid: 1373
+    components:
+    - type: Transform
+      pos: 3.5,13.5
+      parent: 1
+  - uid: 1374
+    components:
+    - type: Transform
+      pos: -2.5,13.5
+      parent: 1
+- proto: PoweredSmallLight
+  entities:
+  - uid: 93
+    components:
+    - type: Transform
+      pos: -3.5,-2.5
+      parent: 1
+  - uid: 94
+    components:
+    - type: Transform
+      pos: 4.5,-2.5
+      parent: 1
+  - uid: 1377
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,-0.5
+      parent: 1
+  - uid: 1380
+    components:
+    - type: Transform
+      pos: 11.5,3.5
+      parent: 1
+- proto: PoweredWarmSmallLight
+  entities:
+  - uid: 1187
+    components:
+    - type: Transform
+      pos: 11.5,13.5
+      parent: 1
+  - uid: 1362
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,10.5
+      parent: 1
+  - uid: 1382
+    components:
+    - type: Transform
+      pos: 11.5,-7.5
+      parent: 1
+  - uid: 1383
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,-5.5
+      parent: 1
+- proto: Rack
+  entities:
+  - uid: 534
+    components:
+    - type: Transform
+      pos: 2.5,-7.5
+      parent: 1
+  - uid: 536
+    components:
+    - type: Transform
+      pos: -1.5,-7.5
+      parent: 1
+  - uid: 697
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 14.5,6.5
+      parent: 1
+- proto: RagItem
+  entities:
+  - uid: 1292
+    components:
+    - type: Transform
+      pos: 2.5680854,11.630583
+      parent: 1
+- proto: Railing
+  entities:
+  - uid: 26
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,8.5
+      parent: 1
+  - uid: 119
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-8.5
+      parent: 1
+  - uid: 297
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-8.5
+      parent: 1
+  - uid: 1384
+    components:
+    - type: Transform
+      pos: -1.5,6.5
+      parent: 1
+  - uid: 1385
+    components:
+    - type: Transform
+      pos: -0.5,6.5
+      parent: 1
+  - uid: 1386
+    components:
+    - type: Transform
+      pos: 0.5,6.5
+      parent: 1
+  - uid: 1387
+    components:
+    - type: Transform
+      pos: 1.5,6.5
+      parent: 1
+  - uid: 1388
+    components:
+    - type: Transform
+      pos: 2.5,6.5
+      parent: 1
+- proto: RailingCorner
+  entities:
+  - uid: 132
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-7.5
+      parent: 1
+  - uid: 158
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-7.5
+      parent: 1
+  - uid: 1238
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,8.5
+      parent: 1
+  - uid: 1242
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,8.5
+      parent: 1
+- proto: RailingCornerSmall
+  entities:
+  - uid: 1389
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,6.5
+      parent: 1
+  - uid: 1390
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,6.5
+      parent: 1
+- proto: RandomSoap
+  entities:
+  - uid: 11
+    components:
+    - type: Transform
+      pos: 4.5,-3.5
+      parent: 1
+- proto: RandomVendingDrinks
+  entities:
+  - uid: 1294
+    components:
+    - type: Transform
+      pos: 4.5,9.5
+      parent: 1
+- proto: RandomVendingSnacks
+  entities:
+  - uid: 1281
+    components:
+    - type: Transform
+      pos: 1.5,13.5
+      parent: 1
+- proto: RubberStampApproved
+  entities:
+  - uid: 46
+    components:
+    - type: Transform
+      pos: 4.286922,3.0468082
+      parent: 1
+- proto: RubberStampDenied
+  entities:
+  - uid: 124
+    components:
+    - type: Transform
+      pos: 4.6947103,3.0468082
+      parent: 1
+- proto: ShelfBar
+  entities:
+  - uid: 1244
+    components:
+    - type: Transform
+      pos: 4.5,14.5
+      parent: 1
+- proto: ShuttersNormalOpen
+  entities:
+  - uid: 50
+    components:
+    - type: Transform
+      pos: -3.5,4.5
+      parent: 1
+  - uid: 160
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-7.5
+      parent: 1
+  - uid: 161
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-8.5
+      parent: 1
+  - uid: 177
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,-7.5
+      parent: 1
+  - uid: 179
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,-5.5
+      parent: 1
+  - uid: 603
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-9.5
+      parent: 1
+  - uid: 604
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-9.5
+      parent: 1
+  - uid: 605
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-9.5
+      parent: 1
+  - uid: 606
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-9.5
+      parent: 1
+  - uid: 1474
+    components:
+    - type: Transform
+      pos: -2.5,4.5
+      parent: 1
+  - uid: 1475
+    components:
+    - type: Transform
+      pos: -0.5,4.5
+      parent: 1
+  - uid: 1476
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+  - uid: 1477
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 1
+  - uid: 1478
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 1
+  - uid: 1479
+    components:
+    - type: Transform
+      pos: 4.5,4.5
+      parent: 1
+  - uid: 1480
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,2.5
+      parent: 1
+  - uid: 1481
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,1.5
+      parent: 1
+  - uid: 1482
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-0.5
+      parent: 1
+  - uid: 1483
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-0.5
+      parent: 1
+  - uid: 1484
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,1.5
+      parent: 1
+    - type: DeviceLinkSink
+      invokeCounter: 1
+  - uid: 1485
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,2.5
+      parent: 1
+- proto: SignBar
+  entities:
+  - uid: 1262
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,13.5
+      parent: 1
+- proto: SignDangerMed
+  entities:
+  - uid: 646
+    components:
+    - type: Transform
+      pos: -7.5,-10.5
+      parent: 1
+  - uid: 647
+    components:
+    - type: Transform
+      pos: -5.5,-10.5
+      parent: 1
+- proto: SignDirectionalAtmos
+  entities:
+  - uid: 1321
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.531326,5.8572693
+      parent: 1
+- proto: SignDirectionalBar
+  entities:
+  - uid: 1324
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.453085,12.73923
+      parent: 1
+- proto: SignDirectionalBridge
+  entities:
+  - uid: 1326
+    components:
+    - type: Transform
+      pos: -4.483673,9.622364
+      parent: 1
+- proto: SignDirectionalBrig
+  entities:
+  - uid: 1327
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.451266,12.307948
+      parent: 1
+- proto: SignDirectionalEng
+  entities:
+  - uid: 1322
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.533521,5.653513
+      parent: 1
+- proto: SignDirectionalJanitor
+  entities:
+  - uid: 1325
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5517826,9.206481
+      parent: 1
+- proto: SignDirectionalMed
+  entities:
+  - uid: 1323
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.451266,12.520911
+      parent: 1
+- proto: SignDirectionalSec
+  entities:
+  - uid: 1319
+    components:
+    - type: Transform
+      pos: -4.483673,9.316809
+      parent: 1
+- proto: SignElectricalMed
+  entities:
+  - uid: 263
+    components:
+    - type: Transform
+      pos: 10.5,-9.5
+      parent: 1
+  - uid: 264
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-3.5
+      parent: 1
+  - uid: 395
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 15.5,-7.5
+      parent: 1
+  - uid: 396
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-11.5
+      parent: 1
+  - uid: 746
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-14.5
+      parent: 1
+  - uid: 756
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-14.5
+      parent: 1
+  - uid: 757
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 15.5,-3.5
+      parent: 1
+- proto: SignNanotrasen1
+  entities:
+  - uid: 1303
+    components:
+    - type: Transform
+      pos: -1.5,14.5
+      parent: 1
+- proto: SignNanotrasen2
+  entities:
+  - uid: 1302
+    components:
+    - type: Transform
+      pos: -0.5,14.5
+      parent: 1
+- proto: SignNanotrasen3
+  entities:
+  - uid: 1268
+    components:
+    - type: Transform
+      pos: 0.5,14.5
+      parent: 1
+- proto: SignNanotrasen4
+  entities:
+  - uid: 1247
+    components:
+    - type: Transform
+      pos: 1.5,14.5
+      parent: 1
+- proto: SignNanotrasen5
+  entities:
+  - uid: 1304
+    components:
+    - type: Transform
+      pos: 2.5,14.5
+      parent: 1
+- proto: Sink
+  entities:
+  - uid: 49
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-2.5
+      parent: 1
+  - uid: 1251
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,12.5
+      parent: 1
+- proto: SMESBasic
+  entities:
+  - uid: 784
+    components:
+    - type: Transform
+      pos: 13.5,6.5
+      parent: 1
+  - uid: 785
+    components:
+    - type: Transform
+      pos: 13.5,5.5
+      parent: 1
+- proto: SodaDispenser
+  entities:
+  - uid: 1254
+    components:
+    - type: Transform
+      pos: 4.5,13.5
+      parent: 1
+- proto: StairDark
+  entities:
+  - uid: 23
+    components:
+    - type: Transform
+      pos: -0.5,-7.5
+      parent: 1
+  - uid: 125
+    components:
+    - type: Transform
+      pos: 0.5,-7.5
+      parent: 1
+  - uid: 181
+    components:
+    - type: Transform
+      pos: 1.5,-7.5
+      parent: 1
+- proto: StairWood
+  entities:
+  - uid: 683
+    components:
+    - type: Transform
+      pos: -2.5,8.5
+      parent: 1
+  - uid: 686
+    components:
+    - type: Transform
+      pos: -1.5,8.5
+      parent: 1
+  - uid: 687
+    components:
+    - type: Transform
+      pos: 3.5,8.5
+      parent: 1
+  - uid: 688
+    components:
+    - type: Transform
+      pos: 2.5,8.5
+      parent: 1
+- proto: StationAnchor
+  entities:
+  - uid: 423
+    components:
+    - type: Transform
+      pos: 15.5,3.5
+      parent: 1
+- proto: SteelBench
+  entities:
+  - uid: 142
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-6.5
+      parent: 1
+- proto: StoolBar
+  entities:
+  - uid: 1239
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,10.5
+      parent: 1
+  - uid: 1240
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,10.5
+      parent: 1
+  - uid: 1241
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,10.5
+      parent: 1
+- proto: StructureGunRack
+  entities:
+  - uid: 541
+    components:
+    - type: Transform
+      pos: -0.5,-5.5
+      parent: 1
+  - uid: 542
+    components:
+    - type: Transform
+      pos: 0.5,-5.5
+      parent: 1
+  - uid: 543
+    components:
+    - type: Transform
+      pos: 1.5,-5.5
+      parent: 1
+- proto: SubstationBasic
+  entities:
+  - uid: 449
+    components:
+    - type: Transform
+      pos: 11.5,5.5
+      parent: 1
+- proto: SuitStorageBase
+  entities:
+  - uid: 527
+    components:
+    - type: Transform
+      pos: -1.5,-5.5
+      parent: 1
+    - type: Lock
+      locked: False
+    - type: Fixtures
+      fixtures:
+        fix1:
+          shape: !type:PolygonShape
+            radius: 0.01
+            vertices:
+            - -0.25,-0.48
+            - 0.25,-0.48
+            - 0.25,0.48
+            - -0.25,0.48
+          mask:
+          - Impassable
+          - TableLayer
+          - LowImpassable
+          layer:
+          - BulletImpassable
+          - Opaque
+          density: 350
+          hard: True
+          restitution: 0
+          friction: 0.4
+    - type: EntityStorage
+      open: True
+      removedMasks: 20
+    - type: PlaceableSurface
+      isPlaceable: True
+  - uid: 538
+    components:
+    - type: Transform
+      pos: 1.5,-10.5
+      parent: 1
+    - type: Lock
+      locked: False
+    - type: Fixtures
+      fixtures:
+        fix1:
+          shape: !type:PolygonShape
+            radius: 0.01
+            vertices:
+            - -0.25,-0.48
+            - 0.25,-0.48
+            - 0.25,0.48
+            - -0.25,0.48
+          mask:
+          - Impassable
+          - TableLayer
+          - LowImpassable
+          layer:
+          - BulletImpassable
+          - Opaque
+          density: 350
+          hard: True
+          restitution: 0
+          friction: 0.4
+    - type: EntityStorage
+      open: True
+      removedMasks: 20
+    - type: PlaceableSurface
+      isPlaceable: True
+  - uid: 539
+    components:
+    - type: Transform
+      pos: 1.5,-11.5
+      parent: 1
+    - type: Lock
+      locked: False
+    - type: Fixtures
+      fixtures:
+        fix1:
+          shape: !type:PolygonShape
+            radius: 0.01
+            vertices:
+            - -0.25,-0.48
+            - 0.25,-0.48
+            - 0.25,0.48
+            - -0.25,0.48
+          mask:
+          - Impassable
+          - TableLayer
+          - LowImpassable
+          layer:
+          - BulletImpassable
+          - Opaque
+          density: 350
+          hard: True
+          restitution: 0
+          friction: 0.4
+    - type: EntityStorage
+      open: True
+      removedMasks: 20
+    - type: PlaceableSurface
+      isPlaceable: True
+  - uid: 540
+    components:
+    - type: Transform
+      pos: 2.5,-5.5
+      parent: 1
+    - type: Lock
+      locked: False
+    - type: Fixtures
+      fixtures:
+        fix1:
+          shape: !type:PolygonShape
+            radius: 0.01
+            vertices:
+            - -0.25,-0.48
+            - 0.25,-0.48
+            - 0.25,0.48
+            - -0.25,0.48
+          mask:
+          - Impassable
+          - TableLayer
+          - LowImpassable
+          layer:
+          - BulletImpassable
+          - Opaque
+          density: 350
+          hard: True
+          restitution: 0
+          friction: 0.4
+    - type: EntityStorage
+      open: True
+      removedMasks: 20
+    - type: PlaceableSurface
+      isPlaceable: True
+- proto: SuitStorageWallmountEVAPrisoner
+  entities:
+  - uid: 173
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-9.5
+      parent: 1
+  - uid: 178
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-9.5
+      parent: 1
+- proto: SurveillanceCameraCommand
+  entities:
+  - uid: 69
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 1
+- proto: SurveillanceCameraRouterCommand
+  entities:
+  - uid: 65
+    components:
+    - type: Transform
+      pos: -0.5,-2.5
+      parent: 1
+- proto: SurveillanceCameraRouterEngineering
+  entities:
+  - uid: 66
+    components:
+    - type: Transform
+      pos: -0.5,-1.5
+      parent: 1
+- proto: SurveillanceCameraRouterMedical
+  entities:
+  - uid: 68
+    components:
+    - type: Transform
+      pos: 1.5,-1.5
+      parent: 1
+- proto: SurveillanceCameraRouterSecurity
+  entities:
+  - uid: 67
+    components:
+    - type: Transform
+      pos: 1.5,-2.5
+      parent: 1
+- proto: SurveillanceCameraWirelessRouterConstructed
+  entities:
+  - uid: 52
+    components:
+    - type: Transform
+      pos: 1.5,-3.5
+      parent: 1
+- proto: TableCounterWood
+  entities:
+  - uid: 758
+    components:
+    - type: Transform
+      pos: 4.5,13.5
+      parent: 1
+  - uid: 759
+    components:
+    - type: Transform
+      pos: 3.5,13.5
+      parent: 1
+  - uid: 1243
+    components:
+    - type: Transform
+      pos: 2.5,11.5
+      parent: 1
+  - uid: 1256
+    components:
+    - type: Transform
+      pos: 4.5,11.5
+      parent: 1
+  - uid: 1257
+    components:
+    - type: Transform
+      pos: 3.5,11.5
+      parent: 1
+- proto: TableFancyGreen
+  entities:
+  - uid: 462
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,11.5
+      parent: 1
+  - uid: 1250
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,12.5
+      parent: 1
+  - uid: 1260
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,12.5
+      parent: 1
+  - uid: 1263
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,11.5
+      parent: 1
+- proto: TableReinforced
+  entities:
+  - uid: 56
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,3.5
+      parent: 1
+  - uid: 61
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,1.5
+      parent: 1
+  - uid: 96
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,2.5
+      parent: 1
+  - uid: 97
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,3.5
+      parent: 1
+  - uid: 99
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,2.5
+      parent: 1
+  - uid: 108
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,3.5
+      parent: 1
+  - uid: 110
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,1.5
+      parent: 1
+  - uid: 111
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,3.5
+      parent: 1
+  - uid: 117
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,4.5
+      parent: 1
+  - uid: 269
+    components:
+    - type: Transform
+      pos: 10.5,-5.5
+      parent: 1
+  - uid: 270
+    components:
+    - type: Transform
+      pos: 10.5,-7.5
+      parent: 1
+  - uid: 281
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,-0.5
+      parent: 1
+  - uid: 285
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,1.5
+      parent: 1
+  - uid: 286
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,1.5
+      parent: 1
+  - uid: 529
+    components:
+    - type: Transform
+      pos: -3.5,-7.5
+      parent: 1
+  - uid: 530
+    components:
+    - type: Transform
+      pos: -3.5,-8.5
+      parent: 1
+  - uid: 531
+    components:
+    - type: Transform
+      pos: 4.5,-8.5
+      parent: 1
+  - uid: 532
+    components:
+    - type: Transform
+      pos: 4.5,-7.5
+      parent: 1
+- proto: ToiletDirtyWater
+  entities:
+  - uid: 267
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,-7.5
+      parent: 1
+  - uid: 268
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,-5.5
+      parent: 1
+- proto: ToiletGoldenDirtyWater
+  entities:
+  - uid: 55
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-3.5
+      parent: 1
+- proto: ToolboxEmergencyFilled
+  entities:
+  - uid: 698
+    components:
+    - type: Transform
+      pos: 14.421993,6.734598
+      parent: 1
+- proto: ToolboxMechanicalFilled
+  entities:
+  - uid: 1166
+    components:
+    - type: Transform
+      pos: 14.609493,6.468973
+      parent: 1
+- proto: TowelColorCentcom
+  entities:
+  - uid: 121
+    components:
+    - type: Transform
+      pos: -2.4994564,-3.2989917
+      parent: 1
+- proto: TowelColorOrange
+  entities:
+  - uid: 273
+    components:
+    - type: Transform
+      pos: 10.514311,-7.357544
+      parent: 1
+  - uid: 274
+    components:
+    - type: Transform
+      pos: 10.498686,-5.373169
+      parent: 1
+- proto: Turnstile
+  entities:
+  - uid: 234
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-1.5
+      parent: 1
+  - uid: 235
+    components:
+    - type: Transform
+      pos: 8.5,-3.5
+      parent: 1
+- proto: TwoWayLever
+  entities:
+  - uid: 1183
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,12.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        1182:
+        - - Left
+          - Forward
+        - - Right
+          - Forward
+        - - Middle
+          - Off
+- proto: VendingMachineBoozePOI
+  entities:
+  - uid: 760
+    components:
+    - type: Transform
+      pos: 2.5,13.5
+      parent: 1
+- proto: VendingMachineTankDispenserEVA
+  entities:
+  - uid: 397
+    components:
+    - type: Transform
+      pos: 9.5,10.5
+      parent: 1
+- proto: WallmountTelevisionFrame
+  entities:
+  - uid: 1246
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,11.5
+      parent: 1
+- proto: WallPlastitanium
+  entities:
+  - uid: 4
+    components:
+    - type: Transform
+      pos: -2.5,-4.5
+      parent: 1
+  - uid: 5
+    components:
+    - type: Transform
+      pos: -4.5,3.5
+      parent: 1
+  - uid: 7
+    components:
+    - type: Transform
+      pos: -3.5,-4.5
+      parent: 1
+  - uid: 13
+    components:
+    - type: Transform
+      pos: -3.5,-1.5
+      parent: 1
+  - uid: 14
+    components:
+    - type: Transform
+      pos: 5.5,3.5
+      parent: 1
+  - uid: 15
+    components:
+    - type: Transform
+      pos: 3.5,-4.5
+      parent: 1
+  - uid: 16
+    components:
+    - type: Transform
+      pos: -4.5,-1.5
+      parent: 1
+  - uid: 18
+    components:
+    - type: Transform
+      pos: -1.5,-2.5
+      parent: 1
+  - uid: 19
+    components:
+    - type: Transform
+      pos: -1.5,-3.5
+      parent: 1
+  - uid: 20
+    components:
+    - type: Transform
+      pos: -1.5,-4.5
+      parent: 1
+  - uid: 21
+    components:
+    - type: Transform
+      pos: -0.5,-4.5
+      parent: 1
+  - uid: 27
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 1
+  - uid: 28
+    components:
+    - type: Transform
+      pos: 5.5,-2.5
+      parent: 1
+  - uid: 29
+    components:
+    - type: Transform
+      pos: 5.5,-4.5
+      parent: 1
+  - uid: 34
+    components:
+    - type: Transform
+      pos: 2.5,-0.5
+      parent: 1
+  - uid: 35
+    components:
+    - type: Transform
+      pos: 2.5,-2.5
+      parent: 1
+  - uid: 36
+    components:
+    - type: Transform
+      pos: 5.5,-3.5
+      parent: 1
+  - uid: 37
+    components:
+    - type: Transform
+      pos: 2.5,-3.5
+      parent: 1
+  - uid: 38
+    components:
+    - type: Transform
+      pos: 2.5,-4.5
+      parent: 1
+  - uid: 39
+    components:
+    - type: Transform
+      pos: 1.5,-4.5
+      parent: 1
+  - uid: 41
+    components:
+    - type: Transform
+      pos: -1.5,-0.5
+      parent: 1
+  - uid: 42
+    components:
+    - type: Transform
+      pos: -4.5,-3.5
+      parent: 1
+  - uid: 45
+    components:
+    - type: Transform
+      pos: -1.5,-1.5
+      parent: 1
+  - uid: 47
+    components:
+    - type: Transform
+      pos: 4.5,-4.5
+      parent: 1
+  - uid: 73
+    components:
+    - type: Transform
+      pos: 2.5,-1.5
+      parent: 1
+  - uid: 75
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,4.5
+      parent: 1
+  - uid: 77
+    components:
+    - type: Transform
+      pos: -4.5,-4.5
+      parent: 1
+  - uid: 80
+    components:
+    - type: Transform
+      pos: -0.5,-0.5
+      parent: 1
+  - uid: 81
+    components:
+    - type: Transform
+      pos: 4.5,-1.5
+      parent: 1
+  - uid: 83
+    components:
+    - type: Transform
+      pos: -4.5,-2.5
+      parent: 1
+  - uid: 84
+    components:
+    - type: Transform
+      pos: 5.5,-1.5
+      parent: 1
+  - uid: 133
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-12.5
+      parent: 1
+  - uid: 134
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-12.5
+      parent: 1
+  - uid: 135
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-11.5
+      parent: 1
+  - uid: 136
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-9.5
+      parent: 1
+  - uid: 137
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-12.5
+      parent: 1
+  - uid: 140
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-9.5
+      parent: 1
+  - uid: 141
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-9.5
+      parent: 1
+  - uid: 143
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-9.5
+      parent: 1
+  - uid: 144
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-10.5
+      parent: 1
+  - uid: 145
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-11.5
+      parent: 1
+  - uid: 146
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-12.5
+      parent: 1
+  - uid: 147
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-9.5
+      parent: 1
+  - uid: 149
+    components:
+    - type: Transform
+      pos: 5.5,-9.5
+      parent: 1
+  - uid: 157
+    components:
+    - type: Transform
+      pos: -4.5,-5.5
+      parent: 1
+  - uid: 185
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-1.5
+      parent: 1
+  - uid: 186
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-2.5
+      parent: 1
+  - uid: 188
+    components:
+    - type: Transform
+      pos: 6.5,-9.5
+      parent: 1
+  - uid: 189
+    components:
+    - type: Transform
+      pos: 7.5,-9.5
+      parent: 1
+  - uid: 190
+    components:
+    - type: Transform
+      pos: 8.5,-9.5
+      parent: 1
+  - uid: 191
+    components:
+    - type: Transform
+      pos: 9.5,-9.5
+      parent: 1
+  - uid: 192
+    components:
+    - type: Transform
+      pos: 10.5,-9.5
+      parent: 1
+  - uid: 194
+    components:
+    - type: Transform
+      pos: 9.5,-3.5
+      parent: 1
+  - uid: 195
+    components:
+    - type: Transform
+      pos: 10.5,-3.5
+      parent: 1
+  - uid: 197
+    components:
+    - type: Transform
+      pos: 13.5,-7.5
+      parent: 1
+  - uid: 198
+    components:
+    - type: Transform
+      pos: 13.5,-8.5
+      parent: 1
+  - uid: 199
+    components:
+    - type: Transform
+      pos: 11.5,-6.5
+      parent: 1
+  - uid: 200
+    components:
+    - type: Transform
+      pos: 12.5,-9.5
+      parent: 1
+  - uid: 201
+    components:
+    - type: Transform
+      pos: 13.5,-9.5
+      parent: 1
+  - uid: 205
+    components:
+    - type: Transform
+      pos: 9.5,-6.5
+      parent: 1
+  - uid: 206
+    components:
+    - type: Transform
+      pos: 13.5,-6.5
+      parent: 1
+  - uid: 207
+    components:
+    - type: Transform
+      pos: 12.5,-6.5
+      parent: 1
+  - uid: 208
+    components:
+    - type: Transform
+      pos: 12.5,-3.5
+      parent: 1
+  - uid: 209
+    components:
+    - type: Transform
+      pos: 13.5,-3.5
+      parent: 1
+  - uid: 210
+    components:
+    - type: Transform
+      pos: 13.5,-4.5
+      parent: 1
+  - uid: 211
+    components:
+    - type: Transform
+      pos: 13.5,-5.5
+      parent: 1
+  - uid: 212
+    components:
+    - type: Transform
+      pos: 10.5,-6.5
+      parent: 1
+  - uid: 225
+    components:
+    - type: Transform
+      pos: 5.5,-8.5
+      parent: 1
+  - uid: 232
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-12.5
+      parent: 1
+  - uid: 233
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-10.5
+      parent: 1
+  - uid: 237
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-1.5
+      parent: 1
+  - uid: 238
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,-1.5
+      parent: 1
+  - uid: 239
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 13.5,-1.5
+      parent: 1
+  - uid: 240
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 13.5,-2.5
+      parent: 1
+  - uid: 242
+    components:
+    - type: Transform
+      pos: 9.5,3.5
+      parent: 1
+  - uid: 246
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,5.5
+      parent: 1
+  - uid: 249
+    components:
+    - type: Transform
+      pos: 13.5,4.5
+      parent: 1
+  - uid: 250
+    components:
+    - type: Transform
+      pos: 13.5,3.5
+      parent: 1
+  - uid: 251
+    components:
+    - type: Transform
+      pos: 13.5,2.5
+      parent: 1
+  - uid: 252
+    components:
+    - type: Transform
+      pos: 13.5,1.5
+      parent: 1
+  - uid: 253
+    components:
+    - type: Transform
+      pos: 13.5,0.5
+      parent: 1
+  - uid: 254
+    components:
+    - type: Transform
+      pos: 13.5,-0.5
+      parent: 1
+  - uid: 259
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,4.5
+      parent: 1
+  - uid: 260
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,4.5
+      parent: 1
+  - uid: 261
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 11.5,4.5
+      parent: 1
+  - uid: 303
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,9.5
+      parent: 1
+  - uid: 307
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,8.5
+      parent: 1
+  - uid: 309
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,9.5
+      parent: 1
+  - uid: 311
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,3.5
+      parent: 1
+  - uid: 312
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,8.5
+      parent: 1
+  - uid: 313
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,9.5
+      parent: 1
+  - uid: 314
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,9.5
+      parent: 1
+  - uid: 315
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,8.5
+      parent: 1
+  - uid: 319
+    components:
+    - type: Transform
+      pos: 20.5,8.5
+      parent: 1
+  - uid: 320
+    components:
+    - type: Transform
+      pos: 20.5,7.5
+      parent: 1
+  - uid: 322
+    components:
+    - type: Transform
+      pos: 17.5,4.5
+      parent: 1
+  - uid: 324
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 16.5,8.5
+      parent: 1
+  - uid: 329
+    components:
+    - type: Transform
+      pos: 19.5,11.5
+      parent: 1
+  - uid: 330
+    components:
+    - type: Transform
+      pos: 15.5,1.5
+      parent: 1
+  - uid: 332
+    components:
+    - type: Transform
+      pos: 16.5,1.5
+      parent: 1
+  - uid: 333
+    components:
+    - type: Transform
+      pos: 17.5,3.5
+      parent: 1
+  - uid: 335
+    components:
+    - type: Transform
+      pos: 17.5,11.5
+      parent: 1
+  - uid: 336
+    components:
+    - type: Transform
+      pos: 18.5,11.5
+      parent: 1
+  - uid: 346
+    components:
+    - type: Transform
+      pos: 17.5,2.5
+      parent: 1
+  - uid: 359
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,11.5
+      parent: 1
+  - uid: 361
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,14.5
+      parent: 1
+  - uid: 367
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,13.5
+      parent: 1
+  - uid: 368
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,13.5
+      parent: 1
+  - uid: 370
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,14.5
+      parent: 1
+  - uid: 381
+    components:
+    - type: Transform
+      pos: 20.5,10.5
+      parent: 1
+  - uid: 400
+    components:
+    - type: Transform
+      pos: -4.5,-13.5
+      parent: 1
+  - uid: 404
+    components:
+    - type: Transform
+      pos: -8.5,-0.5
+      parent: 1
+  - uid: 405
+    components:
+    - type: Transform
+      pos: -7.5,-14.5
+      parent: 1
+  - uid: 407
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,14.5
+      parent: 1
+  - uid: 409
+    components:
+    - type: Transform
+      pos: -5.5,-14.5
+      parent: 1
+  - uid: 417
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,12.5
+      parent: 1
+  - uid: 420
+    components:
+    - type: Transform
+      pos: 20.5,9.5
+      parent: 1
+  - uid: 422
+    components:
+    - type: Transform
+      pos: 14.5,1.5
+      parent: 1
+  - uid: 425
+    components:
+    - type: Transform
+      pos: 20.5,4.5
+      parent: 1
+  - uid: 429
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,15.5
+      parent: 1
+  - uid: 433
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,14.5
+      parent: 1
+  - uid: 434
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,18.5
+      parent: 1
+  - uid: 460
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,12.5
+      parent: 1
+  - uid: 574
+    components:
+    - type: Transform
+      pos: -9.5,4.5
+      parent: 1
+  - uid: 608
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -8.5,-10.5
+      parent: 1
+  - uid: 609
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-10.5
+      parent: 1
+  - uid: 610
+    components:
+    - type: Transform
+      pos: -6.5,-14.5
+      parent: 1
+  - uid: 612
+    components:
+    - type: Transform
+      pos: -8.5,-13.5
+      parent: 1
+  - uid: 620
+    components:
+    - type: Transform
+      pos: -9.5,-9.5
+      parent: 1
+  - uid: 627
+    components:
+    - type: Transform
+      pos: -12.5,-5.5
+      parent: 1
+  - uid: 628
+    components:
+    - type: Transform
+      pos: -12.5,-9.5
+      parent: 1
+  - uid: 629
+    components:
+    - type: Transform
+      pos: -9.5,-5.5
+      parent: 1
+  - uid: 630
+    components:
+    - type: Transform
+      pos: -8.5,-4.5
+      parent: 1
+  - uid: 632
+    components:
+    - type: Transform
+      pos: -8.5,-1.5
+      parent: 1
+  - uid: 636
+    components:
+    - type: Transform
+      pos: -8.5,0.5
+      parent: 1
+  - uid: 659
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,9.5
+      parent: 1
+  - uid: 662
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,13.5
+      parent: 1
+  - uid: 664
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,18.5
+      parent: 1
+  - uid: 665
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,15.5
+      parent: 1
+  - uid: 671
+    components:
+    - type: Transform
+      pos: -9.5,8.5
+      parent: 1
+  - uid: 1167
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,12.5
+      parent: 1
+  - uid: 1169
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,14.5
+      parent: 1
+  - uid: 1170
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,14.5
+      parent: 1
+  - uid: 1171
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,13.5
+      parent: 1
+  - uid: 1351
+    components:
+    - type: Transform
+      pos: 1.5,-0.5
+      parent: 1
+- proto: WallPlastitaniumDiagonal
+  entities:
+  - uid: 9
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,4.5
+      parent: 1
+  - uid: 48
+    components:
+    - type: Transform
+      pos: -4.5,4.5
+      parent: 1
+  - uid: 241
+    components:
+    - type: Transform
+      pos: 9.5,4.5
+      parent: 1
+  - uid: 301
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,8.5
+      parent: 1
+  - uid: 302
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,8.5
+      parent: 1
+  - uid: 304
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -8.5,8.5
+      parent: 1
+  - uid: 305
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -8.5,4.5
+      parent: 1
+  - uid: 306
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,8.5
+      parent: 1
+  - uid: 392
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,3.5
+      parent: 1
+  - uid: 410
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -8.5,-5.5
+      parent: 1
+  - uid: 430
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,14.5
+      parent: 1
+  - uid: 558
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-14.5
+      parent: 1
+  - uid: 559
+    components:
+    - type: Transform
+      pos: -5.5,-13.5
+      parent: 1
+  - uid: 560
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,-13.5
+      parent: 1
+  - uid: 562
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,-14.5
+      parent: 1
+  - uid: 607
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -8.5,-9.5
+      parent: 1
+  - uid: 672
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 20.5,11.5
+      parent: 1
+  - uid: 681
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 17.5,1.5
+      parent: 1
+  - uid: 682
+    components:
+    - type: Transform
+      pos: -9.5,9.5
+      parent: 1
+  - uid: 1172
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,14.5
+      parent: 1
+  - uid: 1173
+    components:
+    - type: Transform
+      pos: 10.5,14.5
+      parent: 1
+- proto: WallPlastitaniumIndestructible
+  entities:
+  - uid: 318
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 16.5,9.5
+      parent: 1
+  - uid: 325
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,9.5
+      parent: 1
+  - uid: 326
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 13.5,8.5
+      parent: 1
+  - uid: 331
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,10.5
+      parent: 1
+  - uid: 334
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 13.5,10.5
+      parent: 1
+  - uid: 337
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 16.5,10.5
+      parent: 1
+  - uid: 338
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 13.5,9.5
+      parent: 1
+  - uid: 339
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,11.5
+      parent: 1
+  - uid: 340
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 11.5,11.5
+      parent: 1
+  - uid: 341
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,11.5
+      parent: 1
+  - uid: 342
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 13.5,11.5
+      parent: 1
+  - uid: 343
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 14.5,11.5
+      parent: 1
+  - uid: 344
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 15.5,11.5
+      parent: 1
+  - uid: 345
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 16.5,11.5
+      parent: 1
+- proto: WallWeaponCapacitorRecharger
+  entities:
+  - uid: 164
+    components:
+    - type: Transform
+      pos: -0.5,-4.5
+      parent: 1
+  - uid: 165
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 1
+  - uid: 166
+    components:
+    - type: Transform
+      pos: 1.5,-4.5
+      parent: 1
+  - uid: 170
+    components:
+    - type: Transform
+      pos: -1.5,-4.5
+      parent: 1
+  - uid: 171
+    components:
+    - type: Transform
+      pos: 2.5,-4.5
+      parent: 1
+- proto: WarningN2
+  entities:
+  - uid: 382
+    components:
+    - type: Transform
+      pos: 12.5,11.5
+      parent: 1
+- proto: WarningO2
+  entities:
+  - uid: 383
+    components:
+    - type: Transform
+      pos: 15.5,11.5
+      parent: 1
+- proto: WarpPoint
+  entities:
+  - uid: 1488
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,-12.5
+      parent: 1
+- proto: WindoorSecure
+  entities:
+  - uid: 98
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,4.5
+      parent: 1
+- proto: WindoorSecureBrigmedicLocked
+  entities:
+  - uid: 762
+    components:
+    - type: Transform
+      pos: 11.5,1.5
+      parent: 1
+- proto: WindoorSecureCentralCommandLocked
+  entities:
+  - uid: 107
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 1
+  - uid: 1178
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 11.5,12.5
+      parent: 1
+- proto: WindowDirectional
+  entities:
+  - uid: 10
+    components:
+    - type: Transform
+      pos: 4.5,-2.5
+      parent: 1
+- proto: WindowReinforcedDirectional
+  entities:
+  - uid: 287
+    components:
+    - type: Transform
+      pos: 10.5,1.5
+      parent: 1
+  - uid: 288
+    components:
+    - type: Transform
+      pos: 12.5,1.5
+      parent: 1
+  - uid: 1179
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 11.5,13.5
+      parent: 1
+...


### PR DESCRIPTION
## About the PR
As requested by Jojy on the Discord.
Adds a miniature version of the CentComm station for admeme purposes.
![image](https://github.com/user-attachments/assets/9d53c916-28c5-42eb-9b59-94322352984f)

## Why / Balance
Requested by admins! Contains an office for paperwork, a staging area for ERT/Deathsquad, a small brig with medical facilities for doing fun things with prisoners, a 'teleporter' room (entirely non-functional and for RP purposes) and a cozy public reception area. It even has a bar! Can YOU spot the hidden drazil?

Functionally just a fancier admin area to be able to stage admeme content from. Designed to be placed in a seperate map from the main stuff, not infeasible to place in-system. Notably, security/office areas are completely lacking in any kind of admeme equipment to facilitate admins spawning in what they like and not having crazy stuff lying around.

## How to test
- Start up environment
- go to a new map with the mapping command
- Load the 'minicentcomm.yml'
- Bask in the glorious greens and golds of CentComm

## Media
Lights+Subfloor
![image](https://github.com/user-attachments/assets/3cbfb2b1-14b5-4d0e-a453-ec22a8cfc176)

Security Buttons - left closes shutters and bolts the doors, right does the same but also bolts the brig doors
![image](https://github.com/user-attachments/assets/182d1064-130c-437a-9489-b5fb17545f01)

Office - Button closes shutters and bolts doors, secure windoors force each other to close to ensure no tablehoppers sneak in.
![image](https://github.com/user-attachments/assets/85af91c9-3e45-494e-9349-cbc41402848b)



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I confirm that AI tools were not used in generating the material in this PR.

**Changelog**
This probably doesn't need a changelog, but correct me if I'm wrong.
