### PR TITLE
Disables collision checking for paused mobs

### DIFF
--- a/Content.Server/Movement/Systems/MobCollisionSystem.cs
+++ b/Content.Server/Movement/Systems/MobCollisionSystem.cs
@@ -31,7 +31,7 @@ public sealed class MobCollisionSystem : SharedMobCollisionSystem
 
         while (query.MoveNext(out var uid, out var comp))
         {
-            if (_actorQuery.HasComp(uid) || !PhysicsQuery.TryComp(uid, out var physics))
+            if (_actorQuery.HasComp(uid) || !PhysicsQuery.TryComp(uid, out var physics) || IsPaused(uid))
                 continue;
 
             HandleCollisions((uid, comp, physics), frameTime);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
It's currently conjectured that the lag explosion that we have from people in cryo originates from an x^x scaling overlap check in the mobcollision system - which does not seem to respect entity pausing, something which needs to be checked for on every component that does updating if you want it to be respected

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
ZA WARUDO! TOKI WO TOMARE!

## Technical details
<!-- Summary of code changes for easier review. -->
Adds a check for entity pausedness to the serverside entity collision checker

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
1. ummmmmmmmmmm! i don't run the big server with lots of people on it so i'm not sure how to test this

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![tenor-279194547](https://github.com/user-attachments/assets/9a354440-9314-43bf-b2d0-2db6d045eafa)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Marlyn
- fix: Potentially thaws the freezing of time from people being in cryo?