### PR TITLE
Re adds Disabler SMG to research

### DIFF
--- a/Resources/Prototypes/_NF/Recipes/Lathes/Packs/blueprints.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/Packs/blueprints.yml
@@ -472,6 +472,7 @@
   - NFAmmunitionBoxBigRifle30Overpressure
   # NFAdvancedRiotControl
   - NFTelescopicShield
+  - NFWeaponEnergySubMachineGunDisabler
   # NFExplosiveTechnology
   - SignallerAdvanced
   - SignalTrigger

--- a/Resources/Prototypes/_NF/Research/techtree.yml
+++ b/Resources/Prototypes/_NF/Research/techtree.yml
@@ -1740,6 +1740,7 @@
   cost: 8000
   recipeUnlocks:
   - NFTelescopicShield
+  - NFWeaponEnergySubMachineGunDisabler
   technologyPrerequisites:
   - NFBountyHunting
   position: 2, 42


### PR DESCRIPTION


## About the PR
Re adds the Disabler SMG to research (why was this removed? purely QoL upgrade from the pistol to me)
## Why / Balance
upgrade from the disabler pistol to the disabler SMG, less clicking needed, faster firing, more ammo, what's not to like.
Not sure why it was removed to begin with
## Technical details
Added the NFEnergySubmachineGunDisabler to two files.


## How to test

Do the research, print your gun, go stun someone with it.
## Media
<img width="393" height="168" alt="image" src="https://github.com/user-attachments/assets/1ce7f18d-6128-43b7-a052-8fe4fa1df489" />


## Requirements

- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes
I did not notice anything,
**Changelog**

:cl:
- add: Re Added the Disabler SMG to research
