### PR TITLE
Non-departmental blueprints

### DIFF
--- a/Resources/Locale/en-US/_NF/research/technologies.ftl
+++ b/Resources/Locale/en-US/_NF/research/technologies.ftl
@@ -1,3 +1,4 @@
+nf-research-discipline-all = All Available
 nf-research-discipline-engineering = Engineering
 nf-research-discipline-medical = Medical
 nf-research-discipline-arsenal-mercenary = Mercenary

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -241,11 +241,7 @@
     whitelist:
       tags:
       - NFBlueprintProtolathe
-  - type: ContainerContainer
-    containers:
-      machine_board: !type:Container
-      machine_parts: !type:Container
-      blueprint: !type:Container
+      - NFBlueprintAdvanced
   # End Frontier: accept blueprints
 
 - type: entity
@@ -496,6 +492,7 @@
       whitelist: # Frontier
         tags: # Frontier
         - NFBlueprintMercenaryTechfab # Frontier
+        - NFBlueprintAdvanced # Frontier
 
 - type: entity
   id: MedicalTechFab
@@ -542,6 +539,7 @@
     whitelist: # Frontier
       tags: # Frontier
       - NFBlueprintMedicalTechfab # Frontier
+      - NFBlueprintAdvanced # Frontier
 
 - type: entity
   parent: BaseLathe

--- a/Resources/Prototypes/_NF/Entities/Objects/Tools/blueprints/blueprints_base.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Tools/blueprints/blueprints_base.yml
@@ -93,7 +93,7 @@
   parent: NFBaseBlueprint
   id: NFBaseBlueprintFaxable
   name: blueprint
-  description: A blueprint with schematics on it. It can be inserted into an autolathe or sent via fax.
+  description: A blueprint with schematics on it. It can be inserted into a protolathe or techfab, or sent via fax.
   abstract: true
   components:
   - type: FaxableObject
@@ -125,12 +125,50 @@
         color: "#636363"
       - state: inhand-right-text
 
+# region General
+- type: entity
+  parent: NFBaseBlueprintFaxable
+  id: NFBlueprintGeneral
+  name: blueprint
+  description: A blueprint with schematics on it. It can be inserted into a protolathe or techfab, or sent via fax.
+  categories: [HideSpawnMenu, DoNotMap]
+  components:
+  - type: Sprite
+    layers:
+      - state: icon-base
+        color: "#3355ff"
+      - state: icon-text
+      - sprite: Objects/Misc/bureaucracy.rsi
+        state: paper_stamp-generic
+        offset: 0.15,-0.1
+        map: ["enum.PaperVisualLayers.Stamp"]
+        visible: false
+      - sprite: Objects/Misc/bureaucracy.rsi
+        state: paper_words
+        map: ["enum.PaperVisualLayers.Writing"]
+        visible: false
+  - type: Item
+    inhandVisuals:
+      left:
+      - state: inhand-left-base
+        color: "#3355ff"
+      - state: inhand-left-text
+      right:
+      - state: inhand-right-base
+        color: "#3355ff"
+      - state: inhand-right-text
+  - type: Tag
+    tags:
+    - NFBlueprintAdvanced
+    - Document
+    - Paper
+
 # region Engineering
 - type: entity
   parent: NFBaseBlueprintFaxable
   id: NFBlueprintEngineering
   name: engineering blueprint
-  description: A blueprint with engineering schematics on it. It can be inserted into an engineering techfab or sent via fax.
+  description: A blueprint with engineering schematics on it. It can be inserted into a protolathe or techfab, or sent via fax.
   categories: [HideSpawnMenu, DoNotMap]
   components:
   - type: Sprite
@@ -160,6 +198,7 @@
   - type: Tag
     tags:
     - NFBlueprintEngineeringTechfab
+    - NFBlueprintAdvanced
     - Document
     - Paper
 
@@ -168,7 +207,7 @@
   parent: NFBaseBlueprintFaxable
   id: NFBlueprintSalvage
   name: salvage blueprint
-  description: A blueprint with salvage schematics on it. It can be inserted into a salvage techfab or sent via fax.
+  description: A blueprint with salvage schematics on it. It can be inserted into a protolathe or techfab, or sent via fax.
   categories: [HideSpawnMenu, DoNotMap]
   components:
   - type: Sprite
@@ -198,6 +237,7 @@
   - type: Tag
     tags:
     - NFBlueprintSalvageTechfab
+    - NFBlueprintAdvanced
     - Document
     - Paper
 
