### PR TITLE
Replace criminal records computers with camera monitors on dengeon maps

### DIFF
--- a/Resources/Maps/_NF/Dungeon/lava_brig.yml
+++ b/Resources/Maps/_NF/Dungeon/lava_brig.yml
@@ -7139,7 +7139,7 @@ entities:
       rot: 3.141592653589793 rad
       pos: 13.5,44.5
       parent: 588
-- proto: ComputerCriminalRecords
+- proto: ComputerSurveillanceWirelessCameraMonitor
   entities:
   - uid: 461
     components:

--- a/Resources/Maps/_NF/Dungeon/lava_mercenary.yml
+++ b/Resources/Maps/_NF/Dungeon/lava_mercenary.yml
@@ -7219,7 +7219,7 @@ entities:
       rot: 3.141592653589793 rad
       pos: 13.5,44.5
       parent: 588
-- proto: ComputerCriminalRecords
+- proto: ComputerSurveillanceWirelessCameraMonitor
   entities:
   - uid: 461
     components:


### PR DESCRIPTION
## About the PR
Should not be mapped on basic dungeon tilesets, remove the point of ever using them as NFSD if anyone can find them and just edit records with no effort.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
No