### PR TITLE
Removes Total playtime alternative way to  play deputy

### DIFF
--- a/Resources/Prototypes/_NF/Roles/Jobs/Nfsd/deputy.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Nfsd/deputy.yml
@@ -9,10 +9,6 @@
     - !type:DepartmentTimeRequirement
       department: Security
       time: 21600 # 6 hours
-  alternateRequirementSets:
-    longerPlaytimeLessSec:
-    - !type:OverallPlaytimeRequirement
-      time: 360000 # 100 hours
   startingGear: DeputyGear
   icon: JobIconDeputy
   supervisors: job-supervisors-sergeant


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

> Learning and being trained in NFSD is very very important for the sector health, as well as the department's reputation as professionals whom the sector can love and respect for protecting them.
There's of course only one path into the department:  To be trained as a Cadet, so you can learn SOP and be trained not to abuse criminals.
But there is another way...
Having enough playtime.
This isn't a great thing, as it lets some players slip into NFSD without even being trained properly, and we all know it shows...
It only takes one bad encounter from someone playing a "bad cop" to sour people's moods for awhile.
You are expected to roleplay and be held to a higher standard in NFSD!!
Yes, we know that the Sheriff doesn't always open Cadet slots.
Yes, it's a bottleneck.
This is important, so that we don't just get Officers in that'll make Cappy sad. (or deputies that even EAT the cat...)
Please, let's do this for Cappy.  Plug the hole.
Remove the time-skip loophole to let people skip to Deputy.
~werebat

https://discord.com/channels/1123826877245694004/1376812991147933697
Ideal originally posted by Werebat
## Technical details
<!-- Summary of code changes for easier review. -->
Removes players being able to play Deputy with strictly just play time.
## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
 load up PR, see that you can no longer play deputy with just play time alone
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/a457f5b5-785a-4bb7-8ab9-da6fc5d80f86)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [x] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Players cant skip cadet to play deputy directly by process of having enough hours