### PR TITLE
Fixes DRM quirks

### DIFF
--- a/Content.Server/Construction/ConstructionSystem.Computer.cs
+++ b/Content.Server/Construction/ConstructionSystem.Computer.cs
@@ -75,8 +75,8 @@ public sealed partial class ConstructionSystem
 
         var board = EntityManager.SpawnEntity(component.BoardPrototype, Transform(ent).Coordinates);
 
-        // Frontier: Only bind the board if the computer itself has the BindToStationComponent and the board doesn't already have BindToStationComponent
-        if (HasComp<BindToStationComponent>(ent))
+        // Frontier: Only bind the board if the computer itself has the StationBoundObjectComponent and the board doesn't already have StationBoundObjectComponent
+        if (HasComp<StationBoundObjectComponent>(ent))
         {
             var computerStation = _station.GetOwningStation(ent);
             if (computerStation != null)

--- a/Content.Server/Construction/ConstructionSystem.Machine.cs
+++ b/Content.Server/Construction/ConstructionSystem.Machine.cs
@@ -66,8 +66,8 @@ public sealed partial class ConstructionSystem
             throw new Exception($"Entity with prototype {component.Board} doesn't have a {nameof(MachineBoardComponent)}!");
         }
 
-        // Frontier: Only bind the board if the machine itself has the BindToStationComponent and the board doesn't already have BindToStationComponent  
-        if (HasComp<BindToStationComponent>(uid) && board != null)
+        // Frontier: Only bind the board if the machine itself has the StationBoundObjectComponent and the board doesn't already have StationBoundObjectComponent
+        if (HasComp<StationBoundObjectComponent>(uid) && board != null)
         {
             var machineStation = _station.GetOwningStation(uid);
             if (machineStation != null)


### PR DESCRIPTION
This PR ensures that machines no longer get their external machine DRM state and internal board DRM state out of sync. This means:
 - Flatpacks you unpack on a ship or station won't get their internal board DRM'd to that station
 - DRM'd boards can't be flatpacked and then deconstructed to get a board whose DRM has been reset

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
I changed the pass in machine part population to only bind the board if the machine it was being generated for was already bound to a station. I also added a loop to the BindToStation method which recurses it onto any contained boards.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bypassing machine station binding is bad, and non-DRM'd boards/machines "becoming" station-locked is a pain in the neck for players.

## Technical details
<!-- Summary of code changes for easier review. -->

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
1. Crowbar a ship machine, observe the internal board retains the boundness of the external machine
2. Flatpack this internal board and unpack it on another grid, and crowbar the resulting machine to observe that the DRM is retained  for the original grid.
3. Unpack an unbound machine flatpack, crowbar the result,  and observe that the extracted board is still unbound
4. Unpack a few other flatpacks to observe they are unaffected

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Marlyn
- fix: Corrected a few cases where board DRM would be incorrectly applied or transferred upon flatpack installation
