### PR TITLE
Crew monitors now only show blips for the same Map/Surface

### DIFF
--- a/Content.Server/Medical/SuitSensors/SuitSensorSystem.cs
+++ b/Content.Server/Medical/SuitSensors/SuitSensorSystem.cs
@@ -21,6 +21,7 @@ using Content.Shared.Mobs.Systems;
 using Content.Shared.Verbs;
 using Robust.Shared.Containers;
 using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
@@ -474,7 +475,6 @@ public sealed class SuitSensorSystem : EntitySystem
 
                     coordinates = new EntityCoordinates(transform.MapUid.Value,
                         _transform.GetWorldPosition(transform, xformQuery)); // Frontier
-
                     locationName = Loc.GetString("suit-sensor-location-space"); // Frontier
                 }
                 else
@@ -483,6 +483,9 @@ public sealed class SuitSensorSystem : EntitySystem
 
                     locationName = Loc.GetString("suit-sensor-location-unknown"); // Frontier
                 }
+
+                if (transform.MapUid != null && TryComp<MapComponent>(transform.MapUid.Value, out var mapComp)) // Frontier - Crew monitor map check
+                    status.MapHash = mapComp.MapId.GetHashCode(); // Frontier
 
                 status.Coordinates = GetNetCoordinates(coordinates);
                 status.LocationName = locationName; // Frontier
@@ -515,6 +518,8 @@ public sealed class SuitSensorSystem : EntitySystem
             payload.Add(SuitSensorConstants.NET_TOTAL_DAMAGE_THRESHOLD, status.TotalDamageThreshold);
         if (status.Coordinates != null)
             payload.Add(SuitSensorConstants.NET_COORDINATES, status.Coordinates);
+        if (status.MapHash != null) // Frontier - Crew monitor map check
+            payload.Add(SuitSensorConstants.NET_MAP_HASH, status.MapHash); // Frontier
         if (status.LocationName != null) // Frontier
             payload.Add(SuitSensorConstants.NET_LOCATION_NAME, status.LocationName); // Frontier
 
@@ -546,6 +551,7 @@ public sealed class SuitSensorSystem : EntitySystem
         payload.TryGetValue(SuitSensorConstants.NET_TOTAL_DAMAGE, out int? totalDamage);
         payload.TryGetValue(SuitSensorConstants.NET_TOTAL_DAMAGE_THRESHOLD, out int? totalDamageThreshold);
         payload.TryGetValue(SuitSensorConstants.NET_COORDINATES, out NetCoordinates? coords);
+        payload.TryGetValue(SuitSensorConstants.NET_MAP_HASH, out int? mapHash); // Frontier - Crew monitor map check
 
         var status = new SuitSensorStatus(ownerUid, suitSensorUid, name, job, jobIcon, jobDepartments, location) // Frontier: add location
         {
@@ -553,6 +559,7 @@ public sealed class SuitSensorSystem : EntitySystem
             TotalDamage = totalDamage,
             TotalDamageThreshold = totalDamageThreshold,
             Coordinates = coords,
+            MapHash = mapHash, // Frontier - Crew monitor map check
         };
         return status;
     }

--- a/Content.Shared/Medical/SuitSensor/SharedSuitSensor.cs
+++ b/Content.Shared/Medical/SuitSensor/SharedSuitSensor.cs
@@ -30,6 +30,7 @@ public sealed class SuitSensorStatus
     public int? TotalDamageThreshold;
     public float? DamagePercentage => TotalDamageThreshold == null || TotalDamage == null ? null : TotalDamage / (float) TotalDamageThreshold;
     public NetCoordinates? Coordinates;
+    public int? MapHash; // Frontier - Crew monitor map check
     public string LocationName; // Frontier
 }
 
@@ -70,6 +71,7 @@ public static class SuitSensorConstants
     public const string NET_COORDINATES = "coords";
     public const string NET_SUIT_SENSOR_UID = "uid";
     public const string NET_LOCATION_NAME = "location"; // Frontier
+    public const string NET_MAP_HASH = "mapHash"; // Frontier - Crew monitor map check
 
     ///Used by the CrewMonitoringServerSystem to send the status of all connected suit sensors to each crew monitor
     public const string NET_STATUS_COLLECTION = "suit-status-collection";


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
I added checks for the crew monitoring interface to only add blips to the map if the sensor reading came from the same Map. Buttons for coordinated people on other maps are disabled, but you can identify coordinatedness by the color of the circle next to the health indicator (green = coordinates)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It's very confusing and distracting to see a bunch of blips for people on FO while on an away mission, and likewise confusing to see blips for expeditioners while on FO. This both makes coordination on expeditions easier, as well as streamlines the process of rescuing injured crew.

## Technical details
<!-- Summary of code changes for easier review. -->
Added another field to the suit sensor packets which contains a "map hash" - this map hash is compared with the map hash where the crew monitor is used, and will then only display blips on that same map.

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
Spawn a bunch of people on FO with suit sensors on, and then fly an expedition shuttle to an away mission. Observe that down on the surface, the crew on that surface are visible on the monitor, while people at FO do not show blips on the monitor. Observe that people in the main sector remain visible on suit sensors to those within the sector.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Before: (sensor readings from FO were leaking)
<img width="1080" height="449" alt="image" src="https://github.com/user-attachments/assets/85ea9970-a031-46cd-bc2e-9ac95cdc0a24" />
After: (people on FO do not show on the blip map anymore)
<img width="1065" height="421" alt="image" src="https://github.com/user-attachments/assets/cd44a514-4c08-4d6f-a07f-d74804d9a958" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
Can adjusting the suit sensor packet format break things?

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Marlyn
- fix: Crew monitors no longer show blips for people on different surfaces (e.g. Seeing FO sensors from an expedition)