### PR TITLE
Remove range checks on material silos

### DIFF
--- a/Content.Server/Materials/OreSiloSystem.cs
+++ b/Content.Server/Materials/OreSiloSystem.cs
@@ -31,7 +31,14 @@ public sealed class OreSiloSystem : SharedOreSiloSystem
         var xform = Transform(ent);
 
         // Sneakily uses override with TComponent parameter
-        _entityLookup.GetEntitiesInRange(xform.Coordinates, ent.Comp.Range, _clientLookup);
+
+        // Frontier: unrestrict silo range
+        // _entityLookup.GetEntitiesInRange(xform.Coordinates, ent.Comp.Range, _clientLookup);
+        if (xform.GridUid is null)
+            return;
+
+        _entityLookup.GetGridEntities(xform.GridUid.Value, _clientLookup);
+        // End Frontier: unrestrict silo range
 
         foreach (var client in _clientLookup)
         {

--- a/Content.Shared/Materials/OreSilo/SharedOreSiloSystem.cs
+++ b/Content.Shared/Materials/OreSilo/SharedOreSiloSystem.cs
@@ -160,8 +160,9 @@ public abstract class SharedOreSiloSystem : EntitySystem
         if (_transform.GetGrid(client) != _transform.GetGrid(silo.Owner))
             return false;
 
-        if (!_transform.InRange((silo.Owner, silo.Comp2), client, silo.Comp1.Range))
-            return false;
+        // Frontier: unrestrict silo range
+        // if (!_transform.InRange((silo.Owner, silo.Comp2), client, silo.Comp1.Range))
+        //     return false;
 
         return true;
     }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
In the context of upstream, material silos have a range so that cargo can't just teleport materials to science.
Since crews are isolated to ships on frontier, that restriction is already imposed by the separation of the grids.
Removing this check makes more sense then from a QoL standpoint.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
While yes it still is teleporting materials across great distances, the distances are still limited to a single grid.

## Technical details
<!-- Summary of code changes for easier review. -->
Commented out range check in `CanTransmitMaterials` and switched the entity lookup from `GetEntitiesInRange` to `GetGridEntities`

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
- Buy a big ship (bigger than 30 tiles)
- Check that material silos can reach machines that would normally be out of range
- Check that if you move the material silo off grid, the linked machines are now out of range

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/bc2458ef-865d-418e-8d03-5993c93464d2



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [ ] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
If you were using the range on the OreSiloComponent, it will have no effect now

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Material silo range restriction has been removed, now all machines on the same grid as a silo can be linked.


