### PR TITLE
Modified shotgun spread patterns

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -13,6 +13,8 @@
     sprite: Objects/Weapons/Guns/Shotguns/bulldog.rsi
   - type: Clothing
     sprite: Objects/Weapons/Guns/Shotguns/bulldog.rsi
+  - type: GunSpreadModifier
+    spread: 1.1
   - type: Gun
     selectedMode: FullAuto
     availableModes:
@@ -33,6 +35,8 @@
     sprite: Objects/Weapons/Guns/Shotguns/db_shotgun.rsi
   - type: Item
     sprite: Objects/Weapons/Guns/Shotguns/db_shotgun_inhands_64x.rsi
+  - type: GunSpreadModifier
+    spread: 0.5
   - type: BallisticAmmoProvider
     capacity: 2
   - type: Construction
@@ -70,6 +74,8 @@
     sprite: _NF/Objects/Weapons/Guns/Shotguns/pump.rsi
   - type: Item
     sprite: _NF/Objects/Weapons/Guns/Shotguns/pump_inhands_64x.rsi
+  - type: GunSpreadModifier
+    spread: 0.7
   - type: BallisticAmmoProvider
     capacity: 5
   - type: NFWeaponDetails
@@ -90,6 +96,8 @@
     size: Normal
     shape:
       - 0,0,2,1
+  - type: GunSpreadModifier
+    spread: 1.4
   - type: BallisticAmmoProvider
     capacity: 2
   - type: NFWeaponDetails
@@ -118,6 +126,8 @@
     sprite: Objects/Weapons/Guns/Shotguns/hm_pistol.rsi
   - type: Item
     size: Small
+  - type: GunSpreadModifier
+    spread: 1.5
   - type: BallisticAmmoProvider
     capacity: 1
   - type: NFWeaponDetails
@@ -148,6 +158,8 @@
     sprite: Objects/Weapons/Guns/Shotguns/blunderbuss.rsi
   - type: Item
     sprite: Objects/Weapons/Guns/Shotguns/blunderbuss.rsi
+  - type: GunSpreadModifier
+    spread: 1.1
   - type: BallisticAmmoProvider
     capacity: 1
   - type: NFWeaponDetails
@@ -166,6 +178,8 @@
     sprite: Objects/Weapons/Guns/Shotguns/improvised_shotgun.rsi
   - type: Item
     sprite: Objects/Weapons/Guns/Shotguns/improvised_shotgun_inhands_64x.rsi
+  - type: GunSpreadModifier
+    spread: 1.2
   - type: BallisticAmmoProvider
     capacity: 1
     proto: null


### PR DESCRIPTION
## About the PR
Adjusted shotgun spread patterns: double-barrel and Kammerer shotguns now have tighter spreads, while the Bulldog, sawn-off, blunderbuss, and improvised shotguns feature wider pellet dispersal.

**Lowered spread:**
- double-barrel: 50% reduction to pellet spread
- kammerer: 30% reduction to pellet spread

**Unchanged spread:**
- enforcer

**Increased spread:**
- bulldog, blunderbuss: 10% increase
- improvised shotgun: 20% increase
- sawn-off shotgun: 40% increase
- handmade pistol: 50% increase

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
yml

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:
- tweak: Adjusted shotgun spread patterns: double-barrel and Kammerer shotguns now have tighter spreads, while the Bulldog, sawn-off, blunderbuss, and improvised shotguns feature wider pellet dispersal.
