### PR TITLE
Shuttle Console: Shuttle, station, custom map targets

### DIFF
--- a/Content.Client/Shuttles/UI/MapScreen.xaml.cs
+++ b/Content.Client/Shuttles/UI/MapScreen.xaml.cs
@@ -473,8 +473,9 @@ public sealed partial class MapScreen : BoxContainer
         {
             Text = mapObj.Name,
             HorizontalExpand = true,
-            SizeFlagsStretchRatio = 4, // Frontier
         };
+
+        gridButton.Label.ClipText = true; // Frontier
 
         var gridContainer = new BoxContainer()
         {
@@ -482,7 +483,7 @@ public sealed partial class MapScreen : BoxContainer
             {
                 new Control()
                 {
-                    MinWidth = 32f,
+                    MinWidth = 16f, // Frontier: 32<16
                 },
                 gridButton
             }
@@ -502,8 +503,8 @@ public sealed partial class MapScreen : BoxContainer
             var trackButton = new Button()
             {
                 Text = Loc.GetString("shuttle-console-map-track"),
-                HorizontalExpand = true,
-                SizeFlagsStretchRatio = 1,
+                MinWidth = 32,
+                MaxWidth = 32
             };
             trackButton.OnPressed += args =>
             {

--- a/Content.Client/Shuttles/UI/NavScreen.xaml
+++ b/Content.Client/Shuttles/UI/NavScreen.xaml
@@ -106,6 +106,35 @@
                                          Margin="0"/>
                     </controls:BoxContainer>
                     <!-- End Frontier - Inertia dampener controls-->
+
+                    <!-- Frontier - settable target -->
+                    <controls:BoxContainer Orientation="Vertical" HorizontalExpand="True" Name="TargetCoordsBox">
+                        <controls:Label Text="{controls:Loc 'shuttle-console-target'}"/>
+                        <controls:BoxContainer Orientation="Horizontal"
+                                               HorizontalExpand="True"
+                                               Align="Center"
+                                               Margin="0 0 0 3">
+                            <controls:LineEdit Name="TargetX" Access="Public" HorizontalExpand="True"/>
+                            <controls:LineEdit Name="TargetY" Access="Public" HorizontalExpand="True"/>
+                            <controls:Button Name="TargetSet"
+                                             Text="{controls:Loc 'shuttle-console-set-target'}"
+                                             TextAlign="Center"
+                                             MinWidth="20"
+                                             ToolTip="{controls:Loc 'shuttle-console-set-target-description'}"
+                                             StyleClasses="OpenRight"
+                                             Margin="0"/>
+                            <controls:Button Name="TargetHide"
+                                             Text="{controls:Loc 'shuttle-console-hide-target'}"
+                                             TextAlign="Center"
+                                             ToggleMode="True"
+                                             MinWidth="20"
+                                             ToolTip="{controls:Loc 'shuttle-console-hide-target-description'}"
+                                             StyleClasses="OpenLeft"
+                                             Margin="0"/>
+                        </controls:BoxContainer>
+                    </controls:BoxContainer>
+                    <!-- End Frontier - settable target -->
+
                     <!-- Frontier - IFF search -->
                     <controls:BoxContainer Orientation="Vertical" HorizontalExpand="True" Name="IffSearchBox">
                         <controls:Label Text="{controls:Loc 'shuttle-console-iff-search'}"/>

--- a/Content.Client/Shuttles/UI/NavScreen.xaml
+++ b/Content.Client/Shuttles/UI/NavScreen.xaml
@@ -123,7 +123,7 @@
                                              ToolTip="{controls:Loc 'shuttle-console-set-target-description'}"
                                              StyleClasses="OpenRight"
                                              Margin="0"/>
-                            <controls:Button Name="TargetHide"
+                            <controls:Button Name="TargetShow"
                                              Text="{controls:Loc 'shuttle-console-hide-target'}"
                                              TextAlign="Center"
                                              ToggleMode="True"

--- a/Content.Client/Shuttles/UI/NavScreen.xaml.cs
+++ b/Content.Client/Shuttles/UI/NavScreen.xaml.cs
@@ -85,7 +85,7 @@ public sealed partial class NavScreen : BoxContainer
     public void UpdateState(NavInterfaceState scc)
     {
         NavRadar.UpdateState(scc);
-        NfUpdateState(); // Frontier Update State
+        NfUpdateState(scc); // Frontier Update State
     }
 
     public void SetMatrix(EntityCoordinates? coordinates, Angle? angle)

--- a/Content.Client/Shuttles/UI/ShuttleConsoleWindow.xaml.cs
+++ b/Content.Client/Shuttles/UI/ShuttleConsoleWindow.xaml.cs
@@ -19,6 +19,7 @@ public sealed partial class ShuttleConsoleWindow : FancyWindow,
 
     public event Action<MapCoordinates, Angle>? RequestFTL;
     public event Action<NetEntity, Angle>? RequestBeaconFTL;
+    public event Action<NetEntity?, NetEntity>? RequestTrackEntity; // Frontier
 
     public event Action<NetEntity, NetEntity>? DockRequest;
     public event Action<NetEntity>? UndockRequest;
@@ -52,6 +53,13 @@ public sealed partial class ShuttleConsoleWindow : FancyWindow,
         {
             RequestBeaconFTL?.Invoke(ent, angle);
         };
+
+        // Frontier: entity tracking
+        MapContainer.RequestTrackEntity += (ent, trackEntity) =>
+        {
+            RequestTrackEntity?.Invoke(ent, trackEntity);
+        };
+        // End Frontier
 
         DockContainer.DockRequest += (entity, netEntity) =>
         {

--- a/Content.Client/_NF/Shuttles/BUI/ShuttleConsoleBoundUserInterface.cs
+++ b/Content.Client/_NF/Shuttles/BUI/ShuttleConsoleBoundUserInterface.cs
@@ -1,6 +1,7 @@
 // New Frontiers - This file is licensed under AGPLv3
 // Copyright (c) 2024 New Frontiers Contributors
 // See AGPLv3.txt for details.
+using System.Numerics;
 using Content.Client.Shuttles.UI;
 using Content.Shared._NF.Shuttles.Events;
 using Content.Shared.Shuttles.Components;
@@ -14,6 +15,9 @@ namespace Content.Client.Shuttles.BUI
             _window ??= new ShuttleConsoleWindow();
             _window.OnInertiaDampeningModeChanged += OnInertiaDampeningModeChanged;
             _window.OnServiceFlagsChanged += OnServiceFlagsChanged;
+            _window.OnSetTargetCoordinates += OnSetTargetCoordinates;
+            _window.OnSetHideTarget += OnSetHideTarget;
+            _window.RequestTrackEntity += OnTrackEntity;
         }
         private void OnInertiaDampeningModeChanged(NetEntity? entityUid, InertiaDampeningMode mode)
         {
@@ -33,5 +37,32 @@ namespace Content.Client.Shuttles.BUI
             });
         }
 
