### PR TITLE
Tweak Pouch Sizes

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Objects/Storage/pouches.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Storage/pouches.yml
@@ -11,8 +11,6 @@
     sprite: _NF/Objects/Storage/Pouches/pouch.rsi
   - type: Item
     size: Normal
-    shape:
-    - 0,0,1,1
   - type: Clothing
     quickEquip: false
     sprite: _NF/Objects/Storage/Pouches/pouch.rsi


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Removed the explicit Item size definition from `NFPouchBase`, allowing entities inheriting from it to omit their own redundant size definitions.

## Why / Balance
Engoodening of stuff

## Technical details
<!-- Summary of code changes for easier review. -->

## How to test
1. Spawn Pouches and Medical pouches, compare sizes.

## Media
<img width="102" height="98" alt="image" src="https://github.com/user-attachments/assets/ce4fb081-3d02-43ba-bac7-566b9c90d8d0" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:
- tweak: Medical pouches now occupy a smaller amount of inventory space.
