### PR TITLE
Changed the size of the Sawn-Off Shotgun

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Shotguns/base_shotgun.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Shotguns/base_shotgun.yml
@@ -28,6 +28,34 @@
     class: weapon-details-class-shotgun
 
 - type: entity
+  id: NFBaseWeaponFrameSmallShotgun
+  parent: [ NFBaseWeaponEncumbrancePistol, NFBaseItemWeaponGun ]
+  abstract: true
+  components:
+  - type: Sprite
+    layers:
+    - state: icon
+      map: [ "enum.GunVisualLayers.Base" ]
+  - type: Gun
+    projectileSpeed: 20
+    minAngle: 4.1
+    maxAngle: 23
+    angleIncrease: 2
+    angleDecay: 4
+    fireRate: 1.5
+    selectedMode: SemiAuto
+    availableModes:
+    - SemiAuto
+    soundGunshot:
+      path: /Audio/Weapons/Guns/Gunshots/shotgun.ogg
+    soundEmpty:
+      path: /Audio/Weapons/Guns/Empty/empty.ogg
+  - type: StaticPrice
+    price: 400
+  - type: NFWeaponDetails
+    class: weapon-details-class-shotgun
+
+- type: entity
   id: NFBaseWeaponFrameShotgunWieldable
   parent: [ NFBaseWeaponEncumbranceRifle, NFBaseWeaponFrameShotgun ]
   abstract: true

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -77,7 +77,7 @@
 
 - type: entity
   id: NFWeaponShotgunSawn
-  parent: [ NFBaseWeaponShotgunChamber50, NFBaseWeaponFrameShotgun ]
+  parent: [ NFBaseWeaponShotgunChamber50, NFBaseWeaponFrameSmallShotgun ]
   name: sawn-off shotgun
   description: |-
     Groovy!


### PR DESCRIPTION


## About the PR
Reduced the size of the Sawn-Off-Shotgun, should also fit in boot slots, but can be changed if needed
## Why / Balance
Bug report https://ptb.discord.com/channels/1123826877245694004/1414934409655750676


## Technical details
New frame, NFSmallShotgun, with a parent of a regular pistol, widened the spread of the gun


## How to test

Spawn a Sawn-Off, notice the 3 cell size
## Media
<img width="769" height="206" alt="image" src="https://github.com/user-attachments/assets/de091e4c-a8f5-46ec-aaec-9ee62c471dfa" />

## Requirements

- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes
2 shotgun shells worth of firepower in a boot?
**Changelog**
:cl:
- fix: The Sawn-Off Shotgun is now smaller.