### PR TITLE
Replace AtmosEnabledMapComponent with AtmosDisabledMapComponent

### DIFF
--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Commands.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Commands.cs
@@ -227,11 +227,11 @@ public sealed partial class AtmosphereSystem
 
         if (enable)
         {
-            EnsureComp<AtmosEnabledMapComponent>(mapUid.Value);
+            RemComp<AtmosDisabledMapComponent>(mapUid.Value);
         }
         else
         {
-            RemComp<AtmosEnabledMapComponent>(mapUid.Value);
+            EnsureComp<AtmosDisabledMapComponent>(mapUid.Value);
         }
     }
     // End Frontier: Toggle atmos per map

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Utils.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Utils.cs
@@ -128,7 +128,7 @@ public partial class AtmosphereSystem
         if (!TryComp<MapComponent>(mapUid, out var mapComp))
             return false;
 
-        return AllowMapGasExtraction || mapComp.MapId == _gameTicker.DefaultMap || HasComp<AtmosEnabledMapComponent>(mapUid);
+        return AllowMapGasExtraction || !HasComp<AtmosDisabledMapComponent>(mapUid);
     }
     // End Frontier: disable atmos off maps
 }

--- a/Content.Server/Salvage/SpawnSalvageMissionJob.cs
+++ b/Content.Server/Salvage/SpawnSalvageMissionJob.cs
@@ -38,6 +38,7 @@ using Content.Server.Station.Systems; // Frontier
 using Content.Server._NF.Salvage.Expeditions.Structure; // Frontier
 using Content.Server._NF.Salvage.Expeditions; // Frontier
 using Content.Shared.Station.Components; // Frontier
+using Content.Shared._NF.Atmos.Components; // Frontier
 
 namespace Content.Server.Salvage;
 
@@ -150,6 +151,7 @@ public sealed class SpawnSalvageMissionJob : Job<bool>
             mapUid,
             _entManager.System<SharedSalvageSystem>().GetFTLName(_prototypeManager.Index(SalvageSystem.PlanetNames), _missionParams.Seed));
         _entManager.AddComponent<FTLBeaconComponent>(mapUid);
+        _entManager.EnsureComponent<AtmosDisabledMapComponent>(mapUid); // Frontier: disable atmos devices on exped map
 
         // Saving the mission mapUid to a CD is made optional, in case one is somehow made in a process without a CD entity
         if (CoordinatesDisk.HasValue)

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
@@ -143,8 +143,6 @@ public sealed partial class ShuttleSystem
         var mapUid = _mapSystem.CreateMap(out var mapId);
         var ftlMap = AddComp<FTLMapComponent>(mapUid);
 
-        EnsureComp<AtmosEnabledMapComponent>(mapUid); // Frontier
-
         _metadata.SetEntityName(mapUid, "FTL");
         Log.Debug($"Setup hyperspace map at {mapUid}");
         DebugTools.Assert(!_mapSystem.IsPaused(mapId));

--- a/Content.Shared/_NF/Atmos/Components/AtmosDisabledMapComponent.cs
+++ b/Content.Shared/_NF/Atmos/Components/AtmosDisabledMapComponent.cs
@@ -1,0 +1,9 @@
+namespace Content.Shared._NF.Atmos.Components;
+
+/// <summary>
+/// Empty component that marks atmos devices as being disabled on a map.
+/// </summary>
+[RegisterComponent]
+public sealed partial class AtmosDisabledMapComponent : Component
+{
+}

--- a/Content.Shared/_NF/Atmos/Components/AtmosEnabledMapComponent.cs
+++ b/Content.Shared/_NF/Atmos/Components/AtmosEnabledMapComponent.cs
@@ -1,7 +1,0 @@
-namespace Content.Shared._NF.Atmos.Components;
-
-// Empty component that marks whether or not atmos devices should process on a map
-[RegisterComponent]
-public sealed partial class AtmosEnabledMapComponent : Component
-{
-}


### PR DESCRIPTION
## About the PR
Swaps `AtmosEnabledMapComponent` with an equivalent but opposite `AtmosDisabledMapComponent`.

## Why / Balance
We are quite right to disable atmos devices on planet maps, because infinite gas etc. Unfortunately, however, the "disabled by default" approach leads to confusing situations sometimes:

- Can't really do experiments in ATAGs, because no devices work.
- Admeme maps also have non-functional atmos devices.
- When mapping, many of our players run `mapinit` to test their ships, only to find they can't verify their atmos system.

It is not clear that you can just run `setmapatmosenabled 123 true` to fix the problem.

Instead, this PR leaves atmos devices *enabled* by default, and specifically and explicitly *disables* atmos device processing on planet maps generated as part of expeditions. Fewer edge cases, everything "just works" except where it's not supposed to. No need to make a special exception for the FTL map, either.

## Technical details
I wrote some C#, innit.

Note that I removed the condition `mapComp.MapId == _gameTicker.DefaultMap`. This *does* mean a silly admin could `setmapatmosenabled (default map ID) false` to turn off atmos devices on the default map, but why would anyone do that? 

## How to test
1. Use a gas analyzer on some atmos devices on the main map. Maybe buy a ship. Make sure everything works as expected.
2. Put a plasma canister on a bus, wait for it to start FTLing, open the canister, and make sure the scrubbers scrubadubdub like they're supposed to.
3. Go on an expedition. Don't siphon the atmosphere because you can't.
4. Send yourself to your own ATAG. Do atmos experiments; verify that the devices work as they should.
5. Play around with `setmapatmosenabled`.

## Media
N/A

## Requirements
- [x] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes
The `AtmosMapEnabledComponent` has been removed and map atmosphere is now *enabled* by default on all maps. In its place, there is an `AtmosMapDisabledComponent`, which is added to expedition planet maps (and only them). If you explicitly added `AtmosMapEnabledComponent` to something, you can safely remove it. If you explicitly *removed* that component from something, you'll now need to *add* `AtmosMapDisabledComponent`.

**Changelog**
N/A, not player-facing