### PR TITLE
Fix items construction using machine part stacks

### DIFF
--- a/Content.Shared/_NF/Construction/Steps/MachinePartConstructionGraphStep.cs
+++ b/Content.Shared/_NF/Construction/Steps/MachinePartConstructionGraphStep.cs
@@ -30,7 +30,7 @@ namespace Content.Shared.Construction.Steps // NOTE: currently exists under base
         public bool EntityValid(EntityUid entity, [NotNullWhen(true)] out StackComponent? stack)
         {
             stack = null;
-            if (IoCManager.Resolve<IEntityManager>().TryGetComponent(entity, out MachinePartComponent? part) && part.PartType != PartPrototypeId
+            if (IoCManager.Resolve<IEntityManager>().TryGetComponent(entity, out MachinePartComponent? part) && part.PartType == PartPrototypeId
                 && IoCManager.Resolve<IEntityManager>().TryGetComponent(entity, out StackComponent? otherStack) && otherStack.Count >= Amount)
             {
                 stack = otherStack;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
During the final refactor of #4371 after reviews, i missed a check when inverting the code logic, making objets constructible with any machine part except the one specified.

Since the constructible items are seldom used (it's limited to Medsec hud and potato cell) this has been undetected (or unreported) since #4371 merge.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Making items according to the recipe.

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->

Build a Medsec hud or potato cell using the right machine part.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
None.
**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Medsec huds and potato cells are now constructible using the right machine parts

