### PR TITLE
Adds the military CMO jumpsuit to the DOC loadout

### DIFF
--- a/Resources/Prototypes/_NF/Loadouts/Jobs/Doc/jumpsuit.yml
+++ b/Resources/Prototypes/_NF/Loadouts/Jobs/Doc/jumpsuit.yml
@@ -1,4 +1,4 @@
 - type: loadout
-  id: DocClothingUniformJumpsuitMilitaryDoc
+  id: DocClothingUniformJumpsuitMilitaryCMO
   equipment:
     jumpsuit: ClothingUniformJumpsuitMilitaryCMO

--- a/Resources/Prototypes/_NF/Loadouts/doc_loadout_groups.yml
+++ b/Resources/Prototypes/_NF/Loadouts/doc_loadout_groups.yml
@@ -6,7 +6,7 @@
   - ChiefMedicalOfficerJumpskirt
   - ChiefMedicalOfficerTurtleneckJumpsuit
   - ChiefMedicalOfficerTurtleneckJumpskirt
-  - DocClothingUniformJumpsuitMilitaryDoc
+  - DocClothingUniformJumpsuitMilitaryCMO
   fallbacks:
   - ChiefMedicalOfficerJumpsuit
   - ChiefMedicalOfficerJumpskirt


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds the military CMO jumpsuit to the DOC loadout

## Why / Balance
The PM gets a free military jumpsuit in their loadout, so why not the DOC?

## Technical details
ID name follows the same convention as the Plant Manager's military jumpsuit (or at least I'm very certain)

## How to test
1. Open the Director of Care loadout
2. Click "Jumpsuit"
3. There it is

## Media
<img width="683" height="505" alt="image" src="https://github.com/user-attachments/assets/3abe841f-41b0-4c2b-8332-e28d0015383b" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: Minerva
- tweak: The military CMO jumpsuit is now available in the Director of Care loadout.
