### PR TITLE
Medical tracking implants - don't trigger on revive

### DIFF
--- a/Content.Server/Explosion/Components/TriggerOnMobstateChangeComponent.cs
+++ b/Content.Server/Explosion/Components/TriggerOnMobstateChangeComponent.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared.Mobs;
+using Content.Shared.Mobs;
 
 namespace Content.Server.Explosion.Components;
 
@@ -21,4 +21,11 @@ public sealed partial class TriggerOnMobstateChangeComponent : Component
     [ViewVariables]
     [DataField("preventSuicide")]
     public bool PreventSuicide = false;
+
+    /// <summary>
+    /// Frontier: If true, prevent execution on mobstate deescalation
+    /// </summary>
+    [ViewVariables]
+    [DataField("preventDeescalation")]
+    public bool PreventDeescalation = false;
 }

--- a/Content.Server/Explosion/EntitySystems/TriggerSystem.Mobstate.cs
+++ b/Content.Server/Explosion/EntitySystems/TriggerSystem.Mobstate.cs
@@ -1,4 +1,4 @@
-﻿using Content.Server.Explosion.Components;
+using Content.Server.Explosion.Components;
 using Content.Shared.Explosion.Components;
 using Content.Shared.Implants;
 using Content.Shared.Interaction.Events;
@@ -19,6 +19,12 @@ public sealed partial class TriggerSystem
 
     private void OnMobStateChanged(EntityUid uid, TriggerOnMobstateChangeComponent component, MobStateChangedEvent args)
     {
+        //Frontier: trigger only on escalation of MobState
+        if (component.PreventDeescalation && args.OldMobState > args.NewMobState)
+        {
+            return;
+        }
+
         if (!component.MobState.Contains(args.NewMobState))
             return;
 

--- a/Resources/Prototypes/_NF/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Misc/subdermal_implants.yml
@@ -23,6 +23,7 @@
       mobState:
       - Critical
       - Dead
+      preventDeescalation: true
     - type: Rattle
       radioChannel: "Medical"
 

--- a/Resources/Prototypes/_NF/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Misc/subdermal_implants.yml
@@ -23,7 +23,7 @@
       mobState:
       - Critical
       - Dead
-      preventDeescalation: true
+      preventDeescalation: true # Frontier: prevent execution on deescalation of mobstate
     - type: Rattle
       radioChannel: "Medical"
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
This PR allows us to (and does it) change how Medical Tracking Implants work. Currently, the medical radio easily gets flooded because multiple alerts are triggered for one person. They're triggered:
- When the person goes critical
- When the person dies
- Again after revive, because they go critical again

It's been suggested to remove the last alert, since it doesn't really make sense for it to be there.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
https://discord.com/channels/1123826877245694004/1404402559929552926

This prevents flooding of the medical channel and prevents situations where medics are unsure whether that's a new alert or one for someone who's already being helped.

## Technical details
- Adds a "PreventDeescalation" property on TriggerOnMobStateChangeComponent. It defaults to false to not change the behavior of existing places where this is used. This is settable in yml through the "preventDeescalation" flag.
- Adds the Prevent Deescalation logic on TriggerSystem.Mobstate. I will add a technical comment here: the next if statement over uses an if statement with no curly brackets. This is bad practice in C#/.NET, which is why I chose not to do that.
- Adds preventDeescalation: true on the Medical Tracking Implant.

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
- Put someone with the medical tracking implant in crit, dead, and then revive them. You should receive a crit alert, dead alert, but not another crit alert after revival.
- Compare behavior to someone with another implant (to test that adding this new field didn't break existing uses of TriggerOnMobstateChange). You should see it behave as it currently does on prod, without my changes.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
https://medal.tv/games/requested/clips/lZyxD6saBlJQVT60E?invite=cr-MSxEYkMsMjI0OTYxOTQ2&v=61

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
Testing should show that no breaking changes occur, it is however worth noting that TriggerOnMobstateChangeComponent received a new public property: PreventDeescalation.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Medical Tracking Implants now don't trigger another critical alert after revival
