### PR TITLE
Remove redundant metabolisms from moth stomach

### DIFF
--- a/Resources/Prototypes/Body/Organs/moth.yml
+++ b/Resources/Prototypes/Body/Organs/moth.yml
@@ -30,8 +30,3 @@
     groups:
       - id: Food
       - id: Drink
-      - id: Medicine
-      - id: Cryogenic # Frontier
-      - id: Poison
-      - id: Narcotic
-      - id: Alcohol


### PR DESCRIPTION
## About the PR
Removed medicine, cryogenic, poison, narcotic, and alcohol metabolisms from moth stomach.

## Why / Balance
These metabolism groups are already processed in their heart and liver. What this meant in practice (through testing) is that they acted twice as quickly on moths as expected. This resulted in things such as: The standard dose of caramexinin in a drink of coffee running out when the coffee was only half-metabolised, and the remainder of the coffee releasing the full dose of theobromine on the moth.

## Technical details
Removed five metabolism groups from the moth stomach prototype.

## How to test
Create a moth character. Inject them with at least one chemical from each metabolism group that was removed while inspecting their solution. Watch as the chemicals go down at the expected rate and have their expected effect.

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

**Changelog**
:cl:
- fix: Moths now metabolise chemicals at the expected rate. They are no longer immune to alcohol poisoning.
