### PR TITLE
Restricted ammo blueprints as expedition loot

### DIFF
--- a/Resources/Prototypes/_NF/Catalog/Fills/Backpacks/npc_loot_mercenaries.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/Backpacks/npc_loot_mercenaries.yml
@@ -524,6 +524,10 @@
       prob: 0.1
     - id: AmmoTechFabCircuitboard
       prob: 0.1
+    # Blueprints
+    - id: NFBlueprintIncendiaryAmmo
+      prob: 0.15
+      amount: 1
     # Bonus Loot T4
     - id: SpaceCash2500
       prob: 0.9

--- a/Resources/Prototypes/_NF/Catalog/Fills/Backpacks/npc_loot_punks.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/Backpacks/npc_loot_punks.yml
@@ -270,6 +270,10 @@
     - id: HoloGraffitiProjector
       amount: 1
       prob: 0.45
+    # Blueprints
+    - id: NFBlueprintEmpAmmo
+      prob: 0.15
+      amount: 1
     # - id: NFBlueprintPortableRecharger # TODO: return this
     #   prob: 0.1
     #   amount: 1

--- a/Resources/Prototypes/_NF/Catalog/Fills/Backpacks/npc_loot_syndicate.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/Backpacks/npc_loot_syndicate.yml
@@ -370,7 +370,7 @@
       - id: SpaceCash10000
       # Blueprints
       - id: NFBlueprintHighCaliberAmmo
-        prob: 0.15
+        prob: 0.25
         amount: 1
       # Bonus Loot T4
       - id: SpaceCash2500

--- a/Resources/Prototypes/_NF/Catalog/Fills/Backpacks/npc_loot_syndicate.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/Backpacks/npc_loot_syndicate.yml
@@ -368,6 +368,10 @@
         prob: 0.2
       - id: ClothingShoesBootsMagSyndie
       - id: SpaceCash10000
+      # Blueprints
+      - id: NFBlueprintHighCaliberAmmo
+        prob: 0.15
+        amount: 1
       # Bonus Loot T4
       - id: SpaceCash2500
         prob: 0.9
@@ -393,6 +397,10 @@
   - type: SpawnItemsOnUse
     items:
       - id: SpaceCash10000
+      # Blueprints
+      - id: NFBlueprintUraniumAmmo
+        prob: 0.15
+        amount: 1
       # Bonus Loot T4
       - id: SpaceCash2500
         prob: 0.9

--- a/Resources/Prototypes/_NF/Entities/Objects/Tools/blueprints/blueprints_expedition_loot.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Tools/blueprints/blueprints_expedition_loot.yml
@@ -78,7 +78,7 @@
   parent: NFBaseBlueprintExpeditionSalvage
   id: NFBlueprintEmpAmmo
   name: restricted ammunition blueprint (EMP)
-  description: A blueprint with the schematics for high-tech small arms ammunition that discharges electromagnetic pulses on impact. It can be inserted into a protolathe or techfab.
+  description: A blueprint with the schematics for high-tech small arms ammunition that discharge electromagnetic pulses on impact. It can be inserted into a protolathe or techfab.
   components:
   - type: Blueprint
     providedRecipes:

--- a/Resources/Prototypes/_NF/Entities/Objects/Tools/blueprints/blueprints_expedition_loot.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Tools/blueprints/blueprints_expedition_loot.yml
@@ -53,11 +53,11 @@
   - type: Blueprint
     providedRecipes:
     - NFAmmunitionBoxRifle20Uranium
-    - NFAmmunitionBoxRifle25Uranium
+  #  - NFAmmunitionBoxRifle25Uranium - Currently unused
     - NFAmmunitionBoxRifle30Uranium
     - NFAmmunitionBoxPistol35Uranium
     - NFAmmunitionBoxPistol45Uranium
-    - NFAmmunitionBoxShellShotgun50Uranium
+    - NFAmmunitionBoxShellShotgunUranium
   
 - type: entity
   parent: NFBaseBlueprintExpeditionSalvage
@@ -68,11 +68,11 @@
   - type: Blueprint
     providedRecipes:
     - NFAmmunitionBoxRifle20Incendiary
-    - NFAmmunitionBoxRifle25Incendiary
+  #  - NFAmmunitionBoxRifle25Incendiary - Currently unused
     - NFAmmunitionBoxRifle30Incendiary
     - NFAmmunitionBoxPistol35Incendiary
     - NFAmmunitionBoxPistol45Incendiary
-    - NFAmmunitionBoxShellShotgun50Incendiary
+    - NFAmmunitionBoxShellShotgunIncendiary
 
 - type: entity
   parent: NFBaseBlueprintExpeditionSalvage

--- a/Resources/Prototypes/_NF/Entities/Objects/Tools/blueprints/blueprints_expedition_loot.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Tools/blueprints/blueprints_expedition_loot.yml
@@ -41,3 +41,57 @@
   - type: Blueprint
     providedRecipes:
     - NFEnergyPickaxe
