### PR TITLE
Sheleg: Age parameters change

### DIFF
--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml
@@ -65,7 +65,7 @@
                                 <BoxContainer HorizontalExpand="True">
                                     <Label Text="{Loc 'humanoid-profile-editor-age-label'}" />
                                     <Control HorizontalExpand="True"/>
-                                    <LineEdit Name="AgeEdit" MinSize="40 0" HorizontalAlignment="Right" />
+                                    <LineEdit Name="AgeEdit" MinSize="50 0" HorizontalAlignment="Right" /> <!-- Frontier: "40 0" < "50 0" -->
                                 </BoxContainer>
                                 <!-- Sex -->
                                 <BoxContainer HorizontalExpand="True">

--- a/Resources/Prototypes/_NF/Species/sheleg.yml
+++ b/Resources/Prototypes/_NF/Species/sheleg.yml
@@ -12,6 +12,9 @@
   maleFirstNames: NamesShelegFirstMale
   femaleFirstNames: NamesShelegFirstFemale
   lastNames: NamesShelegLast
+  youngAge: 80
+  oldAge: 400
+  maxAge: 800
 
 - type: speciesBaseSprites
   id: MobShelegSprites


### PR DESCRIPTION
## About the PR
Based on this https://www.worldanvil.com/w/ostara-donnyprocs/a/jotunn-28giants29-article and general Nordic points about Jotunn.
And the idea from here https://github.com/space-wizards/space-station-14/pull/38467

## Why / Balance
Seems to fit, I was not aware it was that simple to fix the age for the race.

## Technical details
N/A

## How to test
Open editor as Sheleg, up that age.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
:cl:
- tweak: Sheleg age changed, 80 and lower is young, 400 and lower is middle age and 800 and lower is old age.
