### PR TITLE
Pmag in the pirate uplink, extend recharge duration

### DIFF
--- a/Resources/Prototypes/_NF/Catalog/pirate_uplink_catalog.yml
+++ b/Resources/Prototypes/_NF/Catalog/pirate_uplink_catalog.yml
@@ -514,7 +514,7 @@
   productEntity: Pmag
   icon: { sprite: _NF/Objects/Tools/pmag.rsi, state: icon}
   cost:
-    Doubloon: 10
+    Doubloon: 4
   conditions:
     - !type:StoreWhitelistCondition
       whitelist:

--- a/Resources/Prototypes/_NF/Entities/Objects/Tools/emag.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Tools/emag.yml
@@ -59,6 +59,4 @@
   suffix: Limited
   components:
   - type: LimitedCharges
-  - type: AutoRecharge
-    rechargeDuration: 1800
 


### PR DESCRIPTION
## About the PR
Added Whatston3's pmag to the pirate uplink catalog. Extended the recharge time to 30 minutes. It still starts with 3 charges right off the bat. Costs 10 DB. Only available to pirate captains.

## Why / Balance
People yearn for the pmag. Pirates want to play around with DRM. Adds another target for the demag. Demag cooldown was not extended.

## Technical details
YML.

## How to test
Start round in NFPirate preset. Spawn in as pirate captain. Teleport character to a POI with DMR, like NFSDO. Buy machine liberator from uplink. Use machine liberator on machine with DRM. Observe how DRM is removed. Spawn demag. Use demag on pmagged machine. Observe how DRM is returned.

## Requirements
- [ X ] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X ] I have added media to this PR or it does not require an ingame showcase.
- [ X ] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes
None

**Changelog**
:cl:
- add: Added Whatston3's machine liberator to the pirate uplink.
