### PR TITLE
Emergency Sink. Kind of. G... Good job sink?

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Structures/Furniture/sink.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Furniture/sink.yml
@@ -1,0 +1,21 @@
+- type: entity
+  name: scuttlebutt
+  id: NFEmergencySink
+  description: This little sink is drawing moisture from the environmental systems. Not responsible for nosebleeds.
+  parent: SinkStemless
+  suffix: Water
+  components:
+  - type: SolutionRegeneration
+    solution: tank
+    generated:
+      reagents:
+      - ReagentId: Water
+        Quantity: 0.25
+  - type: SolutionContainerManager
+    solutions:
+      drainBuffer:
+        maxVol: 200
+      tank:
+        reagents:
+        - ReagentId: Water
+          Quantity: 50


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

This PR adds a sink variant for free mapping use. It's basically a small sink with a trickle fill and 50u capacity. This, maybe, should allow people to refill their sippy cup while also making people who get fussy about universal industrial water reagent provision on service ships happy.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Not allowing sinks at all seems silly. Water is water.
Some, reasonable, concern about normal sink volume everywhere. 
You're probably better off bringing some supplies with you but this'll let everyone stay topped off.

I'm open to tweaking the numbers. I think this is probably a useful tool and one that addresses a "problem". The fill rate seems to do the job of addressing some concerns but I think the overall capacity could be increased to fit the needs of larger crews.

I decided to not adjust the sprite.

## Technical details
<!-- Summary of code changes for easier review. -->

yaml

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->

Place sink. Drink.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
🆑 
- add: Small capacity sink for mapping purposes. 