### PR TITLE
Makes the shipyard door remote include user accesses

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Objects/Devices/door_remote.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Devices/door_remote.yml
@@ -26,6 +26,8 @@
       color: "#bdac85"
     - state: door_remotescreencolour
       color: "#7194a9"
+  - type: DoorRemote
+    includeUserAccess: true
   - type: GridAccess
   - type: StaticPrice
     price: 55


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Makes the shipyard door remote include user accesses

## Why / Balance
Currently, the shipyard door remote has no accesses. This means ship engineers can't open or close firelocks remotely and  captains/mercenaries can't use it to open/close/emergency access/bolt their access-restricted rooms. For example, the Crescent is one of the ships that comes with both kinds of access-restricted doors (unless something was changed)

People should probably be able to control doors on their ship if they have access to them. Why wouldn't a captain have access to bolt their own room with one? This PR also opens up shipyard door remotes being useful for other roles that might have access restrictions on their ships, like the Guard and NFSD/pirates. This should also hopefully make going to the SR for access changes a tiny bit more common

I did consider (but did not go through with) adding the accesses to the door remote, but door remotes also work as IDs do when it comes to access *regardless* of if they're on a grid. If I did add Mercenary or Captain accesses, they'd effectively be expensive roundstart access increases

## How to test
(toolshed snippets are untested ingame but this is certainly not my first time writing these. regardless all I usually include is just spawning stuff)

1. I'd recommend spawning as a Mercenary because Mercenaries get extra access
2. `self spawn:on DoorRemoteShipyard` or get a shipyard door remote any other way
3. `warp "Frontier Outpost"` or walk over to the ship room to buy a ship to get Captain access and a place to test. Swipe your ID on the shipyard door remote to authorize it. I'd recommend just `warp`ing into the ship to get there faster
4. Spawn in some airlocks with the Locked suffix. I'd recommend Mercenary, Maintenance, and Security
5. Try to control the doors and a firelock. You won't be able to control the ones you have no access to
6. Drop your ID and try again. You can't control any access-locked airlock, including firelocks
7. See that it is still useless outside of the grid

## Media
Recording videos or timing screenshots with 3+ doors is extremely inconvenient and not *that* helpful. Just take my word for it working as I expect

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: Minerva
- tweak: Shipyard door remotes can now access any airlock their user can.
