### PR TITLE
Ranged gun damage buff

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/energy.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/energy.yml
@@ -9,7 +9,7 @@
     impactEffect: BulletImpactEffectOrangeDisabler
     damage:
       types:
-        Heat: 8
+        Heat: 10
 
 # Assault Rifles / Carbines
 - type: entity
@@ -38,7 +38,7 @@
     impactEffect: BulletImpactEffectOrangeDisabler
     damage:
       types:
-        Heat: 12
+        Heat: 15
 
 # Rifles
 - type: entity
@@ -50,7 +50,7 @@
     impactEffect: BulletImpactEffectOrangeDisabler
     damage:
       types:
-        Heat: 14
+        Heat: 17.5
 
 #region Disabler bolts
 - type: entity
@@ -113,7 +113,7 @@
     impactEffect: BulletImpactEffectKinetic
     damage:
       types:
-        Blunt: 10
+        Blunt: 12.5
         Structural: 30
   - type: Ammo
     muzzleFlash: HitscanEffect
@@ -136,7 +136,7 @@
     impactEffect: BulletImpactEffectKinetic
     damage:
       types:
-        Blunt: 13
+        Blunt: 16.25
         Structural: 30
 
 - type: entity
@@ -155,7 +155,7 @@
     impactEffect: BulletImpactEffectKinetic
     damage:
       types:
-        Blunt: 18
+        Blunt: 22.5
         Structural: 30
   - type: PointLight
     color: "#ffffff"

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/hitscan.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/hitscan.yml
@@ -3,7 +3,7 @@
   id: NFRedLightLaser
   damage:
     types:
-      Heat: 8
+      Heat: 10
   muzzleFlash: &lightMuzzleFlash
     sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
     state: muzzle_laser
@@ -20,7 +20,7 @@
   id: NFRedMediumLaser
   damage:
     types:
-      Heat: 12
+      Heat: 15
   muzzleFlash:
     sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
     state: muzzle_beam_heavy
@@ -37,7 +37,7 @@
   id: NFRedHeavyLaser
   damage:
     types:
-      Heat: 14
+      Heat: 17.5
   muzzleFlash:
     sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
     state: muzzle_beam_heavy
@@ -54,7 +54,7 @@
   id: NFRedSpecialLaser
   damage:
     types:
-      Heat: 20
+      Heat: 25
   muzzleFlash: &specialMuzzleFlash
     sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
     state: muzzle_beam_heavy2
@@ -71,8 +71,8 @@
   id: NFXrayLaser
   damage:
     types:
-      Heat: 10
-      Radiation: 10
+      Heat: 12.5
+      Radiation: 12.5
   muzzleFlash:
     sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
     state: muzzle_xray
@@ -89,7 +89,7 @@
   id: NFPulse
   damage:
     types:
-      Heat: 18
+      Heat: 22.5
   muzzleFlash:
     sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
     state: muzzle_blue
@@ -114,13 +114,13 @@
 
 # Shuttle guns
 
-# Whatstone - got a rough value based on 
+# Whatstone - got a rough value based on
 - type: hitscan
   id: NFRedShuttleLaser
   maxLength: 60
   damage:
     types:
-      Heat: 30
+      Heat: 37.5
       Structural: 10
   muzzleFlash: *specialMuzzleFlash
   travelFlash: *specialTravelFlash

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/pistol.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/pistol.yml
@@ -9,10 +9,10 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 4
-        Blunt: 4
+        Piercing: 5
+        Blunt: 5
   - type: StaminaDamageOnCollide
-    damage: 4 # 15 hits to slowdown
+    damage: 5 # 12 hits to slowdown
 
 - type: entity
   id: NFBulletPistol35Overpressure
@@ -23,10 +23,10 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 4
-        Blunt: 5
+        Piercing: 5
+        Blunt: 6
   - type: StaminaDamageOnCollide
-    damage: 5 # 12 hits to slowdown
+    damage: 6 # 10 hits to slowdown
 
 - type: entity
   id: NFBulletPistol35Incendiary
@@ -37,10 +37,10 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 4.8 # 0.6 * base total dmg
-        Heat: 3.2 # 0.4 * base total dmg
+        Blunt: 6 # 0.6 * base total dmg
+        Heat: 4 # 0.4 * base total dmg
   - type: StaminaDamageOnCollide
-    damage: 4 # 15 hits to slowdown
+    damage: 5 # 12 hits to slowdown
 
 - type: entity
   id: NFBulletPistol35Uranium
