### PR TITLE
Botany Walllocker Fill Fix

### DIFF
--- a/Resources/Prototypes/_NF/Catalog/Fills/Lockers/locker_wallmount.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/Lockers/locker_wallmount.yml
@@ -364,40 +364,26 @@
 # endregion
 
 # region Departments
-- type: entity
-  id: LockerWallColorHydroponicsFilled
-  suffix: Filled, Frontier
-  parent: [LockerWallColorHydroponics, LockerBotanistFilled]
-  components: # fixes sprite errors from parenting
-  - type: EntityStorageVisuals
-    stateBaseClosed: base
-    stateDoorOpen: open
-    stateDoorClosed: door
-  - type: ContainerContainer
-    containers:
-      storagebase: !type:Container
-        showEnts: False
-        occludes: True
-        ents: []
-      paper_label: !type:ContainerSlot
-        showEnts: False
-        occludes: True
-        ent: null
-      entity_storage: !type:Container
-        showEnts: False
-        occludes: True
-        ents: []
 
 - type: entity
   id: LockerWallColorHydroponicsEmpty
   suffix: Empty, Frontier
-  parent:
-  - LockerWallColorHydroponics
-  - BaseStructureWallmount
+  parent: [LockerWallColorHydroponics, BaseStructureWallmount]
   name: botanist wall locker
-  components: # fixes sprite errors from parenting
+  components: 
   - type: EntityStorageVisuals
     stateBaseClosed: base
     stateDoorOpen: open
     stateDoorClosed: door
+
+- type: entity
+  id: LockerWallColorHydroponicsFilled
+  suffix: Filled, Frontier
+  parent: LockerWallColorHydroponicsEmpty
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      storagebase: !type:NestedSelector
+        tableId: FillLockerBotanist
+
 # endregion


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Corrected ancient parenting issues with the botany wall locker that corrects both the lack of fill and the fact that the damn thing rotates 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Seems like something should be in there. Seems like botany tools is as good an idea as any.

## Technical details
<!-- Summary of code changes for easier review. -->

yml

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->

spawn LockerWallColorHydroponicsFilled, observe rotation, observe fill

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
🆑 
- fix: Botany wall locker now has proper fill and fix.