### PR TITLE
Increase MaxItem Size Treasure Chest Can Store

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Structures/Storage/magnetbox.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Storage/magnetbox.yml
@@ -240,6 +240,7 @@
           map: [ "enum.ToggleableVisuals.Layer" ]
           shader: unshaded
     - type: Storage
+      maxItemSize: Large
       whitelist:
         components:
           - NFTreasure


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Allows treasure chest to store trophies.

## Why / Balance
Trophies were intended to go in, but due to maxItem size limit of the treasure chests they wouldn't fit. This is a fix for it.

## Technical details
yml

## How to test
1. spawn a treasure chest, activate it
2. spawn trophies
3. observe

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [ ] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:
- fix: Fixed trophies not fitting in treasure chests.
