### PR TITLE
Portable Recharger can now be worn on your belt and suit storage slots

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Power/portable_recharger.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/portable_recharger.yml
@@ -41,7 +41,7 @@
   - type: ItemSlots
     slots:
       charger_slot:
-        ejectOnInteract: true
+        # ejectOnInteract: true # Frontier: In a fit of irony, this prevents you drawing the item in the slot by interacting.
         whitelist:
           components:
           - HitscanBatteryAmmoProvider

--- a/Resources/Prototypes/Entities/Objects/Power/portable_recharger.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/portable_recharger.yml
@@ -14,8 +14,17 @@
     quickEquip: false
     slots:
     - back
+    - Belt # Frontier
+    - suitStorage #Frontier
+    clothingVisuals: #Frontier
+      back:
+      - state: charging-equipped-BACKPACK
+      belt:
+      - state: charging-equipped-BACKPACK
+      suitstorage:
+      - state: charging-equipped-BACKPACK
   - type: Charger
-    chargeRate: 50 # Frontier: chargeRate: 50 
+    chargeRate: 50 # Frontier: chargeRate: 50
     slotId: charger_slot
     portable: true
   - type: PowerChargerVisuals


### PR DESCRIPTION

## About the PR
Lets you use the portable recharger on your belt and suit storage slots
## Why / Balance
The portable recharger and lasers in general have always been in a bit of an odd spot, being in practice weaker than ballistic weaponry due to the low shot count and slow charge time. While this does not fix that, it at least alleviates it by not needing you to drop your backpack space to recharge on the go.
## Technical details
Added belt and suitstorage allowances for the port. recharger, the sprite for both these locations is identical to the current backpack slot sprite. (due to how layering works the belt version is rendered below your armor and bag.)


## How to test
Get a portable charger, put it on your suit slot or belt, charge a gun or other tool of choice

## Media
<img width="783" height="694" alt="image" src="https://github.com/user-attachments/assets/1ece15c0-1e43-40b2-8702-e705f7ac1561" />
<img width="628" height="773" alt="image" src="https://github.com/user-attachments/assets/0754a96d-09d8-46c7-a2f5-3c3563ef1746" />


## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes
Nothing broke in my testing
**Changelog**

:cl:
- tweak: The Portable Recharger can now be worn on your belt and suit storage slots
