### PR TITLE
Match leporazine's threshholds to temperature component base values

### DIFF
--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -518,12 +518,12 @@
       - !type:AdjustTemperature
         conditions:
         - !type:Temperature
-          max: 293.15
+          max: 260.15 # Frontier 293.15<260.15
         amount: 100000 # thermal energy, not temperature!
       - !type:AdjustTemperature
         conditions:
         - !type:Temperature
-          min: 293.15
+          min: 360.15 # Frontier 293.15<360.15
         amount: -10000
       - !type:PopupMessage
         type: Local


### PR DESCRIPTION
## About the PR
Changed 293.15 to upper limit 360.15 and lower limit 260.15 on leporazine's effects. Range values set based on Temperature component's base values for heat and cold damage, I recognise this may be different for some species or pets, most species hover around the 300-315 range. Could narrow it down to 293-315 if that seems more sane and we want lepo use to be less safe for whatever reason.

## Why / Balance
Using 5 units of a specialized temperature stabilizing med on room temp pets shouldn't give them 90 heat damage.

## Technical details
Just yml

## How to test
Inject 5u leporazine into a cat, observe how they don't burn in front of your eyes.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ X ] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X ] I have added media to this PR or it does not require an ingame showcase.
- [ X ] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None
**Changelog**
:cl:
- tweak: Leporazine range brought in line with the base temperature damage threshholds. Room temp pets should no longer ignite internally when treated with lepo.