+        private void OnSetTargetCoordinates(NetEntity? entityUid, Vector2 position)
+        {
+            SendMessage(new SetTargetCoordinatesRequest
+            {
+                ShuttleEntityUid = entityUid,
+                TrackedPosition = position,
+                TrackedEntity = NetEntity.Invalid
+            });
+        }
+
+        private void OnSetHideTarget(NetEntity? entityUid, bool hide)
+        {
+            SendMessage(new SetHideTargetRequest
+            {
+                Hidden = hide
+            });
+        }
+
+        private void OnTrackEntity(NetEntity? entityUid, NetEntity trackEntity)
+        {
+            SendMessage(new SetTargetCoordinatesRequest
+            {
+                ShuttleEntityUid = entityUid,
+                TrackedPosition = Vector2.Zero, // don't care
+                TrackedEntity = trackEntity
+            });
+        }
     }
 }

--- a/Content.Client/_NF/Shuttles/UI/NavScreen.xaml.cs
+++ b/Content.Client/_NF/Shuttles/UI/NavScreen.xaml.cs
@@ -45,7 +45,7 @@ namespace Content.Client.Shuttles.UI
             TargetX.OnTextChanged += _ => _targetCoordsModified = true;
             TargetY.OnTextChanged += _ => _targetCoordsModified = true;
             TargetSet.OnPressed += _ => SetTargetCoords();
-            TargetHide.OnPressed += _ => SetHideTarget(TargetHide.Pressed);
+            TargetShow.OnPressed += _ => SetHideTarget(!TargetShow.Pressed);
         }
 
         private void SetDampenerMode(InertiaDampeningMode mode)
@@ -72,6 +72,7 @@ namespace Content.Client.Shuttles.UI
                 ToggleServiceFlags(NavRadar.ServiceFlags, updateButtonsOnly: true);
             }
 
