### PR TITLE
Add sheathable tag to cap sheath whitelist. Add sheathable tag to plasteel epee.

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -550,12 +550,14 @@
         whitelist:
           tags:
           - CaptainSabre
+          - Sheathable # Frontier
   - type: ItemMapper
     mapLayers:
       sheath-sabre:
         whitelist:
           tags:
           - CaptainSabre
+          - Sheathable # Frontier
   - type: Appearance
 
 # Belts without visualizers

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Melee/plasteel.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Melee/plasteel.yml
@@ -47,6 +47,9 @@
     - Back
     - SuitStorage
     - Belt
+  - type: Tag
+    tags:
+    - Sheathable
 
 - type: entity
   name: plasteel axe

--- a/Resources/Prototypes/_NF/tags.yml
+++ b/Resources/Prototypes/_NF/tags.yml
@@ -171,6 +171,9 @@
 - type: Tag
   id: NFGlowshroomSpores
 
+- type: Tag
+  id: Sheathable
+
 # region Blueprints
 
 # Used for blueprints that are "too advanced" to be used with an autolathe.

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -228,11 +228,6 @@
 - type: Tag
   id: CaptainSabre
 
-# Frontier
-- type: Tag
-  id: Sheathable
-# End Frontier
-
 - type: Tag
   id: Carpet
 

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -228,6 +228,11 @@
 - type: Tag
   id: CaptainSabre
 
+# Frontier
+- type: Tag
+  id: Sheathable
+# End Frontier
+
 - type: Tag
   id: Carpet
 


### PR DESCRIPTION
## About the PR
Plasteel weapons are cool. Let me carry the epee in style. The tag is also reusable for any future changes if we want to allow weapon to be sheathed.

## Why / Balance
Doesn't change much from just carrying the epee in the belt slot, but it does look cooler.

## Technical details
YML

## How to test
Spawn sheath. Spawn epee. Sheathe epee.


## Requirements
- [ X ] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X ] I have added media to this PR or it does not require an ingame showcase.
- [ X ] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes
None.

**Changelog**
:cl:
- add: Added a tag to make items sheathable.
- tweak: Epee is now sheathable in a cap saber sheath.
