### PR TITLE
Use localized reagent name in service selective dropper filter UI

### DIFF
--- a/Content.Client/_NF/Chemistry/UI/ChangeReagentWhitelistWindow.xaml
+++ b/Content.Client/_NF/Chemistry/UI/ChangeReagentWhitelistWindow.xaml
@@ -1,5 +1,5 @@
 ﻿<DefaultWindow
-    SetSize="250 300"
+    SetSize="325 300"
     Margin="4 0"
     xmlns="https://spacestation14.io">
     <BoxContainer Orientation="Vertical">

--- a/Content.Client/_NF/Chemistry/UI/ChangeReagentWhitelistWindow.xaml.cs
+++ b/Content.Client/_NF/Chemistry/UI/ChangeReagentWhitelistWindow.xaml.cs
@@ -78,7 +78,7 @@ public sealed partial class ChangeReagentWhitelistWindow : DefaultWindow
         }
 
         ApplyButton.Text = Loc.GetString("ui-change-reagent-whitelist-apply",
-            ("reagent", _selectedReagent.ID));
+            ("reagent", _selectedReagent.LocalizedName));
         ApplyButton.Disabled = false;
     }
 
@@ -99,7 +99,7 @@ public sealed partial class ChangeReagentWhitelistWindow : DefaultWindow
         foreach (var reagent in _prototypeManager.EnumeratePrototypes<ReagentPrototype>())
         {
             if (!string.IsNullOrEmpty(filter) &&
-                !reagent.ID.ToLowerInvariant().Contains(filter.Trim().ToLowerInvariant()))
+                !reagent.LocalizedName.ToLowerInvariant().Contains(filter.Trim().ToLowerInvariant()))
             {
                 continue;
             }
@@ -112,7 +112,7 @@ public sealed partial class ChangeReagentWhitelistWindow : DefaultWindow
             ItemList.Item reagentItem = new(ReagentList)
             {
                 Metadata = reagent,
-                Text = reagent.ID
+                Text = reagent.LocalizedName,
             };
 
             ReagentList.Add(reagentItem);


### PR DESCRIPTION


## About the PR
Changes the filter UI for the service selective dropper to show in-game names for reagents instead of their internal ID.

## Why / Balance
Reported on Discord: https://discord.com/channels/1123826877245694004/1404533088431640636
Because players generally won't expect they need to filter for "EnergyDrink" when they want to remove Red Bool from a beaker.

## Technical details
Replaces all references to the reagent ID in the ChangeReagentWhitelist UI with `LocalizedName`. The change event emitted from the window passes a full prototype reference, so the rest of the code doesn't need to care what the UI shows.

Also widens the filter window a bit so the apply button doesn't look weird with long names.

## How to test
- Spawn a service selective dropper. Open filter window. Observe that filter window shows "Red Bool" instead of "EnergyDrink" and "Smite" instead of "LemonLime".
- Fill a beaker with Red Bool and Smite (EnergyDrink and LemonLime if you're using the solution editor). Set the filter on the dropper to Red Bool. Draw from the beaker. Observe that the dropper only drew Red Bool and left the Smite alone.
- Use the textbox to search for "Pan-Galactic Gargle Blaster". Click it. Observe that the apply button reads "Only Draw Pan-Galactic Gargle Blaster" and the whole text fits into the button.

## Media
<img width="492" height="456" alt="please, may I have some wine" src="https://github.com/user-attachments/assets/1d378681-5e1d-4a56-a896-8a3d4f7fb91c" />

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes
None.

**Changelog**

:cl: Bonfire Lit
- tweak: The service selective dropper filter now uses in-game names instead of internal IDs.