+            TargetShow.Pressed = !state.HideTarget;
             if (!_targetCoordsModified)
             {
                 if (state.Target != null)

--- a/Content.Client/_NF/Shuttles/UI/NavScreen.xaml.cs
+++ b/Content.Client/_NF/Shuttles/UI/NavScreen.xaml.cs
@@ -1,7 +1,9 @@
 // New Frontiers - This file is licensed under AGPLv3
 // Copyright (c) 2024 New Frontiers Contributors
 // See AGPLv3.txt for details.
+using System.Numerics;
 using Content.Shared._NF.Shuttles.Events;
+using Content.Shared.Shuttles.BUIStates;
 using Content.Shared.Shuttles.Components;
 using Robust.Client.UserInterface.Controls;
 
@@ -12,13 +14,15 @@ namespace Content.Client.Shuttles.UI
         private readonly ButtonGroup _buttonGroup = new();
         public event Action<NetEntity?, InertiaDampeningMode>? OnInertiaDampeningModeChanged;
         public event Action<NetEntity?, ServiceFlags>? OnServiceFlagsChanged;
+        public event Action<NetEntity?, Vector2>? OnSetTargetCoordinates;
+        public event Action<NetEntity?, bool>? OnSetHideTarget;
+
+        private bool _targetCoordsModified = false;
 
         private void NfInitialize()
         {
-            // Frontier - IFF search
             IffSearchCriteria.OnTextChanged += args => OnIffSearchChanged(args.Text);
 
-            // Frontier - Maximum IFF Distance
             MaximumIFFDistanceValue.GetChild(0).GetChild(1).Margin = new Thickness(8, 0, 0, 0);
             MaximumIFFDistanceValue.OnValueChanged += args => OnRangeFilterChanged(args);
 
@@ -37,6 +41,11 @@ namespace Content.Client.Shuttles.UI
             ServiceFlagServices.OnPressed += _ => ToggleServiceFlags(ServiceFlags.Services);
             ServiceFlagTrade.OnPressed += _ => ToggleServiceFlags(ServiceFlags.Trade);
             ServiceFlagSocial.OnPressed += _ => ToggleServiceFlags(ServiceFlags.Social);
+
+            TargetX.OnTextChanged += _ => _targetCoordsModified = true;
+            TargetY.OnTextChanged += _ => _targetCoordsModified = true;
+            TargetSet.OnPressed += _ => SetTargetCoords();
+            TargetHide.OnPressed += _ => SetHideTarget(TargetHide.Pressed);
         }
 
         private void SetDampenerMode(InertiaDampeningMode mode)
@@ -46,7 +55,7 @@ namespace Content.Client.Shuttles.UI
             OnInertiaDampeningModeChanged?.Invoke(shuttle, mode);
         }
 
-        private void NfUpdateState()
+        private void NfUpdateState(NavInterfaceState state)
         {
             if (NavRadar.DampeningMode == InertiaDampeningMode.Station)
             {
@@ -63,12 +72,25 @@ namespace Content.Client.Shuttles.UI
                 ToggleServiceFlags(NavRadar.ServiceFlags, updateButtonsOnly: true);
             }
 
+            if (!_targetCoordsModified)
+            {
+                if (state.Target != null)
+                {
+                    var target = state.Target.Value;
+                    TargetX.Text = target.X.ToString("F1");
+                    TargetY.Text = target.Y.ToString("F1");
+                }
+                else
+                {
+                    TargetX.Text = 0.0f.ToString("F1");
+                    TargetY.Text = 0.0f.ToString("F1");
+                }
+            }
         }
 
-        // Frontier - Maximum IFF Distance
         private void OnRangeFilterChanged(int value)
         {
-            NavRadar.MaximumIFFDistance = (float) value;
+            NavRadar.MaximumIFFDistance = value;
         }
 
         private void ToggleServiceFlags(ServiceFlags flags, bool updateButtonsOnly = false)
@@ -109,7 +131,6 @@ namespace Content.Client.Shuttles.UI
 
         private void NfAddShuttleDesignation(EntityUid? shuttle)
         {
-            // Frontier - PR #1284 Add Shuttle Designation
             if (_entManager.TryGetComponent<MetaDataComponent>(shuttle, out var metadata))
             {
                 var shipNameParts = metadata.EntityName.Split(' ');
@@ -122,8 +143,28 @@ namespace Content.Client.Shuttles.UI
                 else
                     NavDisplayLabel.Text = metadata.EntityName;
             }
-            // End Frontier - PR #1284
         }
 
+        private void SetTargetCoords()
+        {
+            Vector2 outputVector;
+            if (!float.TryParse(TargetX.Text, out outputVector.X))
+                outputVector.X = 0.0f;
+
+            if (!float.TryParse(TargetY.Text, out outputVector.Y))
+                outputVector.Y = 0.0f;
+
+            NavRadar.Target = outputVector;
+            NavRadar.TargetEntity = NetEntity.Invalid;
+            _entManager.TryGetNetEntity(_shuttleEntity, out var shuttle);
+            OnSetTargetCoordinates?.Invoke(shuttle, outputVector);
+            _targetCoordsModified = false;
+        }
+
+        private void SetHideTarget(bool hide)
+        {
+            _entManager.TryGetNetEntity(_shuttleEntity, out var shuttle);
+            OnSetHideTarget?.Invoke(shuttle, hide);
+        }
     }
 }

--- a/Content.Client/_NF/Shuttles/UI/ShuttleConsoleWindow.xaml.cs
+++ b/Content.Client/_NF/Shuttles/UI/ShuttleConsoleWindow.xaml.cs
@@ -1,6 +1,7 @@
 // New Frontiers - This file is licensed under AGPLv3
 // Copyright (c) 2024 New Frontiers Contributors
 // See AGPLv3.txt for details.
