### PR TITLE
Add commands for managing machine DRM

### DIFF
--- a/Content.Server/_NF/Administration/Commands/DrmCommand.cs
+++ b/Content.Server/_NF/Administration/Commands/DrmCommand.cs
@@ -1,0 +1,42 @@
+using Content.Server._NF.BindToStation;
+using Content.Server.Station.Systems;
+using Robust.Shared.Toolshed;
+
+namespace Content.Server.Administration.Commands;
+
+[ToolshedCommand, AdminCommand(Shared.Administration.AdminFlags.Debug)]
+public sealed class DrmCommand : ToolshedCommand
+{
+    private BindToStationSystem? _bindToStation;
+    private StationSystem? _station;
+
+    [CommandImplementation("autobind")]
+    public EntityUid Autobind([PipedArgument] EntityUid input)
+    {
+        _bindToStation ??= GetSys<BindToStationSystem>();
+        _station ??= GetSys<StationSystem>();
+
+        if (_station.GetOwningStation(input) is { } station)
+        {
+            _bindToStation.BindToStation(input, station, enabled: true);
+        }
+
+        return input;
+    }
+
+    [CommandImplementation("bindto")]
+    public EntityUid BindTo([PipedArgument] EntityUid input, EntityUid station)
+    {
+        _bindToStation ??= GetSys<BindToStationSystem>();
+        _bindToStation.BindToStation(input, station, enabled: true);
+        return input;
+    }
+
+    [CommandImplementation("unbind")]
+    public EntityUid Unbind([PipedArgument] EntityUid input)
+    {
+        _bindToStation ??= GetSys<BindToStationSystem>();
+        _bindToStation.BindToStation(input, null, enabled: false);
+        return input;
+    }
+}

--- a/Resources/Locale/en-US/_NF/commands/toolshed-commands.ftl
+++ b/Resources/Locale/en-US/_NF/commands/toolshed-commands.ftl
@@ -1,0 +1,6 @@
+command-description-drm-autobind =
+    Binds a machine, computer or similar to the station it's currently on. If it's not on a station, this command does nothing.
+command-description-drm-bindto =
+    Binds a machine, computer or similar to the specified station.
+command-description-drm-unbind =
+    Removes all DRM protection from a machine, computer or similar.


### PR DESCRIPTION
## About the PR
Adds three new toolshed commands for managing machine (and computer) DRM:

- `drm:autobind` – The thinking man's command: automatically binds the input entity to whatever station it happens to be on. If it's not on a station, nothing happens.
- `drm:bindto STATION` – Binds the input entity to the specified station. Can be used to reassign an already station-bound entity.
- `drm:unbind` – Removes DRM restrictions from the input entity.

## Why / Balance
DRM is a great feature, but it's basically impossible to work with using VV. Even vvwrite doesn't seem to behave sensibly! So why not offer some commands to make admemes much simpler?

`drm:autobind` is the convenience version that saves the admin from having to find the stupid secret invisible station entity.

## Technical details
A single C# file with a pretty boring ToolshedCommand, plus some FTL to describe it. :)

## How to test
1. Buy a ship or visit one of the many POIs.
2. Plonk down a machine or computer.
3. Find its entity ID. Let's call it `ID`. Run `> ent ID drm:autobind`. Verify that it's now registered to the station you put it on.
4. Find a different station using `> stations:list`. Let's call its ID `STATION`. Run `> ent ID drm:bindto STATION`. Verify that the device is now bound to the other station.
5. Try `> ent ID drm:unbind`. The device should no longer have any DRM.

## Media
<img width="594" height="71" alt="image" src="https://github.com/user-attachments/assets/70ee365e-f200-4641-870e-512c53fdf7ad" />

<img width="398" height="285" alt="image" src="https://github.com/user-attachments/assets/784f9ec5-c1cf-4096-80ef-3ae80d5ee13d" />

_What the heck? The Baroness isn't an exped ship! Cool!_

<img width="596" height="150" alt="image" src="https://github.com/user-attachments/assets/e413f864-14dd-4327-9f7d-eff23c802f59" />

<img width="590" height="60" alt="image" src="https://github.com/user-attachments/assets/5253688e-7539-4d5d-a93f-b67976ea11a8" />

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes
None.

**Changelog**
:cl:
- add: Admins can now use commands "drm:autobind", "drm:bindto" and "drm:unbind" to manage machine DRM protections.