### PR TITLE
Gas exude and consumption disabled in mutation pool

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_atmospherics.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_atmospherics.yml
@@ -4,7 +4,7 @@
     sprite: _NF/Structures/Storage/canister.rsi # Frontier: _NF
     state: air # Frontier grey<air
   product: AirCanister
-  cost: 1100 # Frontier: 600<1100
+  cost: 2000 # Frontier: 600<2000
   category: cargoproduct-category-name-atmospherics
   group: market
 
@@ -14,7 +14,7 @@
     sprite: _NF/Structures/Storage/canister.rsi # Frontier: _NF
     state: oxygen # Frontier blue<oxygen
   product: OxygenCanister
-  cost: 1100 # Frontier: 600<1100
+  cost: 2000 # Frontier: 600<2000
   category: cargoproduct-category-name-atmospherics
   group: market
 
@@ -35,7 +35,7 @@
     sprite: _NF/Structures/Storage/canister.rsi # Frontier: _NF
     state: nitrogen # Frontier red<nitrogen
   product: NitrogenCanister
-  cost: 1100 # Frontier: 500<1100
+  cost: 2000 # Frontier: 500<2000
   category: cargoproduct-category-name-atmospherics
   group: market
 

--- a/Resources/Prototypes/Hydroponics/randomMutations.yml
+++ b/Resources/Prototypes/Hydroponics/randomMutations.yml
@@ -172,14 +172,16 @@
       baseOdds: 0.072
       persists: false
       effect: !type:PlantMutateChemicals
-    - name: ChangeExudeGasses
-      baseOdds: 0.0145
-      persists: false
-      effect: !type:PlantMutateExudeGasses
-    - name: ChangeConsumeGasses
-      baseOdds: 0.0036
-      persists: false
-      effect: !type:PlantMutateConsumeGasses
+# Frontier Start
+#    - name: ChangeExudeGasses
+#      baseOdds: 0.0145
+#      persists: false
+#      effect: !type:PlantMutateExudeGasses
+#    - name: ChangeConsumeGasses
+#      baseOdds: 0.0036
+#      persists: false
+#      effect: !type:PlantMutateConsumeGasses
+# Frontier End
     - name: ChangeHarvest
       baseOdds: 0.036
       persists: false


### PR DESCRIPTION
Edit: Some will contest this. A great deal of work has gone into producing a gas mining loop with specific shuttles, tools, miles of code, a POI and other means to enable a novel gameplay loop directed at the collection and refining of gas on Frontier. I would urge you to consider the hundreds of hours of time that has been poured directly into ensuring that gameplay loop exists on the server in the unique form that it does when evaluating your criticism of this exploitative system being temporarily disabled until a suitable replacement method can be put into place.

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

This PR removes gas production and consumption from the list of possible gas mutations.

It also increases the flat purchase cost of air, nitrogen and oxygen canisters from 1.1 to 2k.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

For a considerable length of time the production of gasses through botany has sat on the fringes of problematic but fringe behavior. With the occasional spike of interest driving extreme value for some in shifts. Given that this gameplay style is transitioning from the fringe to the mainstream a balance response is warranted.

This system has begun to transition into the mainstream, with the production of plasma via what are essentially self sustaining gas miners. This is far outside of the gas mining loop that has been provided and represents an undesired self sustaining economic loop.

This is supplemented by the procurement of oxygen canisters from trade. Which have also seen a modest price increase. I feel that this price change will have a negligible impact on persons who seek to procure additional gas for their shuttles (these being available in bulk in space and gas grenades being a far better solution for depressurized hulls at any rate) but will knock a little bit of hole in the arbitrage bucket for frezon production chains.

I would prefer harmful and exotic gasses be produced via botmos for the chaos and merryment of the server. However I believe that is a heavier lift than addressing the short term needs of this economic hole demands. That can be tomorrow's project with the simple resotration of the mutation.

## Technical details
<!-- Summary of code changes for easier review. -->

yml

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->

Gas production mutation should not be possible.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
🆑 
- tweak: Gas production and consumption mutations are no longer possible.
- tweak: Filled gas canisters at trade are now 2000 spesos.