### PR TITLE
Bus schedules and trade crates display time remaining, not absolute time

### DIFF
--- a/Content.Server/_NF/Cargo/Systems/NFCargoSystem.TradeCrates.cs
+++ b/Content.Server/_NF/Cargo/Systems/NFCargoSystem.TradeCrates.cs
@@ -12,7 +12,6 @@ namespace Content.Server._NF.Cargo.Systems;
 
 public sealed partial class NFCargoSystem
 {
-    [Dependency] private GameTicker _gameTicker = default!;
     [Dependency] private LabelSystem _label = default!;
     private readonly List<EntityUid> _destinations = new();
 
@@ -87,17 +86,26 @@ public sealed partial class NFCargoSystem
         if (!TryComp(ent.Comp.DestinationStation, out MetaDataComponent? metadata))
             return;
 
-        ev.PushMarkup(Loc.GetString("trade-crate-destination-station", ("destination", metadata.EntityName)));
+        using (ev.PushGroup(nameof(TradeCrateComponent)))
+        {
+            ev.PushMarkup(Loc.GetString("trade-crate-destination-station", ("destination", metadata.EntityName)));
 
-        if (ent.Comp.ExpressDeliveryTime == null)
-            return;
+            if (ent.Comp.ExpressDeliveryTime == null)
+                return;
 
-        ev.PushMarkup(ent.Comp.ExpressDeliveryTime >= _timing.CurTime ?
-            Loc.GetString("trade-crate-priority-active") :
-            Loc.GetString("trade-crate-priority-inactive"));
+            ev.PushMarkup(ent.Comp.ExpressDeliveryTime >= _timing.CurTime ?
+                Loc.GetString("trade-crate-priority-active") :
+                Loc.GetString("trade-crate-priority-inactive"));
 
-        var shiftTime = ent.Comp.ExpressDeliveryTime - _gameTicker.RoundStartTimeSpan;
-        ev.PushMarkup(Loc.GetString("trade-crate-priority-time", ("time", shiftTime.Value.ToString(@"hh\:mm\:ss"))));
+            var timeLeft = ent.Comp.ExpressDeliveryTime.Value - _timing.CurTime;
+            var timeLeftSeconds = timeLeft.TotalSeconds;
+            if (timeLeftSeconds > 1)
+                ev.PushMarkup(Loc.GetString("trade-crate-priority-time", ("time", timeLeft.ToString(@"hh\:mm\:ss"))));
+            else if (timeLeftSeconds >= 0)
+                ev.PushMarkup(Loc.GetString("trade-crate-priority-time-now"));
+            else
+                ev.PushMarkup(Loc.GetString("trade-crate-priority-past-due", ("time", timeLeft.ToString(@"hh\:mm\:ss"))));
+        }
     }
 
     private void OnTradeCrateThrow(Entity<TradeCrateComponent> ent, ref ThrowItemAttemptEvent ev)

--- a/Content.Server/_NF/PublicTransit/PublicTransitSystem.cs
+++ b/Content.Server/_NF/PublicTransit/PublicTransitSystem.cs
@@ -146,45 +146,48 @@ public sealed class PublicTransitSystem : EntitySystem
         if (!args.IsInDetailsRange)
             return;
 
-        if (!TryComp(ent, out TransformComponent? xform)
-            || xform.GridUid == null)
+        using (args.PushGroup(nameof(BusScheduleComponent)))
         {
-            args.PushMarkup(Loc.GetString("bus-schedule-no-bus"));
-            return;
-        }
-
-        if (TryComp<TransitShuttleComponent>(xform.GridUid, out var transitShuttle))
-        {
-            // This is a bus, it only serves one route - even if the schedule is for a different route, give our info.
-            PrintBusSchedule(transitShuttle.RouteId, (xform.GridUid.Value, transitShuttle), ref args);
-        }
-        else if (TryComp<StationTransitComponent>(xform.GridUid, out var stationTransit))
-        {
-            // Get the route associated with this grid.
-            if (stationTransit.Routes.Count <= 0)
+            if (!TryComp(ent, out TransformComponent? xform)
+                || xform.GridUid == null)
             {
                 args.PushMarkup(Loc.GetString("bus-schedule-no-bus"));
                 return;
             }
 
-            var route = ent.Comp.RouteId;
-            if (route == null)
+            if (TryComp<TransitShuttleComponent>(xform.GridUid, out var transitShuttle))
             {
-                route = stationTransit.Routes.First().Key;
+                // This is a bus, it only serves one route - even if the schedule is for a different route, give our info.
+                PrintBusSchedule(transitShuttle.RouteId, (xform.GridUid.Value, transitShuttle), ref args);
             }
-            else if (!stationTransit.Routes.ContainsKey(route.Value))
+            else if (TryComp<StationTransitComponent>(xform.GridUid, out var stationTransit))
             {
-                args.PushMarkup(Loc.GetString("bus-schedule-no-buses-on-route"));
+                // Get the route associated with this grid.
+                if (stationTransit.Routes.Count <= 0)
+                {
+                    args.PushMarkup(Loc.GetString("bus-schedule-no-bus"));
+                    return;
+                }
+
+                var route = ent.Comp.RouteId;
+                if (route == null)
+                {
+                    route = stationTransit.Routes.First().Key;
+                }
+                else if (!stationTransit.Routes.ContainsKey(route.Value))
+                {
+                    args.PushMarkup(Loc.GetString("bus-schedule-no-buses-on-route"));
+                    return;
+                }
+
+                PrintStationSchedule(route.Value, xform.GridUid.Value, ref args);
+            }
+            else
+            {
+                // If any of the above have failed, or if no case was met, this thing isn't a bus and doesn't have bus service.
+                args.PushMarkup(Loc.GetString("bus-schedule-no-bus"));
                 return;
             }
-
-            PrintStationSchedule(route.Value, xform.GridUid.Value, ref args);
-        }
-        else
-        {
-            // If any of the above have failed, or if no case was met, this thing isn't a bus and doesn't have bus service.
-            args.PushMarkup(Loc.GetString("bus-schedule-no-bus"));
-            return;
         }
     }
 
