### PR TITLE
Shuttle (Update): Hammer QoL - accessible wiring

### DIFF
--- a/Resources/Maps/_NF/Shuttles/hammer.yml
+++ b/Resources/Maps/_NF/Shuttles/hammer.yml
@@ -1,11 +1,11 @@
 meta:
   format: 7
   category: Grid
-  engineVersion: 261.2.0
+  engineVersion: 267.3.0
   forkId: ""
   forkVersion: ""
-  time: 09/08/2025 15:09:55
-  entityCount: 412
+  time: 02/09/2026 10:01:23
+  entityCount: 433
 maps: []
 grids:
 - 2
@@ -513,9 +513,9 @@ entities:
     - type: DeviceList
       devices:
       - 182
-      - 306
+      - 307
       - 18
-  - uid: 320
+  - uid: 321
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -524,12 +524,12 @@ entities:
     - type: DeviceList
       devices:
       - 210
-      - 311
+      - 313
       - 343
       - 18
-      - 313
-      - 337
-      - 307
+      - 319
+      - 342
+      - 310
   - uid: 354
     components:
     - type: Transform
@@ -542,7 +542,7 @@ entities:
       - 157
       - 156
       - 299
-      - 310
+      - 311
   - uid: 358
     components:
     - type: Transform
@@ -900,11 +900,6 @@ entities:
     - type: Transform
       pos: 5.5,3.5
       parent: 2
-  - uid: 65
-    components:
-    - type: Transform
-      pos: 6.5,-0.5
-      parent: 2
   - uid: 70
     components:
     - type: Transform
@@ -919,6 +914,11 @@ entities:
     components:
     - type: Transform
       pos: 4.5,-2.5
+      parent: 2
+  - uid: 96
+    components:
+    - type: Transform
+      pos: 6.5,-0.5
       parent: 2
   - uid: 123
     components:
@@ -1130,8 +1130,33 @@ entities:
     - type: Transform
       pos: 4.5,1.5
       parent: 2
+  - uid: 430
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 2
+  - uid: 431
+    components:
+    - type: Transform
+      pos: -1.5,4.5
+      parent: 2
+  - uid: 432
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 2
+  - uid: 433
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 2
 - proto: CableHV
   entities:
+  - uid: 1
+    components:
+    - type: Transform
+      pos: -3.5,-2.5
+      parent: 2
   - uid: 223
     components:
     - type: Transform
@@ -1166,6 +1191,61 @@ entities:
     components:
     - type: Transform
       pos: -4.5,-3.5
+      parent: 2
+  - uid: 395
+    components:
+    - type: Transform
+      pos: -2.5,-2.5
+      parent: 2
+  - uid: 396
+    components:
+    - type: Transform
+      pos: -1.5,-2.5
+      parent: 2
+  - uid: 397
+    components:
+    - type: Transform
+      pos: -0.5,-2.5
+      parent: 2
+  - uid: 414
+    components:
+    - type: Transform
+      pos: -0.5,-1.5
+      parent: 2
+  - uid: 415
+    components:
+    - type: Transform
+      pos: -0.5,-0.5
+      parent: 2
+  - uid: 416
+    components:
+    - type: Transform
+      pos: -0.5,1.5
+      parent: 2
+  - uid: 418
+    components:
+    - type: Transform
+      pos: -0.5,2.5
+      parent: 2
+  - uid: 419
+    components:
+    - type: Transform
+      pos: -0.5,3.5
+      parent: 2
+  - uid: 422
+    components:
+    - type: Transform
+      pos: -0.5,4.5
+      parent: 2
+  - uid: 423
+    components:
+    - type: Transform
+      pos: -0.5,0.5
+      parent: 2
+  - uid: 424
+    components:
+    - type: Transform
+      pos: -0.5,5.5
       parent: 2
 - proto: CableMV
   entities:
@@ -1283,6 +1363,31 @@ entities:
     components:
     - type: Transform
       pos: 4.5,2.5
+      parent: 2
+  - uid: 425
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 2
+  - uid: 426
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 2
+  - uid: 427
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 2
+  - uid: 428
+    components:
+    - type: Transform
+      pos: -1.5,4.5
+      parent: 2
+  - uid: 429
+    components:
+    - type: Transform
+      pos: -1.5,5.5
       parent: 2
 - proto: CableTerminal
   entities:
@@ -1467,7 +1572,7 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 320
+      - 321
       - 172
   - uid: 100
     components:
@@ -1500,7 +1605,7 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 320
+      - 321
   - uid: 211
     components:
     - type: Transform
@@ -1543,7 +1648,7 @@ entities:
       color: '#990000FF'
 - proto: GasPipeBend
   entities:
-  - uid: 96
+  - uid: 126
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1551,7 +1656,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 158
+  - uid: 159
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1559,7 +1664,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 159
+  - uid: 173
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1573,18 +1678,11 @@ entities:
       rot: 3.141592653589793 rad
       pos: 4.5,-3.5
       parent: 2
-  - uid: 292
+  - uid: 296
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,-1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 296
-    components:
-    - type: Transform
-      pos: 6.5,1.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
@@ -1594,7 +1692,14 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -3.5,-2.5
       parent: 2
-  - uid: 382
+  - uid: 298
+    components:
+    - type: Transform
+      pos: 6.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 392
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1602,7 +1707,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 392
+  - uid: 393
     components:
     - type: Transform
       pos: -0.5,0.5
@@ -1611,7 +1716,7 @@ entities:
       color: '#0055CCFF'
 - proto: GasPipeBendAlt1
   entities:
-  - uid: 286
+  - uid: 287
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1681,7 +1786,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 126
+  - uid: 158
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1689,7 +1794,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 173
+  - uid: 180
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1697,7 +1802,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 194
+  - uid: 197
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1715,7 +1820,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 215
+  - uid: 286
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1723,14 +1828,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 287
+  - uid: 289
     components:
     - type: Transform
       pos: 6.5,0.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 289
