### PR TITLE
Modular grenades require a full grenade to explode

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -333,7 +333,6 @@
         !type:DamageTrigger
         damage: 50
       behaviors:
-      - !type:TriggerBehavior
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
   - type: Appearance


### PR DESCRIPTION
Thanks for the assistance @arimah 
## About the PR
Modular grenades no longer trigger their effects on taking enough damage.
## Why / Balance
Maintainer discussion regarding #3918 and concerns of "Backpack explosives" like upstream has

## Technical details

Removed TriggerBehavior from mod.grenades

## How to test
put two modular grenades next to each other
detonate one, notice how only one grenade's worth of explosion went off.

## Media
<img width="1024" height="208" alt="image" src="https://github.com/user-attachments/assets/40f18036-b4da-4ca5-8f82-7eebaaff4e09" />


## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes
I couldn't see any, but sanity check's are always nice
**Changelog**
:cl:
- remove: Modular Grenades no longer activate their effects when taking enough damage.