### PR TITLE
Highlight key phrases in NFSD's public paperwork

### DIFF
--- a/Resources/Prototypes/_NF/Catalog/Fills/Paper/forms_nfsd.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/Paper/forms_nfsd.yml
@@ -276,7 +276,7 @@
 
       This document is a contract between the above Contraband Holder and Frontier Command.
 
-      Any crimes of contraband possession for the Contraband Holder will be waived so long as all class 3 contraband items, and any class 2 contraband items not subject to a Class 2 Contraband Permit are turned in within reasonable time (subject to the clause below), and not used for malicious purposes. Noncompliance with this document results in voiding any standing Class 2 Contraband Permits.
+      Any crimes of [bold]contraband possession[/bold] for the Contraband Holder [bold]will be waived so long as all[/bold] class 3 contraband items, and any class 2 contraband items not subject to a Class 2 Contraband Permit [bold]are turned in within reasonable time[/bold] (subject to the clause below), and [bold]not used for malicious purposes[/bold]. Noncompliance with this document results in voiding any standing Class 2 Contraband Permits.
 
       If the Contraband Holder is not paid in full at the above rate for any contraband turned in, they may remain in possession of the contraband without penalty at their discretion.
 
@@ -304,7 +304,7 @@
 
       [bold]Shift Time:[/bold] 
 
-      This Permit allows the Holder and crew, as listed above, to possess and use class 2 contraband.
+      This Permit allows the Holder and crew, as listed above, to [bold]possess and use class 2 contraband[/bold].
       Non-compliance with a Contraband Amnesty agreement voids this Permit.
       Refer to §6.1.4 of Space Law for a full definition of class 2 contraband.
 
@@ -332,19 +332,19 @@
           [bullet]XXXXXXXX, Station Representative
           [bullet]XXXXXXXX, Sheriff
 
-      This document authorizes the above vessel and its captain to assist and cooperate with the NFSD and Frontier authorities in neutralizing hostile bluespace threats to Frontier. These include, but are not limited to:
+      This document authorizes the above vessel and its captain to assist and [bold]cooperate with the NFSD and Frontier authorities[/bold] in neutralizing [bold]hostile bluespace threats[/bold] to Frontier. These include, but are not limited to:
           [bullet] Cultist vessels
           [bullet] Syndicate vessels
           [bullet] Wizard Federation vessels
           [bullet] Arcadia Industries vessels
 
-      This document does NOT deputize the authorized party. The authorized party is not granted special privileges to arrest, detain, and prosecute individuals associated with Nanotrasen.
+      This document [bold]does NOT deputize[/bold] the authorized party. The authorized party is not granted special privileges to arrest, detain, and prosecute individuals associated with Nanotrasen.
 
-      [bold]Any contraband seized during operations aboard hostile vessels must be surrendered, either to the NFSD or the Station Representative, for a cash bounty. Failure to surrender contraband will lead to the forfeiture of this agreement, and the authorized party may be liable for criminal charges.[/bold]
+      [bold]Any contraband[/bold] seized during operations aboard hostile vessels [bold]must be surrendered[/bold], either to the NFSD or the Station Representative, for a cash bounty. Failure to surrender contraband will lead to the forfeiture of this agreement, and the authorized party may be liable for criminal charges.
 
-      The authorized party is to keep a copy of this document for inspection. The authorized party is expected to maintain contact with NFSD command and/or the Station Representative to minimize casualties.
+      The authorized party is to [bold]keep a copy of this[/bold] document for inspection. The authorized party is expected to [bold]maintain contact with NFSD[/bold] command and/or the Station Representative to minimize casualties.
 
-      Before engaging with hostile vessels, the authorized party is expected to follow any instructions given by the NFSD for staging or other preparation prior to boarding.
+      [bold]Before engaging[/bold] with hostile vessels, the authorized party is expected to [bold]follow any instructions given by the NFSD[/bold] for staging or other preparation prior to boarding.
 
 
 


### PR DESCRIPTION
## About the PR
Added more bold tags to 3 NFSD paperwork, namely the C3 amnesty, Bluespace permit and C2 license. On the bluespace permit, removed the bolding from one of the paragraphs and highlighted only some parts of it.
Makes the key phrases in each paper a bit more pronounced.

## Why / Balance
A minor push towards accessibility and interpretable paperwork

## Technical details
Barely even YML, just content change on paperwork.

## How to test
Spawn filled NFSD form folder. Observe new bolds.

## Media
<img width="1897" height="962" alt="image" src="https://github.com/user-attachments/assets/d7bd9426-fa77-4548-9db2-ba26b0666d05" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ X ] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X ] I have added media to this PR or it does not require an ingame showcase.
- [ X ] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes
None

**Changelog**
:cl:
- tweak: Emboldened key phrases in public-facing NFSD paperwork. Credit for the paperwork itself remains with Blumbee and Starly.
