### PR TITLE
Update to Pirate EVA Suit References

### DIFF
--- a/Resources/Locale/en-US/_NF/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/_NF/store/uplink-catalog.ftl
@@ -237,8 +237,8 @@ uplink-security-lasercanon-name = Laser Cannon
 uplink-security-lasercanon-desc = A heavy duty, high powered laser sniper rifle.
 
 # region Pirate
-uplink-pirate-hardsuit-name = Pirate Hardsuit
-uplink-pirate-hardsuit-desc = A heavy space suit that provides some basic protection from the cold harsh realities of deep space.
+uplink-pirate-EVA-name = Pirate EVA Suit
+uplink-pirate-EVA-desc = A heavy space suit that provides some basic protection from the cold harsh realities of deep space.
 
 uplink-pirate-hardsuit-captain-name = Pirate Captain's Hardsuit
 uplink-pirate-hardsuit-captain-desc = An ancient armored hardsuit, perfect for defending against space scurvy and toolbox-wielding scallywags.

--- a/Resources/Prototypes/_NF/Catalog/pirate_uplink_catalog.yml
+++ b/Resources/Prototypes/_NF/Catalog/pirate_uplink_catalog.yml
@@ -1,7 +1,7 @@
 - type: listing
-  id: UplinkPirateHardsuit
-  name:  uplink-pirate-hardsuit-name
-  description: uplink-pirate-hardsuit-desc
+  id: UplinkPirateEVASuit
+  name:  uplink-pirate-EVA-name
+  description: uplink-pirate-EVA-desc
   productEntity: ClothingOuterEVASuitPirate
   icon: { sprite: Clothing/OuterClothing/Hardsuits/pirateeva.rsi, state: icon }
   cost:


### PR DESCRIPTION
## About the PR
Updated the pirate uplink to more accurately describe the EVA suit

## Why / Balance
With it being the same as the basic EVA suits elsewhere in the sector, calling it a hardsuit misrepresents the level of protection it offers. 

## Technical details
Changed the name and references to the UplinkPirateEVASuit from the UplinkPirateHardsuit for more accuracy

## How to test
1. Become a pirate
2. Check your uplink
3. Find the EVA suit

## Media
<img width="552" height="187" alt="image" src="https://github.com/user-attachments/assets/ce9a2727-40ee-44d0-8cac-773492058882" />

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

**Changelog**

:cl:
- tweak: Updated Pirate EVA suit name in the uplink