+using System.Numerics;
 using Content.Shared._NF.Shuttles.Events;
 using Content.Shared.Shuttles.Components;
 
@@ -10,6 +11,8 @@ namespace Content.Client.Shuttles.UI
     {
         public event Action<NetEntity?, InertiaDampeningMode>? OnInertiaDampeningModeChanged;
         public event Action<NetEntity?, ServiceFlags>? OnServiceFlagsChanged;
+        public event Action<NetEntity?, Vector2>? OnSetTargetCoordinates;
+        public event Action<NetEntity?, bool>? OnSetHideTarget;
 
         private void NfInitialize()
         {
@@ -20,6 +23,14 @@ namespace Content.Client.Shuttles.UI
             NavContainer.OnServiceFlagsChanged += (entity, flags) =>
             {
                 OnServiceFlagsChanged?.Invoke(entity, flags);
+            };
+            NavContainer.OnSetTargetCoordinates += (entity, position) =>
+            {
+                OnSetTargetCoordinates?.Invoke(entity, position);
+            };
+            NavContainer.OnSetHideTarget += (entity, hide) =>
+            {
+                OnSetHideTarget?.Invoke(entity, hide);
             };
         }
 

--- a/Content.Client/_NF/Shuttles/UI/ShuttleNavControl.xaml.cs
+++ b/Content.Client/_NF/Shuttles/UI/ShuttleNavControl.xaml.cs
@@ -17,24 +17,29 @@ namespace Content.Client.Shuttles.UI;
 
 public sealed partial class ShuttleNavControl
 {
+    // Dependency
     private readonly StationSystem _station;
     private readonly RadarBlipSystem _blips;
 
     // Constants for gunnery system
     // These 2 handle timing updates
     private const float RadarUpdateInterval = 0f;
+    private const float FireRateLimit = 0.1f; // 100ms between shots
+    private static readonly Color TargetColor = Color.FromHex("#99ff66");
     private float _updateAccumulator = 0f;
 
     private bool _isMouseDown;
     private bool _isMouseInside;
     private Vector2 _lastMousePos;
     private float _lastFireTime;
-    private const float FireRateLimit = 0.1f; // 100ms between shots
 
     // Constants for IFF system
     public float MaximumIFFDistance { get; set; } = -1f;
     public bool HideCoords { get; set; } = false;
     private static Color _dockLabelColor = Color.White;
+    public bool HideTarget { get; set; } = false;
+    public Vector2? Target { get; set; } = null;
+    public NetEntity TargetEntity { get; set; } = NetEntity.Invalid;
 
     public InertiaDampeningMode DampeningMode { get; set; }
     public ServiceFlags ServiceFlags { get; set; } = ServiceFlags.None;
@@ -45,9 +50,16 @@ public sealed partial class ShuttleNavControl
     /// <param name="state">The navigation interface state.</param>
     private void NFUpdateState(NavInterfaceState state)
     {
+        if (state.MaxIffRange != null)
+            MaximumIFFDistance = state.MaxIffRange.Value;
+        HideCoords = state.HideCoords;
+        Target = state.Target;
+        TargetEntity = state.TargetEntity;
+        HideTarget = state.HideTarget;
+
         if (!EntManager.GetCoordinates(state.Coordinates).HasValue ||
             !EntManager.TryGetComponent(EntManager.GetCoordinates(state.Coordinates).GetValueOrDefault().EntityId, out TransformComponent? transform) ||
-            !EntManager.TryGetComponent(transform.GridUid, out PhysicsComponent? physicsComponent))
+            !EntManager.HasComponent<PhysicsComponent>(transform.GridUid))
         {
             return;
         }

--- a/Content.Client/_NF/Shuttles/UI/ShuttleNavControl.xaml.cs
+++ b/Content.Client/_NF/Shuttles/UI/ShuttleNavControl.xaml.cs
@@ -39,7 +39,7 @@ public sealed partial class ShuttleNavControl
     private static Color _dockLabelColor = Color.White;
     public bool HideTarget { get; set; } = false;
     public Vector2? Target { get; set; } = null;
-    public NetEntity TargetEntity { get; set; } = NetEntity.Invalid;
+    public NetEntity? TargetEntity { get; set; } = null;
 
     public InertiaDampeningMode DampeningMode { get; set; }
     public ServiceFlags ServiceFlags { get; set; } = ServiceFlags.None;

--- a/Content.Server/Shuttles/Components/ShuttleConsoleComponent.cs
+++ b/Content.Server/Shuttles/Components/ShuttleConsoleComponent.cs
@@ -33,13 +33,13 @@ namespace Content.Server.Shuttles.Components
         /// <summary>
         ///     While disabled by EMP
         /// </summary>
-        [DataField("timeoutFromEmp", customTypeSerializer: typeof(TimeOffsetSerializer))]
+        [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
         public TimeSpan TimeoutFromEmp = TimeSpan.Zero;
 
-        [DataField("disableDuration"), ViewVariables(VVAccess.ReadWrite)]
+        [DataField]
         public float DisableDuration = 60f;
 
-        [DataField, ViewVariables(VVAccess.ReadWrite)]
+        [DataField]
         public InertiaDampeningMode DampeningMode = InertiaDampeningMode.Dampen;
         // End Frontier
     }

--- a/Content.Server/Shuttles/Systems/RadarConsoleSystem.cs
+++ b/Content.Server/Shuttles/Systems/RadarConsoleSystem.cs
@@ -92,7 +92,7 @@ public sealed partial class RadarConsoleSystem : SharedRadarConsoleSystem // Fro
         else
         {
             ent.Comp.Target = target;
-            ent.Comp.TargetEntity = EntityUid.Invalid;
+            ent.Comp.TargetEntity = null;
         }
         Dirty(ent);
     }

--- a/Content.Server/Shuttles/Systems/RadarConsoleSystem.cs
+++ b/Content.Server/Shuttles/Systems/RadarConsoleSystem.cs
@@ -7,13 +7,15 @@ using Content.Shared.PowerCell;
 using Content.Shared.Movement.Components;
 using Robust.Server.GameObjects;
 using Robust.Shared.Map;
+using Content.Server.Shuttles.Components; // Frontier
 
 namespace Content.Server.Shuttles.Systems;
 
-public sealed class RadarConsoleSystem : SharedRadarConsoleSystem
+public sealed partial class RadarConsoleSystem : SharedRadarConsoleSystem // Frontier: add partial
 {
     [Dependency] private readonly ShuttleConsoleSystem _console = default!;
     [Dependency] private readonly UserInterfaceSystem _uiSystem = default!;
+    [Dependency] private readonly TransformSystem _transform = default!; // Frontier
 
     public override void Initialize()
     {
@@ -66,9 +68,39 @@ public sealed class RadarConsoleSystem : SharedRadarConsoleSystem
             if (component.MaxIffRange != null)
                 state.MaxIffRange = component.MaxIffRange.Value;
             state.HideCoords = component.HideCoords;
+            state.Target = component.Target;
+            state.TargetEntity = component.TargetEntity;
+            state.HideTarget = component.HideTarget;
             // End Frontier
 
             _uiSystem.SetUiState(uid, RadarConsoleUiKey.Key, new NavBoundUserInterfaceState(state));
         }
     }
+
+    // Frontier: settable waypoints
+    public void SetTarget(Entity<RadarConsoleComponent> ent, NetEntity targetEntity, Vector2 target)
+    {
+        // Try to get entity
+        if (EntityManager.TryGetEntity(targetEntity, out var targetUid)
+            && HasComp<ShuttleComponent>(targetUid)
+            && (!TryComp(targetUid, out IFFComponent? iff) || (iff.Flags & (IFFFlags.Hide | IFFFlags.HideLabel)) == 0)
+            && TryComp(targetUid, out TransformComponent? xform))
+        {
+            ent.Comp.TargetEntity = targetEntity;
+            ent.Comp.Target = _transform.GetMapCoordinates(xform).Position;
+        }
+        else
+        {
+            ent.Comp.Target = target;
+            ent.Comp.TargetEntity = NetEntity.Invalid;
+        }
+        Dirty(ent);
+    }
+
+    public void SetHideTarget(Entity<RadarConsoleComponent> ent, bool hideTarget)
+    {
+        ent.Comp.HideTarget = hideTarget;
+        Dirty(ent);
+    }
+    // End Frontier
 }

