### PR TITLE
Introduce miss-chance to ranged NPCs

### DIFF
--- a/Content.Server/NPC/Components/NPCRangedCombatComponent.cs
+++ b/Content.Server/NPC/Components/NPCRangedCombatComponent.cs
@@ -61,4 +61,12 @@ public sealed partial class NPCRangedCombatComponent : Component
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
     public SoundSpecifier? SoundTargetInLOS;
+
+    // Frontier
+    /// <summary>
+    /// The chance that a shot will miss the projected path.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite)]
+    public float MissChance = 0.25f;
+    // End Frontier
 }

--- a/Content.Server/NPC/Systems/NPCCombatSystem.Ranged.cs
+++ b/Content.Server/NPC/Systems/NPCCombatSystem.Ranged.cs
@@ -6,7 +6,7 @@ using Content.Shared.Weapons.Ranged.Components;
 using Content.Shared.Weapons.Ranged.Events;
 using Robust.Shared.Map;
 using Robust.Shared.Physics.Components;
-using Robust.Shared.Random;
+using Robust.Shared.Random; //Frontier
 
 namespace Content.Server.NPC.Systems;
 

--- a/Content.Server/NPC/Systems/NPCCombatSystem.Ranged.cs
+++ b/Content.Server/NPC/Systems/NPCCombatSystem.Ranged.cs
@@ -6,6 +6,7 @@ using Content.Shared.Weapons.Ranged.Components;
 using Content.Shared.Weapons.Ranged.Events;
 using Robust.Shared.Map;
 using Robust.Shared.Physics.Components;
+using Robust.Shared.Random;
 
 namespace Content.Server.NPC.Systems;
 
@@ -123,6 +124,13 @@ public sealed partial class NPCCombatSystem
 
             var worldPos = _transform.GetWorldPosition(xform);
             var targetPos = _transform.GetWorldPosition(targetXform);
+            
+            // Frontier -- Ranged NPC miss chance
+            if (_random.Prob(comp.MissChance))
+            {
+                targetPos = targetPos + _random.NextVector2(1.0f, 2.0f);
+            }
+            // End Frontier
 
             // We'll work out the projected spot of the target and shoot there instead of where they are.
             var distance = (targetPos - worldPos).Length();


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added a small codebit to ranged npc systems to introduce a chance to miss. The ranged NPC component had a deceptively named accuracy component, that only checked the max degrees of distance between current rotation and target location before considering them for shooting. This introduces the MissChance variable that sometimes makes the AI miss the target by 1 to 2 tiles in a random direction.

## Why / Balance
Melee NPCs already have this behaviour, ranged NPCs just target lock you and laser you down with just weapon accuracy and movement/cover playing a factor in NPCs missing. With this miss chance, sometimes the AI will be off-target, and abandon their aimbot. Bullet spread, velocity and player movement will still introduce variance to hits, but it is a clearer way to tweak chance to be hit, additionally brings parity with melee NPCs who already have this feature.

## Technical details
New component for ranged NPCs denoting their chance to miss set to 1 in 4 by base. When the AI lands on a miss, they will think their target is one to two tiles off in a random direction.

## How to test
Get any ranged npc. Confine them to one place using crates while that remains an option to jail them. Watch them miss their target on occasion. Some undesired behaviour is missing the target in the opposite direction, making the AI shoot away from the target when up close, I don't think it's unrealistic to have weapons fire in random directions occasionally when someone is in your face, though.

## Requirements
- [ X ] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X ] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes
None

**Changelog**
:cl:
- add: Added a chance for ranged NPCs to miss their target independent of bullet spread.
