### PR TITLE
Add hairflower to loadout

### DIFF
--- a/Resources/Prototypes/_NF/Loadouts/Jobs/Contractor/backpack_items.yml
+++ b/Resources/Prototypes/_NF/Loadouts/Jobs/Contractor/backpack_items.yml
@@ -237,6 +237,14 @@
   storage:
     back:
     - UrnMortuary
+    
+- type: loadout
+  id: ContractorClothingHeadHatHairflower
+  price: 0
+  storage:
+    back:
+    - ClothingHeadHatHairflower
+
 
 #T1
 - type: loadout

--- a/Resources/Prototypes/_NF/Loadouts/contractor_loadout_groups.yml
+++ b/Resources/Prototypes/_NF/Loadouts/contractor_loadout_groups.yml
@@ -792,6 +792,7 @@
   - ContractorBeachBall
   - ContractorCrayonBox
   - ContractorSoapNT
+  - ContractorClothingHeadHatHairflower
   - PlushieLizard
   - ContractorPlushieSharkGrey
   - ContractorPlushieSharkBlue


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added the hairflower to the starting contractor loadout

## Why / Balance
It's an important part of a character that I have, and it was something that I saw mentioned ideas a really long time ago!

## Technical details
Added ContractorClothingHeadHairFlower as a T0 $0 item under the misc part of contractor backpack items. (Put in backpack items instead of head because it's a trinket in upstream)
Put ContractorClothingHeadHatHairflower into the ContractorBackpackItems loadout group

## How to test
Start server
Navigate to loadout menu
Select hairflower
Pretty flower!

## Media
![HairflowerInLoadout](https://github.com/user-attachments/assets/b5e99d9f-006f-48b9-9896-f4dcdb2eec34)
![HairflowerInBag](https://github.com/user-attachments/assets/9ae9c716-621c-4b74-b3f7-ea404a58feb0)

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: Eli_Real_
- add: Added hairflower to the backpack loadout
