### PR TITLE
Pirate Longcoat Update

### DIFF
--- a/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/yarrrdrobe.yml
+++ b/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/yarrrdrobe.yml
@@ -16,6 +16,8 @@
     ClothingOuterCoatPirate: 4
     ClothingOuterCoatVictorian: 4
     ClothingOuterCoatVictorianRed: 4
+    ClothingLongcoatBlack: 4
+    ClothingLongcoatBrown: 4
     ClothingShoesBootsPirate: 4
     ClothingShoesBootsPirateLuffy: 4
     PirateHandyFlag: 4

--- a/Resources/Prototypes/_NF/Recipes/Lathes/Packs/clothing.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/Packs/clothing.yml
@@ -216,6 +216,8 @@
   - ClothingUniformJumpsuitPirateSlops
   - ClothingUniformJumpskirtColorBrown
   # Outer
+  - ClothingLongcoatBlack
+  - ClothingLongcoatBrown
   - ClothingOuterCoatPirate
   - ClothingOuterCoatGentle
   - ClothingOuterCoatPirateCaptain


### PR DESCRIPTION
## About the PR
Adds the black and brown longcoats to the Yarrdrobe and Pirate Stitcher

## Why / Balance
They're available in the pirate loadouts since #4383 but there's no way to easily provide them to pirates that forgot theirs at home. 

## Technical details
Added to the blueprints for the Pirate Stitcher and to the inventory of the Yarrdrobe

## How to test
1. Wake up at the Cove, woefully bereft of a coat
2. Check the Yarrdrobe and find that you can now exchange spesos for longcoats
3. Get a pirate stitcher and find that if you're broke (what good pirate isn't?) at least you can print them!

## Media
<img width="873" height="550" alt="image" src="https://github.com/user-attachments/assets/4c1f475c-afb7-485b-bee1-bd0cbec0f7c7" />

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

**Changelog**
:cl:
- add: Added the black and brown longcoat to the Yarrdrobe and Pirate Stitcher to correspond with loadouts.
