### PR TITLE
Tightened shotgun spread

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
@@ -106,7 +106,7 @@
   components:
   - type: ProjectileSpread
     count: 7 # eight(?) total, includes the spread as a bullet
-    spread: 10
+    spread: 7.5
 
 - type: entity
   categories: [ HideSpawnMenu ]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Reduced the pellet spread of shotgun shells to bring the weapon in line with the numbers declared in this [PR](https://github.com/new-frontiers-14/frontier-station-14/pull/3938)

## Why / Balance
Small adjustment I forgot to make in previous PR

## Technical details
yml

## How to test
1. Spawn in devenv, navigate to shooting range, grab a shotgun, shoot.
2. At least 5 out of 7 pellets should be within 11th tile.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:
- tweak: Reduced the pellet spread of shotgun shells.
