### PR TITLE
Make vgroids show up in the direction of barrier gate

### DIFF
--- a/Content.Server/_NF/StationEvents/Components/BiasTargetComponent.cs
+++ b/Content.Server/_NF/StationEvents/Components/BiasTargetComponent.cs
@@ -1,0 +1,13 @@
+namespace Content.Server._NF.StationEvents.Components;
+
+// A component to bias the direction that objects spawn in.
+// Only the direction relative to 0,0 is considered
+[RegisterComponent]
+public sealed partial class BiasTargetComponent : Component
+{
+    /// <summary>
+    /// The type of this bias target. Should match between this component and whatever you want to spawn's bluespaceerrorrulecomponent.
+    /// </summary>
+    [DataField(required: true)]
+    public string id = "";
+}

--- a/Content.Server/_NF/StationEvents/Components/BluespaceErrorRuleComponent.cs
+++ b/Content.Server/_NF/StationEvents/Components/BluespaceErrorRuleComponent.cs
@@ -68,6 +68,11 @@ public interface IBluespaceSpawnGroup
     public float MaximumDistance { get; }
 
     /// <summary>
+    /// Type of bias target to search for to bias the spawning direction.
+    /// </summary>
+    public string? SpawnBiasTarget { get; }
+
+    /// <summary>
     /// A localized name. Overrides other name fields.
     /// </summary>
     public List<LocId> NameLoc { get; }
@@ -126,12 +131,14 @@ public sealed class BluespaceDungeonSpawnGroup : IBluespaceSpawnGroup
     /// </summary>
     public List<ProtoId<DungeonConfigPrototype>> Protos = new();
 
-    /// <summary>
-    /// Minimum distance from the map's origin to
-    /// </summary>
+    /// <inheritdoc />
     public float MinimumDistance { get; }
 
+    /// <inheritdoc />
     public float MaximumDistance { get; }
+
+    /// <inheritdoc />
+    public string? SpawnBiasTarget { get; }
 
     /// <inheritdoc />
     public List<LocId> NameLoc { get; } = new();
@@ -171,6 +178,8 @@ public sealed class BluespaceGridSpawnGroup : IBluespaceSpawnGroup
 
     /// <inheritdoc />
     public float MaximumDistance { get; }
+    /// <inheritdoc />
+    public string? SpawnBiasTarget { get; }
     public List<LocId> NameLoc { get; } = new();
     public ProtoId<LocalizedDatasetPrototype>? NameDataset { get; }
 

--- a/Content.Server/_NF/StationEvents/Events/BluespaceErrorRule.cs
+++ b/Content.Server/_NF/StationEvents/Events/BluespaceErrorRule.cs
@@ -19,6 +19,7 @@ using Content.Server.StationEvents.Events;
 using Content.Server._NF.Station.Systems;
 using Content.Server._NF.StationEvents.Components;
 using Robust.Shared.EntitySerialization.Systems;
+using System.Runtime.Intrinsics;
 
 namespace Content.Server._NF.StationEvents.Events;
 
@@ -72,14 +73,20 @@ public sealed class BluespaceErrorRule : StationEventSystem<BluespaceErrorRuleCo
                 {
                     var query = EntityQueryEnumerator<BiasTargetComponent>();
 
+                    List<Vector2> targets = new();
+
                     while (query.MoveNext(out var ent, out var biasComp))
                     {
                         if (biasComp.id == group.SpawnBiasTarget)
                         {
-                            // We don't care where it is, only its direction
-                            biasDirection = Vector2.Normalize(_transform.GetMapCoordinates(ent).Position);
-                            break;
+                            targets.Add(_transform.GetMapCoordinates(ent).Position);
                         }
+                    }
+
+                    if (targets.Count > 0)
+                    {
+                        // Pick a random one from the list of possible targets. We don't care where it is, only its direction.
+                        biasDirection = Vector2.Normalize(_random.Pick<Vector2>(targets));
                     }
                 }
 

