### PR TITLE
Mothership Console Additions - Edison

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers_shipyard_mothership.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers_shipyard_mothership.yml
@@ -90,7 +90,6 @@
     - Adder
     - Prospector
     - Chisel
-    - Gaslight
 
 # The crescent console
 - type: entity


### PR DESCRIPTION
## About the PR
Added the Firefighter to the Edison shipyard console.

## Why / Balance
The Firefighter being a newly added engineering ship, it ought to be added to the Edison shipyard console as the main engineer POI.

## Technical details
Edited Resources/Prototypes/_NF/Entities/Structures/Machines/Computers and added the Firefighter under the Edison console.

## How to test
1. Visit the Edison Power Plant.
2. Use the shipyard console and see that the Firefighter can now be purchased.

## Media
<img width="1096" height="752" alt="image" src="https://github.com/user-attachments/assets/7d3f4c09-1458-4450-9113-f9155d38f8b5" />

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

**Changelog**
:cl: 
- add: Added the Firefighter to the Edison shipyard console.
