### PR TITLE
Enforcer Crate Fix

### DIFF
--- a/Resources/Prototypes/_NF/Catalog/Fills/Crates/armory.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/Crates/armory.yml
@@ -40,7 +40,7 @@
   components:
   - type: StorageFill
     contents:
-      - id: NFWeaponShotgunKammererExpedition
+      - id: NFWeaponShotgunEnforcerExpedition
         amount: 2
       - id: NFAmmunitionBoxShellShotgunBuckshot
         amount: 3


### PR DESCRIPTION

## About the PR
Replaces the Kammerers in the Expedition Shotgun crate with Enforcers to match the crate's description
## Why / Balance
It's meant to have enforcers, it says so on the tin, it took me five minutes of spawning nothing but the spawner that crate can come in to get a shotgun crate, so I'd say RNG is pretty reasonable for it.

## Technical details
Replaced KammerExpedition with EnforcerExpedition.

## How to test
run the spawner [ Dungeon, Armory, Weapon] until the shotgun box rolls

## Media
<img width="407" height="161" alt="image" src="https://github.com/user-attachments/assets/afab44e3-6d39-4f19-9fd7-85efb1cbea3f" />

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

**Changelog**
:cl:
- fix: The Enforcer crate on expeditions now contains Enforcers