--- a/Content.Server/Shuttles/Systems/RadarConsoleSystem.cs
+++ b/Content.Server/Shuttles/Systems/RadarConsoleSystem.cs
@@ -69,7 +69,7 @@ public sealed partial class RadarConsoleSystem : SharedRadarConsoleSystem // Fro
                 state.MaxIffRange = component.MaxIffRange.Value;
             state.HideCoords = component.HideCoords;
             state.Target = component.Target;
-            state.TargetEntity = component.TargetEntity;
+            state.TargetEntity = GetNetEntity(component.TargetEntity);
             state.HideTarget = component.HideTarget;
             // End Frontier
 
@@ -86,13 +86,13 @@ public sealed partial class RadarConsoleSystem : SharedRadarConsoleSystem // Fro
             && (!TryComp(targetUid, out IFFComponent? iff) || (iff.Flags & (IFFFlags.Hide | IFFFlags.HideLabel)) == 0)
             && TryComp(targetUid, out TransformComponent? xform))
         {
-            ent.Comp.TargetEntity = targetEntity;
+            ent.Comp.TargetEntity = targetUid.Value;
             ent.Comp.Target = _transform.GetMapCoordinates(xform).Position;
         }
         else
         {
             ent.Comp.Target = target;
-            ent.Comp.TargetEntity = NetEntity.Invalid;
+            ent.Comp.TargetEntity = EntityUid.Invalid;
         }
         Dirty(ent);
     }

