### PR TITLE
Add greeting key to PTech

### DIFF
--- a/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/cart.yml
+++ b/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/cart.yml
@@ -23,6 +23,7 @@
     HandLabeler: 4294967295 #Infinite
     BrbSign: 4294967295 #Infinite
     DeskBell: 4294967295 #Infinite
+    EncryptionKeyGreeting: 4294967295 #Infinite
     EncryptionKeySecurity: 4294967295 #Infinite
     EncryptionKeyService: 4294967295 #Infinite
     EncryptionKeyNfsd: 5


### PR DESCRIPTION
## About the PR
https://discord.com/channels/1123826877245694004/1416880968962146455
Title. Pairs well with #3896.

## Why / Balance
Something the SR or another Frontier Command member can hand out for people to communicate with new players. Or to hand out directly to new players, given it's otherwise a valet exclusive.

## Technical details
A single line of YML. Not everything's gotta be novel.

## How to test
- Find or spawn the SR's PTech.
- View inventory.
- Greeting key.
- Buy.
- Congratulations, you now have one (1) Greeting key.

## Media
N/A

## Requirements
- [x] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

**Changelog**
:cl:
- add: Encryption keys for the Greeting radio channel have been added to the Station Representative's PTech.