### PR TITLE
Removing the bone crusher from the salvage pool and flagging it as a …

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
@@ -633,6 +633,7 @@
   parent: ClothingHandsKnuckleDusters
   id: ClothingHandsKnuckleBoneCrushers
   name: bone crushers
+  suffix: Admeme
   description: "Blessed by the Gods to break all those who don't obey."
   components:
   - type: Sprite

--- a/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/Items/weapon_tables.yml
+++ b/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/Items/weapon_tables.yml
@@ -150,7 +150,6 @@
   table: !type:GroupSelector
     children:
     - id: HyperEutacticBlade
-    - id: ClothingHandsKnuckleBoneCrushers
     - id: ArmBlade
     - id: Kanabou
 


### PR DESCRIPTION
…admeme item properly

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
The item bone crusher had the hasttag admeme flag on it however it didnt get the proper suffix, as such it was accidentally added to the pool of salvage and didnt have its name properly flagged.

So it was removed from the salvage pool and had the proper name attached.

## Why / Balance
This thing does 70 DPS, the items in the same category as this does 30 DPS. Since it was suppost to be flagged an admeme item it was being set properly

## Technical details
Deleted the bonecrusher from the pool, added the suffix

## How to test
Play game, spawn salvage pool items, and check the F5 spawn menu for the proper suffix.

## Media
<img width="336" height="383" alt="image" src="https://github.com/user-attachments/assets/6494bee3-3ebd-4622-921e-3ec451974141" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x ] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x ] I have added media to this PR or it does not require an ingame showcase.
- [x ] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [x ] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Only thing added is a suffix it should work as normal

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- fix: Flagged bone crushers as Admeme item and removed it from the salvage loot.
-->
