### PR TITLE
Rename t1 machine parts to basic

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/machine_parts.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/machine_parts.yml
@@ -20,7 +20,7 @@
 
 - type: entity
   id: MicroManipulatorStockPart
-  name: manipulator # Frontier: modular machine part<manipulator
+  name: basic manipulator # Frontier: modular machine part<basic manipulator
   parent: BaseStockPart
   description: A basic manipulator used in the construction of a variety of devices. # Frontier:
   suffix: Rating 1

--- a/Resources/Prototypes/_NF/Entities/Objects/Misc/machine_parts.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Misc/machine_parts.yml
@@ -4,7 +4,7 @@
 
 - type: entity
   id: CapacitorStockPart
-  name: capacitor
+  name: basic capacitor
   parent: BaseStockPart
   description: A basic capacitor used in the construction of a variety of devices.
   suffix: Rating 1
@@ -21,7 +21,7 @@
 
 - type: entity
   id: MatterBinStockPart
-  name: matter bin
+  name: basic matter bin
   parent: BaseStockPart
   description: A basic matter bin used in the construction of a variety of devices.
   suffix: Rating 1


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added the word “basic” to the names of Tier 1 machine parts so they group more neatly in menus, similar to how advanced variants are organized.

## Why / Balance
Most minor QoL

## Technical details
<!-- Summary of code changes for easier review. -->

## How to test
Look up machine parts in entity spawn menu or in any lathe capable of printing them

## Media
<img width="267" height="87" alt="image" src="https://github.com/user-attachments/assets/d6cc218a-8ea0-4b5b-b345-2b650e7c8e1e" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:
- tweak: Renamed tier 1 machine parts to basic machine parts.
