### PR TITLE
Small gyro buff

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Structures/Shuttles/thrusters.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Shuttles/thrusters.yml
@@ -189,7 +189,7 @@
     thrust: 650
     thrustPerPartLevel: [650, 812, 974, 1136]
   - type: ApcPowerReceiver
-    powerLoad: 200
+    powerLoad: 500
   - type: Sprite
     sprite: _NF/Structures/Shuttles/gyroscope.rsi
     layers:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Large gyros currently produce 2000 thrust.
Small gyros currently produce 250 thrust.

This PR gives a smidge of adjustment from 1/8th to 1/3 potency. Increasing the thrust of the small gyro to 650 and the power draw to 500.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

At the moment the disparity between the large and small gyro usually results in the large providing far too much rotational force while the small, on even our most diminutive small shuttles, still feels hopelessly ponderous. This PR seeks to bridge that sense of frustration by increasing the thrust power of the small gyro to be 1/3 that of its larger counterpart. 

This feels like it becomes a much stronger candidate for smaller shuttles that cannot utilize a large thruster without feeling comically and frustratingly robust but still feel like they're moving underwater with a single small gyro.

## Technical details
<!-- Summary of code changes for easier review. -->
yml

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->

Pick a shuttle with a small thruster and give it a spin. See how it feels. 

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/fb8f0ce2-cff2-47ff-9c01-400c38f97f0d


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

This PR will increase the power draw of small gyros from 200 to 500. Which will require a quick shuttle pass to ensure that all shuttles that have small gyros are set to provide the appropriate amount of power from their generators and aren't moving towards a brownout. This is a trivial change but one that would be troublesome to add to this PR.

#4232 should help alleviate this concern and help address the overall issue of small shuttles feeling a little troublesome to produce and use.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
🆑 
- tweak: Small gyros are slightly more robust.