@@ -51,10 +51,10 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 6.6 # 0.6 * (1.4 * base total dmg)
-        Radiation: 4.4 # 0.4 * (1.4 * base total dmg)
+        Blunt: 8.4 # 0.6 * (1.4 * base total dmg)
+        Radiation: 5.6 # 0.4 * (1.4 * base total dmg)
   - type: StaminaDamageOnCollide
-    damage: 4 # 15 hits to slowdown
+    damage: 6 # 10 hits to slowdown
 
 - type: entity
   id: NFBulletPistol35Practice
@@ -78,10 +78,10 @@
   - type: Projectile
     damage:
       types:
-        Shock: 4
-        Blunt: 4
+        Shock: 5
+        Blunt: 5
   - type: StaminaDamageOnCollide
-    damage: 4 # 15 hits to slowdown
+    damage: 6 # 10 hits to slowdown
 
 - type: entity
   id: NFBulletPistol35Rubber
@@ -106,10 +106,10 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 6
-        Blunt: 6
+        Piercing: 7.5
+        Blunt: 7.5
   - type: StaminaDamageOnCollide
-    damage: 6 # 10 hits to slowdown
+    damage: 8 # ~8 hits to slowdown
 
 - type: entity
   id: NFBulletPistol45Overpressure
@@ -120,10 +120,10 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 6
-        Blunt: 7
+        Piercing: 8
+        Blunt: 9
   - type: StaminaDamageOnCollide
-    damage: 7 # ~9 hits to slowdown
+    damage: 9 # ~7 hits to slowdown
 
 - type: entity
   id: NFBulletPistol45Incendiary
@@ -134,10 +134,10 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 7.2 # 0.6 * base total dmg
-        Heat: 4.8 # 0.4 * base total dmg
+        Blunt: 9 # 0.6 * base total dmg
+        Heat: 6 # 0.4 * base total dmg
   - type: StaminaDamageOnCollide
-    damage: 6 # 10 hits to slowdown
+    damage: 8 # ~8 hits to slowdown
 
 - type: entity
   id: NFBulletPistol45Uranium
@@ -148,10 +148,10 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 9.6 # 0.6 * (1.4 * base total dmg)
-        Radiation: 6.4 # 0.6 * (1.4 * base total dmg)
+        Blunt: 12.6 # 0.6 * (1.4 * base total dmg)
+        Radiation: 8.4 # 0.6 * (1.4 * base total dmg)
   - type: StaminaDamageOnCollide
-    damage: 6 # 10 hits to slowdown
+    damage: 9 # ~7 hits to slowdown
 
 - type: entity
   id: NFBulletPistol45Practice
@@ -175,10 +175,10 @@
   - type: Projectile
     damage:
       types:
-        Shock: 6
-        Blunt: 6
+        Shock: 8
+        Blunt: 7
   - type: StaminaDamageOnCollide
-    damage: 6 # 10 hits to slowdown
+    damage: 10 # 6 hits to slowdown
 
 - type: entity
   id: NFBulletPistol45Rubber

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/rifle.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/rifle.yml
@@ -9,7 +9,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 11
+        Piercing: 13.75
 
 - type: entity
   id: NFBulletRifle10Practice
@@ -45,7 +45,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 13
+        Piercing: 16.25
 
 - type: entity
   id: NFBulletRifle20Overpressure
@@ -56,7 +56,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 14
+        Piercing: 18
 
 - type: entity
   id: NFBulletRifle20Incendiary
@@ -67,8 +67,8 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 7.8 # 0.6 * base total dmg
-        Heat: 5.2 # 0.4 * base total dmg
+        Piercing: 9.75 # 0.6 * base total dmg
+        Heat: 6.5 # 0.4 * base total dmg
 
 - type: entity
   id: NFBulletRifle20Uranium
@@ -79,8 +79,8 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 10.8 # 0.6 * (1.4 * base total dmg)
-        Radiation: 7.2 # 0.4 * (1.4 * base total dmg)
+        Piercing: 13.2 # 0.6 * (1.4 * base total dmg)
+        Radiation: 8.8 # 0.4 * (1.4 * base total dmg)
 
 - type: entity
   id: NFBulletRifle20Practice
@@ -116,7 +116,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 14
+        Piercing: 17.5
 
 - type: entity
   id: NFBulletRifle25Overpressure
@@ -127,7 +127,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 16
+        Piercing: 20
 
 - type: entity
   id: NFBulletRifle25Incendiary
@@ -138,8 +138,8 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 8.4 # 0.6 * base total dmg
-        Heat: 5.6 # 0.4 * base total dmg
+        Piercing: 10.5 # 0.6 * base total dmg
+        Heat: 7 # 0.4 * base total dmg
 
 - type: entity
   id: NFBulletRifle25Uranium
