### PR TITLE
Fix merc biosuit description

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/armor.yml
@@ -28,7 +28,7 @@
   parent: ClothingOuterBioGeneral
   id: ClothingOuterBioArmoredMercenary
   name: mercenary bio suit
-  description: The choice of armor for any mercenaries battling bio-hazards.
+  description: The choice of armor for any mercenaries battling bio-hazards in atmosphere.
   components:
   - type: Sprite
     sprite: _NF/Clothing/OuterClothing/Bio/mercenary.rsi


### PR DESCRIPTION
## About the PR
Changed the description of the merc biosuit
Favorite protective gear of any syndicate chemical warfare enjoyers. -> The choice of armor for any mercenaries battling bio-hazards in atmosphere.

## Why / Balance
Remnant from copying the syndie suit, clearly not intended

## Technical details
One yml attribute changed

## How to test
Spawn a biosuit, read the description

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ X ] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X ] I have added media to this PR or it does not require an ingame showcase.
- [ X ] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes
None

**Changelog**
:cl: co-authored @Herbtheon
- tweak: Changed merc biosuit description