@@ -206,7 +246,7 @@
   parent: NFBaseBlueprintFaxable
   id: NFBlueprintScience
   name: science blueprint
-  description: A blueprint with science schematics on it. It can be inserted into a protolathe or sent via fax.
+  description: A blueprint with science schematics on it. It can be inserted into a protolathe or techfab, or sent via fax.
   categories: [HideSpawnMenu, DoNotMap]
   components:
   - type: Sprite
@@ -236,6 +276,7 @@
   - type: Tag
     tags:
     - NFBlueprintProtolathe
+    - NFBlueprintAdvanced
     - Document
     - Paper
 
@@ -244,7 +285,7 @@
   parent: NFBaseBlueprintFaxable
   id: NFBlueprintService
   name: service blueprint
-  description: A blueprint with service schematics on it. It can be inserted into a service techfab or sent via fax.
+  description: A blueprint with service schematics on it. It can be inserted into a protolathe or techfab, or sent via fax.
   categories: [HideSpawnMenu, DoNotMap]
   components:
   - type: Sprite
@@ -274,6 +315,7 @@
   - type: Tag
     tags:
     - NFBlueprintServiceTechfab
+    - NFBlueprintAdvanced
     - Document
     - Paper
 
@@ -282,7 +324,7 @@
   parent: NFBaseBlueprintFaxable
   id: NFBlueprintMedical
   name: medical blueprint
-  description: A blueprint with medical schematics on it. It can be inserted into a medical techfab or sent via fax.
+  description: A blueprint with medical schematics on it. It can be inserted into a protolathe or techfab, or sent via fax.
   categories: [HideSpawnMenu, DoNotMap]
   components:
   - type: Sprite
@@ -312,6 +354,7 @@
   - type: Tag
     tags:
     - NFBlueprintMedicalTechfab
+    - NFBlueprintAdvanced
     - Document
     - Paper
 
@@ -320,7 +363,7 @@
   parent: NFBaseBlueprintFaxable
   id: NFBlueprintArsenalMercenary
   name: combat blueprint
-  description: A blueprint with combat schematics on it. It can be inserted into an NFSD or mercenary techfab or sent via fax.
+  description: A blueprint with combat schematics on it. It can be inserted into a protolathe or techfab, or sent via fax.
   categories: [HideSpawnMenu, DoNotMap]
   components:
   - type: Sprite
@@ -350,6 +393,7 @@
   - type: Tag
     tags:
     - NFBlueprintMercenaryTechfab
+    - NFBlueprintAdvanced
     - Document
     - Paper
 
@@ -357,7 +401,7 @@
   parent: NFBaseBlueprintFaxable
   id: NFBlueprintArsenalNfsd
   name: restricted combat blueprint
-  description: A blueprint with combat schematics on it. It can be inserted into an NFSD techfab or sent via fax.
+  description: A blueprint with combat schematics on it. It can be inserted into a protolathe or techfab, or sent via fax.
   categories: [HideSpawnMenu, DoNotMap]
   components:
   - type: Sprite
@@ -387,6 +431,7 @@
   - type: Tag
     tags:
     - NFBlueprintNfsdTechfab
+    - NFBlueprintAdvanced
     - Document
     - Paper
 
@@ -441,6 +486,7 @@
   - type: Tag
     tags:
     - NFBlueprintSalvageTechfab
+    - NFBlueprintAdvanced
     - Document
     - Paper
 
@@ -480,5 +526,6 @@
     tags:
     - NFBlueprintMercenaryTechfab
     - NFBlueprintNfsdTechfab
+    - NFBlueprintAdvanced
     - Document
     - Paper

--- a/Resources/Prototypes/_NF/Entities/Objects/Tools/blueprints/blueprints_expedition_loot.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Tools/blueprints/blueprints_expedition_loot.yml
@@ -4,7 +4,7 @@
   parent: NFBaseBlueprintExpeditionArmory
   id: NFBlueprintWeaponLaserCannon
   name: laser cannon blueprint
-  description: A blueprint with a schematic of a laser cannon. It can be inserted into a mercenary or NFSD techfab.
+  description: A blueprint with a schematic of a laser cannon. It can be inserted into a protolathe or techfab.
   components:
   - type: Blueprint
     providedRecipes:
@@ -14,7 +14,7 @@
   parent: NFBaseBlueprintExpeditionArmory
   id: NFBlueprintWeaponXrayCannon
   name: x-ray cannon blueprint
-  description: A blueprint with a schematic of an x-ray cannon. It can be inserted into a mercenary or NFSD techfab.
+  description: A blueprint with a schematic of an x-ray cannon. It can be inserted into a protolathe or techfab.
   components:
   - type: Blueprint
     providedRecipes:
