### PR TITLE
Fix multiple boss spawns on expeditions (again)

### DIFF
--- a/Resources/Prototypes/_NF/Procedural/salvage_factions.yml
+++ b/Resources/Prototypes/_NF/Procedural/salvage_factions.yml
@@ -23,9 +23,9 @@
     - proto: NFMobXenoPraetorian
       cost: 3
       prob: 0.2
-    - proto: NFMobXenoQueen
-      cost: 4
-      prob: 0.1
+    #- proto: NFMobXenoQueen
+      #cost: 4
+      #prob: 0.1
     - proto: NFMobXenoRavager
       cost: 2
     - proto: NFMobXenoRunner
@@ -69,9 +69,9 @@
     - proto: NFMobRainbowWyvernCaustic
       cost: 3
       prob: 0.05
-    - proto: NFMobDragonDungeon
-      cost: 4
-      prob: 0.05
+    #- proto: NFMobDragonDungeon
+      #cost: 4
+      #prob: 0.05
   configs:
     DefenseStructure: CarpStatue
     Megafauna: NFMobDragonDungeon
@@ -86,9 +86,9 @@
     - proto: SpawnMobAberrantFleshNewbornExpeditions
       cost: 2
       prob: 0.1
-    - proto: MobHorrorExpeditions
-      cost: 3
-      prob: 0.1
+    #- proto: MobHorrorExpeditions
+      #cost: 3
+      #prob: 0.1
   configs:
     DefenseStructure: AberrantFleshDigestiveSack
     Megafauna: MobHorrorExpeditions
@@ -123,9 +123,9 @@
       cost: 2
     - proto: MobArgocyteEnforcerExpeditions
       cost: 3
-    - proto: MobArgocyteLeviathingExpeditions
-      cost: 4
-      prob: 0.05
+    #- proto: MobArgocyteLeviathingExpeditions
+      #cost: 4
+      #prob: 0.05
   configs:
     DefenseStructure: ArgocyteEgg
     Megafauna: MobArgocyteLeviathingExpeditions
@@ -151,9 +151,9 @@
       cost: 3
     - proto: MobPunkGangerShotgun
       cost: 6
-    - proto: MobPunkGangerLeader
-      cost: 4
-      prob: 0.05
+    #- proto: MobPunkGangerLeader
+      #cost: 4
+      #prob: 0.05
   configs:
     DefenseStructure: PunkPartySupplies
     Megafauna: MobPunkGangerLeader
@@ -181,9 +181,9 @@
       cost: 4
     - proto: MobDinosaurStegoExpeditions
       cost: 5
-    - proto: MobDinosaurTrexExpeditions
-      cost: 6
-      prob: 0.05
+    #- proto: MobDinosaurTrexExpeditions
+      #cost: 6
+      #prob: 0.05
   configs:
     DefenseStructure: DinosaurEgg
     Megafauna: MobDinosaurTrexExpeditions
@@ -211,9 +211,9 @@
     - proto: MobMercenarySpecialistAssault
       cost: 6
       prob: 0.3
-    - proto: MobMercenaryCaptain
-      cost: 6
-      prob: 0.05
+    #- proto: MobMercenaryCaptain
+      #cost: 6
+      #prob: 0.05
   configs:
     DefenseStructure: MercenaryCounterfeitCache
     Megafauna: MobMercenaryCaptain
@@ -244,9 +244,9 @@
     - proto: SpawnMobSyndicateNavalCaptain
       cost: 5
       prob: 0.1
-    - proto: MobSyndicateNavalCommanderA
-      cost: 7
-      prob: 0.1
+    #- proto: MobSyndicateNavalCommanderA
+      #cost: 7
+      #prob: 0.1
     - proto: SpawnMobSyndicateNavalHorror
       cost: 5
       prob: 0.01
@@ -276,9 +276,9 @@
     - proto: MobExplorerHauler
       cost: 4
       prob: 0.1
-    - proto: MobExplorerBoss
-      cost: 6
-      prob: 0.05
+    #- proto: MobExplorerBoss
+      #cost: 6
+      #prob: 0.05
   configs:
     DefenseStructure: ExplorersLootRadar
     Megafauna: MobExplorerBoss
@@ -305,9 +305,9 @@
     - proto: MobRogueSiliconScrapFlayer
       cost: 2
       prob: 0.1
-    - proto: MobRogueSiliconBoss
-      cost: 4
-      prob: 0.05
+    #- proto: MobRogueSiliconBoss
+      #cost: 4
+      #prob: 0.05
     - proto: MobRogueSiliconGuardian
       cost: 8
       prob: 0.05
@@ -340,9 +340,9 @@
     - proto: SpawnMobBloodCultistJanitor
       cost: 3
       prob: 0.05
-    - proto: MobBloodCultistAscended
-      cost: 6
-      prob: 0.05
+    #- proto: MobBloodCultistAscended
+      #cost: 6
+      #prob: 0.05
   configs:
     DefenseStructure: BloodCollector
     Megafauna: MobBloodCultistAscended


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Commented out the lines in the `Resources\Prototypes\_NF\Procedural\salvage_factions.yml`

## Why / Balance
Spawning multiple bosses in a dungeon for an “Eliminate” mission creates unnecessary confusion. I chose to comment out the lines instead of removing them, as I believe the bosses should be updated, and the old ones could be repurposed as high-threat mobs.

## Technical details
yml

## How to test
1 . Go on expeditions with "Eliminate" mission type.
2. Observe only one boss NPC is spawned.
3.  Verify that expedition completes successfully upon death of that NPC.

## Media
not needed

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [ ] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:
- fix: Fixed multiple bosses spawning on expeditions.
