### PR TITLE
GCQueue optimizations

### DIFF
--- a/Content.Server/Worldgen/Prototypes/GCQueuePrototype.cs
+++ b/Content.Server/Worldgen/Prototypes/GCQueuePrototype.cs
@@ -20,10 +20,10 @@ public sealed class GCQueuePrototype : IPrototype
     public int Depth { get; }
 
     /// <summary>
-    ///     The maximum amount of time that can be spent processing this queue.
+    ///     How many miliseconds to spend deleting objects per object in the queue above the MinDepth? Mono Dynamic Queueing
     /// </summary>
-    [DataField("maximumTickTime")]
-    public TimeSpan MaximumTickTime { get; } = TimeSpan.FromMilliseconds(1);
+    [DataField]
+    public double TimeDeletePerObject { get; } = 0.1; // Mono - at 100 objects past the MinDepth will spend up to 10 milliseconds trying to do deletions
 
     /// <summary>
     ///     The minimum depth before entities in the queue actually get processed for deletion.

--- a/Content.Server/Worldgen/Systems/GC/GCQueueSystem.cs
+++ b/Content.Server/Worldgen/Systems/GC/GCQueueSystem.cs
@@ -48,7 +48,15 @@ public sealed class GCQueueSystem : EntitySystem
                 continue;
 
             queueWatch.Restart();
-            while (queueWatch.Elapsed < proto.MaximumTickTime && queue.Count >= proto.MinDepthToProcess &&
+
+            // Mono Begin - Dynamic Queue Times (Like League of Legends)
+            var entsOverDepth = Math.Abs(queue.Count - proto.MinDepthToProcess);
+            // We get a constant associated with the prototype, and multiply it by the count of objects in that prototype. Dynamic scaling, instead of static constants.
+            TimeSpan maxQueueTickTime = TimeSpan.FromMilliseconds(entsOverDepth * proto.TimeDeletePerObject);
+
+            // Mono End
+
+            while (queueWatch.Elapsed < maxQueueTickTime && queue.Count >= proto.MinDepthToProcess &&
                    overallWatch.Elapsed < _maximumProcessTime)
             {
                 var e = queue.Dequeue();

--- a/Resources/Prototypes/GC/world.yml
+++ b/Resources/Prototypes/GC/world.yml
@@ -1,5 +1,5 @@
 ﻿- type: gcQueue
   id: SpaceDebris
-  depth: 256 # Frontier
-  minDepthToProcess: 128 # Frontier
-  trySkipQueue: true  # Frontier - Attempt immediate removal if possible
+  depth: 150 # Mono
+  minDepthToProcess: 25 # Mono
+#  trySkipQueue: true  # Frontier - Attempt immediate removal if possible


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

There are a lot of issues with the way Frontier has its GCQueue system for wrecks/asteroids set up currently.

The first is that trySkipQueue: true, which makes all wrecks skip the queued deletion. This essentially just calls QueueDels immediately and constantly, causing substantial CPU lag.

This also means that the second a wreck leaves the range of a console, its pretty much deleted. This is not ideal for ships who may go past a wreck, notice it, and want to go back.

The other substantial issue is before we don't use trySkipQueue, it instead caps queuing deletions to 1 millisecond per tick in the Queue Prototype by default. Frontier did change the overall GCQueueSystem _maximumProcessTime, however this didn't affect the GCQueue prototype at all, as that has a separate amount that is also processed.

My solution here uses the count of the queue depth to determine how much time is maximally alotted towards running the GCqueue. A low depth will spend a lower amount of time, but if a large amount of wrecks build up a larger amount of time will be spent deleting wrecks. This will prevent a substantial buildup of wrecks while still properly controlling the amount of time spent deleting wrecks and preventing a buildup. 

While also not skipping the queue entirely, deleting wrecks instantly that leave the range of a player, and not letting too many wrecks exist.

If the amount of wrecks exceeds the depth anyways, it will just call QueueDel on everything so its not that big of a deal.

This is my own work, originally created on Monolith.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Wrecks will no longer immediately delete once a ship leaves vision.