@@ -24,7 +24,7 @@
   parent: NFBaseBlueprintExpeditionArmory
   id: NFBlueprintWeaponTemperatureGun
   name: temperature gun blueprint
-  description: A blueprint with a schematic of a temperature gun. It can be inserted into a mercenary or NFSD techfab.
+  description: A blueprint with a schematic of a temperature gun. It can be inserted into a protolathe or techfab.
   components:
   - type: Blueprint
     providedRecipes:
@@ -36,7 +36,7 @@
   parent: NFBaseBlueprintExpeditionSalvage
   id: NFBlueprintEnergyPickaxe
   name: holopickaxe blueprint
-  description: A blueprint with a schematic of a holopickaxe. It can be inserted into a salvage techfab.
+  description: A blueprint with a schematic of a holopickaxe. It can be inserted into a protolathe or techfab.
   components:
   - type: Blueprint
     providedRecipes:

--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/lathe.yml
@@ -6,6 +6,7 @@
     whitelist:
       tags:
       - BlueprintAutolathe
+      - NFBlueprintAdvanced
   - type: ContainerContainer
     containers:
       machine_board: !type:Container
@@ -51,6 +52,7 @@
     whitelist:
       tags:
       - NFBlueprintServiceTechfab
+      - NFBlueprintAdvanced
   - type: OreSiloClient
 
 - type: entity
@@ -112,6 +114,7 @@
     whitelist:
       tags:
       - NFBlueprintEngineeringTechfab
+      - NFBlueprintAdvanced
   - type: OreSiloClient
 
 - type: entity
@@ -148,6 +151,7 @@
     whitelist:
       tags:
       - NFBlueprintSalvageTechfab
+      - NFBlueprintAdvanced
   - type: OreSiloClient
 
 - type: entity
@@ -184,6 +188,7 @@
     whitelist:
       tags:
       - NFBlueprintNfsdTechfab
+      - NFBlueprintAdvanced
   - type: OreSiloClient
 
 - type: entity
@@ -218,6 +223,7 @@
     whitelist:
       tags:
       - NFBlueprintMercenaryTechfab
+      - NFBlueprintAdvanced
   - type: OreSiloClient
 
 - type: entity
@@ -266,6 +272,7 @@
       tags:
       - NFBlueprintMercenaryTechfab
       - NFBlueprintNfsdTechfab
+      - NFBlueprintAdvanced
   - type: OreSiloClient
 
 - type: entity

--- a/Resources/Prototypes/_NF/Research/blueprints.yml
+++ b/Resources/Prototypes/_NF/Research/blueprints.yml
@@ -1,4 +1,20 @@
 - type: blueprint
+  id: NFAllResearchable
+  name: nf-research-discipline-all
+  blueprint: NFBlueprintGeneral
+  packs:
+  - NFBlueprintsCommon
+  - NFBlueprintsEngineering
+  - NFBlueprintsEngineeringScience
+  - NFBlueprintsMedical
+  - NFBlueprintsMercenary
+  - NFBlueprintsMercenaryNfsd
+  - NFBlueprintsNfsd
+  - NFBlueprintsSalvage
+  - NFBlueprintsScience
+  - NFBlueprintsService
+
+- type: blueprint
   id: NFEngineering
   name: nf-research-discipline-engineering
   blueprint: NFBlueprintEngineering

--- a/Resources/Prototypes/_NF/tags.yml
+++ b/Resources/Prototypes/_NF/tags.yml
@@ -169,6 +169,12 @@
   id: NFHotdog
 
 # region Blueprints
+
+# Used for blueprints that are "too advanced" to be used with an autolathe.
+# Requires a techfab or protolathe.
+- type: Tag
+  id: NFBlueprintAdvanced
+
 - type: Tag
   id: NFBlueprintMedicalTechfab
 


### PR DESCRIPTION
## About the PR
Makes all blueprints non-departmental. This means any blueprint can be inserted into any protolathe or techfab. Note that autolathes _can't_ accept most blueprints, due to being "too basic" (or whatever).

## Why / Balance
Frontier's blueprint system was introduced in #2114. In the year (almost to the day, wow!) since it was introduced, blueprints have been mostly a blessing. They are a pretty cool QoL thing for scientists, especially after we disabled cross-grid server linking. We've made many improvements since, including material cost and other things.

