### PR TITLE
Shuttle (Update): fix Kestrel station prototype

### DIFF
--- a/Resources/Prototypes/_NF/Shipyard/kestrel.yml
+++ b/Resources/Prototypes/_NF/Shipyard/kestrel.yml
@@ -30,7 +30,7 @@
   minPlayers: 0
   stations:
     Kestrel:
-      stationProto: StandardFrontierExpeditionVessel
+      stationProto: StandardFrontierVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Kestrel {1}'
@@ -41,4 +41,4 @@
           availableJobs:
             ContractorInterview: [ 0, 0 ]
             PilotInterview: [ 0, 0 ]
-            MercenaryInterview: [ 0, 0 ]  
+            MercenaryInterview: [ 0, 0 ]


### PR DESCRIPTION
## About the PR
Replaced the Kestrel's station prototype with `StandardFrontierVessel`.

## Why / Balance
The Kestrel is not expedition capable, so shouldn't spawn with those components. It doesn't have an expedition console anyway, so you can't send it on expeds in the first place, but you know.

## Technical details
.yml

## How to test
1. Buy a Kestrel!
2. Find the ship's station entity.
3. Ensure it *does not* have the `SalvageExpeditionData` component.

## Media
N/A

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes
None.

**Changelog**
N/A, not player-facing in any capacity.