### PR TITLE
Crushers now have a guaranteed number of leech hits per target

### DIFF
--- a/Content.Shared/Weapons/Marker/LeechOnMarkerComponent.cs
+++ b/Content.Shared/Weapons/Marker/LeechOnMarkerComponent.cs
@@ -13,4 +13,9 @@ public sealed partial class LeechOnMarkerComponent : Component
     [ViewVariables(VVAccess.ReadWrite)]
     [DataField("leech", required: true)]
     public DamageSpecifier Leech = new();
+
+    // Frontier - Limited leech hits on dead mobs
+    // The number of leech hits you can do on a mob until draining stops happening
+    // Leeching always works if the foe is alive, but is checked against this when the mob is dead.
+    [DataField] public int NumGuaranteedLeechHits = 5;
 }

--- a/Content.Shared/_NF/Weapons/Components/NFSharedMarkerCounterComponent.cs
+++ b/Content.Shared/_NF/Weapons/Components/NFSharedMarkerCounterComponent.cs
@@ -1,0 +1,7 @@
+namespace Content.Shared._NF.Weapons.Components;
+
+[RegisterComponent]
+public sealed partial class NFMarkerCounterComponent : Component
+{
+    [DataField] public int WhacksRemaining = 5;
+}


### PR DESCRIPTION

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Leeching always works on the living, but you're guaranteed a minimum of 5 leech hits so long as you started to leech the target while they were still alive. This value can be changed for easy balance tuning later.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Needing to minimax crusher hits versus other damage types means that squishier enemies or enemies that caught stray hits from other teammates often only provide a scant vestige of health. This regularizes a floor of how much health you can get per enemy.

## Technical details
<!-- Summary of code changes for easier review. -->
Added a NFMarkerCounterComponent which keeps track of how many guaranteed leech hits you're allowed, which is applied when you leech a living mob, and deducted on every hit. If you leech a dead mob, if they have this component on them and it has remaining charges, you also gain life. Upon reviving the mob, the marker counter component goes away to allow this cycle to happen again.

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
1. Leech a mob that's already dead. Observe no lifesteal.
2. Leech a mob that then dies, and leech them more. Observe you steal life a few times still.
3. Leech a mob 5 times, killing them, and observe you do not leech any more life.
4. Revive a leeched mob and observe you can leech them as fresh.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/8f55d452-f208-435b-ada9-82b115174375



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Marlyn
- add: Crushers now have a number of hits they're guaranteed to leech on targets you fight while using it.
