### PR TITLE
Adds binoculars to lathes

### DIFF
--- a/Resources/Prototypes/_NF/Recipes/Lathes/Packs/misc.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/Packs/misc.yml
@@ -28,6 +28,7 @@
   - Multitool
   - AppraisalTool
   - HandLabeler
+  - Binoculars
   - Signaller
   - ClothingMaskWeldingGas
   - SprayPainter

--- a/Resources/Prototypes/_NF/Recipes/Lathes/misc.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/misc.yml
@@ -260,6 +260,13 @@
   materials:
     Steel: 250
 
+- type: latheRecipe
+  id: Binoculars
+  result: Binoculars
+  materials:
+    Steel: 400
+    Glass: 200
+
 # Toys
 - type: latheRecipe
   id: MysteryFigureBox


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds binoculars to lathes. They are now accessible from about any techfab, or autolathe, or about anything that can print a crowbar.

The cost is 4 steel sheets and 2 glass sheets. For reference, a multitool is 2 steel sheets and 2 plastic sheets

## Why / Balance
This'd **very likely** affect game balance, because this makes ways to extend view range more common. Let me go over the ways binoculars can be obtained before this PR.
- Maintenance. From my testing, it's rare (because it's in the rare group, same as the spectral locator), but that still means it's regular-player-accessible. Just RNG-based.
- NFSD's station. This is the only guaranteed source of them, and there's only two.
- On Amber Station. Hahahahahahahahahahaha nope. That's never gonna happen.

Binoculars would be a cool item for players to have easier access to.
- NFSD might appreciate them being easier to get outside of the two pairs mapped roundstart
- Pilots could scope out salvage sites more effectively. Marking hazards or identifying if it's even worth staying at quicker with the extra flair of a pilot/captain using binoculars
- Captains could use it for checking on their salvagers as long as they are within view range+5 tiles away
- Private investigators/the Detective could use it for enhanced spying
- ~~The Mail Carrier could use it for sniping people with mail undetected~~
- People could do... whatever it is people do with exactly 5 more tiles of view range. That's just all the use-cases I can think of

This isn't a PVP-focused fork, so players using binoculars in combat against other players probably shouldn't be too much of a problem. Other than that, it's just a fun thing to have and will add to some gimmicks

Keep in mind they were accessible before, just rarely found in maintenance

From my testing, easier binocular access might be exploited on expeditions, where the AI doesn't know better. Binoculars don't provide much range for mobs to safely wander, though. Only five tiles. Some guns will have trouble shooting long-range. Binoculars are a two-handed thing, meaning you can't hold a gun at the same time, meaning you'd need to juggle guns and hope the enemy doesn't move or you could have a dedicated spotter. Regardless, it's probably one of the more wasteful, riskier ways someone could exploit enemy AI. If someone has a dedicated spotter, then it becomes the coolest way to exploit enemy AI

Binoculars have been added to the general tools pack of lathes, adding them to autolathes and more. This includes about any lathe that can make a crowbar, including the NFSD fabricator. I did briefly think about restricting it to the mercenary fabricator (something something tactical something), but I don't want to encourage exploiting enemy AIs by making it printable by mercenaries exclusively

Please tell me if the resource cost needs changed

## How to test
1. Spawn an autolathe. Or about any techfab
2. Insert steel and glass. I just spawn in "steel sheet crate" or "glass sheet crate" instead of combing for the items.
3. Search for binoculars. Print.
4. Binoculars come out

## Media
<img width="363" height="307" alt="image" src="https://github.com/user-attachments/assets/15237036-0635-4b0d-b205-eb5d6ba4a358" />

Binoculars already randomly spawn
<img width="460" height="397" alt="image" src="https://github.com/user-attachments/assets/6f4a2670-3c46-4d89-8c0e-0c14a84ab809" />

Roundstart pair 1
<img width="436" height="325" alt="image" src="https://github.com/user-attachments/assets/f43b16c8-1e8a-4049-a8be-0ab58433b341" />

Roundstart pair 2
<img width="466" height="640" alt="image" src="https://github.com/user-attachments/assets/0a81fd80-b3ec-433d-ab0f-a06288067f8a" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: Minerva
- add: Binoculars can now be printed in any lathe with standard tools, including autolathes or any techfab.
