### PR TITLE
Shipyard Console: use confirm buttons

### DIFF
--- a/Content.Client/UserInterface/Controls/ConfirmButton.cs
+++ b/Content.Client/UserInterface/Controls/ConfirmButton.cs
@@ -30,6 +30,13 @@ public sealed class ConfirmButton : Button
     /// </summary>
     public new event Action<ButtonEventArgs>? OnPressed;
 
+    // Frontier: multiple confirm button handlers
+    /// <summary>
+    /// Fired when the button was pressed and starts confirming.
+    /// </summary>
+    public event Action<ButtonEventArgs>? OnConfirming;
+    // End Frontier: multiple confirm button handlers
+
     /// <inheritdoc cref="Button.Text"/>
     /// <remarks>
     /// Hides the buttons text property to be able to sanely replace the button text with
@@ -126,9 +133,10 @@ public sealed class ConfirmButton : Button
         switch (IsConfirming)
         {
             case false:
-                _nextCooldown  = _gameTiming.CurTime + CooldownTime;
+                _nextCooldown = _gameTiming.CurTime + CooldownTime;
                 _nextReset = _gameTiming.CurTime + ResetTime;
                 Disabled = true;
+                OnConfirming?.Invoke(buttonEvent); // Frontier
                 break;
             case true:
                 OnPressed?.Invoke(buttonEvent);
@@ -139,4 +147,13 @@ public sealed class ConfirmButton : Button
 
         IsConfirming = !IsConfirming;
     }
+
+    // Frontier: clear IsConfirming, respect other state
+    public void ClearIsConfirming()
+    {
+        IsConfirming = false;
+        base.Text = Text;
+        DrawModeChanged();
+    }
+    // End Frontier: clear IsConfirming, respect other state
 }

--- a/Content.Client/UserInterface/Controls/ConfirmButton.cs
+++ b/Content.Client/UserInterface/Controls/ConfirmButton.cs
@@ -133,7 +133,7 @@ public sealed class ConfirmButton : Button
         switch (IsConfirming)
         {
             case false:
-                _nextCooldown = _gameTiming.CurTime + CooldownTime;
+                _nextCooldown  = _gameTiming.CurTime + CooldownTime;
                 _nextReset = _gameTiming.CurTime + ResetTime;
                 Disabled = true;
                 OnConfirming?.Invoke(buttonEvent); // Frontier

--- a/Content.Client/_NF/Shipyard/UI/ShipyardConsoleMenu.xaml.cs
+++ b/Content.Client/_NF/Shipyard/UI/ShipyardConsoleMenu.xaml.cs
@@ -30,6 +30,8 @@ public sealed partial class ShipyardConsoleMenu : FancyWindow
     private List<string> _lastUnavailableProtos = new();
     private bool _freeListings = false;
     private bool _validId = false;
+    // The currently confirming button
+    private ConfirmButton? _currentlyConfirmingButton = null;
 
     public ShipyardConsoleMenu()
     {
@@ -146,9 +148,23 @@ public sealed partial class ShipyardConsoleMenu : FancyWindow
                 Guidebook = { Disabled = prototype.GuidebookPage is null, TooltipDelay = 0.2f, ToolTip = prototype.Description },
                 Price = { Text = priceText },
             };
-            vesselEntry.Purchase.OnPressed += (args) => { OnOrderApproved?.Invoke(args); };
+            vesselEntry.Purchase.OnConfirming += OnStartConfirmingPurchase;
+            vesselEntry.Purchase.OnPressed += (args) => { _currentlyConfirmingButton = null; OnOrderApproved?.Invoke(args); };
             Vessels.AddChild(vesselEntry);
         }
+    }
+
+    /// <summary>
+    /// Confirming handler: ensures that only one button is confirming at a time.
+    /// </summary>
+    private void OnStartConfirmingPurchase(ButtonEventArgs args)
+    {
+        if (args.Button is not ConfirmButton confirmButton)
+            return;
+
+        if (_currentlyConfirmingButton != null)
+            _currentlyConfirmingButton.ClearIsConfirming();
+        _currentlyConfirmingButton = confirmButton;
     }
 
     /// <summary>

--- a/Content.Client/_NF/Shipyard/UI/VesselRow.xaml
+++ b/Content.Client/_NF/Shipyard/UI/VesselRow.xaml
@@ -1,5 +1,6 @@
 <PanelContainer xmlns="https://spacestation14.io"
                 xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
+                xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
                 HorizontalExpand="True">
     <BoxContainer Orientation="Horizontal"
                   HorizontalExpand="True">
@@ -12,7 +13,7 @@
             Align="Right"
             Margin="0 0 5 0"
             HorizontalAlignment="Right" /> <!-- Right margin to account for scroll bar -->
-        <Button Name="Purchase"
+        <controls:ConfirmButton Name="Purchase"
             Access="Public"
             ToolTip=""
             Text="{Loc 'shipyard-console-purchase-available'}"
@@ -21,7 +22,7 @@
             HorizontalAlignment="Right" /> <!-- 130 px: approximate width of "Purchase"-->
         <Button Name="Guidebook"
             Access="Public"
-            Text="{Loc 'shipyard-console-guidebook'}" 
+            Text="{Loc 'shipyard-console-guidebook'}"
             StyleClasses="LabelSubText"
             Margin="0 0 12 0"
             HorizontalAlignment="Right" /> <!-- Left margin only -->


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Changes the shipyard console to use confirm buttons for purchase.

Adds an event for when a confirm button starts confirming (should really exist upstream) to ensure only one button is confirming at a time.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Fewer mistakes.

## Technical details
<!-- Summary of code changes for easier review. -->

New fields in the ShipyardConsoleMenu to track which button is currently pressed.  New handler to swap this value.

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->

Use the shipyard console.  Ships shouldn't purchase until confirmed.  Confirm state should reset on its own, and only one button should ever be left confirming.  Text should always be updated - you should never have a grey button saying "Confirm"

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/7f6bbe72-b217-4bb1-b1fa-f6bc0da0cf10

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
meh