@@ -201,14 +204,17 @@ public sealed class PublicTransitSystem : EntitySystem
         FormattedMessage message = new();
         message.AddMarkupPermissive(Loc.GetString("bus-schedule-arrival-header"));
 
-        var arrivalTime = grid.Comp.NextTransfer - _ticker.RoundStartTimeSpan + routeData.Prototype.TravelTime;
+        var arrivalTime = grid.Comp.NextTransfer - _timing.CurTime + routeData.Prototype.TravelTime;
         // On the way to the next grid
         int maxIndex = routeData.GridStops.Count;
         if (HasComp<FTLComponent>(grid))
         {
             var nextStopArrival = arrivalTime - routeData.Prototype.WaitTime - routeData.Prototype.TravelTime;
             message.PushNewline();
-            message.AddMarkupPermissive(Loc.GetString("bus-schedule-arrival", ("station", Name(grid.Comp.CurrentGrid)), ("time", nextStopArrival.ToString(@"hh\:mm\:ss"))));
+            if (nextStopArrival.TotalSeconds >= 1)
+                message.AddMarkupPermissive(Loc.GetString("bus-schedule-arrival", ("station", Name(grid.Comp.CurrentGrid)), ("time", nextStopArrival.ToString(@"hh\:mm\:ss"))));
+            else
+                message.AddMarkupPermissive(Loc.GetString("bus-schedule-arrival-now", ("station", Name(grid.Comp.CurrentGrid))));
             maxIndex -= 1; // Don't double count the furthest index.
         }
 
@@ -217,7 +223,10 @@ public sealed class PublicTransitSystem : EntitySystem
             var stopUid = routeData.GridStops.GetValueAtIndex((destInfo.stopIndex + i) % routeData.GridStops.Count);
 
             message.PushNewline();
-            message.AddMarkupPermissive(Loc.GetString("bus-schedule-arrival", ("station", Name(stopUid)), ("time", arrivalTime.ToString(@"hh\:mm\:ss"))));
+            if (arrivalTime.TotalSeconds >= 1)
+                message.AddMarkupPermissive(Loc.GetString("bus-schedule-arrival", ("station", Name(stopUid)), ("time", arrivalTime.ToString(@"hh\:mm\:ss"))));
+            else
+                message.AddMarkupPermissive(Loc.GetString("bus-schedule-arrival-now", ("station", Name(stopUid))));
             arrivalTime += routeData.Prototype.TravelTime + routeData.Prototype.WaitTime;
         }
         args.PushMessage(message);
@@ -264,10 +273,13 @@ public sealed class PublicTransitSystem : EntitySystem
         }
 
         // Calculate the departure time from this stop and the arrival time at the next stops.
-        var departureTime = nextBus.Comp.NextTransfer + stopDistance * (routeData.Prototype.TravelTime + routeData.Prototype.WaitTime) - _ticker.RoundStartTimeSpan;
+        var departureTime = nextBus.Comp.NextTransfer + stopDistance * (routeData.Prototype.TravelTime + routeData.Prototype.WaitTime) - _timing.CurTime;
 
         FormattedMessage message = new();
