### PR TITLE
Add inflatable floor recipe to lathes

### DIFF
--- a/Resources/Locale/en-US/_NF/lathe/recipes.ftl
+++ b/Resources/Locale/en-US/_NF/lathe/recipes.ftl
@@ -36,6 +36,7 @@ lathe-recipe-NFSheetPaperFromWood-name = paper (wood)
 lathe-recipe-NFSheetPaperFromCardboard-name = paper (cardboard)
 
 # Inflatables
+lathe-recipe-NFInflatableFloorStack1-name = inflatable floor
 lathe-recipe-NFInflatableWallStack1-name = inflatable wall
 lathe-recipe-NFInflatableWindowStack1-name = inflatable window
 lathe-recipe-NFInflatableDoorStack1-name = inflatable door

--- a/Resources/Prototypes/_NF/Recipes/Lathes/Packs/inflatables.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/Packs/inflatables.yml
@@ -1,6 +1,7 @@
 - type: latheRecipePack
   id: NFInflatablesStatic
   recipes:
+  - NFInflatableFloorStack1
   - NFInflatableWallStack1
   - NFInflatableWindowStack1
   - NFInflatableDoorStack1

--- a/Resources/Prototypes/_NF/Recipes/Lathes/inflatables.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/inflatables.yml
@@ -1,5 +1,4 @@
-# Base prototypes
-
+# region Base
 - type: latheRecipe
   abstract: true
   id: NFBaseInflatablesRecipe
@@ -11,47 +10,52 @@
 
 - type: latheRecipe
   abstract: true
-  id: NFBaseInflatablesComplexRecipe
   parent: NFBaseInflatablesRecipe
+  id: NFBaseInflatablesComplexRecipe
   completetime: 2
   materials:
     Steel: 150
     Plastic: 150
 
-# Recipes
+# region Recipes
+- type: latheRecipe
+  parent: NFBaseInflatablesRecipe
+  id: NFInflatableFloorStack1
+  result: NFInflatableFloorStack1
+  name: lathe-recipe-NFInflatableFloorStack1-name
 
 - type: latheRecipe
-  id: NFInflatableWallStack1
   parent: NFBaseInflatablesRecipe
+  id: NFInflatableWallStack1
   result: NFInflatableWallStack1
   name: lathe-recipe-NFInflatableWallStack1-name
 
 - type: latheRecipe
-  id: NFInflatableWindowStack1
   parent: NFBaseInflatablesRecipe
+  id: NFInflatableWindowStack1
   result: NFInflatableWindowStack1
   name: lathe-recipe-NFInflatableWindowStack1-name
 
 - type: latheRecipe
-  id: NFInflatableDoorStack1
   parent: NFBaseInflatablesRecipe
+  id: NFInflatableDoorStack1
   result: NFInflatableDoorStack1
   name: lathe-recipe-NFInflatableDoorStack1-name
 
 - type: latheRecipe
-  id: NFInflatableDoorWindowStack1
   parent: NFBaseInflatablesRecipe
+  id: NFInflatableDoorWindowStack1
   result: NFInflatableDoorWindowStack1
   name: lathe-recipe-NFInflatableDoorWindowStack1-name
 
 - type: latheRecipe
-  id: NFInflatableDockStack1
   parent: NFBaseInflatablesComplexRecipe
+  id: NFInflatableDockStack1
   result: NFInflatableDockStack1
   name: lathe-recipe-NFInflatableDockStack1-name
 
 - type: latheRecipe
-  id: NFInflatableCrateStack1
   parent: NFBaseInflatablesRecipe
+  id: NFInflatableCrateStack1
   result: NFInflatableCrateStack1
   name: lathe-recipe-NFInflatableCrateStack1-name


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds missing inflatable floor recipe to lathe recipe pack.

## Why / Balance
Bug fix.

## Technical details
Yml

## How to test
1. Spawn engi/salvage techfab, look for inflatable floor, print one.

## Media
Not needed.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [ ] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:
- fix: Added missing inflatable floor recipe to engineering and salvage techfabs.
