### PR TITLE
Extra Cargo Options fix

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_cargo.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_cargo.yml
@@ -39,13 +39,14 @@
   cost: 750
   category: cargoproduct-category-name-cargo
   group: market
-
-- type: cargoProduct
-  id: CargoCrusherDagger
-  icon:
-    sprite: Objects/Weapons/Melee/crusher_dagger.rsi
-    state: icon
-  product: CrateCrusherDagger
-  cost: 2500
-  category: cargoproduct-category-name-cargo
-  group: market
+# frontier: Unused
+# - type: cargoProduct
+#   id: CargoCrusherDagger
+#   icon:
+#     sprite: Objects/Weapons/Melee/crusher_dagger.rsi
+#     state: icon
+#   product: CrateCrusherDagger
+#   cost: 2500
+#   category: cargoproduct-category-name-cargo
+#   group: market
+# End frontier

--- a/Resources/Prototypes/Catalog/Cargo/cargo_materials.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_materials.yml
@@ -55,6 +55,7 @@
 
 - type: cargoProduct
   id: MaterialGold
+  abstract: true # Frontier
   icon:
     sprite: Objects/Materials/ingots.rsi
     state: gold_3
@@ -65,6 +66,7 @@
 
 - type: cargoProduct
   id: MaterialSilver
+  abstract: true # Frontier
   icon:
     sprite: Objects/Materials/ingots.rsi
     state: silver_3

--- a/Resources/Prototypes/Catalog/Cargo/salvage_rewards.yml
+++ b/Resources/Prototypes/Catalog/Cargo/salvage_rewards.yml
@@ -1,83 +1,85 @@
-# Rank 2
-- type: cargoProduct
-  id: CargoDoubleEmergencyTank
-  icon:
-    sprite: Objects/Tanks/emergency_double.rsi
-    state: icon
-  product: CrateDoubleEmergencyTank
-  cost: 2400
-  category: cargoproduct-category-name-cargo
-  group: SalvageJobReward2
+#Frontier: Removes the equipment from the cargo order pool
+ # Rank 2
+# - type: cargoProduct
+#   id: CargoDoubleEmergencyTank
+#   icon:
+#     sprite: Objects/Tanks/emergency_double.rsi
+#     state: icon
+#   product: CrateDoubleEmergencyTank
+#   cost: 2400
+#   category: cargoproduct-category-name-cargo
+#   group: SalvageJobReward2
 
-- type: cargoProduct
-  id: CargoSeismicCharge
-  icon:
-    sprite: Objects/Weapons/Bombs/seismic.rsi
-    state: icon
-  product: CrateSeismicCharge
-  cost: 1800
-  category: cargoproduct-category-name-cargo
-  group: SalvageJobReward2
+# - type: cargoProduct
+#   id: CargoSeismicCharge
+#   icon:
+#     sprite: Objects/Weapons/Bombs/seismic.rsi
+#     state: icon
+#   product: CrateSeismicCharge
+#   cost: 1800
+#   category: cargoproduct-category-name-cargo
+#   group: SalvageJobReward2
 
-- type: cargoProduct
-  id: CargoCrusher
-  icon:
-    sprite: Objects/Weapons/Melee/crusher.rsi
-    state: icon
-  product: CrateCrusher
-  cost: 5000
-  category: cargoproduct-category-name-cargo
-  group: SalvageJobReward2
+# - type: cargoProduct
+#   id: CargoCrusher
+#   icon:
+#     sprite: Objects/Weapons/Melee/crusher.rsi
+#     state: icon
+#   product: CrateCrusher
+#   cost: 5000
+#   category: cargoproduct-category-name-cargo
+#   group: SalvageJobReward2
 
-- type: cargoProduct
-  id: CargoSalvageHardsuit
-  icon:
-    sprite: Clothing/OuterClothing/Hardsuits/salvage.rsi
-    state: icon
-  product: CrateSalvageHardsuit
-  cost: 7500
-  category: cargoproduct-category-name-cargo
-  group: SalvageJobReward2
+# - type: cargoProduct
+#   id: CargoSalvageHardsuit
+#   icon:
+#     sprite: Clothing/OuterClothing/Hardsuits/salvage.rsi
+#     state: icon
+#   product: CrateSalvageHardsuit
+#   cost: 7500
+#   category: cargoproduct-category-name-cargo
+#   group: SalvageJobReward2
 