--- a/Content.Server/Shuttles/Systems/ShuttleConsoleSystem.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleConsoleSystem.cs
@@ -430,7 +430,7 @@ public sealed partial class ShuttleConsoleSystem : SharedShuttleConsoleSystem
             _shuttle.NfGetInertiaDampeningMode(entity), // Frontier
             _shuttle.NfGetServiceFlags(entity), // Frontier
             entity.Comp1.Target, // Frontier
-            entity.Comp1.TargetEntity, // Frontier
+            GetNetEntity(entity.Comp1.TargetEntity), // Frontier
             entity.Comp1.HideTarget); // Frontier
     }
 

--- a/Content.Server/Shuttles/Systems/ShuttleConsoleSystem.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleConsoleSystem.cs
@@ -289,7 +289,7 @@ public sealed partial class ShuttleConsoleSystem : SharedShuttleConsoleSystem
         }
         else
         {
-            navState = new NavInterfaceState(0f, null, null, new Dictionary<NetEntity, List<DockingPortState>>(), InertiaDampeningMode.Dampen, ServiceFlags.None); // Frontier: inertia dampening);
+            navState = new NavInterfaceState(0f, null, null, new Dictionary<NetEntity, List<DockingPortState>>(), InertiaDampeningMode.Dampen, ServiceFlags.None, null, NetEntity.Invalid, true); // Frontier: inertia dampening
             mapState = new ShuttleMapInterfaceState(
                 FTLState.Invalid,
                 default,
@@ -404,7 +404,7 @@ public sealed partial class ShuttleConsoleSystem : SharedShuttleConsoleSystem
     public NavInterfaceState GetNavState(Entity<RadarConsoleComponent?, TransformComponent?> entity, Dictionary<NetEntity, List<DockingPortState>> docks)
     {
         if (!Resolve(entity, ref entity.Comp1, ref entity.Comp2))
-            return new NavInterfaceState(SharedRadarConsoleSystem.DefaultMaxRange, null, null, docks, Shared._NF.Shuttles.Events.InertiaDampeningMode.Dampen, ServiceFlags.None); // Frontier: add inertia dampening
+            return new NavInterfaceState(SharedRadarConsoleSystem.DefaultMaxRange, null, null, docks, InertiaDampeningMode.Dampen, ServiceFlags.None, null, NetEntity.Invalid, true); // Frontier: add inertia dampening, target
 
         return GetNavState(
             entity,
@@ -420,7 +420,7 @@ public sealed partial class ShuttleConsoleSystem : SharedShuttleConsoleSystem
         Angle angle)
     {
         if (!Resolve(entity, ref entity.Comp1, ref entity.Comp2))
-            return new NavInterfaceState(SharedRadarConsoleSystem.DefaultMaxRange, GetNetCoordinates(coordinates), angle, docks, InertiaDampeningMode.Dampen, ServiceFlags.None); // Frontier: add inertial dampening
+            return new NavInterfaceState(SharedRadarConsoleSystem.DefaultMaxRange, GetNetCoordinates(coordinates), angle, docks, InertiaDampeningMode.Dampen, ServiceFlags.None, null, NetEntity.Invalid, true); // Frontier: add inertial dampening, target
 
         return new NavInterfaceState(
             entity.Comp1.MaxRange,
@@ -428,7 +428,10 @@ public sealed partial class ShuttleConsoleSystem : SharedShuttleConsoleSystem
             angle,
             docks,
             _shuttle.NfGetInertiaDampeningMode(entity), // Frontier
-            _shuttle.NfGetServiceFlags(entity)); // Frontier
+            _shuttle.NfGetServiceFlags(entity), // Frontier
+            entity.Comp1.Target, // Frontier
+            entity.Comp1.TargetEntity, // Frontier
+            entity.Comp1.HideTarget); // Frontier
     }
 
     /// <summary>

--- a/Content.Shared/Shuttles/BUIStates/NavInterfaceState.cs
+++ b/Content.Shared/Shuttles/BUIStates/NavInterfaceState.cs
@@ -54,7 +54,7 @@ public sealed class NavInterfaceState
     /// <summary>
     /// A settable target to show on radar
     /// </summary>
-    public NetEntity TargetEntity { get; set; }
+    public NetEntity? TargetEntity { get; set; }
 
     /// <summary>
     /// Frontier: whether or not to show the target coords
@@ -69,7 +69,7 @@ public sealed class NavInterfaceState
         InertiaDampeningMode dampeningMode, // Frontier
         ServiceFlags serviceFlags, // Frontier
         Vector2? target, // Frontier
-        NetEntity targetEntity, // Frontier
+        NetEntity? targetEntity, // Frontier
         bool hideTarget) // Frontier
     {
         MaxRange = maxRange;

--- a/Content.Shared/Shuttles/BUIStates/NavInterfaceState.cs
+++ b/Content.Shared/Shuttles/BUIStates/NavInterfaceState.cs
@@ -1,7 +1,8 @@
 using Robust.Shared.Map;
 using Robust.Shared.Serialization;
 using Content.Shared._NF.Shuttles.Events;
-using Content.Shared.Shuttles.Components; // Frontier - InertiaDampeningMode access
+using Content.Shared.Shuttles.Components; // Frontier
+using System.Numerics; // Frontier - InertiaDampeningMode access
 
 namespace Content.Shared.Shuttles.BUIStates;
 
@@ -43,7 +44,22 @@ public sealed class NavInterfaceState
     /// <summary>
     /// Service Flags
     /// </summary>
-    public ServiceFlags ServiceFlags { get; set; } // Frontier
+    public ServiceFlags ServiceFlags { get; set; }
+
+    /// <summary>
+    /// A settable target to show on radar
+    /// </summary>
+    public Vector2? Target { get; set; }
+
+    /// <summary>
+    /// A settable target to show on radar
+    /// </summary>
+    public NetEntity TargetEntity { get; set; }
+
+    /// <summary>
+    /// Frontier: whether or not to show the target coords
+    /// </summary>
+    public bool HideTarget = true;
     // End Frontier fields
     public NavInterfaceState(
         float maxRange,
@@ -51,7 +67,10 @@ public sealed class NavInterfaceState
         Angle? angle,
         Dictionary<NetEntity, List<DockingPortState>> docks,
         InertiaDampeningMode dampeningMode, // Frontier
-        ServiceFlags serviceFlags) // Frontier
+        ServiceFlags serviceFlags, // Frontier
+        Vector2? target, // Frontier
+        NetEntity targetEntity, // Frontier
+        bool hideTarget) // Frontier
     {
         MaxRange = maxRange;
         Coordinates = coordinates;
@@ -59,6 +78,9 @@ public sealed class NavInterfaceState
         Docks = docks;
         DampeningMode = dampeningMode; // Frontier
         ServiceFlags = serviceFlags; // Frontier
+        Target = target; // Frontier
+        TargetEntity = targetEntity; // Frontier
+        HideTarget = hideTarget; // Frontier
     }
 }
 

