### PR TITLE
Readds Truncheon to research

### DIFF
--- a/Resources/Prototypes/_NF/Recipes/Lathes/Packs/blueprints.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/Packs/blueprints.yml
@@ -472,6 +472,7 @@
   - NFAmmunitionBoxBigRifle30Overpressure
   # NFAdvancedRiotControl
   - NFTelescopicShield
+  - NFTruncheon
   # NFExplosiveTechnology
   - SignallerAdvanced
   - SignalTrigger

--- a/Resources/Prototypes/_NF/Research/techtree.yml
+++ b/Resources/Prototypes/_NF/Research/techtree.yml
@@ -1740,6 +1740,7 @@
   cost: 8000
   recipeUnlocks:
   - NFTelescopicShield
+  - NFTruncheon
   technologyPrerequisites:
   - NFBountyHunting
   position: 2, 42


### PR DESCRIPTION
Harmbaton is back

## About the PR
Re-adds the Truncheon into the tech tree
## Why / Balance

Variety in melee weapons, primarily, might somehow lead to some interesting plays with the stamina damage on exped mobs.

## Technical details
Added NFTruncheon to two files


## How to test
research the advanced riot control tech (which already had the image of the truncheon on it funnily enough.

## Media
<img width="443" height="143" alt="image" src="https://github.com/user-attachments/assets/312490ed-cd0d-462f-875a-297c659b7ceb" />
## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes
**Changelog**

:cl:
- add: Re added the Trunheon to the tech tree.
