### PR TITLE
Fix SR and STC forms' space law references

### DIFF
--- a/Resources/Prototypes/_NF/Catalog/Fills/Paper/forms_sr.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/Paper/forms_sr.yml
@@ -188,7 +188,7 @@
 
       This is a formal declaration from Frontier's Station Traffic Controller, hereby declaring the above vessel to be abandoned by its captain, and recognized as salvage. This vessel has been unresponsive on both radio and fax for over twenty (20) minutes.
 
-      Pursuant to Space Law §9.3, this vessel will be moved out to three hundred (300) meters from Frontier Station by an agent representing Frontier Station or the NFSD, and will be salvageable by any other vessel operating within the sector.
+      Pursuant to Space Law §6.3, this vessel will be moved out to three hundred (300) meters from Frontier Station by an agent representing Frontier Station or the NFSD, and will be salvageable by any other vessel operating within the sector.
 
       Neither Frontier Station nor the Nanotrasen Corporation will reimburse any party affiliated with this vessel for losses incurred.
 
@@ -285,7 +285,7 @@
 
       This Permit allows the Holder and crew, as listed above, to possess and use class 2 contraband.
       Non-compliance with a Contraband Amnesty agreement voids this Permit.
-      Refer to §6.1.4 of Space Law for a full definition of class 2 contraband.
+      Refer to §5.3 of Space Law for a full definition of class 2 contraband.
 
 
 

--- a/Resources/Prototypes/_NF/Catalog/Fills/Paper/forms_stc.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/Paper/forms_stc.yml
@@ -101,7 +101,7 @@
 
         [head=2]Vessel Callsign:[/head]
 
-        [head=2]Infraction:[/head] Unathorized Docking Maneuver
+        [head=2]Infraction:[/head] Unauthorized Docking Maneuver
 
         [head=2]Amount of Fine:[/head] 2,500 spesos
 

--- a/Resources/Prototypes/_NF/Catalog/Fills/Paper/forms_stc.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/Paper/forms_stc.yml
@@ -75,7 +75,7 @@
         [bold]Time of Authorization:[/bold]
 
 
-        [color=#AAAAAA]This citation is only valid when approved and signed by an agent representing the traffic control division of the corporation or by the authorized station representative. Additional fines may be issued for each 10 minutes over the maximum.  This citation is a result of a violation of Space Law Section Nine, Article Five, governing the docking rules in and around Frontier Station and the Trade Outpost.
+        [color=#AAAAAA]This citation is only valid when approved and signed by an agent representing the traffic control division of the corporation or by the authorized station representative. Additional fines may be issued for each 10 minutes over the maximum.  This citation is a result of a violation of Space Law §6.4.2, governing the docking rules in and around Frontier Station and the Trade Outpost.
 
 
         Failure to pay outstanding citations in a timely fashion will result in unpaid citations being forwarded to the New Frontier Sheriff's Department for processing as a criminal offense.[/color]
@@ -116,7 +116,7 @@
         [bold]Authorizing Officer:[/bold]
 
 
-        [color=#AAAAAA]This citation is only valid when approved and signed by an agent representing the traffic control division of the corporation or by the authorized station representative. This citation is a result of a violation of Space Law Section Nine, Article Five, governing the docking rules in and around Frontier Station and the Trade Outpost.
+        [color=#AAAAAA]This citation is only valid when approved and signed by an agent representing the traffic control division of the corporation or by the authorized station representative. This citation is a result of a violation of Space Law §6.4.4, governing the docking rules in and around Frontier Station and the Trade Outpost.
 
 
         Failure to pay outstanding citations in a timely fashion will result in unpaid citations being forwarded to the New Frontier Sheriff's Department for processing as a criminal offense.[/color]
@@ -150,7 +150,7 @@
         [head=2]Amount of Fine(s):[/head]
 
 
-        [color=#AAAAAA]This citation is only valid when approved and signed by an agent representing the traffic control division of the corporation or by the authorized station representative. This request is a result of a violation of Space Law Section Nine, Article Five, governing the docking rules in and around Frontier Station and the Trade Outpost.[/color]
+        [color=#AAAAAA]This citation is only valid when approved and signed by an agent representing the traffic control division of the corporation or by the authorized station representative. This request is a result of a violation of Space Law §6.4, governing the docking rules in and around Frontier Station and the Trade Outpost.[/color]
 
 - type: entity # Based on form made by TakuTaco
   id: PaperWrittenStcFormTrafficLog
@@ -195,7 +195,7 @@
 
 
 
-        This constitutes a wellness check on the destionary vessel and its crew. You are required to contact the Station Traffic Controller within twenty (20) minutes of this notice being sent. If the vessel is unresponsive exceeding the time stated above, it will be declared salvage on account of Space Law §9.3.
+        This constitutes a wellness check on the destionary vessel and its crew. You are required to contact the Station Traffic Controller within twenty (20) minutes of this notice being sent. If the vessel is unresponsive exceeding the time stated above, it will be declared salvage on account of Space Law §6.3.
 
 
 

--- a/Resources/Prototypes/_NF/Catalog/Fills/Paper/forms_stc.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/Paper/forms_stc.yml
@@ -101,7 +101,7 @@
 
         [head=2]Vessel Callsign:[/head]
 
-        [head=2]Infraction:[/head] Reckless Operation
+        [head=2]Infraction:[/head] Unathorized Docking Maneuver
 
         [head=2]Amount of Fine:[/head] 2,500 spesos
 


### PR DESCRIPTION
## About the PR
Updated the space law references in the paperwork

## Why / Balance
Reference not referencing the correct reference

## Technical details
YML, content change on paperwork

## How to test
Spawn in folders, look for space law references, try to look up reference in space law, see if it's correct

## Requirements
- [ X ] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X ] I have added media to this PR or it does not require an ingame showcase.
- [ X ] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes
None

**Changelog**
:cl:
- fix: SR and STC forms now reference space law correctly. The paperworks themselves still attributed to Blumbee, DmitriTheDemon and Shock.
