### PR TITLE
remove explosions from destroying a explosive payload (#38049)

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/payload.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/payload.yml
@@ -37,12 +37,6 @@
   - type: Destructible
     thresholds:
     - trigger:
-        !type:DamageTypeTrigger
-        damageType: Heat
-        damage: 25
-      behaviors:
-      - !type:ExplodeBehavior
-    - trigger:
         !type:DamageTrigger
         damage: 50
       behaviors:


### PR DESCRIPTION

## About the PR
Cherrypicks [Wizden 38049](https://github.com/space-wizards/space-station-14/pull/38049) by @KamTheSythe 

## Why / Balance
Maintainer discussion regarding #3918 

## Technical details
The author removed the explode interaction when taking 25 damage from explosive paylooads.

## How to test
stuff a toolbox full of exploding payloads and a single exploding grenade

watch how the explosion is around the size of a single grenade

## Media
<img width="435" height="383" alt="image" src="https://github.com/user-attachments/assets/91e5b008-3b46-4675-8f14-138a2d857202" />
One explosive grenade + 2 payloads was in that box

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

**Changelog**
:cl:
- tweak: Exploding payloads no longer chain off one another 
