### PR TITLE
Adds Spesos to the Pirate Uplink

### DIFF
--- a/Resources/Locale/en-US/_NF/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/_NF/store/uplink-catalog.ftl
@@ -330,6 +330,9 @@ uplink-pirate-pouch-captain-desc = This pouch shows your status as the captain. 
 uplink-pirate-pouch-name = Pirate's Pouch
 uplink-pirate-pouch-desc = A pouch for organizing miscellaneous items.
 
+uplink-pirate-cash2500-name = 2,500 Spesos
+uplink-pirate-cash2500-desc = Well plundered booty.
+
 uplink-pirate-jetpack-name = Pirate Jetpack
 uplink-pirate-jetpack-desc = This jetpack hides your radar signature, allowing you to fly undetected in outer space.
 

--- a/Resources/Prototypes/_NF/Catalog/pirate_uplink_catalog.yml
+++ b/Resources/Prototypes/_NF/Catalog/pirate_uplink_catalog.yml
@@ -543,6 +543,22 @@
   - UplinkPirateUtility
 
 - type: listing
+  id: UplinkPirateCash2500
+  name:  uplink-pirate-cash2500-name
+  description: uplink-pirate-cash2500-desc
+  productEntity: SpaceCash2500
+  icon: { sprite: Objects/Economy/cash.rsi, state: cash_1000 }
+  cost:
+    Doubloon: 1
+  categories:
+    - UplinkPirateUtility
+  conditions:
+    - !type:StoreWhitelistCondition
+      whitelist:
+        tags:
+          - PirateUplink
+
+- type: listing
   id: UplinkPirateJetpack
   name:  uplink-pirate-jetpack-name
   description: uplink-pirate-jetpack-desc


### PR DESCRIPTION
## About the PR
Pirates can now turn 1 doubloon into 2.5k spesos 

## Why / Balance
Being pirates should be more rewarding, crime should pay. This helps off set the pirates super high risk and large investment with minimum profits, and further encourages pirates to go after bounties. 

## Technical details
Adds spesos to the pirate uplink, and descriptions to the uplink catalog. 

## How to test
Grab yer uplink, purchase ye plunder 

## Media
<img width="689" height="530" alt="image" src="https://github.com/user-attachments/assets/01aee6fe-75f3-4df0-a912-8db4b9f22f2f" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**

:cl:
- add: Pirates can now exchange doubloons for spesos! 
