### PR TITLE
Disable moth displacement maps

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/moth.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/moth.yml
@@ -126,7 +126,7 @@
         sizeMaps:
           32:
             sprite: Mobs/Species/Moth/displacement.rsi 
-#            state: jumpsuit-female   #Frontier
+#            state: jumpsuit-female   #Frontier: Comment out moth displacement maps
 #      back:
 #        sizeMaps:
 #          32:
@@ -172,7 +172,7 @@
 #       sizeMaps:
 #         32:
 #           sprite: Mobs/Species/Moth/displacement.rsi
-#           state: shoes
+#           state: shoes # End Frontier
 - type: entity
   parent: BaseSpeciesDummy
   id: MobMothDummy

--- a/Resources/Prototypes/Entities/Mobs/Species/moth.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/moth.yml
@@ -125,54 +125,8 @@
       jumpsuit:
         sizeMaps:
           32:
-            sprite: Mobs/Species/Moth/displacement.rsi
+            sprite: Mobs/Species/Human/displacement.rsi
             state: jumpsuit-female
-      back:
-        sizeMaps:
-          32:
-            sprite: Mobs/Species/Moth/displacement.rsi
-            state: back
-      outerClothing:
-        sizeMaps:
-          32:
-            sprite: Mobs/Species/Moth/displacement.rsi
-            state: outerclothing
-      gloves:
-        sizeMaps:
-          32:
-            sprite: Mobs/Species/Moth/displacement.rsi
-            state: hand
-      shoes:
-        sizeMaps:
-          32:
-            sprite: Mobs/Species/Moth/displacement.rsi
-            state: shoes
-    displacements:
-      jumpsuit:
-        sizeMaps:
-          32:
-            sprite: Mobs/Species/Moth/displacement.rsi
-            state: jumpsuit-male
-      back:
-        sizeMaps:
-          32:
-            sprite: Mobs/Species/Moth/displacement.rsi
-            state: back
-      outerClothing:
-        sizeMaps:
-          32:
-            sprite: Mobs/Species/Moth/displacement.rsi
-            state: outerclothing
-      gloves:
-        sizeMaps:
-          32:
-            sprite: Mobs/Species/Moth/displacement.rsi
-            state: hand
-      shoes:
-        sizeMaps:
-          32:
-            sprite: Mobs/Species/Moth/displacement.rsi
-            state: shoes
 
 - type: entity
   parent: BaseSpeciesDummy

--- a/Resources/Prototypes/Entities/Mobs/Species/moth.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/moth.yml
@@ -125,7 +125,7 @@
       jumpsuit:
         sizeMaps:
           32:
-            sprite: Mobs/Species/Human/displacement.rsi
+            sprite: Mobs/Species/Human/displacement.rsi #Disabled moth displacement maps, left the if someone in the future wants to make a toggle or reuse the displacement maps though
             state: jumpsuit-female
 
 - type: entity

--- a/Resources/Prototypes/Entities/Mobs/Species/moth.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/moth.yml
@@ -125,9 +125,54 @@
       jumpsuit:
         sizeMaps:
           32:
-            sprite: Mobs/Species/Human/displacement.rsi #Disabled moth displacement maps, left the if someone in the future wants to make a toggle or reuse the displacement maps though
-            state: jumpsuit-female
-
+            sprite: Mobs/Species/Moth/displacement.rsi 
+#            state: jumpsuit-female   #Frontier
+#      back:
+#        sizeMaps:
+#          32:
+#            sprite: Mobs/Species/Moth/displacement.rsi
+#            state: back
+#      outerClothing:
+#        sizeMaps:
+#          32:
+#            sprite: Mobs/Species/Moth/displacement.rsi
+#            state: outerclothing
+#      gloves:
+#        sizeMaps:
+#          32:
+#            sprite: Mobs/Species/Moth/displacement.rsi
+#            state: hand
+#      shoes:
+#        sizeMaps:
+#          32:
+#            sprite: Mobs/Species/Moth/displacement.rsi
+#            state: shoes
+#    displacements:
+#      jumpsuit:
+#        sizeMaps:
+#          32:
+#            sprite: Mobs/Species/Moth/displacement.rsi
+#            state: jumpsuit-male
+#      back:
+#        sizeMaps:
+#          32:
+#            sprite: Mobs/Species/Moth/displacement.rsi
+#            state: back
+#      outerClothing:
+#        sizeMaps:
+#          32:
+#            sprite: Mobs/Species/Moth/displacement.rsi
+#            state: outerclothing
+#      gloves:
+#        sizeMaps:
+#          32:
+#            sprite: Mobs/Species/Moth/displacement.rsi
+#            state: hand
+#      shoes:
+#       sizeMaps:
+#         32:
+#           sprite: Mobs/Species/Moth/displacement.rsi
+#           state: shoes
 - type: entity
   parent: BaseSpeciesDummy
   id: MobMothDummy


### PR DESCRIPTION
## About the PR
Disables moth displacement maps from upstream PR #37231.

## Why / Balance
The current displacement maps make certain clothes and outfits look much worse, especially large outer clothes like coats. Note the gloves and shoes looking strange, where gloves don't cover the whole hand, and shoes lack volume.

## Technical details
Commented out the line in Resources\Prototypes\Entities\Mobs\Species\moth.yml that applies moth displacement maps.

## How to test
1. Open game
2. Spawn a mothperson
3. Give the moth clothes
4. Note how the moth looks more fluffy and less like a stickbug

## Media
### Examples of outfits on moths before:
![mothbefore](https://github.com/user-attachments/assets/44808993-4aa7-4c26-bf4a-44b89bb01628)
![mothtiderbefore](https://github.com/user-attachments/assets/88b8210b-13ea-4c04-834e-8e9c324a8217)
### Examples of outfits on moths after:
![mothafter](https://github.com/user-attachments/assets/e646e26f-0ef4-41fe-af8b-a2d30f52fbb8)
![mothtiderafter](https://github.com/user-attachments/assets/986d2bbd-c15a-43ea-82e4-1895f80cc3db)



## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes
N/A

**Changelog**
:cl:
- tweak: Disabled moth displacement maps, moths now look fluffier!