### PR TITLE
Edison Tweaks

### DIFF
--- a/Content.Server/_NF/Power/Components/PowerTransmissionComponent.cs
+++ b/Content.Server/_NF/Power/Components/PowerTransmissionComponent.cs
@@ -50,7 +50,7 @@ public sealed partial class PowerTransmissionComponent : Component
     /// The rate per joule to credit the account while in the linear mode.
     ///</summary>
     [DataField]
-    public float LinearRate = 0.00001f; // $1/100 kJ
+    public float LinearRate = 0.00003f; // $1/100 kJ
 
     ///<summary>
     /// The maximum value (inclusive) of the linear mode per deposit, in watts
@@ -73,7 +73,7 @@ public sealed partial class PowerTransmissionComponent : Component
     /// Note: should be set to LinearRate*LinearMaxValue for a continuous function.
     ///</summary>
     [DataField]
-    public float LogarithmCoefficient = 10f;
+    public float LogarithmCoefficient = 30f;
 
     ///<summary>
     /// The exponential subtrahend of the logarithmic mode: R in Tk*a^(log10(x/T)-R)

--- a/Content.Server/_NF/Power/Components/PowerTransmissionComponent.cs
+++ b/Content.Server/_NF/Power/Components/PowerTransmissionComponent.cs
@@ -56,7 +56,7 @@ public sealed partial class PowerTransmissionComponent : Component
     /// The maximum value (inclusive) of the linear mode per deposit, in watts
     ///</summary>
     [DataField]
-    public float LinearMaxValue = 1_000_000; // 1 MW ($10/s)
+    public float LinearMaxValue = 1_000_000; // 1 MW ($30/s)
     #endregion Linear Rates
 
     // Logarithmic fields: at very high levels of power generation, incremental gains decrease logarithmically to prevent runaway cash generation
@@ -86,7 +86,7 @@ public sealed partial class PowerTransmissionComponent : Component
     ///<summary>
     ///</summary>
     [DataField]
-    public float MaxValuePerSecond = 150.0f; // ~902 MW, ~$540k/h
+    public float MaxValuePerSecond = 150.0f; // ~57 MW, ~$540k/h
 
     ///<summary>
     /// True if the entity was powered last tick.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
Math done by Pocket (pocketmed discord)
## About the PR
Tripled the power sell prices

## Why / Balance
Prices we have today are just not enough to even cover the costs for maintenance and base wages(33k hourly with 1 MW selling, I havent seen export numbers higher than 2-3 MW). this multiplying lowers the effective power selling point to the 50MW( leaving the possibility to go further for NT grats, I dunno).  

## Technical details
Changed LinearRate and LogarithmCoefficient variables in the PowerTransmissionPower

## How to test
Come to the Edison's Power plant and start generating power in there -> be no more opressed by shitty payoffs -> yay!

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
thats just some variables, lol. if you need things back just divide LinearRate and LogarithmCoefficient by 3

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- tweak: Changed Power sell prices for Edison's Power Transmitter
-->