-        message.AddMarkupPermissive(Loc.GetString("bus-schedule-next-departure", ("bus", Name(nextBus)), ("time", departureTime.ToString(@"hh\:mm\:ss"))));
+        if (departureTime.TotalSeconds >= 1)
+            message.AddMarkupPermissive(Loc.GetString("bus-schedule-next-departure", ("bus", Name(nextBus)), ("time", departureTime.ToString(@"hh\:mm\:ss"))));
+        else
+            message.AddMarkupPermissive(Loc.GetString("bus-schedule-next-departure-now", ("bus", Name(nextBus))));
         message.PushNewline();
         message.AddMarkupPermissive(Loc.GetString("bus-schedule-arrival-header"));
 
@@ -277,7 +289,10 @@ public sealed class PublicTransitSystem : EntitySystem
             var stopUid = routeData.GridStops.GetValueAtIndex((destInfo.stopIndex + i) % routeData.GridStops.Count);
 
             message.PushNewline();
-            message.AddMarkupPermissive(Loc.GetString("bus-schedule-arrival", ("station", Name(stopUid)), ("time", arrivalTime.ToString(@"hh\:mm\:ss"))));
+            if (arrivalTime.TotalSeconds >= 1)
+                message.AddMarkupPermissive(Loc.GetString("bus-schedule-arrival", ("station", Name(stopUid)), ("time", arrivalTime.ToString(@"hh\:mm\:ss"))));
+            else
+                message.AddMarkupPermissive(Loc.GetString("bus-schedule-arrival-now", ("station", Name(stopUid))));
             arrivalTime += routeData.Prototype.TravelTime + routeData.Prototype.WaitTime;
         }
         args.PushMessage(message);

--- a/Resources/Locale/en-US/_NF/cargo/trade-crate.ftl
+++ b/Resources/Locale/en-US/_NF/cargo/trade-crate.ftl
@@ -1,6 +1,6 @@
 trade-crate-destination-station = This crate's destination is [color=springgreen]{$destination}[/color].
 trade-crate-priority-time = This crate is due in [color=lightblue]{$time}[/color].
