### PR TITLE
Makes the captain ID card NOT contraband

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
@@ -106,7 +106,7 @@
     - state: idintern-service
 
 - type: entity
-  parent: [IDCardStandard] # Frontier: BaseC2ContrabandUnredeemable] # Frontier: BaseSecurityCommandContraband<BaseC2ContrabandUnredeemable
+  parent: [IDCardStandard] # Frontier: Removed BaseSecurityCommandContraband
   id: CaptainIDCard
   name: captain ID card
   components:


### PR DESCRIPTION
## About the PR
Makes the captain ID card NOT contraband.

Also yes I'm aware of the doubled Frontier comments I just wasn't very sure what to do. It's probably fine and at least says that line was changed twice

## Why / Balance
I really doubt you're supposed to be able to spawn in with C2 as  Contractor...

<img width="534" height="110" alt="image" src="https://github.com/user-attachments/assets/d5a8dbed-afde-4907-a3e1-1c624f675df6" />

## How to test
1. `spawn CaptainPDA`
2. Remove ID
3. Examine it

## Media
<img width="485" height="179" alt="image" src="https://github.com/user-attachments/assets/4ca7237e-54d2-4535-aee4-baa27dc916ae" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: Minerva
- fix: Captain ID cards are no longer contraband.
