### PR TITLE
Fixes hoverbikes causing you to get roasted by thrusters

### DIFF
--- a/Content.Server/Shuttles/Systems/ThrusterSystem.cs
+++ b/Content.Server/Shuttles/Systems/ThrusterSystem.cs
@@ -37,6 +37,7 @@ public sealed class ThrusterSystem : EntitySystem
     [Dependency] private readonly SharedPointLightSystem _light = default!;
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
     [Dependency] private readonly ConstructionSystem _construction = default!; // Frontier
+    [Dependency] private readonly SharedTransformSystem _transform = default!; // Frontier
 
     // Essentially whenever thruster enables we update the shuttle's available impulses which are used for movement.
     // This is done for each direction available.
@@ -523,7 +524,7 @@ public sealed class ThrusterSystem : EntitySystem
         var query = EntityQueryEnumerator<ThrusterComponent>();
         var curTime = _timing.CurTime;
 
-        while (query.MoveNext(out var comp))
+        while (query.MoveNext(out var ent, out var comp)) // Frontier: add out var ent
         {
             if (comp.NextFire > curTime)
                 continue;
@@ -535,6 +536,14 @@ public sealed class ThrusterSystem : EntitySystem
 
             foreach (var uid in comp.Colliding.ToArray())
             {
+                // Frontier: make sure they're still in danger
+                if (!_transform.InRange(ent, uid, 2f))
+                {
+                    comp.Colliding.Remove(uid);
+                    continue;
+                }
+                // End Frontier
+
                 _damageable.TryChangeDamage(uid, comp.Damage);
             }
         }

--- a/Content.Server/Shuttles/Systems/ThrusterSystem.cs
+++ b/Content.Server/Shuttles/Systems/ThrusterSystem.cs
@@ -537,6 +537,7 @@ public sealed class ThrusterSystem : EntitySystem
             foreach (var uid in comp.Colliding.ToArray())
             {
                 // Frontier: make sure they're still in danger
+                // Frontier TODO: Actually fix the cause of this bug (EndCollideEvent not firing on buckled entities)
                 if (!_transform.InRange(ent, uid, 2f))
                 {
                     comp.Colliding.Remove(uid);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Adds a range check before dealing damage to things in the thruster exhaust plume.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes a bug where being buckled when you turn on a thruster while in the exhaust collision hitbox added you to the list of things to burn, but then exiting said hitbox didn't remove you from that list.

Well, it doesn't actually fix that bug, but it fixes the symptoms. Fixing that bug is most likely in-engine as to how `StartCollideEvent`s are processed for buckled entities but `EndCollideEvent`s aren't

## Technical details
<!-- Summary of code changes for easier review. -->
if burney target > 2m away, no burney


## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
Reproduce the bug. See that it doesn't happen as long as you get far enough away from the thruster.
Note that you can still get roasted by the bug, you just need to be adjacent to the thruster.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed a bug where hoverbikes would mark players to be roasted by thrusters even after they left the exhaust plume.

