### PR TITLE
Fixes condiments_bottles.yml not changing sprites

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Objects/Consumable/Drinks/condiments_bottles.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Consumable/Drinks/condiments_bottles.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: DrinkBottlePlasticBaseFull
+  parent: [DrinkBottleVisualsOpenable, DrinkBottlePlasticBaseFull]
   id: DrinkAstrotameJug
   name: astrotame jug
   description: The sweetness of a thousand sugars but none of the calories. Put it in your coffee.
@@ -16,7 +16,7 @@
     currentLabel: reagent-name-astrotame
 
 - type: entity
-  parent: DrinkBottlePlasticBaseFull
+  parent: [DrinkBottleVisualsOpenable, DrinkBottlePlasticBaseFull]
   id: DrinkBbqSauceJug
   name: bbq sauce jug
   description: Finally, ketchup for grownups.
@@ -33,7 +33,7 @@
     currentLabel: reagent-name-bbq-sauce
 
 - type: entity
-  parent: DrinkBottlePlasticBaseFull
+  parent: [DrinkBottleVisualsOpenable, DrinkBottlePlasticBaseFull]
   id: DrinkColdsauceJug
   name: coldsauce jug
   description: Something to make every meal a little cooler.
@@ -50,7 +50,7 @@
     currentLabel: reagent-name-coldsauce
 
 - type: entity
-  parent: DrinkBottlePlasticBaseFull
+  parent: [DrinkBottleVisualsOpenable, DrinkBottlePlasticBaseFull]
   id: DrinkHorseradishSauceJug
   name: horseradish sauce jug
   description: Now with 50% more horse.
@@ -67,7 +67,7 @@
     currentLabel: reagent-name-horseradish-sauce
 
 - type: entity
-  parent: DrinkBottlePlasticBaseFull
+  parent: [DrinkBottleVisualsOpenable, DrinkBottlePlasticBaseFull]
   id: DrinkHotsauceJug
   name: hotsauce jug
   description: The antithesis of no more tears shampoo.
@@ -84,7 +84,7 @@
     currentLabel: reagent-name-hotsauce
 
 - type: entity
-  parent: DrinkBottlePlasticBaseFull
+  parent: [DrinkBottleVisualsOpenable, DrinkBottlePlasticBaseFull]
   id: DrinkKetchupJug
   name: ketchup jug
   description: Someone filled a tomato with sugar until it burst. Delicious.
@@ -101,7 +101,7 @@
     currentLabel: reagent-name-ketchup
 
 - type: entity
-  parent: DrinkBottlePlasticBaseFull
+  parent: [DrinkBottleVisualsOpenable, DrinkBottlePlasticBaseFull]
   id: DrinkMustardJug
   name: mustard jug
   description: All of the implications of real mustard with none of the flavor.
@@ -118,7 +118,7 @@
     currentLabel: reagent-name-mustard
 
 - type: entity
-  parent: DrinkBottlePlasticBaseFull
+  parent: [DrinkBottleVisualsOpenable, DrinkBottlePlasticBaseFull]
   id: DrinkSoysauceJug
   name: soy sauce jug
   description: You can only dream of putting some of this on a bowl of rice.
@@ -135,7 +135,7 @@
     currentLabel: reagent-name-soysauce
 
 - type: entity
-  parent: DrinkBottlePlasticBaseFull
+  parent: [DrinkBottleVisualsOpenable, DrinkBottlePlasticBaseFull]
   id: DrinkMayoJug
   name: mayonnaise jug
   description: When this jug is emptied it will fall to you to fill it. Will you have the strength. Will you have the resolve.
@@ -153,7 +153,7 @@
 
 # imp coffee machine
 - type: entity
-  parent: DrinkBottlePlasticBaseFull
+  parent: [DrinkBottleVisualsOpenable, DrinkBottlePlasticBaseFull]
   id: JugCaramexinin
   name: caramexinin jug
   suffix: For Drinks, Full
@@ -171,7 +171,7 @@
     currentLabel: reagent-name-caramexinin
 
 - type: entity
-  parent: DrinkBottlePlasticBaseFull
+  parent: [DrinkBottleVisualsOpenable, DrinkBottlePlasticBaseFull]
   id: JugNanocaf
   name: nanocaf jug
   suffix: For Drinks, Full
@@ -189,11 +189,11 @@
     currentLabel: reagent-name-nanocaf
 
 - type: entity
-  parent: DrinkBottlePlasticBaseFull
+  parent: [DrinkBottleVisualsOpenable, DrinkBottlePlasticBaseFull]
   id: JugWater
   name: water powder jug
   suffix: For Drinks, Full
-  description: A jug of water. Also probably microplastics. 
+  description: A jug of water. Also probably microplastics.
   components:
   - type: SolutionContainerManager
     solutions:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds a new parent "DrinkBottleVisualsOpenable", to any (all) prototype that does not have them, resulting in a parent of [DrinkBottleVisualsOpenable, DrinkBottlePlasticBaseFull]

## Why / Balance
Fixes #4351

## Technical details
The jugs were missing DrinkBottleVisualsOpenable parent, which seemingly allows the sprite to change states based on whether or not it is open or not. I did not examine DrinkBottleVisualsOpenable further once I have confirmed the addition of its fixes the issue.

## How to test
Get any prototype in said .yml (for example, caramexin jug) and open it, observe that it changed sprites.

## Media
<img width="54" height="60" alt="image" src="https://github.com/user-attachments/assets/32d2cdf8-be76-4211-9949-a6899994f102" />
<img width="62" height="64" alt="image" src="https://github.com/user-attachments/assets/c3837cf3-89fe-4198-a7b0-78a35424edae" />

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes
Unlikely to have caused any breaking changes, at worst it duplicated some parents (parent and grandparent are the same one)

**Changelog**
:cl: AmbitiousFailure
- fix: Fixed Frontier-unique jugs not updating their sprites when opened.
