### PR TITLE
Interview hologram light + gravity ignore

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Mobs/Player/interview_hologram.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/Player/interview_hologram.yml
@@ -70,9 +70,10 @@
   - type: ActionsContainer
   - type: MovementIgnoreGravity
   - type: PointLight
-    radius: 1.7
+    radius: 1.5
     falloff: 3
     softness: 5
+    energy: 15
     autoRot: true
     color: "#65b8e2"
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds a light to interview holograms, as well as making them ignore gravity (as in never floating!)

## Why / Balance
They're holograms and shouldn't care about gravity, and they glow anyway because they're fullbright

Also, joining in on a depowered ship as an interview hologram makes it really hard to navigate. You can't see *anything* if there's no lights

## How to test
1. Get a ship
2. Open a slot on the station records console
3. Delete the gravity generator (because it has a power buffer). Switch off the substation
4. `respawn`
5. Join as an interview hologram
6. You do not float, and you actually emit light

## Media
<img width="319" height="296" alt="image" src="https://github.com/user-attachments/assets/19a312be-a922-497a-841f-e393b4700968" />

Light on the image above is outdated
<img width="323" height="316" alt="image" src="https://github.com/user-attachments/assets/d5e11a4b-bb61-4216-a580-61e0e5e08822" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: Minerva
- tweak: Interview holograms now emit light and always have gravity.