### PR TITLE
Add Ingredients to the Cooking Bag

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Objects/Specific/Kitchen/Equipment/cooking_bag.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Specific/Kitchen/Equipment/cooking_bag.yml
@@ -21,6 +21,8 @@
     whitelist:
       components:
         - Food
+      tags:
+        - Ingredient
     blacklist:
       components:
         - BadFood


### PR DESCRIPTION
## About the PR
Adds the Ingredient tag to the cooking bag's whitelist.

## Why / Balance
Frequently requested in the idea threat for the cooking bag, given it cannot take any variety of dough due to them not having a Food (Edible?) component. 

## How to test
1. Make a cooking bag
2. Mix up some dough. Or batter.
3. Find that it goes in the bag now. 

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

**Changelog**
:cl:
- add: Added ingredients to the whitelist for the Cooking Bag.
