### PR TITLE
Adds gavels to NFSD and Service lathes

### DIFF
--- a/Resources/Prototypes/_NF/Recipes/Lathes/Packs/nfsd.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/Packs/nfsd.yml
@@ -84,6 +84,8 @@
 - type: latheRecipePack
   id: NfsdReportingStatic
   recipes:
-    - CassetteTape
-    - TapeRecorder
-    - ClothingNeckBodyCameraNFSD
+  - CassetteTape
+  - TapeRecorder
+  - ClothingNeckBodyCameraNFSD
+  - Gavel
+  - GavelBlock

--- a/Resources/Prototypes/_NF/Recipes/Lathes/Packs/service.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/Packs/service.yml
@@ -137,6 +137,8 @@
   - ServiceSelectiveDropper
   - PlantAnalyzer
   - HotplateMachineCircuitboard
+  - Gavel
+  - GavelBlock
 
 - type: latheRecipePack
   id: NFServiceTechfabEmagStatic

--- a/Resources/Prototypes/_NF/Recipes/Lathes/misc.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/misc.yml
@@ -267,6 +267,18 @@
     Steel: 400
     Glass: 200
 
+- type: latheRecipe
+  id: Gavel
+  result: Gavel
+  materials:
+    Wood: 200
+
+- type: latheRecipe
+  id: GavelBlock
+  result: GavelBlock
+  materials:
+    Wood: 200
+
 # Toys
 - type: latheRecipe
   id: MysteryFigureBox


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
This PR adds gavels to the NFSD (because law) and Service (because lawyer) fabricators.

I also did a very minor indentation fix since the fact it was inconsistent with everything else in the file was bothering me

## Why / Balance
The **only** gavel and gavel block pair is mapped on the Courthouse POI, making it a really funny prank to steal the only gavel that exists outside of admin intervention

2 wood for the gavel and block. Seems logical since they're visually very small

Because there's *only one,* that means they aren't accessible to lawyer characters or officers that want to have a gavel for... some reason. This PR would allow people to have the *Full Courtroom Experience* on their shuttles

I chose not to make it Autolathe accessible because there's kind of a lot of items there anyway and it's more of a NFSD+Service item, not a NFSD+Service+everyone item

## How to test
1. Spawn in an autolathe to check it's not in there. It isn't because I didn't add it there
2. Spawn in a NFSD techfab to check it's in there. It is
3. Spawn in a Service techfab to check it'sin there. It is

## Media
<img width="484" height="283" alt="image" src="https://github.com/user-attachments/assets/149c891c-9daa-4093-ad8d-459b06ecc2d0" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: Minerva
- add: Gavels can now be made in the NFSD and Service techfabs.