### PR TITLE
Make inflatable dock rotatable while anchored

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Objects/Misc/inflatables.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Misc/inflatables.yml
@@ -81,8 +81,6 @@
   id: NFInflatableDoor
   name: inflatable door
   suffix: Frontier
-  placement:
-    mode: SnapgridCenter
   components:
   - type: Sprite
     sprite: _NF/Objects/Misc/inflatable_door.rsi
@@ -112,8 +110,6 @@
   id: NFInflatableDoorWindow
   name: inflatable windoor
   suffix: Frontier
-  placement:
-    mode: SnapgridCenter
   components:
   - type: Sprite
     sprite: _NF/Objects/Misc/inflatable_door_window.rsi
@@ -137,22 +133,13 @@
   description: An inflated membrane with reinforced hardpoints, capable of docking. Activate to deflate. Do not puncture.
   suffix: Frontier, Docking
   components:
+  - type: Rotatable
+    rotateWhileAnchored: true
   - type: Docking
   - type: NavMapDoor
   - type: Sprite
     sprite: _NF/Objects/Misc/inflatable_dock.rsi
     state: closed
-  - type: Door
-    openSound:
-      path: /Audio/Misc/zip.ogg
-    closeSound:
-      path: /Audio/Misc/zip.ogg
-  - type: Anchorable
-  - type: Transform
-    anchored: true
-  - type: Rotatable
-  - type: Physics
-    bodyType: Static
   - type: Fixtures
     fixtures:
       fix1:
@@ -176,6 +163,7 @@
       - South
   - type: Tag
     tags:
+      - Structure
       - ForceNoFixRotations
   - type: DisassembleOnAltVerb
     prototypeToSpawn: NFInflatableDockStack1


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Allows inflatable dock to be rotated while anchored.

## Why / Balance
Bugfix, convenience, some clean up

## Technical details
<!-- Summary of code changes for easier review. -->

## How to test
1. Spawn `NFInflatableDockStack1`, deploy it
2. Use wrench - should do nothing
3. Use context menu to rotate the airlock
4. Deflate the airlock (alt+lmb)

## Media
<img width="807" height="449" alt="image" src="https://github.com/user-attachments/assets/dab3aeb4-d1f4-41fa-ba22-d0ab3a477f3c" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [ ] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:
- fix: Fixed an issue where the inflatable external airlock could not be rotated while anchored.
