### PR TITLE
Enable humanoid NPC z-level climbing during pathfinding

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_base.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_base.yml
@@ -378,7 +378,7 @@
        task: SimpleHostileCompound
     blackboard:
       NavClimb: !type:Bool
-        false
+        true
       NavInteract: !type:Bool
         true
       NavPry: !type:Bool
@@ -395,7 +395,7 @@
        task: SimpleRangedHostileCompound
     blackboard:
       NavClimb: !type:Bool
-        false
+        true
       NavInteract: !type:Bool
         true
       NavPry: !type:Bool
@@ -412,7 +412,7 @@
        task: SimpleHumanoidHostileCompound
     blackboard:
       NavClimb: !type:Bool
-        false
+        true
       NavInteract: !type:Bool
         true
       NavPry: !type:Bool


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Enabled the climbing navigation action on the humanoid NPC prototype's blackboard. This behaviour could overcome crating if anchored crates were climbable. Since the crates are usually unanchored, though, it seems wiser to create another blackboard task to open EntityStorage entities and flag them during obstacle search in pathfinding.

## Why / Balance
Turns out we already had the capabilities to stop this manner of AI abuse, it was just disabled. Upstream's Xeno prototypes that we used were already doing it, humanoids should too. Now it's enabled.

## Technical details
Yaml. False -> True

## How to test
Put a cultist or syndie in a jail made of climbable objects that are fixed to the grid, such as tables, girders, railings, but not unanchored entities that are part of the collission mask, those do not get processed. Ranged enemies will often choose to shoot from within their confines, but they will also escape the jail during idling, or when losing line of sight.

## Requirements
- [ X ] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X ] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes
None

**Changelog**
:cl:
- tweak: Humanoid NPCs now climb things like tables to get to you.
