### PR TITLE
BindToStation (Hotfix)

### DIFF
--- a/Content.Server/Construction/ConstructionSystem.Computer.cs
+++ b/Content.Server/Construction/ConstructionSystem.Computer.cs
@@ -13,6 +13,7 @@ public sealed partial class ConstructionSystem
 {
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
     [Dependency] private readonly StationSystem _station = default!; // Frontier
+    [Dependency] private readonly BindToStationSystem _bindToStation = default!; // Frontier
 
     private void InitializeComputer()
     {

--- a/Content.Server/Construction/ConstructionSystem.Computer.cs
+++ b/Content.Server/Construction/ConstructionSystem.Computer.cs
@@ -1,5 +1,7 @@
+using Content.Server._NF.BindToStation; // Frontier
 using Content.Server.Construction.Components;
 using Content.Server.Power.Components;
+using Content.Server.Station.Systems; // Frontier
 using Content.Shared._NF.BindToStation; // Frontier
 using Content.Shared.Computer;
 using Content.Shared.Power;
@@ -10,6 +12,7 @@ namespace Content.Server.Construction;
 public sealed partial class ConstructionSystem
 {
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+    [Dependency] private readonly StationSystem _station = default!; // Frontier
 
     private void InitializeComputer()
     {
@@ -70,6 +73,17 @@ public sealed partial class ConstructionSystem
             return;
 
         var board = EntityManager.SpawnEntity(component.BoardPrototype, Transform(ent).Coordinates);
+
+        // Frontier: Only bind the board if the computer itself has the BindToStationComponent
+        if (HasComp<BindToStationComponent>(ent))
+        {
+            var computerStation = _station.GetOwningStation(ent);
+            if (computerStation != null)
+            {
+                _bindToStation.BindToStation(board, computerStation);
+            }
+        }
+        // End Frontier
 
         if (!_container.Insert(board, container))
             Log.Warning($"Couldn't insert board {board} to computer {ent}!");

--- a/Content.Server/Construction/ConstructionSystem.Machine.cs
+++ b/Content.Server/Construction/ConstructionSystem.Machine.cs
@@ -1,6 +1,7 @@
 using System.Linq; // Frontier
 using Content.Server._NF.BindToStation; // Frontier
 using Content.Server.Construction.Components;
+using Content.Server.Station.Systems; // Frontier
 using Content.Shared._NF.BindToStation; // Frontier
 using Content.Shared.Construction.Components;
 using Content.Shared.Construction.Prototypes;
@@ -14,7 +15,7 @@ namespace Content.Server.Construction;
 public sealed partial class ConstructionSystem
 {
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!; // Frontier
-    [Dependency] private readonly BindToStationSystem _bindToStation = default!; // Frontier
+
     private void InitializeMachines()
     {
         SubscribeLocalEvent<MachineComponent, ComponentInit>(OnMachineInit);
@@ -64,6 +65,17 @@ public sealed partial class ConstructionSystem
         {
             throw new Exception($"Entity with prototype {component.Board} doesn't have a {nameof(MachineBoardComponent)}!");
         }
+
+        // Frontier: Only bind the board if the machine itself has the BindToStationComponent
+        if (HasComp<BindToStationComponent>(uid))
+        {
+            var machineStation = _station.GetOwningStation(uid);
+            if (machineStation != null && board != null)
+            {
+                _bindToStation.BindToStation(board.Value, machineStation.Value);
+            }
+        }
+        // End Frontier
 
         foreach (var (stackType, amount) in machineBoard.StackRequirements)
         {


### PR DESCRIPTION
## About the PR
Fix bind computer and machine boards on POI by making sure the bind stay also stay alive on the machine build level.

* Computer Construction (`Content.Server/Construction/ConstructionSystem.Computer.cs`)**:
  - Added dependencies on `StationSystem` and `BindToStationSystem` for managing station assignments.
  - Modified the `CreateComputerBoard` method to bind the computer board to its station if the computer has a `BindToStationComponent`.

* Machine Construction (`Content.Server/Construction/ConstructionSystem.Machine.cs`)**:
  - Added dependency on `StationSystem` for station management.
  - Updated the `CreateBoardAndStockParts` method to bind the machine board to its station if the machine has a `BindToStationComponent`.

## Why / Balance
Bug with how the binding worked.

## Technical details
N/A

## How to test
Start a round, go on any POI that has no exception / Frontier.
Break / open a machine or a computer, the board will come with a bind on it.
Spawn a new clean board and build a machine / computer and see its coming with no lock.

Test a ship to confirm no issues.

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
N/A