+  - uid: 290
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1738,7 +1843,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 290
+  - uid: 292
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1784,7 +1889,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 348
+  - uid: 349
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1792,7 +1897,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 349
+  - uid: 350
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1800,7 +1905,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 350
+  - uid: 381
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1808,7 +1913,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 381
+  - uid: 382
     components:
     - type: Transform
       pos: -2.5,1.5
@@ -1825,7 +1930,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 180
+  - uid: 194
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1881,7 +1986,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 342
+  - uid: 344
     components:
     - type: Transform
       pos: 1.5,-2.5
@@ -1905,7 +2010,7 @@ entities:
       color: '#0055CCFF'
 - proto: GasPipeTJunction
   entities:
-  - uid: 298
+  - uid: 301
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1913,7 +2018,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 301
+  - uid: 302
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1921,7 +2026,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 393
+  - uid: 394
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1931,7 +2036,7 @@ entities:
       color: '#0055CCFF'
 - proto: GasPipeTJunctionAlt1
   entities:
-  - uid: 197
+  - uid: 215
     components:
     - type: Transform
       pos: 1.5,-1.5
@@ -1945,7 +2050,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 302
+  - uid: 306
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1961,7 +2066,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 344
+  - uid: 348
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2014,7 +2119,7 @@ entities:
       color: '#990000FF'
 - proto: GasVentPump
   entities:
-  - uid: 306
+  - uid: 307
     components:
     - type: Transform
       pos: 5.5,4.5
@@ -2024,17 +2129,17 @@ entities:
       - 172
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 307
+  - uid: 310
     components:
     - type: Transform
       pos: 0.5,-1.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 320
+      - 321
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 310
+  - uid: 311
     components:
     - type: Transform
       pos: -2.5,2.5
@@ -2044,7 +2149,7 @@ entities:
       - 354
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 311
+  - uid: 313
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2052,7 +2157,7 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 320
+      - 321
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 328
@@ -2107,19 +2212,19 @@ entities:
       - 354
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 313
+  - uid: 319
     components:
     - type: Transform
       pos: 0.5,-2.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 320
+      - 321
     - type: AtmosPipeLayers
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 337
+  - uid: 342
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2127,7 +2232,7 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 320
+      - 321
     - type: AtmosPipeLayers
       pipeLayer: Secondary
     - type: AtmosPipeColor
@@ -2142,7 +2247,7 @@ entities:
       pipeLayer: Secondary
     - type: DeviceNetwork
       deviceLists:
-      - 320
+      - 321
     - type: AtmosPipeColor
       color: '#990000FF'
 - proto: GravityGeneratorMini
@@ -2238,14 +2343,14 @@ entities:
       parent: 2
 - proto: LockerEngineerFilled
   entities:
-  - uid: 334
+  - uid: 336
     components:
     - type: Transform
       pos: 3.5,0.5
       parent: 2
 - proto: LockerWallEVAColorEngineerFilled
   entities:
-  - uid: 1
+  - uid: 65
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2437,7 +2542,7 @@ entities:
     - type: Transform
       pos: -6.5,-3.5
       parent: 2
-  - uid: 319
+  - uid: 320
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2510,12 +2615,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 2.5,4.5
       parent: 2
-  - uid: 322
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,3.5
-      parent: 2
   - uid: 323
     components:
     - type: Transform
@@ -2534,6 +2633,12 @@ entities:
       pos: 8.5,4.5
       parent: 2
   - uid: 331
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,3.5
+      parent: 2
+  - uid: 332
     components:
     - type: Transform
       pos: 5.5,6.5
@@ -2636,7 +2741,7 @@ entities:
         101:
         - - Pressed
           - Toggle
-  - uid: 332
+  - uid: 334
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2650,7 +2755,7 @@ entities:
         324:
         - - Pressed
           - Toggle
-        331:
+        332:
         - - Pressed
           - Toggle
         323:
@@ -2662,7 +2767,7 @@ entities:
         230:
         - - Pressed
           - Toggle
-        322:
+        331:
         - - Pressed
           - Toggle
 - proto: SignalSwitchDirectional
@@ -2758,7 +2863,7 @@ entities:
       parent: 2
 - proto: SteelBench
   entities:
-  - uid: 321
+  - uid: 322
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2853,7 +2958,7 @@ entities:
       parent: 2
 - proto: ToolboxElectricalFilled
   entities:
-  - uid: 336
+  - uid: 337
     components:
     - type: Transform
       pos: 7.5220494,-0.51292974


### PR DESCRIPTION
## About the PR
Add a bunch of HV, MV and LV wiring to the Hammer, leading to the space door.

## Why / Balance
I frequently see people run power cables to the space door, for building on the outside of the ship. Unfortunately that means spending time tearing up a bunch of flooring, ruining the decals in the process. By making all three types of wiring accessible to the outside, I'm hoping such engineering projects will be considerably simpler and more aesthetically pleasing.

## Technical details
YAML, my beloved

## How to test
1. Buy a Hammer.
2. Reveal the subfloor or use a t-ray scanner to behold the wiring.
3. Use `nodevis` to make sure I haven't double-stacked any cables like I originally noticed I had done while typing up this PR.
4. I dunno, build something nice? :)

## Media
<img width="1102" height="909" alt="image" src="https://github.com/user-attachments/assets/91fc0e24-fc92-439a-8bd6-15136fc0bc77" />

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes
None.

**Changelog**
:cl:
- tweak: The Hammer's wiring now goes all the way to the space door, for ease of construction. Consult the power monitoring computer or a t-ray scanner for exact wire layout.