### PR TITLE
NFSD/Pirate Bike changes

### DIFF
--- a/Resources/Prototypes/_NF/Catalog/pirate_uplink_catalog.yml
+++ b/Resources/Prototypes/_NF/Catalog/pirate_uplink_catalog.yml
@@ -126,7 +126,7 @@
   productEntity: VehicleHoverbikePirateKey
   icon: { sprite: _NF/Objects/Vehicles/hoverbike.rsi, state: keys }
   cost:
-    Doubloon: 10
+    Doubloon: 5
   categories:
     - UplinkPirateUtility
   conditions:

--- a/Resources/Prototypes/_NF/Catalog/security_uplink_catalog.yml
+++ b/Resources/Prototypes/_NF/Catalog/security_uplink_catalog.yml
@@ -1056,7 +1056,7 @@
   productEntity: HoverbikeNfsdFlatpack
   icon: { sprite: _NF/Objects/Vehicles/hoverbike.rsi, state: vehicle }
   cost:
-    FrontierUplinkCoin: 3
+    FrontierUplinkCoin: 5
   categories:
     - UplinkSecurityUtility
   conditions:


### PR DESCRIPTION

## About the PR
Changed the prices of the NFSD and Pirate hoverbikes

## Why / Balance
Hoverbikes are a massive advantage in combat, functioning as a jetpack with unlimited fuel, storage space, and speedboots all at once, I've frequently seen them used in combat against AI to just completely negate any threat the AI might pose, so gonna make em slightly more expensive for NFSD and cheaper for pirates (they were 10 DB for some reason)

## Technical details
Number value changes in uplink files

## How to test
spawn as NFSD, check uplink, your bike is more expensive
spawn as pirate, your bike is cheaper.
## Media
<img width="82" height="169" alt="image" src="https://github.com/user-attachments/assets/8713a96e-1415-499c-b33e-d3f994a0d23d" />

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes
None I could see
**Changelog**
:cl:
- tweak: The NFSD and Pirate hoverbikes cost 5 FUC/DB per unit.