### PR TITLE
Plasma Generator Buff

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Power/Generation/portable_generator.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/portable_generator.yml
@@ -193,6 +193,7 @@
     # Frontier: magnet pickup, fuel adapter
     - type: MaterialStorageMagnetPickup
       range: 0.30
+      magnetEnabled: true # Frontier
     - type: FuelGradeAdapter
       conversions:
       - input: Plasma
@@ -267,6 +268,7 @@
     # Frontier: magnet pickup, fuel adapter
     - type: MaterialStorageMagnetPickup
       range: 0.30
+      magnetEnabled: true # Frontier
     - type: FuelGradeAdapter
       conversions:
       - input: Uranium


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

This PR nudges the plasma generator + 5000 in terms of base and maximum power generation.

The generators should also have their magnets on by default. That seems useful. Atomize your own PRs.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

The Plasma generator is slightly fraught on Frontier. It provides JUST not enough power to be applicable on as many shuttles as we feel that it should be applicable on. This is largely due to thruster, gyro and other tools putting just enough baseline power drain on a generator that a majority of our shuttles end up tipping over into uranium.

I think that seems like a shame and have thought so for, like, a year. So it seemed like it might be worth spending 13 seconds on a quick change.

For shuttles that are running uranium generators at like 158% efficiency this provides an opportunity to step down to a more commonly available fuel. For shuttles that are running a plasma generator at 100% efficiency, this is mostly our baby miner fleet and various civilian fun shuttles will have an opportunity for either a modest efficiency buff or a little overage on their default settings.

I think the overall impact is negligible and the widening of the circle of plasma proofed shuttles is worth it.

## Technical details
<!-- Summary of code changes for easier review. -->

yaml

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->

Check default magnet state is on for our solid fuel generators.
Check that the power draw for plasma generators is 20kw at 100% and 30kw at max.
Check that I used the > in the right direction in the yml.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

![OIP-1588933875](https://github.com/user-attachments/assets/7a1e2c59-cbcb-46fc-8289-9c54da23d1c5)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
🆑 
- tweak: Plasma generators now 100% at 20kw and cap at 30kw.