### PR TITLE
Fix Infoshades inventory footprint, hide health icon

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Clothing/Eyes/glasses_punks.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Eyes/glasses_punks.yml
@@ -40,15 +40,14 @@
 # HUDs
 - type: entity
   id: ClothingEyesPunkInfoShades
-  parent: [ ClothingEyesHudMedical, RecyclableItemClothDevice ]
+  parent: [ ClothingEyesBase, RecyclableItemClothDevice ]
   name: punk infoshades
   description: How can you see anything in this with all the lights?
   components:
   - type: VisionCorrection
   - type: Item
     shape:
-    - 0,0,1,0
-    storedOffset: -20,-20
+    - 0,0,0,1
   - type: Sprite
     sprite: _NF/Clothing/Eyes/Glasses/punk_glasses.rsi
     layers:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Removed `storedOffset` component, changed parent on the infoshades

## Why / Balance
bug fix
removed the health icon display, as it doesn’t provide any additional information beyond what the health bar currently shows, but takes up screen space

## Technical details
yml

## How to test
1. Spawn `ClothingEyesPunkInfoShades`, wear, store in inventory

## Media
<img width="256" height="374" alt="image" src="https://github.com/user-attachments/assets/c8f24cdd-0030-4a45-b6a6-505c1f1579be" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [ ] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:
- tweak: Infoshades no longer display health icons.
- fix: Fixed infoshades' inventory footprint.