--- a/Content.Shared/Shuttles/Components/RadarConsoleComponent.cs
+++ b/Content.Shared/Shuttles/Components/RadarConsoleComponent.cs
@@ -50,7 +50,7 @@ public sealed partial class RadarConsoleComponent : Component
     /// If not null, the target whose information will be displayed on the radar.
     /// </summary>
     [DataField]
-    public EntityUid TargetEntity = EntityUid.Invalid;
+    public EntityUid TargetEntity;
 
     /// <summary>
     /// Whether or not to display the target IFF

--- a/Content.Shared/Shuttles/Components/RadarConsoleComponent.cs
+++ b/Content.Shared/Shuttles/Components/RadarConsoleComponent.cs
@@ -1,5 +1,6 @@
 using Content.Shared.Shuttles.Systems;
 using Robust.Shared.GameStates;
+using System.Numerics; // Frontier
 
 namespace Content.Shared.Shuttles.Components;
 
@@ -38,5 +39,23 @@ public sealed partial class RadarConsoleComponent : Component
     /// </summary>
     [DataField]
     public bool HideCoords = false;
+
+    /// <summary>
+    /// A settable target to display on IFF
+    /// </summary>
+    [DataField]
+    public Vector2? Target;
+
+    /// <summary>
+    /// If not null, the target whose information will be displayed on the radar.
+    /// </summary>
+    [DataField]
+    public NetEntity TargetEntity = NetEntity.Invalid;
+
+    /// <summary>
+    /// Whether or not to display the target IFF
+    /// </summary>
+    [DataField]
+    public bool HideTarget = false;
     // End Frontier
 }

--- a/Content.Shared/Shuttles/Components/RadarConsoleComponent.cs
+++ b/Content.Shared/Shuttles/Components/RadarConsoleComponent.cs
@@ -50,7 +50,7 @@ public sealed partial class RadarConsoleComponent : Component
     /// If not null, the target whose information will be displayed on the radar.
     /// </summary>
     [DataField]
-    public NetEntity TargetEntity = NetEntity.Invalid;
+    public EntityUid TargetEntity = EntityUid.Invalid;
 
     /// <summary>
     /// Whether or not to display the target IFF

