### PR TITLE
Address scurrets being unable to put anything in the backslot

### DIFF
--- a/Resources/Prototypes/InventoryTemplates/scurret_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/scurret_inventory_template.yml
@@ -55,7 +55,7 @@
     stripTime: 3
     uiWindowPos: 2,0
     strippingWindowPos: 2,5
-    dependsOn: jumpsuit
+    dependsOn: outerClothing
     dependsOnComponents:
     - type: AllowSuitStorage
     displayName: Suit Storage

--- a/Resources/Prototypes/InventoryTemplates/scurret_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/scurret_inventory_template.yml
@@ -59,6 +59,9 @@
     dependsOnComponents:
     - type: AllowSuitStorage
     displayName: Suit Storage
+    whitelist:
+      tags:
+      - ScurretWearable
   - name: outerClothing
     slotTexture: suit
     slotFlags: OUTERCLOTHING

--- a/Resources/Prototypes/InventoryTemplates/scurret_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/scurret_inventory_template.yml
@@ -55,7 +55,7 @@
     stripTime: 3
     uiWindowPos: 2,0
     strippingWindowPos: 2,5
-    dependsOn: outerClothing
+    dependsOn: outerClothing # Frontier - jumpsuit<outerClothing
     dependsOnComponents:
     - type: AllowSuitStorage
     displayName: Suit Storage

--- a/Resources/Prototypes/InventoryTemplates/scurret_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/scurret_inventory_template.yml
@@ -59,11 +59,6 @@
     dependsOnComponents:
     - type: AllowSuitStorage
     displayName: Suit Storage
-    # Frontier begin
-    whitelist:
-      tags:
-      - ScurretWearable
-    # Frontier end
   - name: outerClothing
     slotTexture: suit
     slotFlags: OUTERCLOTHING

--- a/Resources/Prototypes/InventoryTemplates/scurret_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/scurret_inventory_template.yml
@@ -59,9 +59,11 @@
     dependsOnComponents:
     - type: AllowSuitStorage
     displayName: Suit Storage
+    # Frontier begin
     whitelist:
       tags:
       - ScurretWearable
+    # Frontier end
   - name: outerClothing
     slotTexture: suit
     slotFlags: OUTERCLOTHING


### PR DESCRIPTION
## About the PR
Scurrets can't hold anything in the backslot right now. It's The backslot depends on the jumpsuit, which has no intersection as far as I'm aware with any item that has allowsuitstorage. This PR changes the dependance to the proper clothing and keeps the whitelist for scurret wearable stuff as displacement maps don't cover things sufficiently.

To address both issues, we resolve the null set intersection, and open it up to further contribs to add the scurretwearable tag on items where the displacement maps aren't broken. Eg. jetpacks, spears.

## Why / Balance
Why even have the backslot if nothing can be put in it, either take it off the template or make it hold stuff.

## Technical details
dependsOn: outerClothing # Frontier - jumpsuit<outerClothing as well as the whitelist

## How to test
Spawn scurret. Spawn something that usually goes in the backslot. Try putting it on, it'll refuse. Use "> ent $netid tag:add ScurretWearable" on that something. Observe how it'll go on. Spawn something that usually doesn't go in the backslot. Add the tag similarly. Observe how it won't go on.

## Media
<img width="707" height="250" alt="image" src="https://github.com/user-attachments/assets/b3937362-7055-4587-8755-93b6b3deb388" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ X ] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X ] I have added media to this PR or it does not require an ingame showcase.
- [ X ] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Displacement maps would be an issue, but since the whitelist is there, this functionally changes nothing just yet.

**Changelog**
:cl:
- fix: Scurret backslots no longer expect jumpsuit items making it impossible to use it. Valid displacements still need to be filtered, but you can contribute to add the ScurretWearable tag to any backslot compatible item now if the sprites aren't broken.
