### PR TITLE
Makes the Tall trait give Felinids humanlike density

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/felinid.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/felinid.yml
@@ -96,6 +96,8 @@
   - type: NoShoesSilentFootsteps
   - type: TallWhitelist # Frontier
     scale: 1 # Frontier
+    density: 185 # Frontier
+    cosmeticOnly: false # Frontier
   - type: Inventory # Frontier
     speciesId: felinid # Frontier
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Makes the Tall trait give Felinids humanlike density, which is 185. This allows them to pull things a bit better *and* carry humans

~~I left the pseudoitem stuff untouched because I don't want to wake up with a dead mouse on my pillow~~ (I'd just rather not interrupt peoples... Silly Creature gimmicks or whatever. Will remove if asked)
- To continue this thought outside of the parentheses: I would really really really like to not remove any features in this PR because I feel some people may have at least partially built their character with that in mind, if that makes sense? It's something people probably like and if they want to have a (now-only-somewhat-)cosmetic size increase, I don't want to stop them

I made this PR with the intent of allowing felinids to carry humans

## Why / Balance
The Tall trait, currently, just makes Felinids have normal height. Purely cosmetic to my understanding. This doesn't change their density and thus strength or whatnot. The Small trait *does* reduce density on the Reptilian species

I *am* somewhat hesitant adding anything even resembling a positive trait (the ever-present threat of minmaxers) but I don't feel as if *many* minmaxers are gonna be picking Felinid (less stamina... +15% Blunt/Slash/Piercing...) and forcing them to pick the Tall trait is probably fine as a downside ~~knowing the average Felinid player~~? It'd also likely be making them slightly harder to drag—like out of danger—though probably not by that much
- In the guidebook page for Felinids, the Tall trait removes 1/7 benefits (smaller sprite) and after this PR it would remove 2/4 drawbacks (lower density, worse carrying/pulling)
- If this is deemed too much (and I believe it may be), I'd be willing to settle for a smaller (but still restrictive) density increase (something something felinids are a bit lighter regardless of height?) or removing the pseudoitem stuff (which I believe I can do somewhat easily?)
- Something I find worth mentioning: one of the things mentioned in one of the drawbacks is "can't carry an oni" where "can't carry a human" (which is also true) is a lot worse 

The Tall trait makes Felinids human sized, so why shouldn't they get the density increase of 45 (off the top of my head, if I got the numbers right) to make them have human strength? People who choose Tall for Felinids are probably opting out of the being weak and tiny thing if that makes sense. In my case, wanting to play a human with some new markings and flavoring

Maybe I'm stressing about a small optional density change too much
(I use stressing in the least serious way possible. I do not actually care that much)

## Technical details
There's some weird stuff going on here, I think. I have no clue how weird or how consequential
- One Felinid I spawned in was at full Oni-carrying strength without the Tall trait. For some reason! I made a new character and it worked as expected. See if you can reproduce this or if I'm just imagining things
- Tall Felinids can be carried even by Felinids/short Reptilians. I don't understand why but it's probably fine
- ~~Tall Felinids do not break glass tables where I think their density would have. I do not understand why~~ Tall Felinids do not break glass tables because glass tables use mass (which apparently is not updated by the Tall trait), not density

I believe a lot of these problems come from the fact it doesn't update mass? I think? 

<img width="343" height="300" alt="image" src="https://github.com/user-attachments/assets/eb18f257-c3a6-4a59-a1a4-d9d555419b50" />

## How to test
1. Spawn in a McFelinid or join as a Felinid with the Tall trait
2. Mess around. Make sure nothing's wrong. Go carry some people
3. Check the technical details to make sure I'm not going insane and nothing weird or unexpected happens

Useful Toolshed snippets:
- Make me into a McFelinid: `self spawn:on MobFelinid | do "controlmob $ID"`
- Open VV on Density: `vv /entity/(id)/Fixtures/Fixtures[fix1]/Density`

## Media
(this shows the density of both mobs)
<img width="277" height="323" alt="image" src="https://github.com/user-attachments/assets/9145b995-0716-4f11-9340-88cafe75fdbf" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: Minerva
- tweak: Felinids with the Tall trait are now as dense as humans, which means better carrying and slightly easier dragging.