### PR TITLE
Added Mech hydraulic sound variation param

### DIFF
--- a/Content.Server/Mech/Equipment/Components/MechGrabberComponent.cs
+++ b/Content.Server/Mech/Equipment/Components/MechGrabberComponent.cs
@@ -43,7 +43,12 @@ public sealed partial class MechGrabberComponent : Component
     /// The sound played when a mech is grabbing something
     /// </summary>
     [DataField("grabSound")]
-    public SoundSpecifier GrabSound = new SoundPathSpecifier("/Audio/Mecha/sound_mecha_hydraulic.ogg");
+    public SoundSpecifier GrabSound = new SoundPathSpecifier("/Audio/Mecha/sound_mecha_hydraulic.ogg")
+    // Frontier: Add sound variation
+    {  
+        Params = AudioParams.Default.WithVariation(0.125f)  
+    };
+    // End Frontier
 
     public EntityUid? AudioStream;
 

--- a/Content.Server/_NF/Mech/Equipment/Components/MechForkComponent.cs
+++ b/Content.Server/_NF/Mech/Equipment/Components/MechForkComponent.cs
@@ -44,7 +44,12 @@ public sealed partial class MechForkComponent : Component
     /// The sound played when a mech is grabbing something
     /// </summary>
     [DataField]
-    public SoundSpecifier GrabSound = new SoundPathSpecifier("/Audio/Mecha/sound_mecha_hydraulic.ogg");
+    public SoundSpecifier GrabSound = new SoundPathSpecifier("/Audio/Mecha/sound_mecha_hydraulic.ogg")
+    // Frontier: Add sound variation
+    {  
+        Params = AudioParams.Default.WithVariation(0.125f)  
+    };
+    // End Frontier
 
     [ViewVariables(VVAccess.ReadOnly)]
     public EntityUid? AudioStream;


### PR DESCRIPTION
## About the PR
edited MechForkComponent.cs and MechGrabberComponent.cs to have variation params

## Why / Balance
Running Cargo in-game, you hear sound_mecha_hydraulic A LOT, with no variation or change, just the exact same sound hundreds of times, back to back. This change adds the variation param to the sound to just make it a bit easier to handle.

## Technical details
Both MechForkComponet and MechGrabberComponet were given the following change:
```cs
    public SoundSpecifier GrabSound = new SoundPathSpecifier("/Audio/Mecha/sound_mecha_hydraulic.ogg")
    // Frontier: Add sound variation
    {  
        Params = AudioParams.Default.WithVariation(0.125f)  
    };
    // End Frontier
```

## How to test
Use EMU hauler in-game and hear pitch shifting on the GrabSounds.

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).


## Breaking changes
None noticed while testing.

**Changelog**
:cl:
- tweak: Changed the sound of the EMU Hauler to have variance.
