### PR TITLE
Fixes Department Department typo

### DIFF
--- a/Resources/Prototypes/_NF/Catalog/Fills/Paper/forms_stc.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/Paper/forms_stc.yml
@@ -45,7 +45,7 @@
   components:
     - type: Paper
       content: >+
-        [color=#4f6e40]◥[bold]N[/bold]◣ [bold]New Frontier Traffic Department Department[/bold][/color]
+        [color=#4f6e40]◥[bold]N[/bold]◣ [bold]New Frontier Traffic Department[/bold][/color]
 
         [color=#4f6e40]‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾[/color]
 
@@ -88,7 +88,7 @@
   components:
     - type: Paper
       content: >+
-        [color=#4f6e40]◥[bold]N[/bold]◣ [bold]New Frontier Traffic Department Department[/bold][/color]
+        [color=#4f6e40]◥[bold]N[/bold]◣ [bold]New Frontier Traffic Department[/bold][/color]
 
         [color=#4f6e40]‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾[/color]
 
@@ -129,7 +129,7 @@
   components:
     - type: Paper
       content: >-
-        [color=#4f6e40]◥[bold]N[/bold]◣ [bold]New Frontier Traffic Department Department[/bold][/color]
+        [color=#4f6e40]◥[bold]N[/bold]◣ [bold]New Frontier Traffic Department[/bold][/color]
 
         [color=#4f6e40]‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾[/color]
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixes Department Department typo in the STCs forms

## Why / Balance
There seems to have been a mixup with the Department Department Department which caused New Frontier Traffic Department paperwork to be mislabeled as New Frontier Traffic Department Department

To be more serious, this is extremely unlikely to be intentional

## How to test
1. `self spawn:on BoxFolderStc`
2. Open the folder. Look at the documents

## Media
<img width="751" height="121" alt="image" src="https://github.com/user-attachments/assets/61d97007-77e3-44c6-b214-1e993533f83d" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

This is an exceptionally small typo fix to premapped STC paperwork so I don't think this needs a changelog
