### PR TITLE
Lathe Archetype Pass - Engineering

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/lathe.yml
@@ -151,6 +151,7 @@
     - NFEngineeringStructureBoardsStatic
     - NFEngineeringMaterialsStatic
     - NFInflatablesStatic
+    - NFEngineeringArchetypeStatic
 
   - type: BlueprintReceiver
     whitelist:

--- a/Resources/Prototypes/_NF/Recipes/Lathes/Packs/engineering.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/Packs/engineering.yml
@@ -47,6 +47,7 @@
   - GasRecyclerMachineCircuitboard
   - PortableScrubberMachineCircuitBoard
   - ThermomachineFreezerMachineCircuitBoard
+  - CondenserMachineCircuitBoard
 
 - type: latheRecipePack
   id: NFEngineeringMaterialsStatic
@@ -59,11 +60,23 @@
   - NFSheetRUGlass1Processed
 
 - type: latheRecipePack
+  id: NFEngineeringArchetypeStatic
+  recipes:
+  - GasMiningDrillMachineCircuitboard
+  - GaslockFrameMachineCircuitboard
+  - RPED
+  - AdvancedCapacitorStockPart
+  - AdvancedMatterBinStockPart
+  - NanoManipulatorStockPart
+  - PowerDrill
+  - JawsOfLife
+  - BorgModuleRCD
+  - BorgModuleAdvancedTool
+
+- type: latheRecipePack
   id: NFEngineeringBoards
   recipes:
   - PortableGeneratorDKJrMachineCircuitboard
-  - GasMiningDrillMachineCircuitboard
-  - GaslockFrameMachineCircuitboard
 
 - type: latheRecipePack
   id: NFEngineering
@@ -74,10 +87,6 @@
   - ClothingBeltChiefEngineer
   - ClothingShoesBootsMag
   # - FireExtinguisherBluespace # Delta-V
-  - RPED
-  - AdvancedCapacitorStockPart
-  - AdvancedMatterBinStockPart
-  - NanoManipulatorStockPart
   - SuperCapacitorStockPart
   - SuperMatterBinStockPart
   - PicoManipulatorStockPart


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

I opted to begin with the engineering techfab as it would require the fewest number of novel parts to feel "complete".

The general theme for this lathe is one of being in a position to provide foundational upgrades.

The Engineering techfab is aimed at upgrades and providing foundational tools for gas mining systems to be provided. While I would have preferred a differentiated gas mining mining lathe to prevent the production of tools that aren't universally employed on gas mining shuttles that is not currently viewed as desired.

This PR makes the following changes to the engineering techfab.

- The gas condenser board is now added to the engineering board list.
- The gas mining drill and portable gaslock boards are now printable.
- The power drill and jaws of life can now be produced.
- The engineering techfab can now produce t2 parts by default. For basic upgrades. (Erhard suggestion which I find agreeable)
- The RPED can now be produced.
- The advanced engineering borg modules can now be produced.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

The Lathe Archetype Pass project is one in which we bring the lathes up to date to complete the vision initially set out with the archetype system. To provide specific lathes with tools that allow equipped shuttles to perform a specific task in a way that freed that shuttle up from some initial science hurdles while providing for an avenue of access for those tools through science/etc.

## Technical details
<!-- Summary of code changes for easier review. -->

Yaml

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->

Produce the listed components on an engineering techfab.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

🆑 
- tweak: Engineering techfab recipe list expanded to support its archetype.