### PR TITLE
Addition of Med Topicals to Merc Techfab

### DIFF
--- a/Resources/Prototypes/_NF/Recipes/Lathes/Packs/Deprecated/mercenary_techfab.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/Packs/Deprecated/mercenary_techfab.yml
@@ -107,3 +107,10 @@
   - NFSpeedLoaderPistol45Empty
   - NFMagazineClipRifle20Empty
   - MagazineLightRifleLowCapacityEmpty
+## Medical Slop
+  - Brutepack
+  - Ointment
+  - Gauze
+  - BodyBag
+  - EmergencyRollerBedSpawnFolded
+  - Tourniquet

--- a/Resources/Prototypes/_NF/Recipes/Lathes/Packs/medical.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/Packs/medical.yml
@@ -19,6 +19,7 @@
   - CraftClothingEyesHudMedical
   - CraftClothingEyesEyepatchHudMedical
   - CraftClothingMaskBreathMedical
+  - Tourniquet
 
 - type: latheRecipePack
   id: NFMedical

--- a/Resources/Prototypes/_NF/Recipes/Lathes/medical.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/medical.yml
@@ -97,3 +97,11 @@
     Steel: 100
     Plastic: 200
     Glass: 50
+
+- type: latheRecipe
+  id: Tourniquet
+  result: Tourniquet
+  completetime: 5
+  materials:
+    Steel: 25
+    Plastic: 100


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

This PR is connected to the ongoing charm of #3857 

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

- Adds a recipe for the tourniquet.
- Adds the tourniquet to the medical techfab.

Adds the following noise to the mercenary techfab:
- Brutepack
- Ointment
- Gauze
- BodyBag
- EmergencyRollerBedSpawnFolded
- Tourniquet

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

As the subject has been fairly topical as of late *pause for effect* 'ol Leostel on the discord asked why we don't just chuck medical topicals into the mercenary techfab.

Within the context of the proposed changes in #3857 and the addition of mercenary techfabs to the exped/similar vessels moving forward it struck me as an interesting question. Being able to trade materials for sustain meds is not entirely without interest and it seems reasonable to speculate that these kinds of tools are so highly sought by mercs that they're willing to go to extreme lengths to procure them otherwise. 

It's a bit of a go with the flow and see where it takes us PR.

Topicals allow you to recover after a fight. Which is currently a role that is being hard carried by the fairly OP crusher set. I don't think that these will impact mercs still biting the dust and needing rescue. But it will allow for a measure of longevity that is currently otherwise being scraped out of medical hulls. 

I think it's an interesting idea and one that I feel folds nicely into the other plans proposed in that pr.

## Technical details
<!-- Summary of code changes for easier review. -->

yml

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->

Print off the new recipes.
Check to see if the tourn'i'quit's recipe seems reasonable.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![ss+(2025-09-09+at+05 05 22)](https://github.com/user-attachments/assets/69e4e0d7-5a9a-430d-8bb8-cf07e0bd6c6b)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

To be integrated into #4025 

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
🆑 
- add: A new recipe for the Tourniquet and topicals added to the medical/mercenary techfab.