### PR TITLE
Add Missing Chem Machines to Med Lathe and Research

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -556,6 +556,7 @@
     - NFBasicEVAToolsStatic # Frontier
     - ReportingStatic # DeltaV
     - NFPaperAndPaperAccessories # Frontier
+    - NFMedicalBoards # Frontier
     - NFMedicalStatic # Frontier
     - NFMedicalClothingStatic # Frontier
     - NFChemistryBasicStatic # Frontier

--- a/Resources/Prototypes/_NF/Recipes/Lathes/Packs/blueprints.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/Packs/blueprints.yml
@@ -175,6 +175,8 @@
   # IndustrialMedicine
   - MedicalAssemblerMachineCircuitboard
   - HotplateMachineCircuitboard
+  - ElectrolysisUnitMachineCircuitboard
+  - CentrifugeMachineCircuitboard
   - DefibrillatorCompact
   # SyringeGun
   - LauncherSyringe

--- a/Resources/Prototypes/_NF/Recipes/Lathes/Packs/medical.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/Packs/medical.yml
@@ -111,3 +111,5 @@
   - ChemMasterMachineCircuitboard
   - ReagentGrinderMachineCircuitboard
   - HotplateMachineCircuitboard
+  - ElectrolysisUnitMachineCircuitboard
+  - CentrifugeMachineCircuitboard

--- a/Resources/Prototypes/_NF/Research/techtree.yml
+++ b/Resources/Prototypes/_NF/Research/techtree.yml
@@ -583,6 +583,8 @@
   recipeUnlocks:
   - MedicalAssemblerMachineCircuitboard
   - HotplateMachineCircuitboard
+  - ElectrolysisUnitMachineCircuitboard
+  - CentrifugeMachineCircuitboard
   - DefibrillatorCompact
   technologyPrerequisites:
   - NFBasicMedicine


### PR DESCRIPTION
## About the PR
Added the electrolysis unit and centrifuge boards to medical research under industrial chemistry as well as to the starting blueprints of medical lathes. 

## Why / Balance
As it stands, there is no way to build either of these devices but they're important to chemistry labs. Without this change, they can only be found by buying a new med ship or finding them on expeds/vgroids which poses potential problems if a chemlab were damaged or blown up. 

## Technical details
Modified the medical blueprints list and added the centrifuge and electrolysis unit boards to the industrial chemistry tech and NFMedicalBoards recipe pack; added the NFMedicalBoards pack to the list of static packs for the medical lathe.

## How to test
1. Spawn in a ship with a medical lathe.
2. See that the centrifuge and electrolysis unit boards can be printed.
3. Beg a science ship for medical tech.
3. See that the centrifuge and electrolysis unit are now unlocked alongside the hotplate and medical assembler. 

## Media
<img width="1562" height="752" alt="image" src="https://github.com/user-attachments/assets/a42cf4fa-177d-432d-bea8-67115b65bec0" />
<img width="1489" height="723" alt="image" src="https://github.com/user-attachments/assets/01d563a8-1755-473a-823e-2386887ef4d4" />

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes
In testing this hasn't broken anything, shouldn't interfere with anything to any notable extent. 

**Changelog**
:cl:
- add: Added the electrolysis unit and centrifuge to the starting blueprints on the medical lathe and to the Industrial Chemistry tech. 