-trade-crate-priority-time-now = This crate is due now!
+trade-crate-priority-time-now = This crate is due [color=lightblue]now[/color]!
 trade-crate-priority-past-due = This crate was due [color=lightblue]{$time}[/color] ago.
 trade-crate-priority-active = This crate is an [color=yellow]express delivery[/color]. It's [bold]still on time[/bold]!
 trade-crate-priority-inactive = This crate is an [color=#886600]express delivery[/color]. It's [bold]late[/bold].

--- a/Resources/Locale/en-US/_NF/cargo/trade-crate.ftl
+++ b/Resources/Locale/en-US/_NF/cargo/trade-crate.ftl
@@ -1,4 +1,6 @@
 trade-crate-destination-station = This crate's destination is [color=springgreen]{$destination}[/color].
-trade-crate-priority-time = This crate is due by [color=lightblue]{$time}[/color].
+trade-crate-priority-time = This crate is due in [color=lightblue]{$time}[/color].
+trade-crate-priority-time-now = This crate is due now!
+trade-crate-priority-past-due = This crate was due [color=lightblue]{$time}[/color] ago.
 trade-crate-priority-active = This crate is an [color=yellow]express delivery[/color]. It's [bold]still on time[/bold]!
 trade-crate-priority-inactive = This crate is an [color=#886600]express delivery[/color]. It's [bold]late[/bold].

--- a/Resources/Locale/en-US/_NF/publictransit/bus-schedule-component.ftl
+++ b/Resources/Locale/en-US/_NF/publictransit/bus-schedule-component.ftl
@@ -1,8 +1,8 @@
 bus-schedule-no-bus = This station is not receiving bus service.
 bus-schedule-no-buses-on-route = This route is not receiving bus service.
 bus-schedule-no-stops-on-route = This route is not serving any stations.
-bus-schedule-next-departure = The next bus ({$bus}) will depart in [color=lightblue]{$time}[/color]
-bus-schedule-next-departure-now = The next bus ({$bus}) will depart [color=lightblue]any moment now![/color]
+bus-schedule-next-departure = The next bus ({$bus}) will depart in [color=lightblue]{$time}[/color].
+bus-schedule-next-departure-now = The next bus ({$bus}) will depart [color=lightblue]any moment now[/color]!
 bus-schedule-arrival-header = The bus will arrive at the following stations:
 bus-schedule-arrival-now = [color=yellow]{$station}[/color] [color=lightblue]any moment now![/color]
 bus-schedule-arrival = [color=yellow]{$station}[/color] in [color=lightblue]{$time}[/color]

--- a/Resources/Locale/en-US/_NF/publictransit/bus-schedule-component.ftl
+++ b/Resources/Locale/en-US/_NF/publictransit/bus-schedule-component.ftl
@@ -1,6 +1,8 @@
 bus-schedule-no-bus = This station is not receiving bus service.
 bus-schedule-no-buses-on-route = This route is not receiving bus service.
 bus-schedule-no-stops-on-route = This route is not serving any stations.
-bus-schedule-next-departure = The next bus ({$bus}) will depart at [color=lightblue]{$time}[/color]
+bus-schedule-next-departure = The next bus ({$bus}) will depart in [color=lightblue]{$time}[/color]
+bus-schedule-next-departure-now = The next bus ({$bus}) will depart [color=lightblue]any moment now![/color]
 bus-schedule-arrival-header = The bus will arrive at the following stations:
-bus-schedule-arrival = [color=yellow]{$station}[/color] at [color=lightblue]{$time}[/color]
+bus-schedule-arrival-now = [color=yellow]{$station}[/color] [color=lightblue]any moment now![/color]
+bus-schedule-arrival = [color=yellow]{$station}[/color] in [color=lightblue]{$time}[/color]

--- a/Resources/Prototypes/_NF/Entities/Structures/Specific/TradingCrates/crates.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Specific/TradingCrates/crates.yml
@@ -45,7 +45,7 @@
   - type: TradeCrate
     valueAtDestination: 2500
     valueElsewhere: 1200
-    expressDeliveryDuration: 1680 # twenty-eight minutes, go go (worst distance is ~6.5 km trade-cargo A, then 12 km to cargo b, 15.4 min at 20 m/s, giving ~10 minutes in adverse conditions for cargo pickup and dropoff)
+    expressDeliveryDuration: 60 # twenty-eight minutes, go go (worst distance is ~6.5 km trade-cargo A, then 12 km to cargo b, 15.4 min at 20 m/s, giving ~10 minutes in adverse conditions for cargo pickup and dropoff)
     expressOnTimeBonus: 1500
     expressLatePenalty: 1500 # 0/1000
   - type: Icon

--- a/Resources/Prototypes/_NF/Entities/Structures/Specific/TradingCrates/crates.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Specific/TradingCrates/crates.yml
@@ -45,7 +45,7 @@
   - type: TradeCrate
     valueAtDestination: 2500
     valueElsewhere: 1200
-    expressDeliveryDuration: 60 # twenty-eight minutes, go go (worst distance is ~6.5 km trade-cargo A, then 12 km to cargo b, 15.4 min at 20 m/s, giving ~10 minutes in adverse conditions for cargo pickup and dropoff)
+    expressDeliveryDuration: 1680 # twenty-eight minutes, go go (worst distance is ~6.5 km trade-cargo A, then 12 km to cargo b, 15.4 min at 20 m/s, giving ~10 minutes in adverse conditions for cargo pickup and dropoff)
     expressOnTimeBonus: 1500
     expressLatePenalty: 1500 # 0/1000
   - type: Icon


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Switches the bus schedules and trade crate deadlines to display using relative time (e.g. this happens 2 minutes from now) vs. (this happens at 03:14:15).

Both printouts are now grouped properly using disposable PushGroups, so they shouldn't be mangled in practice.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Minor quality of life, easier to parse.

## Technical details
<!-- Summary of code changes for easier review. -->

Mostly just time checks.  Anything within a second is displayed as "arriving any minute now" or "due now", and trading crates also tell how long ago they were due on failure.  Note that buses do not - due to the FTL scheduling, the bus lingers for a few seconds before the next one is considered next to arrive.

A lot of the TotalSeconds checks are a bit dumb in practice, though it does work.

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->

0. In Resources\Prototypes\_NF\Entities\Structures\Specific\TradingCrates\crates.yml, set CrateTradeSecureHigh.TradeCrate.expressDeliveryDuration to 30.
1. View a bus schedule on a station.
2. All times should be printed in relative terms.
3. When there's under a second left before the bus arrives, the schedule should say the bus is due "any minute now".
4. View a station on a bus.
5. All times should be printed in relative terms.
6. When there's under a second left before the bus arrives, the schedule should say that the bus is arriving "any minute now".
7. Spawn an express trade crate.
8. The crate should print out the time left until it's due in seconds, that it's due "now" when there's under a second left, and that it was due "XX:YY:ZZ" ago after that.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

An example of an express crate.
![image](https://github.com/user-attachments/assets/7be072a7-6612-4c02-a649-03621f99f50d)

An example of a bus schedule.
![image](https://github.com/user-attachments/assets/6ea2aedc-e24c-425b-9089-c7ec1d6ce646)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Bus schedules now print the wait until the next bus, not the shift time at arrivals.
- tweak: Trade crates now print the time left until the crate is due, not the shift time when it is due.