### PR TITLE
Remove sleep on SSD.

### DIFF
--- a/Content.Shared/CCVar/CCVars.Ic.cs
+++ b/Content.Shared/CCVar/CCVars.Ic.cs
@@ -75,7 +75,7 @@ public sealed partial class CCVars
     ///     Forces SSD characters to sleep after ICSSDSleepTime seconds
     /// </summary>
     public static readonly CVarDef<bool> ICSSDSleep =
-        CVarDef.Create("ic.ssd_sleep", true, CVar.SERVER);
+        CVarDef.Create("ic.ssd_sleep", false, CVar.SERVER); // Frontier: true < false
 
     /// <summary>
     ///     Time between character getting SSD status and falling asleep


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Toggles the CVAR that puts humanoids to sleep after 10 minutes.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

https://github.com/user-attachments/assets/d2e7ddd1-c3e9-464d-b37e-f1e855033974

Unlike upstream, we have large amounts of humanoid NPCs that fall victim to this CVAR, falling asleep and dropping weapons 10 minutes after spawn. I was planning on just fixing this behavior, but this is one in a series of bugs introduced by the sleeping timer that we keep having to track down. I don't think the juice is worth the squeeze here. Snoring SSD players are cute, but not worth this much dev time.

## Technical details
<!-- Summary of code changes for easier review. -->
CVAR

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
Make a humanoid NPC, wait ten minutes and see them still functioning.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
None.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
None.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
- remove: Humanoids no longer fall asleep after being SSD.