+
+# Ammo types
+
+- type: entity
+  parent: NFBaseBlueprintExpeditionSalvage
+  id: NFBlueprintUraniumAmmo
+  name: restricted ammunition blueprint (Uranium)
+  description: A blueprint with the schematics for ammunition tipped with enriched-uranium. It can be inserted into a protolathe or techfab.
+  components:
+  - type: Blueprint
+    providedRecipes:
+    - NFAmmunitionBoxRifle20Uranium
+    - NFAmmunitionBoxRifle25Uranium
+    - NFAmmunitionBoxRifle30Uranium
+    - NFAmmunitionBoxPistol35Uranium
+    - NFAmmunitionBoxPistol45Uranium
+    - NFAmmunitionBoxShellShotgun50Uranium
+  
+- type: entity
+  parent: NFBaseBlueprintExpeditionSalvage
+  id: NFBlueprintIncendiaryAmmo
+  name: restricted ammunition blueprint (Incendiary)
+  description: A blueprint with the schematics for ammunition with spark-ignition payloads. It can be inserted into a protolathe or techfab.
+  components:
+  - type: Blueprint
+    providedRecipes:
+    - NFAmmunitionBoxRifle20Incendiary
+    - NFAmmunitionBoxRifle25Incendiary
+    - NFAmmunitionBoxRifle30Incendiary
+    - NFAmmunitionBoxPistol35Incendiary
+    - NFAmmunitionBoxPistol45Incendiary
+    - NFAmmunitionBoxShellShotgun50Incendiary
+
+- type: entity
+  parent: NFBaseBlueprintExpeditionSalvage
+  id: NFBlueprintEmpAmmo
+  name: restricted ammunition blueprint (EMP)
+  description: A blueprint with the schematics for high-tech small arms ammunition that discharges electromagnetic pulses on impact. It can be inserted into a protolathe or techfab.
+  components:
+  - type: Blueprint
+    providedRecipes:
+    - NFAmmunitionBoxPistol35Emp
+    - NFAmmunitionBoxPistol45Emp
+
+- type: entity
+  parent: NFBaseBlueprintExpeditionSalvage
+  id: NFBlueprintHighCaliberAmmo
+  name: restricted ammunition blueprint (.60 cal)
+  description: A blueprint with the schematics for high-caliber ammunition. It can be inserted into a protolathe or techfab.
+  components:
+  - type: Blueprint
+    providedRecipes:
+    - NFAmmunitionBoxRifle60
+    - NFAmmunitionBoxRifle60Rubber

--- a/Resources/Prototypes/_NF/Recipes/Lathes/security.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/security.yml
@@ -384,6 +384,22 @@
     Plasma: 200
     Silver: 100
 
+#region .60 Ammo Box
+- type: latheRecipe
+  parent: BaseAmmoRecipe
+  id: NFAmmunitionBoxRifle60
+  result: NFAmmunitionBoxRifle60
+  materials:
+    Steel: 600 # box - free, 30 [bullets] * 20 [Steel per bullet]
+
+- type: latheRecipe
+  parent: BaseAmmoRecipe
+  id: NFAmmunitionBoxRifle60Rubber
+  result: NFAmmunitionBoxRifle60Rubber
+  materials:
+    Plastic: 300 # box - free, 30 [bullets] * 10 [Plastic per bullet]
+    Steel: 300 # box - free, 30 [bullets] * 10 [Steel per bullet]
+
 #region Empty Mags
 - type: latheRecipe # novalite mag empty
   parent: BaseEmptyMagazineRecipe


### PR DESCRIPTION
## About the PR
Adds lathe recipes for the .60 caliber ammo boxes. Adds 4 blueprints for 60 cal, emp, uranium and incendiary ammo. Adds these blueprints to the drop-table of expedition bosses. Syndicate drops high cal and uranium, mercenaries drop incendiary, punks drop emp. The high cal has 25% drop chance, the rest 15%.

## Why / Balance
These are already obtainable as floor loot, and drop from enemies on occasion. This incentivizes using the ammunition instead of hoarding boxes like consumables that you'll need for that BIG encounter that if ever comes, won't give you the time to load these and gives you a way to upgrade your arsenal if you get sufficiently lucky. The bottlenecks are tough enemies that have a low chance of awarding them. They're also contraband, though the ammunition itself isn't, so trading the ammo won't get you in trouble, but if the NFSD notices you've got a lot of it, they might take an interest in why you have a stockpile and where it comes from, making it a potential entry for conflict rp.

## Technical details
Just yml.

## How to test
Open exped boss bags (T4MercCap, PunkBoss, SyndieCommanderC and D), find restricted ammo blueprint, add it to a lathe.

## Requirements
- [ X ] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X ] I have added media to this PR or it does not require an ingame showcase.
- [ X ] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes
None

**Changelog**
:cl:
- add: Adds blueprints for different ammo types as expedition boss loot.
