### PR TITLE
Enable anchoring on CuddlyCritter and Autotune

### DIFF
--- a/Resources/Maps/_NF/Outpost/frontier.yml
+++ b/Resources/Maps/_NF/Outpost/frontier.yml
@@ -33246,7 +33246,7 @@ entities:
     - type: Transform
       pos: -49.5,18.5
       parent: 2173
-- proto: VendingMachineCuddlyCritterVend
+- proto: VendingMachineCuddlyCritterVendPOI
   entities:
   - uid: 718
     components:

--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/vending_machines.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [BaseStructureDisableAnchoring, VendingMachine]
+  parent: VendingMachine
   id: VendingMachineCuddlyCritterVend
   name: CuddlyCritterVend
   description: Step into the world of wonder and warmth with Cuddly Critters Vending Machine, a haven for plushie and toy enthusiasts alike.
@@ -299,7 +299,7 @@
       color: "#ff033e"
 
 - type: entity
-  parent: [BaseStructureDisableAnchoring, VendingMachine]
+  parent: VendingMachine
   id: VendingMachineAutoTuneVend
   name: AutoTune
   description: Feeling BASSed? Time to TUNE into AutoVend! Take NOTES and let your audience TREBLE.
@@ -808,6 +808,22 @@
   components:
   - type: VendingMachine
     pack: BoozeOMatInventory
+
+- type: entity
+  parent: [VendingMachineCuddlyCritterVend, BaseStructureDisableAnchoring]
+  id: VendingMachineCuddlyCritterVendPOI
+  suffix: POI
+  components:
+  - type: VendingMachine
+    pack: CuddlyCritterVendInventory
+
+- type: entity
+  parent: [VendingMachineAutoTuneVend, BaseStructureDisableAnchoring]
+  id: VendingMachineAutoTuneVendPOI
+  suffix: POI
+  components:
+  - type: VendingMachine
+    pack: AutoTuneVendInventory
 
 # Gas Tank Dispenser
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Enables anchoring on the CuddlyCritter and the AutoTune vending machines

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
CuddlyCritterVend and Autotune are vending machines that only bring fun with the instruments, toys and plushies, and it never made sense to me that they couldn't be salvaged off dungeons. I feel like they might have been unintentionally forgotten and left unanchorable after getting the grid binding system

## Technical details
<!-- Summary of code changes for easier review. -->
Removed the BaseStructureDisableAnchoring parent on both vending machines and made a POI version of both instead

Replaced the CuddlyCritterVend on Frontier Outpost with the POI version

I did not replace the vending machines with POI variants other than the one Frontier Outpost, since POIs are meant to be modified by players, and they are bound to the POIs anyway

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
Try unanchoring the CuddlyCritterVend on Frontier Outpost : Doesn't work
Try unanchoring any other CuddlyCritterVend : Works !
Try unanchoring any Autotune : Works !

Check that the vending machines both have POI variants in the entity spawner 

<!-- ## Media -->
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- ## Breaking changes -->
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: CuddlyCritterVend and Autotune can now be unanchored!