### PR TITLE
Allow spesos and spessos to fit in envelopes

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/paper.yml
@@ -425,6 +425,8 @@
         insertSound: /Audio/Effects/packetrip.ogg
         ejectSound: /Audio/Effects/packetrip.ogg
         whitelist:
+          components: # Frontier: Allow spesos and spessos to fit in envelopes
+            - Cash
           tags:
             - Paper
   - type: ActivatableUI


### PR DESCRIPTION
## About the PR
Allow spesos and spessos to fit in envelopes

## Why / Balance
I think a different kind of paper would almost certainly fit in an envelope. PLUS, it'd let you do about-tamperproof business via mail. (The envelope is broken upon opening. It can also be signed... I think)

You could also leave a speso envelope for someone with a note written on it

## Technical details
It's anything that uses the "Cash" component, which, as of writing, is only spesos and spessos.

## How to test
1. Spawn in an envelope, and get spesos and "spessos" (the counterfeit ones)
2. Put them into the envelope. They will be put in and swap like they were paper
3. Seal the envelope
4. Open the envelope. The spesos come out

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: Minerva
- tweak: Spesos and spessos now fit in envelopes.