### PR TITLE
Remove door electronics config UI

### DIFF
--- a/Content.Server/Doors/Electronics/Systems/DoorElectronicsSystem.cs
+++ b/Content.Server/Doors/Electronics/Systems/DoorElectronicsSystem.cs
@@ -20,7 +20,7 @@ public sealed class DoorElectronicsSystem : EntitySystem
     public override void Initialize()
     {
         base.Initialize();
-        SubscribeLocalEvent<DoorElectronicsComponent, DoorElectronicsUpdateConfigurationMessage>(OnChangeConfiguration);
+        // SubscribeLocalEvent<DoorElectronicsComponent, DoorElectronicsUpdateConfigurationMessage>(OnChangeConfiguration); // Frontier: no message handler
         SubscribeLocalEvent<DoorElectronicsComponent, AccessReaderConfigurationChangedEvent>(OnAccessReaderChanged);
         SubscribeLocalEvent<DoorElectronicsComponent, BoundUIOpenedEvent>(OnBoundUIOpened);
     }
@@ -42,6 +42,8 @@ public sealed class DoorElectronicsSystem : EntitySystem
         _uiSystem.SetUiState(uid, DoorElectronicsConfigurationUiKey.Key, state);
     }
 
+    // Frontier: no door electronics message handler
+    /*
     private void OnChangeConfiguration(
         EntityUid uid,
         DoorElectronicsComponent component,
@@ -50,6 +52,8 @@ public sealed class DoorElectronicsSystem : EntitySystem
         var accessReader = EnsureComp<AccessReaderComponent>(uid);
         _accessReader.SetAccesses(uid, accessReader, args.AccessList);
     }
+    */
+    // End Frontier: no door electronics message handler
 
     private void OnAccessReaderChanged(
         EntityUid uid,

--- a/Resources/Prototypes/Entities/Objects/Devices/Electronics/door.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Electronics/door.yml
@@ -14,12 +14,14 @@
     - type: StaticPrice
       price: 55
     - type: AccessReader
-    - type: ActivatableUI
-      key: enum.DoorElectronicsConfigurationUiKey.Key
-      requiredItems:
-        tags:
-        - DoorElectronicsConfigurator
-    - type: UserInterface
-      interfaces:
-        enum.DoorElectronicsConfigurationUiKey.Key:
-          type: DoorElectronicsBoundUserInterface
+    # Frontier: no inherent UI, use the access configurator if needed
+    # - type: ActivatableUI
+    #   key: enum.DoorElectronicsConfigurationUiKey.Key
+    #   requiredItems:
+    #     tags:
+    #     - DoorElectronicsConfigurator
+    # - type: UserInterface
+    #   interfaces:
+    #     enum.DoorElectronicsConfigurationUiKey.Key:
+    #       type: DoorElectronicsBoundUserInterface
+    # Frontier: no inherent UI, use the access configurator if needed


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Outright removes the door electronics config UI.  If configuration is needed, use the access configurator, that works as normal.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Fixes https://github.com/new-frontiers-14/frontier-station-14/issues/3610.

Why remove it entirely?  Being able to set accesses that you don't have doesn't really make sense - the only other way to change accesses at the moment is with an access configurator, and those are far more restrictive with what and when you can change.  Lean into that, remove the multitool configuration.

## Technical details
<!-- Summary of code changes for easier review. -->

Removes the UI entirely, removes the event handler for door electronics messages.

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->

Use a multitool on door electronics.  Nothing happens.
Use an access configurator on door electronics.  Works as usual.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Not this time.
![image](https://github.com/user-attachments/assets/81453144-a685-4492-8ded-4163bb902491)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- remove: Door electronics can no longer be configured via multitool.  Use an access configurator if needed.