### PR TITLE
Prioritize signing papers over eating them

### DIFF
--- a/Content.Shared/Paper/PaperSystem.cs
+++ b/Content.Shared/Paper/PaperSystem.cs
@@ -396,7 +396,8 @@ public sealed class PaperSystem : EntitySystem
             {
                 TrySign((uid, component), args.User, args.Using.Value);
             },
-            Text = Loc.GetString("paper-component-verb-sign")
+            Text = Loc.GetString("paper-component-verb-sign"),
+            Priority = 3 //Frontier, higher than edible verbs
             // Icon = Don't have an icon yet. Todo for later.
         };
         args.Verbs.Add(verb);

--- a/Content.Shared/Paper/PaperSystem.cs
+++ b/Content.Shared/Paper/PaperSystem.cs
@@ -397,7 +397,7 @@ public sealed class PaperSystem : EntitySystem
                 TrySign((uid, component), args.User, args.Using.Value);
             },
             Text = Loc.GetString("paper-component-verb-sign"),
-            Priority = 3 //Frontier, higher than edible verbs
+            Priority = 3 // Higher than edible verbs
             // Icon = Don't have an icon yet. Todo for later.
         };
         args.Verbs.Add(verb);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Adjusted the alternative *sign* verb priority, so the logical action when holding a paper with a pen in the other hand is to sign it, not eat it.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
<img width="998" height="61" alt="image" src="https://github.com/user-attachments/assets/122abf75-868e-417b-afbe-16389cf0ce60" />

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
Alt-click any paper with pen in hand, sign it. 

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Alt-clicking paper with pen in hand now prioritize signing it over eating it.
