### PR TITLE
Auto-apply job-specific cartridges and channels

### DIFF
--- a/Resources/Prototypes/_NF/Roles/Jobs/Civilian/janitor.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Civilian/janitor.yml
@@ -37,8 +37,9 @@
     belt: ClothingBeltJanitorFilled
   storage:
     back:
-    - EncryptionKeyService
     - ShipVoucherFrontierJanitor
+  encryptionKeys:
+  - EncryptionKeyService
 
 - type: chameleonOutfit
   id: NFJanitorChameleonOutfit

--- a/Resources/Prototypes/_NF/Roles/Jobs/Civilian/valet.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Civilian/valet.yml
@@ -33,10 +33,10 @@
     id: ValetPDA
   storage:
     back:
-    - EncryptionKeyService
     - ShipVoucherFrontierValet
   encryptionKeys:
   - EncryptionKeyGreeting
+  - EncryptionKeyService
 
 - type: chameleonOutfit
   id: ValetChameleonOutfit

--- a/Resources/Prototypes/_NF/Roles/Jobs/Frontier/security_guard.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Frontier/security_guard.yml
@@ -37,12 +37,14 @@
     pocket2: NFMagazineHighCapacityPistol35
   storage:
     back:
-    - EncryptionKeyService
-    - EncryptionKeySecurity
     - Flash
     - NFMagazineHighCapacityPistol35
     - NFMagazineHighCapacityPistol35Rubber
     - ShipVoucherFrontierGuard
+  encryptionKeys:
+  - EncryptionKeyService
+  - EncryptionKeySecurity
+
 
 - type: chameleonOutfit
   id: SecurityGuardChameleonOutfit

--- a/Resources/Prototypes/_NF/Roles/Jobs/Frontier/stc.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Frontier/stc.yml
@@ -36,10 +36,10 @@
     back:
     - Flash
     - RubberStampStc
-    - EncryptionKeyStationMaster
+    - BoxFolderStc
     - ShipVoucherFrontierStc
   encryptionKeys:
-  - BoxFolderStc
+  - EncryptionKeyStationMaster
 
 - type: chameleonOutfit
   id: StationTrafficControllerChameleonOutfit

--- a/Resources/Prototypes/_NF/Roles/Jobs/Nfsd/brigmedic.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Nfsd/brigmedic.yml
@@ -36,11 +36,12 @@
     pocket1: NFWeaponPistolUniversalNfsdLessLethal
   storage:
     back:
-    - EncryptionKeyMedical
     - Flash
     - NFMagazineHighCapacityPistol35Overpressure
     - NFMagazineHighCapacityPistol35Rubber
     - FrontierUplinkCoin10
+  encryptionKeys:
+  - EncryptionKeyMedical
 
 - type: chameleonOutfit
   id: BrigmedicChameleonOutfit

--- a/Resources/Prototypes/_NF/Roles/Jobs/Nfsd/nfdetective.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Nfsd/nfdetective.yml
@@ -43,9 +43,10 @@
     - ForensicPad
     - ForensicScanner
     - FrontierUplinkCoin10
-    - LogProbeCartridge
     - RubberStampDetective
     - ContrabandForensicsModule
+  cartridges:
+  - LogProbeCartridge
 
 - type: chameleonOutfit
   id: NFDetectiveChameleonOutfit

--- a/Resources/Prototypes/_NF/Roles/Jobs/Service/mail_carrier.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Service/mail_carrier.yml
@@ -36,10 +36,12 @@
     belt: NFMailBag
   storage:
     back:
-    - EncryptionKeyService # Frontier
     - HandheldCrewMonitor # Frontier
     - ShipVoucherFrontierMailCarrier # Frontier
-    - MailMetricsCartridge # Frontier
+  encryptionKeys:
+  - EncryptionKeyService
+  cartridges:
+  - MailMetricsCartridge
 
 - type: chameleonOutfit
   id: MailCarrierChameleonOutfit


### PR DESCRIPTION
## About the PR
A few jobs still had radio keys and cartridges in their bags. This fixes that.

## Why / Balance
QoL. Pairable with #3893.

## Technical details
YML changes.

## How to test
- Join as job that previously had a key or cartridge in backpack.
  - Most Frontier jobs were guilty of this.
- Look inside.
- No key/cartridge.
- Look at headset/PDA.
- Rejoice in saving a whole 10 seconds of your 4-hour shift to pre-installation QoL.

## Media
<img width="140" height="52" alt="image" src="https://github.com/user-attachments/assets/248e5d9c-0395-4649-99f5-0f225e1ccd6d" />

## Requirements
- [x] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

**Changelog**
:cl:
- fix: Jobs that did not auto-install encryption keys or PDA cartridges now do so
