### PR TITLE
Silly Assault Specialist Has the Right INFO!

### DIFF
--- a/Resources/ServerInfo/_NF/Guidebook/MobsHostileExpedition/mercenaries.xml
+++ b/Resources/ServerInfo/_NF/Guidebook/MobsHostileExpedition/mercenaries.xml
@@ -104,9 +104,9 @@
   </Box>
   - [bold][color=#a4885c]Health thresholds:[/color][/bold] 100 (crit), 130 (death)
   - [bold][color=#a4885c]Run (walk) speed:[/color][/bold] 4.5 m/s (2.5 m/s)
-  - [bold][color=#a4885c]Damage (type):[/color][/bold] 14 [color=orange]Heat[/color] (retro laser pistol); 5 [color=red]Blunt[/color], 5 [color=red]Slash[/color], 5 [color=yellow]Piercing[/color] (circular saw)
+  - [bold][color=#a4885c]Damage (type):[/color][/bold] 15 [color=yellow]Piercing[/color] (.30 round)
   - [bold][color=#a4885c]Damage resistances:[/color][/bold] [color=red]Blunt[/color], [color=red]Slash[/color] and [color=yellow]Piercing[/color] 25%; [color=orange]Heat[/color] 20%; [color=orange]Caustic[/color] 10%
-  - [bold][color=#a4885c]Special abilities:[/color][/bold] Shooter (retro laser pistol)
+  - [bold][color=#a4885c]Special abilities:[/color][/bold] Shooter (Gestio)
   
   [bold][color=#a4885c]________________________________________________________________________[/color]
   


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Took me forever to find this. Expedition entry for the Assault Specialist in the mercenary section was CONFUSINGLY a copy/paste of the MEDIC. my brother, you aren't using a retro laser or a circular saw, that is a rifle

## Why / Balance
It was wrong, that's why.

## Technical details
Removed the copied part and matched the color to the colors for the other shooters.
RESISTANCE INFORMATION WAS NOT FOUND IN MY SEARCH if this needs updated PLEASE tell me if you have the numbers. I am clueless

## How to test
Open Guidebook
Open Expeditions
Open Mercenaries
SCROOOOOOLL
Enjoy

## Media


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes


**Changelog**
:cl:
fix: Guidebook entry for one of the mercenary mobs was very very wrong. It's fixed now. He now proudly uses his Gestio with finesse.
