### PR TITLE
Changed bluespace authorization text to allow signing by the NFSD CO

### DIFF
--- a/Resources/Prototypes/_NF/Catalog/Fills/Paper/forms_nfsd.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/Paper/forms_nfsd.yml
@@ -329,9 +329,9 @@
       [bold]Vessel IFF:[/bold]
       [bold]Shift Time:[/bold]
 
-      [bold]Issuing Frontier Command:[/bold]
-          [bullet]XXXXXXXX, Station Representative
-          [bullet]XXXXXXXX, Sheriff
+      [head=3][bold]Issuing Frontier Authority[/bold][/head]
+      [bold]Commanding Officer Name:[/bold]
+      [bold]Commanding Officer Rank:[/bold]
 
       This document authorizes the above vessel and its captain to assist and [bold]cooperate with the NFSD and Frontier authorities[/bold] in neutralizing [bold]hostile bluespace threats[/bold] to Frontier. These include, but are not limited to:
           [bullet] Cultist vessels
@@ -349,7 +349,7 @@
 
 
 
-      [color=#AAAAAA]This Form is void without the signatures of both Parties and a stamp of Frontier Command (Sheriff or Station Representative).[/color]
+      [color=#AAAAAA]This Form is void without the signatures of both the permitted Captain and the issuing Commanding Officer, as well as their stamp when one is available at their rank.[/color]
       
 - type: entity # Based on form made by Red
   id: PaperWrittenNFSDWritOfTheFrontier


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Changed the content of the bluespace authorization to allow Commanding Officers to sign and officiate the paper. This comes following an admin vote on the matter that passed with 73% backing.

## Why / Balance
UIV content is meant to be engaged by mercs and NFSD, currently they are often locked down by NFSD despite them having no intent to raid it for warying reasons. The two groups often work together well when a sheriff is present, and this paperwork can be issued, but in practice people find it logical to issue an NFZ and stare at the thing when it cannot be issued. It should not be barred entirely when no command is around, to discourage this kind of deadlock where NFSD won't engage the UIV due to risk of dying, but won't ignore it due to them having contra and won't work together with mercs because there is no command around to enable that option. Tangentially related is the new way to track security status for authorized people that enables the CO to mark the people they've issued these to. (https://github.com/new-frontiers-14/frontier-station-14/pull/4433)

## Technical details
Barely even yml. Paperwork content change.

## How to test
Spawn NFSD Pal folders (green, brown variants), check the bluespace authorization paper in the fill.

## Requirements
- [ X ] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X ] I have added media to this PR or it does not require an ingame showcase.
- [ X ] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes
SOP needs to be updated on the wiki, none for the codebase.

**Changelog**
:cl:
- tweak: Changed bluespace authorization content to allow NFSD Commanding Officers to also authorize them. (Note: Not all papers, just that the bluespace auth.) Credit for the paper remains with Starly.
