### PR TITLE
Check AntiRottingContainer on all containers

### DIFF
--- a/Content.Shared/Atmos/Rotting/SharedRottingSystem.cs
+++ b/Content.Shared/Atmos/Rotting/SharedRottingSystem.cs
@@ -123,11 +123,16 @@ public abstract class SharedRottingSystem : EntitySystem
         if (TryComp<MobStateComponent>(uid, out var mobState) && !_mobState.IsDead(uid, mobState))
             return false;
 
-        if (_container.TryGetOuterContainer(uid, Transform(uid), out var container) &&
-            HasComp<AntiRottingContainerComponent>(container.Owner))
+        // Frontier: prevent rot if *any* container has AntiRottingContainer
+        //if (_container.TryGetOuterContainer(uid, Transform(uid), out var container) &&
+        //    HasComp<AntiRottingContainerComponent>(container.Owner))
+        //    return false;
+        foreach (var container in _container.GetContainingContainers(uid))
         {
-            return false;
+            if (HasComp<AntiRottingContainerComponent>(container.Owner))
+                return false;
         }
+        // End Frontier
 
         var ev = new IsRottingEvent();
         RaiseLocalEvent(uid, ref ev);


### PR DESCRIPTION
## About the PR
Updates the rotting system so that `AntiRottingContainerComponent` applies even if it's not the outermost container.

## Why / Balance
We have a situation in which it makes sense to store an anti-rotting container inside something else: the crate storage rack. You could stick a freezer in there, or a medical pod. With upstream's rotting logic, this effectively disables the anti-rotting container, as it only checks the outermost container. I would classify this as unintuitive and undesirable behaviour.

My change checks *every* container for the `AntiRottingContainerComponent`. In terms of performance, note:

* It is exceedingly rare for perishables to be nested more than a few containers deep.
* The previous code already walks every container to find the outer container.
* Rot accumulates occasionally, not every frame.

I expect this will have no appreciable effect on anything.

## Technical details
I swapped an `if` for a loop with an `if`. C#.

Yes, I'm aware I could also have used `.Any(...)`, but LINQ is generally avoided in the codebase for performance reasons and `foreach` is easy enough to read.

## How to test
1. Spawn a crate storage rack and an EMU, or Ripley with appropriate attachments.
2. Spawn a medical pod, put it in the crate storage rack.
3. Spawn a freezer, put some raw meat or other perishable thing in it, then put the freezer in the crate storage rack.
4. Wait.
5. Verify that the perishables have not perished.
6. To speed up the process, open a View Variables window on the perishable items' `PerishableComponent` and check that the RotAccumulator doesn't increase when they're stored in an anti-rot container.

## Media
N/A

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes
No.

**Changelog**
:cl:
- fix: Medical pods and freezers can safely be put in crate storage racks without their contents rotting.