### PR TITLE
Adds balaclavas to Mercenary loadout

### DIFF
--- a/Resources/Prototypes/_NF/Loadouts/Jobs/Mercenary/face.yml
+++ b/Resources/Prototypes/_NF/Loadouts/Jobs/Mercenary/face.yml
@@ -11,3 +11,10 @@
   storage:
     back:
     - ClothingMaskGasSecurity
+
+- type: loadout
+  id: MercenaryClothingMaskBalaclavaBlack
+  price: 0
+  storage:
+    back:
+    - ClothingMaskBalaclavaBlack

--- a/Resources/Prototypes/_NF/Loadouts/mercenary_loadout_groups.yml
+++ b/Resources/Prototypes/_NF/Loadouts/mercenary_loadout_groups.yml
@@ -141,6 +141,7 @@
   loadouts:
   - MercenaryClothingMaskGasMercenary
   - MercenaryClothingMaskGasSecurity
+  - MercenaryClothingMaskBalaclavaBlack
   subgroups:
   - PilotFace
   - ContractorFace


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds balaclavas to the Mercenary loadout.

Yes, I'm aware of the unintended useless line changes. No, this is not the day I learn how to interactively edit while adding. I finished this PR a week or two ago and that was the thing stopping me from PRing this. It looks fine in the file view

## Why / Balance
This probably belongs among the free, roundstart Mercenary-specific gear items. It's a good fit with the rest of the *tactical* stuff, and provides a good alternative to the other Mercenary mask options

There's already precedent for useless loadout mask items too (sterile masks)

## How to test
1. Edit your Mercenary loadout to have the balaclava. Save
2. Spawn in. You have the balaclava in your backpack. You don't have a mask to breathe with but whatever. Who needs oxygen/nitrogen anyway when you have *style?*

## Media
(I did not bother with showing anything else in this one because masks appear in the backpack, not on the preview)
<img width="781" height="346" alt="image" src="https://github.com/user-attachments/assets/ced93872-2663-4f4e-ac82-ee748880ef48" />

It spawned in the backpack
<img width="223" height="268" alt="image" src="https://github.com/user-attachments/assets/1c036648-7801-4f1f-bc93-f93614322254" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: Minerva
- tweak: Mercenaries can now select balaclavas for their loadout.