### PR TITLE
Bluespace air tank fix

### DIFF
--- a/Resources/Prototypes/_NF/Research/techtree.yml
+++ b/Resources/Prototypes/_NF/Research/techtree.yml
@@ -1651,7 +1651,7 @@
   - BluespaceAirTank
   - SmallBluespaceAirTank
   technologyPrerequisites:
-  - NFPersonalPropulsion
+  - NFAdvancedPersonalPropulsion
   position: 3, 36
 # region Munitions
 


### PR DESCRIPTION

## About the PR
Fixes the bluespace air tank having the wrong prerequisite
## Why / Balance
YAMMEL strikes again, forgot a word in the research.

## Technical details
one word added in YML


<img width="617" height="245" alt="image" src="https://github.com/user-attachments/assets/f1bed1e2-8d9a-43df-94df-ceb2c24a076a" />

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

**Changelog**
:cl:
- fix: Fixed bluespace air tanks using the wrong prerequisite technology.