### PR TITLE
Lathe Material Refund Functionality

### DIFF
--- a/Content.Server/Lathe/LatheSystem.cs
+++ b/Content.Server/Lathe/LatheSystem.cs
@@ -534,6 +534,7 @@ namespace Content.Server.Lathe
                 LogImpact.Low,
                 $"{ToPrettyString(args.Actor):player} deleted a lathe job for ({batch.ItemsPrinted}/{batch.ItemsRequested}) {GetRecipeName(batch.Recipe)} at {ToPrettyString(uid):lathe}");
 
+            RefundMaterials(uid, component, batch); // Frontier: Refund materials should they
             component.Queue.Remove(node);
             UpdateUserInterfaceState(uid, component);
         }
@@ -592,6 +593,20 @@ namespace Content.Server.Lathe
                 LogImpact.Low,
                 $"{ToPrettyString(args.Actor):player} aborted printing {GetRecipeName(component.CurrentRecipe.Value)} at {ToPrettyString(uid):lathe}");
 
+            // Frontier: Refund materials for the current recipe being aborted
+            if (_proto.TryIndex(component.CurrentRecipe.Value, out var recipe))
+            {
+                foreach (var (mat, amount) in recipe.Materials)
+                {
+                    var adjustedAmount = recipe.ApplyMaterialDiscount
+                        ? (int)(amount * component.FinalMaterialUseMultiplier)
+                        : amount;
+
+                    _materialStorage.TryChangeMaterialAmount(uid, mat, adjustedAmount);
+                }
+            }
+            // End Frontier
+
             component.CurrentRecipe = null;
             FinishProducing(uid, component);
         }
@@ -647,6 +662,29 @@ namespace Content.Server.Lathe
                         ModifyPrintedEntityPrice(uid, component, ent);
                     }
                 }
+            }
+        }
+        /// <summary>
+        /// Refunds materials for unprinted items in a batch
+        /// </summary>
+        private void RefundMaterials(EntityUid uid, LatheComponent component, LatheRecipeBatch batch)
+        {
+            if (!_proto.TryIndex(batch.Recipe, out var recipe))
+                return;
+
+            var unprintedCount = batch.ItemsRequested - batch.ItemsPrinted;
+            if (unprintedCount <= 0)
+                return;
+
+            // Refund materials using the same calculation as consumption (but positive to add back)
+            foreach (var (mat, amount) in recipe.Materials)
+            {
+                var adjustedAmount = recipe.ApplyMaterialDiscount
+                    ? (int)(amount * component.FinalMaterialUseMultiplier)
+                    : amount;
+                adjustedAmount *= unprintedCount;
+
+                _materialStorage.TryChangeMaterialAmount(uid, mat, adjustedAmount);
             }
         }
         #endregion


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Ports https://github.com/project-wayfarer/wayfarer-14/pull/407

Edit: Nvm, closing this as upstream already has a solution to this in https://github.com/space-wizards/space-station-14/pull/42416

## Why / Balance
Sometimes, you accidentally click the wrong thing to produce with a lathe. Sometimes, that ends up costing you an hour of mining, and sometimes, something longer than that depending on the amount you had things set to.

This aims to fix that, allowing players to get materials back when cancelling the production of a recipe. Also takes into account upgrades.

## Technical details
One new method in the frontier region of client.server's LatheSystem.cs, one loop. Pretty simple.

## How to test
Add materials to a lathe. Try printing something. Cancel it.

## Media
https://github.com/user-attachments/assets/6922bbff-6098-458e-b737-7de0945934d0


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Lathes should now refund materials from cancelled recipes in the queue.
