### PR TITLE
Initialize Frontier triggers in TriggerSystem init

### DIFF
--- a/Content.Shared/Trigger/Systems/TriggerSystem.cs
+++ b/Content.Shared/Trigger/Systems/TriggerSystem.cs
@@ -53,6 +53,7 @@ public sealed partial class TriggerSystem : EntitySystem
         InitializeTimer();
         InitializeSpawn();
         InitializeVoice();
+        NFInitialize(); // Frontier
     }
 
     /// <summary>


### PR DESCRIPTION
## About the PR
Call `NFInitialize()` in `TriggerSystem.Initialize()`.

## Why / Balance
Upstream reworked the entire trigger system and we missed this ONE line of code. Dang. Among other things, this makes explosive and EMP crossbow bolts work again.

## Technical details
One single line of the sharpest C#.

## How to test
1. Spawn an explosive bolt and an EMP bolt.
2. Get yourself a crossbow.
3. Shoot something.
4. Bang! 💥 Zap! ⚡

## Media
N/A, so smol PR

## Requirements
- [x] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes
I hope not.

**Changelog**
:cl:
- fix: Explosive and EMP crossbow bolts now explode and EMP, respectively, on impact.