### PR TITLE
Add PacifismAllowedGun to the holoflare pistol

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Battery/battery_pistols.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Battery/battery_pistols.yml
@@ -283,5 +283,6 @@
           Cyan: { state: mode-cyan }
           Red: { state: mode-red }
           Yellow: { state: mode-yellow }
+  - type: PacifismAllowedGun # harmless
   - type: StaticPrice
     price: 250


### PR DESCRIPTION
## About the PR
Adds PacifismAllowedGun to the holoflare pistol, so that pacified players can still bring light into the world. Temporarily.

## Why / Balance
It's totally harmless, and very handy if you have a pacified crewmember supporting you in dungeons and such.

## Technical details
YAML is tasty

## How to test
1. Pacify yourself.
2. Fire a holoflare pistol.
3. 💡

## Media
N/A

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes
No.

**Changelog**
:cl:
- fix: Pacifists can now use holoflare pistols.