### PR TITLE
Added Ambuzol and Ambuzol Plus medipens to the Spawn Tables

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/Items/medical_tables.yml
+++ b/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/Items/medical_tables.yml
@@ -497,6 +497,7 @@
       - id: PyraAutoInjector
       - id: EphedrineAutoInjector
       - id: PolyAutoInjector
+      - id: AmbuzolAutoInjector
     # Rare (either good or undesirable)
     - !type:GroupSelector
       weight: 0.05
@@ -507,6 +508,7 @@
       - id: WehMedipen
       - id: EthylredoxrazineAutoInjector
       - id: StimulantAutoInjector
+      - id: AmbuzolPlusAutoInjector
 
 # region Hyposprays
 - type: entityTable


### PR DESCRIPTION
## About the PR
Added the Ambuzol medipen to the uncommon table and Ambuzol Plus to the rare table for random medipen spawns.

## Why / Balance
With #4467 I added these medipens with the intent of making the chems more accessible to mercenaries running zombie expeds and vgroids. What I missed was to add it to the random loot they might find, giving them that little bit of extra relevance to said mercenaries. 

## Technical details
Added AmbuzolAutoInjector under uncommon drops and AmbuzolPlusAutoInjector under rare drops for TableDungeonLootMedicalToolsMedipens in Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/Items/medical_tables.yml

## How to test
1. Be a mercenary
2. Look for random medipens
3. Rejoice as you find the solution to all your zombie problems

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

**Changelog**
:cl:
- add: Added the Ambuzol and Ambuzol Plus Auto-Injectors to the random medipen spawn pool.