--- a/Content.Server/_NF/StationEvents/Events/BluespaceErrorRule.cs
+++ b/Content.Server/_NF/StationEvents/Events/BluespaceErrorRule.cs
@@ -66,9 +66,37 @@ public sealed class BluespaceErrorRule : StationEventSystem<BluespaceErrorRuleCo
             {
                 EntityUid spawned;
 
+                Vector2? biasDirection = null;
+                // If there is a bias target, see if one exists with a matching ID
+                if (group.SpawnBiasTarget is not null)
+                {
+                    var query = EntityQueryEnumerator<BiasTargetComponent>();
+
+                    while (query.MoveNext(out var ent, out var biasComp))
+                    {
+                        if (biasComp.id == group.SpawnBiasTarget)
+                        {
+                            // We don't care where it is, only its direction
+                            biasDirection = Vector2.Normalize(_transform.GetMapCoordinates(ent).Position);
+                            break;
+                        }
+                    }
+                }
+
                 if (group.MinimumDistance > 0f)
                 {
-                    spawnCoords = spawnCoords.WithPosition(_random.NextVector2(group.MinimumDistance, group.MaximumDistance));
+                    if (biasDirection is not null)
+                    {
+                        // The spawning region describes a circle with a diameter equal to the width between the minimum and maximum distance.
+                        // We construct this by placing the centre of the circle with a vector in the direction of the bias target with a magnitude equal to the average of the two
+                        // and adding a random vector with a maximum magnitude half of the difference between the two.
+                        var spawnCentre = biasDirection.Value * ((group.MaximumDistance + group.MinimumDistance) / 2);
+                        spawnCoords = spawnCoords.WithPosition(spawnCentre + _random.NextVector2((group.MaximumDistance - group.MinimumDistance) / 2));
+                    }
+                    else
+                    {
+                        spawnCoords = spawnCoords.WithPosition(_random.NextVector2(group.MinimumDistance, group.MaximumDistance));
+                    }
                 }
 
                 switch (group)

--- a/Resources/Prototypes/_NF/Events/nf_bluespace_dungeons_events.yml
+++ b/Resources/Prototypes/_NF/Events/nf_bluespace_dungeons_events.yml
@@ -31,6 +31,7 @@
         nameDataset: NamesBorer
         minimumDistance: 1500
         maximumDistance: 2500
+        spawnBiasTarget: 'vgroid'
         addComponents: &dungeonComponents
         - type: Gravity
           enabled: true
@@ -59,6 +60,7 @@
         nameDataset: NamesBorer
         minimumDistance: 1500
         maximumDistance: 2500
+        spawnBiasTarget: 'vgroid'
         addComponents: *dungeonComponents
         protos:
         - NFVGRoidSnow
@@ -74,6 +76,7 @@
         nameDataset: NamesBorer
         minimumDistance: 1500
         maximumDistance: 2500
+        spawnBiasTarget: 'vgroid'
         addComponents: *dungeonComponents
         protos:
         - NFVGRoidCave
@@ -89,6 +92,7 @@
         nameDataset: NamesBorer
         minimumDistance: 1500
         maximumDistance: 2500
+        spawnBiasTarget: 'vgroid'
         addComponents: *dungeonComponents
         protos:
         - NFVGRoidChromite
@@ -104,6 +108,7 @@
         nameDataset: NamesBorer
         minimumDistance: 1500
         maximumDistance: 2500
+        spawnBiasTarget: 'vgroid'
         addComponents: *dungeonComponents
         protos:
         - NFVGRoidScrap
@@ -119,6 +124,7 @@
         nameDataset: NamesBorer
         minimumDistance: 1500
         maximumDistance: 2500
+        spawnBiasTarget: 'vgroid'
         addComponents: *dungeonComponents
         protos:
         - NFVGRoidCaveZombie

--- a/Resources/Prototypes/_NF/Events/nf_bluespace_dungeons_events.yml
+++ b/Resources/Prototypes/_NF/Events/nf_bluespace_dungeons_events.yml
@@ -30,7 +30,7 @@
       vgroid: !type:DungeonSpawnGroup
         nameDataset: NamesBorer
         minimumDistance: 1500
-        maximumDistance: 2500
+        maximumDistance: 3500
         spawnBiasTarget: 'vgroid'
         addComponents: &dungeonComponents
         - type: Gravity
@@ -59,7 +59,7 @@
       vgroid: !type:DungeonSpawnGroup
         nameDataset: NamesBorer
         minimumDistance: 1500
-        maximumDistance: 2500
+        maximumDistance: 3500
         spawnBiasTarget: 'vgroid'
         addComponents: *dungeonComponents
         protos:
@@ -75,7 +75,7 @@
       vgroid: !type:DungeonSpawnGroup
         nameDataset: NamesBorer
         minimumDistance: 1500
-        maximumDistance: 2500
+        maximumDistance: 3500
         spawnBiasTarget: 'vgroid'
         addComponents: *dungeonComponents
         protos:
@@ -91,7 +91,7 @@
       vgroid: !type:DungeonSpawnGroup
         nameDataset: NamesBorer
         minimumDistance: 1500
-        maximumDistance: 2500
+        maximumDistance: 3500
         spawnBiasTarget: 'vgroid'
         addComponents: *dungeonComponents
         protos:
@@ -107,7 +107,7 @@
       vgroid: !type:DungeonSpawnGroup
         nameDataset: NamesBorer
         minimumDistance: 1500
-        maximumDistance: 2500
+        maximumDistance: 3500
         spawnBiasTarget: 'vgroid'
         addComponents: *dungeonComponents
         protos:
@@ -123,7 +123,7 @@
       vgroid: !type:DungeonSpawnGroup
         nameDataset: NamesBorer
         minimumDistance: 1500
-        maximumDistance: 2500
+        maximumDistance: 3500
         spawnBiasTarget: 'vgroid'
         addComponents: *dungeonComponents
         protos:

--- a/Resources/Prototypes/_NF/PointsOfInterest/barriergate.yml
+++ b/Resources/Prototypes/_NF/PointsOfInterest/barriergate.yml
@@ -21,6 +21,8 @@
   - type: SolarPoweredGrid
     trackOnInit: true
     doNotCull: true
+  - type: BiasTarget
+    id: 'vgroid'
 
 - type: gameMap
   id: BarrierGate


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
This PR changes the spawning logic for vgroids to bias them towards a target. In this case the target chosen is barrier gate, but the specific target can be placed on any POI (or actually really any entity at all) and the things that are affected by the target can also be customised.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Dusty said "hmm it might be interesting if..." and here we are.

## Technical details
<!-- Summary of code changes for easier review. -->

- Added a new marker component `BiasTargetComponent` which contains a string field `id` which is just a way of grouping targets and spawns.
- Added the `BiasTargetComponent` to barrier gate with the group `vgroid`
- Added the `SpawnBiasTarget` field to `BluespaceErrorRule` comps (actually comp interfaces) which try and spawn in the general direction of whatever has a `BiasTargetComponent` with a matching group id
- Added spawn bias targets to all vgroids with the group `vgroid`
- Added some code that moves the spawn region of event grids to be biased (wow) towards the bias target (no way!) if it exists.

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
- Start the round, vv barrier gate and see it has the server component `BiasTargetComponent` with the id "vgroid"
- Spam `addgamerule BluespaceDungeonBasalt` or whatever your favourite flavour of vgroid is
- On a shuttle console, open a map and pin barrier gate. Once the vgroids bluespace in, rescan and see that all the vgroids are in the general direction of barrier gate.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<img width="661" height="458" alt="diagram" src="https://github.com/user-attachments/assets/cee259c5-36a1-4902-b1b4-afa1e142d3fa" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [ ] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: VGroids now appear in the general direction of Barrier Gate instead of everywhere around Frontier Outpost.