--- a/Content.Shared/Shuttles/Components/RadarConsoleComponent.cs
+++ b/Content.Shared/Shuttles/Components/RadarConsoleComponent.cs
@@ -50,7 +50,7 @@ public sealed partial class RadarConsoleComponent : Component
     /// If not null, the target whose information will be displayed on the radar.
     /// </summary>
     [DataField]
-    public EntityUid TargetEntity;
+    public EntityUid? TargetEntity;
 
     /// <summary>
     /// Whether or not to display the target IFF

--- a/Content.Shared/_NF/Shuttles/Events/SetTrackedCoordinatesRequest.cs
+++ b/Content.Shared/_NF/Shuttles/Events/SetTrackedCoordinatesRequest.cs
@@ -1,0 +1,32 @@
+// New Frontiers - This file is licensed under AGPLv3
+// Copyright (c) 2024 New Frontiers Contributors
+// See AGPLv3.txt for details.
+
+using System.Numerics;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._NF.Shuttles.Events;
+
+/// <summary>
+/// Raised on the client when it wishes to track a particular coordinate.
+/// </summary>
+[Serializable, NetSerializable]
+public sealed class SetTargetCoordinatesRequest : BoundUserInterfaceMessage
+{
+    public NetEntity? ShuttleEntityUid { get; set; }
+    public Vector2 TrackedPosition { get; set; }
+    /// <summary>
+    /// The entity that is being tracked.
+    /// Currently only used for ID purposes, does not actually track the entity.
+    /// </summary>
+    public NetEntity TrackedEntity { get; set; }
+}
+
+/// <summary>
+/// Raised on the client when it wishes to hide or show the target.
+/// </summary>
+[Serializable, NetSerializable]
+public sealed class SetHideTargetRequest : BoundUserInterfaceMessage
+{
+    public bool Hidden { get; set; }
+}

--- a/Resources/Locale/en-US/_NF/shuttles/console.ftl
+++ b/Resources/Locale/en-US/_NF/shuttles/console.ftl
@@ -19,3 +19,11 @@ shuttle-console-service-flag-Social-shortform = ☺
 shuttle-console-service-flag-Services-description = Services (e.g. medical, dining, engineering) offered onboard.
 shuttle-console-service-flag-Trade-description = Goods sold onboard.
 shuttle-console-service-flag-Social-description = A social space to gather and hang out.
+
+shuttle-console-target = Radar Target
+shuttle-console-set-target = Set
+shuttle-console-set-target-description = Sets a target waypoint coordinate on the radar console.
+shuttle-console-hide-target = Show
+shuttle-console-hide-target-description = Toggles the visibility of the target waypoint on the radar console.
+shuttle-console-target-name = Target
+shuttle-console-map-track = ⌖


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Adds settable map position controls (X/Y) to the nav screen, and a "track this" button beside each target on the map screen.

Custom positions are displayed as "Target" in the nav map, whereas entity targets show up as their respective name.  The colour of the control is currently a light green (open to suggestions)

The position _does not actively track the target entity_ (god, imagine the cheese), merely the position of it when the tracking was requested.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Quality of life.  Roughly in the "holy shit why isn't this a thing" category.

## Technical details
<!-- Summary of code changes for easier review. -->

New events in the ShuttleConsoleBUI, new state in the RadarConsoleComponent (though currently not used by the radar console proper and not admeme-able since the Vector2 is nullable), and a new server-side setter in the RadarConsoleSystem to set these fields (to circumvent access issues)

Fixes a small bug where the triangular "blips" for each shuttle/station were getting redrawn a bunch of times.

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->

1. Open a shuttle console, set X, Y coordinates in the Radar Target field, press "Set", see the marker.  Hover over, see the hover text.  Ensure the coordinates make sense.
2. Open the map screen, scan (should happen much quicker), click on the crosshair button to the right of one of the names in the list.
3. Go back to the nav screen, you should see the coords in the X/Y controls (unless you edited them), and the Show button should be lit up.
4. Press the Show button, the target should disappear.  Press it again, it should reappear.
5. Set another set of coordinates in the X, Y controls.  Press "Set", the marker should reposition and change to "Target"
6. Edit the controls, then change to a new target through the Map screen.  The coordinates should not change.  Press Set, the target marker should update to the location requested.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

A few screenshots showing the target marker (the light green one) in use.
![image](https://github.com/user-attachments/assets/f342a579-493b-41d1-b84d-3e49a4667ba0)
![image](https://github.com/user-attachments/assets/677b246f-ec1a-49e2-8831-3a30389fa0ae)
![image](https://github.com/user-attachments/assets/19f40d0a-21e6-4928-ae3b-2e824285acf2)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: A custom (X, Y) target can be added to the radar screen on the shuttle console.  It can also mark a station or shuttle's momentary position through the map screen.
- tweak: The map screen now fills out its list faster.