### PR TITLE
Fix development.toml no longer forcing you to use a random race

### DIFF
--- a/Resources/ConfigPresets/Build/development.toml
+++ b/Resources/ConfigPresets/Build/development.toml
@@ -42,8 +42,8 @@ shipyard = true
 see_own_notes = true
 
 [ic]
-random_characters = true
-random_species_weights = ""
+# random_characters = true # Frontier: No
+# random_species_weights = "" # Frontier: No
 
 # Frontier: expedition params
 [nf14.salvage]


### PR DESCRIPTION
## About the PR
This isn't helping with testing at all.

## Media
No

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
No

**Changelog**
No
