### PR TITLE
 Fix observing on roundstart causing an invisible respawn timer

### DIFF
--- a/Content.Server/_Corvax/Respawn/RespawnSystem.cs
+++ b/Content.Server/_Corvax/Respawn/RespawnSystem.cs
@@ -14,7 +14,7 @@ using Robust.Shared.Player; // Frontier
 using Content.Shared.Ghost; // Frontier
 using Content.Server.Administration.Managers; // Frontier
 using Content.Server.Administration; // Frontier
-using Content.Shared.GameTicking; // Frontier
+using Content.Server.GameTicking.Events; // Frontier
 using Content.Shared._NF.Roles.Components; // Frontier
 
 namespace Content.Server._Corvax.Respawn;
@@ -46,7 +46,7 @@ public sealed class RespawnSystem : EntitySystem
         SubscribeLocalEvent<MindContainerComponent, MindRemovedMessage>(OnMindRemoved);
         SubscribeLocalEvent<MindContainerComponent, CryosleepBeforeMindRemovedEvent>(OnCryoBeforeMindRemoved);
         SubscribeLocalEvent<MindContainerComponent, CryosleepWakeUpEvent>(OnCryoWakeUp);
-        SubscribeLocalEvent<RoundRestartCleanupEvent>(OnRoundRestart); // Frontier
+        SubscribeLocalEvent<RoundStartingEvent>(OnRoundStart); // Frontier
 
         _admin.OnPermsChanged += OnAdminPermsChanged; // Frontier
         _player.PlayerStatusChanged += PlayerStatusChanged; // Frontier
@@ -193,7 +193,7 @@ public sealed class RespawnSystem : EntitySystem
     }
 
     // Frontier: reset game state, we have a new round.
-    private void OnRoundRestart(RoundRestartCleanupEvent ev)
+    private void OnRoundStart(RoundStartingEvent ev)
     {
         _respawnInfo.Clear();
     }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Moved the OnRoundRestart trigger in RespawnSystem to OnRoundStart to beat a race condition. This allows ghosts to respawn properly at roundstart.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This is a bug that really annoys people that want to observe at roundstart.

## Technical details
<!-- Summary of code changes for easier review. -->
A respawn timer was being applied to players at roundstart because the OnRoundRestart event in RespawnSystem was triggering before the server wiped all mob minds. The wiping of mob minds triggered OnMindRemoval in the RespawnSystem, causing the server to treat the mob as if they had died. By moving the respawn clear to the next round start, it breaks the race condition and causes the respawn to (mostly) reset properly. At the least, it will not cause a respawn timer if the player did not have one.

If a player had a respawn timer at the end of the previous round, it will persist. I don't know why this happens, but it appears to be a separate existing issue that was hidden by the one fixed here. I will look to fix this as well, but I have no idea why it is happening as-is, since the data should be clear.

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
Start a test server with two clients, one admin and one deadmin'd. Start the round and spawn the player as a mob, then restart the round. Start the new round, and the player will be able to observe without having a respawn timer forced on them. If they had a respawn timer at the end of last round, it will persist.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
No breaking changes.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Observing at roundstart will no longer force a respawn timer. This is a partial fix however, as a separate bug will cause you to have a respawn timer if you were dead with one at the end of the last round.