-# Rank 3
-- type: cargoProduct
-  id: CargoFulton
-  icon:
-    sprite: /Textures/Objects/Tools/fulton.rsi
-    state: extraction_pack
-  product: CrateFulton
-  cost: 3000
-  category: cargoproduct-category-name-cargo
-  group: SalvageJobReward3
+# # Rank 3
+# - type: cargoProduct
+#   id: CargoFulton
+#   icon:
+#     sprite: /Textures/Objects/Tools/fulton.rsi
+#     state: extraction_pack
+#   product: CrateFulton
+#   cost: 3000
+#   category: cargoproduct-category-name-cargo
+#   group: SalvageJobReward3
 
-- type: cargoProduct
-  id: CargoVoidJetpack
-  icon:
-    sprite: Objects/Tanks/Jetpacks/void.rsi
-    state: icon
-  product: CrateVoidJetpack
-  cost: 4000
-  category: cargoproduct-category-name-cargo
-  group: SalvageJobReward3
+# - type: cargoProduct
+#   id: CargoVoidJetpack
+#   icon:
+#     sprite: Objects/Tanks/Jetpacks/void.rsi
+#     state: icon
+#   product: CrateVoidJetpack
+#   cost: 4000
+#   category: cargoproduct-category-name-cargo
+#   group: SalvageJobReward3
 
-- type: cargoProduct
-  id: CargoCrusherGlaive
-  icon:
-    sprite: Objects/Weapons/Melee/crusher_glaive.rsi
-    state: icon
-  product: CrateCrusherGlaive
-  cost: 8000
-  category: cargoproduct-category-name-cargo
-  group: SalvageJobReward3
+# - type: cargoProduct
+#   id: CargoCrusherGlaive
+#   icon:
+#     sprite: Objects/Weapons/Melee/crusher_glaive.rsi
+#     state: icon
+#   product: CrateCrusherGlaive
+#   cost: 8000
+#   category: cargoproduct-category-name-cargo
+#   group: SalvageJobReward3
 
-# Max Rank
+# # Max Rank
 
-- type: cargoProduct
-  id: CargoSupremeSalvagerCloak
-  icon:
-    sprite: Clothing/Neck/Cloaks/miner.rsi
-    state: icon
-  product: CrateSupremeSalvagerCloak
-  cost: 25000
-  category: cargoproduct-category-name-cargo
-  group: SalvageJobRewardMAX
+# - type: cargoProduct
+#   id: CargoSupremeSalvagerCloak
+#   icon:
+#     sprite: Clothing/Neck/Cloaks/miner.rsi
+#     state: icon
+#   product: CrateSupremeSalvagerCloak
+#   cost: 25000
+#   category: cargoproduct-category-name-cargo
+#   group: SalvageJobRewardMAX
+#End Frontier


### PR DESCRIPTION
## About the PR
Resolves https://ptb.discord.com/channels/1123826877245694004/1400852919221223526
## Why / Balance
Upstream items slipped in with the merge. Fixed the additional icons that appeared.
## Technical details

Pressed Control+ slash a couple of times

## How to test
Load up a server and notice the lack of extra cargo mess


## Media
<img width="537" height="169" alt="image" src="https://github.com/user-attachments/assets/e7edc1b5-8c52-431a-bcf5-76ee0fc4247e" />
<img width="611" height="124" alt="image" src="https://github.com/user-attachments/assets/1c5b8ee5-ec00-452d-8e2d-b2578634877c" />

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes
None I can notice, but if something breaks later down the line from this, oops
**Changelog**

:cl:
- fix: The Salvage crates (Crushers, Seismic Charge, Fulton) and Gold/Silver crates no longer appear in cargo order terminals