### PR TITLE
Don't promote latejoin players to pirate

### DIFF
--- a/Resources/Prototypes/_NF/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_NF/GameRules/roundstart.yml
@@ -102,7 +102,7 @@
     - prefRoles: [ NFPirateCaptain ]
       max: 999
       playerRatio: -1
-      lateJoinAdditional: true
+      lateJoinAdditional: false
       allowNonHumans: true
       multiAntagSetting: All
       components: &pirateComponents
@@ -121,7 +121,7 @@
     - prefRoles: [ NFPirateFirstMate ]
       max: 999
       playerRatio: -1
-      lateJoinAdditional: true
+      lateJoinAdditional: false
       allowNonHumans: true
       multiAntagSetting: All
       components: *pirateComponents
@@ -135,7 +135,7 @@
     - prefRoles: [ NFPirate ]
       max: 999
       playerRatio: -1
-      lateJoinAdditional: true
+      lateJoinAdditional: false
       allowNonHumans: true
       multiAntagSetting: All
       components: *pirateComponents


### PR DESCRIPTION
## About the PR
Set `lateJoinAdditional` to `false` for all pirate roles.

## Why / Balance
The previous value, `true`, causes the game to randomly try and promote latejoin players to pirate. Seems like an innocent oversight. We most certainly don't want random Contractors to be randomly told they're a pirate now. The pirate role should only ever be selected explicitly.

## Technical details
YAML, my beloved.

## How to test
Er. I don't know. Latejoin with loads of clients, make sure you don't get turned into a pirate? How does one prove a negative?

## Media
N/A

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes
None.

**Changelog**
:cl:
- fix: Non-pirate latejoins should no longer randomly be turned into pirates.