### PR TITLE
Removes practice ammo from exped pools

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/Items/weapon_tables.yml
+++ b/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/Items/weapon_tables.yml
@@ -379,9 +379,9 @@
     - !type:NestedSelector
       weight: 0.15
       tableId: TableDungeonLootWeaponsAmmunitionUranium
-    - !type:NestedSelector
-      weight: 0.05
-      tableId: TableDungeonLootWeaponsAmmunitionPractice
+   # - !type:NestedSelector
+   #   weight: 0.05
+   #   tableId: TableDungeonLootWeaponsAmmunitionPractice
 
 # region ammo lethal
 - type: entityTable


### PR DESCRIPTION

## About the PR
removed practice ammo from the expedition loot pool
## Why / Balance
It's practice ammo, there's not particularly anything useful or exciting about it, if you really want some go to exped lodge and buy a pack from the firing range.
## Technical details
put # over a few lines of YML

## How to test

load your local host, run an exped, notice that every box  of ammo you get lacks practice ammo.

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes
None were noticed during my testing.
**Changelog**
:cl:
- remove: Removed practice ammo spawns from expedition spawners.
