### PR TITLE
Expanded Gas Deposit Scanner range to 64 tiles.

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Objects/Specific/Atmospherics/deposits.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Specific/Atmospherics/deposits.yml
@@ -526,7 +526,7 @@
   - type: ItemToggle
   - type: ProximityBeeper
   - type: ProximityDetector
-    range: 20
+    range: 64
     components:
     - type: GasDeposit
   - type: Beeper


### PR DESCRIPTION

## About the PR
Expands the gas deposit scanner's range from 20 tiles to 64 tiles.
## Why / Balance
Small QoL change that makes it less frustrating to find gas deposits, especially on larger asteroids

## Technical details
Changed the variable "Range" for ProximityDetector from 20 to 64


## How to test
Grab a gas scanner, grab a ship, hover at the 64M marking on the ship console, and if it beeps, you know there is gas.

## Media
<img width="320" height="342" alt="image" src="https://github.com/user-attachments/assets/adde35eb-b6b8-4cd3-80bf-a27233fdd2b4" /> (It's beeping, trust me)
## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes
Shouldnt break anything
**Changelog**

:cl:
- tweak: The gas deposit scanner now can locate deposits up to 64 tiles away from itself.
