### PR TITLE
Weapon rack construction graph fixes: empty container + check not locked

### DIFF
--- a/Resources/Prototypes/_NF/Recipes/Construction/Graphs/furniture/armory_racks_graphs.yml
+++ b/Resources/Prototypes/_NF/Recipes/Construction/Graphs/furniture/armory_racks_graphs.yml
@@ -13,6 +13,7 @@
       - !type:SpawnPrototype
         prototype: CableApcStack1
         amount: 2
+      - !type:EmptyAllContainers
       - !type:DeleteEntity {}
 
     edges:
@@ -104,6 +105,9 @@
     entity: StructureGunRack
     edges:
       - to: start
+        conditions:
+          - !type:Locked
+            locked: false
         steps:
           - tool: Screwing
             doAfter: 5
@@ -112,6 +116,9 @@
     entity: StructureGunRackWallmounted
     edges:
       - to: start
+        conditions:
+          - !type:Locked
+            locked: false
         steps:
           - tool: Screwing
             doAfter: 5
@@ -120,6 +127,9 @@
     entity: StructureMeleeWeaponRack
     edges:
       - to: start
+        conditions:
+          - !type:Locked
+            locked: false
         steps:
           - tool: Screwing
             doAfter: 5
@@ -128,6 +138,9 @@
     entity: StructureMeleeWeaponRackWallmounted
     edges:
       - to: start
+        conditions:
+          - !type:Locked
+            locked: false
         steps:
           - tool: Screwing
             doAfter: 5
@@ -136,6 +149,9 @@
     entity: StructurePistolRack
     edges:
       - to: start
+        conditions:
+          - !type:Locked
+            locked: false
         steps:
           - tool: Screwing
             doAfter: 5
@@ -144,6 +160,9 @@
     entity: StructurePistolRackWallmounted
     edges:
       - to: start
+        conditions:
+          - !type:Locked
+            locked: false
         steps:
           - tool: Screwing
             doAfter: 5


### PR DESCRIPTION
## About the PR
Fixes construction graphs for gun and melee weapon racks:

* Empty all containers when deconstructed.
* Check that it's not locked.

## Why / Balance
Guns go poof when you deconstruct the rack. Oh no! My fancy L6! Other deconstructible containers also use `!type:EmptyAllContainers` to ensure the contents are not deleted.

With this change, it also becomes very necessary to check if the rack is locked. Otherwise you can get to the contents of a locked NFSD rack with a screwdriver and five seconds of time. Other locked containers use the same condition.

## Technical details
YAML.

## How to test
1. Spawn a whole bunch of gun, sidearm and melee weapon racks.
2. Fill the racks with some stuff.
3. Deconstruct them (screwdriver).
4. Ensure the contents are not thrown into the void, never to be seen again.

## Media
https://github.com/user-attachments/assets/b6556c00-3808-4f6a-8b71-0cd46f51f5cb

(Not shown: sidearm racks. They work the same. Feel free to test.)

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes
No :)

**Changelog**
:cl:
- fix: Weapon racks can now be deconstructed without deleting the contained weapons.