@@ -150,8 +150,8 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 11.4 # 0.6 * (1.4 * base total dmg)
-        Radiation: 7.6 # 0.4 * (1.4 * base total dmg)
+        Piercing: 14.4 # 0.6 * (1.4 * base total dmg)
+        Radiation: 9.6 # 0.4 * (1.4 * base total dmg)
 
 - type: entity
   id: NFBulletRifle25Practice
@@ -187,7 +187,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 15
+        Piercing: 18.75
 
 - type: entity
   id: NFBulletRifle30Overpressure
@@ -198,7 +198,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 17
+        Piercing: 21
 
 - type: entity
   id: NFBulletRifle30Incendiary
@@ -209,8 +209,8 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 9
-        Heat: 6
+        Piercing: 11.25
+        Heat: 7.5
 
 - type: entity
   id: NFBulletRifle30Uranium
@@ -221,8 +221,8 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 12.6
-        Radiation: 8.4
+        Piercing: 15.6
+        Radiation: 10.4
 
 - type: entity
   id: NFBulletRifle30Practice
@@ -258,7 +258,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 35
+        Piercing: 43.75
         Structural: 200
     penetrationThreshold: 360
     penetrationDamageTypeRequirement:

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
@@ -8,7 +8,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 4
+        Piercing: 5
 
 - type: entity
   categories: [ HideSpawnMenu ]
@@ -19,7 +19,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 5
+        Piercing: 6.25
 
 - type: entity
   categories: [ HideSpawnMenu ]
@@ -30,8 +30,8 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 2.4
-        Heat: 1.6
+        Blunt: 3
+        Heat: 2
 
 - type: entity
   categories: [ HideSpawnMenu ]
@@ -53,8 +53,8 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 3.5
-        Radiation: 3.5
+        Piercing: 4.4
+        Radiation: 4.4
 
 - type: entity
   categories: [ HideSpawnMenu ]
@@ -73,8 +73,8 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 2
-        Slash: 2
+        Piercing: 2.5
+        Slash: 2.5
 
 - type: entity
   categories: [ HideSpawnMenu ]
@@ -85,7 +85,7 @@
   - type: Projectile
     damage:
       types:
-        Slash: 3.5
+        Slash: 4.4
 
 - type: entity
   categories: [ HideSpawnMenu ]
@@ -96,8 +96,8 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 4
-        Structural: 5
+        Piercing: 5
+        Structural: 6.25
 
 #region PelletsSpread
 - type: entity
@@ -182,8 +182,8 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 20
-        Blunt: 5
+        Piercing: 25
+        Blunt: 6.25
 
 - type: entity
   categories: [ HideSpawnMenu ]
@@ -194,7 +194,7 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 10
+        Blunt: 12.5
   - type: StaminaDamageOnCollide
     damage: 30 # 4 hits to stun
 


### PR DESCRIPTION
## About the PR
Almost a universal 25% buff to ranged projectile damage - both kinetic (such as .35 pistol or .20 rifle) and energy bolts/beams. What wasn’t buffed: arrows, crossbow bolts, special mob projectiles (e.g., xeno acid spit, blood cult magic bolts, etc.), and stamina-based projectiles.

## Why / Balance
The initial rework of projectile damage was balanced around unarmored targets, which in retrospect wasn’t the right approach. This PR adjusts the values to be balanced around targets wearing basic combat armor like bulletproof vest or mercenary hardsuit (25-30%).

As a side effect, expeditions with enemies that rely heavily on ranged weapons (punks, mercenaries, and syndicate agents) _might_ become more difficult, as those mobs use the same projectiles.

The table with new values can be seen here: [T2RebalancedValues](https://docs.google.com/spreadsheets/d/1y4ZafY2NIjpexmwyrK5nPaWvOnVg3hQ40tCN1dXBHac/edit?usp=sharing)

## Technical details
numbers

## How to test
1. Spawn ammo, inspect damage values
2. Embark on expeditions/vgrouds without punks/mercenaries/syndies
3. Embark on expeditions/vgrouds with punks/mercenaries/syndies

## Media
New values:
<img width="574" height="405" alt="image" src="https://github.com/user-attachments/assets/70666c87-fb68-43ce-891e-880f9faf6614" />
Old values:
<img width="574" height="401" alt="image" src="https://github.com/user-attachments/assets/7902a300-bf4d-4031-bf17-f940c3f6252a" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [ ] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:
- tweak: Increased ranged projectile damage by 25% (kinetic and energy).
