### PR TITLE
Gas analyzer fix for gas pipe manifolds (#41325)

### DIFF
--- a/Content.Server/Atmos/Piping/EntitySystems/GasPipeManifoldSystem.cs
+++ b/Content.Server/Atmos/Piping/EntitySystems/GasPipeManifoldSystem.cs
@@ -51,6 +51,7 @@ public sealed partial class GasPipeManifoldSystem : EntitySystem
             return;
 
         var pipeNames = ent.Comp.InletNames.Union(ent.Comp.OutletNames);
+        var pipeCount = pipeNames.Count();
 
         foreach (var pipeName in pipeNames)
         {
@@ -58,8 +59,8 @@ public sealed partial class GasPipeManifoldSystem : EntitySystem
                 continue;
 
             var pipeLocal = pipe.Air.Clone();
-            pipeLocal.Multiply(pipe.Volume / pipe.Air.Volume);
-            pipeLocal.Volume = pipe.Volume;
+            pipeLocal.Multiply(pipe.Volume * pipeCount / pipe.Air.Volume);
+            pipeLocal.Volume = pipe.Volume * pipeCount;
 
             args.GasMixtures.Add((Name(ent), pipeLocal));
             break;

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/pipes.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/pipes.yml
@@ -366,31 +366,37 @@
         nodeGroupID: Pipe
         pipeDirection: South
         pipeLayer: 0
+        volume: 50
       south1:
         !type:PipeNode
         nodeGroupID: Pipe
         pipeDirection: South
         pipeLayer: 1
+        volume: 50
       south2:
         !type:PipeNode
         nodeGroupID: Pipe
         pipeDirection: South
         pipeLayer: 2
+        volume: 50
       north0:
         !type:PipeNode
         nodeGroupID: Pipe
         pipeDirection: North
         pipeLayer: 0
+        volume: 50
       north1:
         !type:PipeNode
         nodeGroupID: Pipe
         pipeDirection: North
         pipeLayer: 1
+        volume: 50
       north2:
         !type:PipeNode
         nodeGroupID: Pipe
         pipeDirection: North
         pipeLayer: 2
+        volume: 50
   - type: GasPipeManifold
   - type: AtmosMonitoringConsoleDevice
     navMapBlip: GasPipeManifold


### PR DESCRIPTION
## About the PR
Ports https://github.com/space-wizards/space-station-14/pull/41325 by chromiumboy
## Why / Balance
Getting it in faster than november's upstream merge


## How to test
Scan a manifold with a gas analyzer, notice it says 300L rather than 200L
Read the YML file saying that each pipe node is 50L?


## Media
Left is a pipe with 200L, right is a manifold with 300L
<img width="363" height="415" alt="image" src="https://github.com/user-attachments/assets/fc46978e-29cc-4c47-bdb7-b38259420ae3" />
Frontier's current YML for gas manifolds, note the lack of override.
<img width="283" height="145" alt="image" src="https://github.com/user-attachments/assets/59cc9478-ae81-4074-aff5-aec62961ec4a" />
Upstream's YML file, note the 50L volume tag
<img width="242" height="119" alt="image" src="https://github.com/user-attachments/assets/c04f1dfd-08b4-49fa-a3c0-bbd580359e10" />



## Requirementsckets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).


**Changelog**
:cl: chromiumboy
- fix: Gas analyzers now correctly report the total volume and the number of moles of gas contained in gas pipe manifolds.
- tweak: The total volume of gas that gas pipe manifolds can contain has been reduced from 1200L to 300L.
