### PR TITLE
Re adds Exploding Payload to research

### DIFF
--- a/Resources/Prototypes/_NF/Recipes/Lathes/Packs/blueprints.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/Packs/blueprints.yml
@@ -479,6 +479,7 @@
   - TimerTrigger
   - FlashPayload
   - ChemicalPayload
+  - ExplosivePayload
   # NFBasicShuttleArmament
   - PowerCageRechargerCircuitboard
   - PowerCageSmall

--- a/Resources/Prototypes/_NF/Research/techtree.yml
+++ b/Resources/Prototypes/_NF/Research/techtree.yml
@@ -1806,6 +1806,7 @@
   - TimerTrigger
   - FlashPayload
   - ChemicalPayload
+  - ExplosivePayload
   technologyPrerequisites:
   - NFAdvancedRiotControl
   position: 3, 41


### PR DESCRIPTION


## About the PR
Re added the exploding payload to research
## Why / Balance
If people can make explosions with the chemical payload to begin with, I don't see the reason  to stop em from using actual grenades on UIV/expeds/VGroids.

## Technical details

Added ExplosivePayload to two files
## How to test
Do the research, print the payload, enjoy your newfound explosive delights.

## Medias, etc).
<img width="421" height="106" alt="image" src="https://github.com/user-attachments/assets/cd4bf91b-aaa1-41e3-b01b-8639ebac97b9" />

## Requirements

- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes
None I can see
**Changelog**
:cl:
- add: Re added the Explosive Payload to research