### PR TITLE
Erroneous Information in Anomalous Research entry(Alt: Guidebook Still Clowning)

### DIFF
--- a/Resources/ServerInfo/Guidebook/Science/AnomalousResearch.xml
+++ b/Resources/ServerInfo/Guidebook/Science/AnomalousResearch.xml
@@ -16,7 +16,7 @@ Scanners, vessels, and A.P.E.s are all used in the containment and observation o
 <GuideEntityEmbed Entity="MachineAnomalyGenerator"/>
 </Box>
 
-The anomaly generator can produce a random anomaly somewhere on the station at the cost of bananium.
+The anomaly generator can produce a random anomaly somewhere on the station at the cost of anomalite.
 
 ## Anomalies
 Anomalies are static objects that appear on the station. They cannot be moved, and must be worked around, no matter their location.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Guidebook entry to anomalous research still states it uses bananium and someone mentioned it

## Why / Balance
Yet More Slip Ups For Newer Players

## Technical details
Removed bananium
added anomalite

## How to test
Open guidebook
Open Science dropdown
Open anomalous research section
Enjoy

## Media


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
If this breaks anything I don't think I'll be the only one surprised

**Changelog**
:cl:
fix: Guidebook for Anomalous Research has been updated to state anomalite and not bananium.
