### PR TITLE
Makes the medassemblers Help button only show medical recipes

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/microwave_recipe_assemblers.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/microwave_recipe_assemblers.yml
@@ -255,6 +255,9 @@
       visible: false
   - type: ApcPowerReceiver
     powerLoad: 500
+  - type: GuideHelp
+    guides:
+    - MedicalRecipes
   - type: Machine
     board: MedicalAssemblerMachineCircuitboard
   - type: ActivatableUI


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Makes the medical assemblers guidebook button only show medical recipes. Previously, it showed every cooking recipe (which includes medical recipes) because it inherited that from the Microwave indirectly

## Why / Balance
Medics are not chefs and don't need a convenient way to look up how to make donk-pockets with a medical assembler

## How to test
1. `self spawn:on MedicalAssembler`
2. Examine it. Press the Help button. It only shows medical recipes

## Media
<img width="500" height="523" alt="image" src="https://github.com/user-attachments/assets/e1aa77fa-651a-4afc-b3db-e10d646872b5" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: Minerva
- fix: The medical assemblers Help button now only shows medical recipes.