In #3196, blueprints were made _departmental_. This means you can only insert service blueprints into a service techfab, engineering blueprints into an engineering techfab, and so on. While this may seem okay on the surface, it has had an unfortunate effect: it has basically killed blueprint trading. We've essentially made it impossible to grow _laterally_: that is, you can't easily upgrade to a discipline outside of what your ship is capable of by default. Unless you loot a new techfab from a dungeon, you ain't printing that sweet combat blueprint you found. This also means scientists _can't sell you_ blueprints for anything but your chosen profession, nor can they manufacture half the things they can unlock.

On top of that, the random blueprints you get from the scrap processor are generally unusable on the ships that acquire them. It's meant to encourage player trade, but in reality just feels limiting. The situation is exacerbated by the fact several disciplines have common recipes. If I've just received a science blueprint with super parts, why can't I put that in my engineering techfab? Why does it have to be an engineering blueprint specifically?

This PR makes _all_ blueprints non-departmental. Even restricted combat blueprints and NFSD blueprints. If you can find or make a blueprint for it, you can use it in any protolathe or techfab. Yes, you can get your service techfab to print guns and ammo if you want to!

The various departmental colours are *retained*. This way we can have themed blueprints in dungeons: if you see a "service blueprint", you can be assured it'll have service-related recipes. This prevents dungeon blueprints from becoming a hodge-podge mess of arbitrary nonsense. They can still be inserted into any lathe. The blueprint lithograph can also still print departmental-style blueprints, for roleplay or whatever. They can still be inserted into any lathe.

## Technical details
The blueprint lithograph system is *complicated as fuck*. To keep this PR simple and hopefully reduce maintenance burden on downstreams, I've made the following changes:

- Add a new tag, `NFBlueprintAdvanced`, for blueprints that are "too advanced" to go in a protolathe.
- Add the tag `NFBlueprintAdvanced` to all blueprints.
- Add the tag `NFBlueprintAdvanced` to the protolathe and all techfabs.
- Add a new blueprint prototype called "All Available", which, as the name suggests, contains all available blueprints.
- Add a new blueprint entity called "blueprint", which is blue. This is a generic blueprint, more generic than upstream's blue blueprint print blue.

For downstreams that wish to limit blueprints by department, remove `NFBlueprintAdvanced` from either the lathe or the blueprint that you want to limit. The previous departmental assignment is *retained* explicitly to support this use case.

### Known bugs
The many blueprint prototypes sometimes have common recipes. When selecting "All Available", you can sometimes get duplicated items like this:
<img width="388" height="693" alt="image" src="https://github.com/user-attachments/assets/facde88b-5d19-40c5-a4af-e05f0105d2f2" />

This will have to be fixed by either creating new blueprint prototypes for each recipe that can appear in multiple packs, thus de-duplicating, or by performing de-duplication in the UI somewhere. This PR does neither.

## How to test
1. Make sure you have an R&D server and console.
2. Spawn yourself a debug point disk.
3. Unlock whatever you want, go nuts! Yes, it takes an awfully long time to click.
4. Give yourself a blueprint lithograph and put some paper (material) in it. Link with the server.
5. Make sure there's an "All Available" category (may not be selected initially). Select it.
6. Choose some recipes, print a blueprint. Behold its beautiful blueness.
7. Repeat with other disciplines as desired.
8. Inspect the blueprints, observe that the description makes it clear they can be used anywhere.
9. Spawn a holopickaxe blueprint. Hell, laser cannon and x-ray cannon too! They, too, can be inserted wherever.
10. Insert your blueprints wherever. Experiment with the different techfabs, and the protolathe. Oh boy, there's a lot!

## Media
<img width="420" height="351" alt="image" src="https://github.com/user-attachments/assets/e55a6498-803a-4fb0-8cd7-6ea9952ce11c" />
<img width="425" height="353" alt="image" src="https://github.com/user-attachments/assets/5e00f9d7-e38f-4ba1-b845-df71679be149" />
<img width="403" height="310" alt="image" src="https://github.com/user-attachments/assets/9bcf54dc-cb26-40fe-8902-5f4889498e28" />

Inserting a restricted combat blueprint into a service techfab:
<img width="523" height="247" alt="image" src="https://github.com/user-attachments/assets/c1eb5fda-0007-4bcc-b68d-f399aa211fff" />
<img width="862" height="527" alt="image" src="https://github.com/user-attachments/assets/5cd86c25-f9ae-499f-81b8-1042778e29cb" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
- [ ] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [ ] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Yesn't.

**Changelog**
:cl:
- tweak: All blueprints can now be used in all techfabs and protolathes. No more departmental restrictions.