### PR TITLE
Give cooked whole birds the correct reagents

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Objects/Consumable/Food/meat.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Consumable/Food/meat.yml
@@ -309,8 +309,10 @@
   - type: Sprite
     sprite: _NF/Objects/Consumable/Food/meat.rsi
     state: bird-whole-cooked
+  - type: SolutionContainerManager
     solutions:
       food:
+        maxVol: 22
         reagents:
         - ReagentId: Nutriment
           Quantity: 10
@@ -333,8 +335,10 @@
   - type: Sprite
     sprite: _NF/Objects/Consumable/Food/meat.rsi
     state: bird-whole-cooked
+  - type: SolutionContainerManager
     solutions:
       food:
+        maxVol: 22
         reagents:
         - ReagentId: Nutriment
           Quantity: 10
@@ -358,8 +362,10 @@
     sprite: _NF/Objects/Consumable/Food/meat.rsi
     state: bird-whole-cooked
     scale: 1.3, 1.3
+  - type: SolutionContainerManager
     solutions:
       food:
+        maxVol: 32
         reagents:
         - ReagentId: Nutriment
           Quantity: 15


### PR DESCRIPTION
## About the PR
Fixes the nutritional content of whole cooked chicken, duck and penguin.

## Why / Balance
Oops, someone put `solutions:` under the sprite component. It happens. It is easy to fix. Now cooked birds have the right nutritional content. I gave their solutions a little bit of free space for condiments, so you can flavour your bland meat with tasty things.

Thanks to FranOpossum for noticing and reporting this!

## Technical details
Why do they call it a YAML when you YAM in the cold food of out hot eat the L

## How to test
1. Spawn a whole raw chicken, duck and penguin.
2. Cook them in an oven for 20 seconds each.
3. Inspect the solutions to make sure they contain appropriate nutrients.

## Media
N/A

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes
None.

**Changelog**
:cl:
- fix: Cooked whole chicken, duck and penguin now have the correct nutritional content.