### PR TITLE
Xenoartifacts trigger from rads

### DIFF
--- a/Content.Shared/Xenoarchaeology/Artifact/XAT/XATDamageThresholdReachedSystem.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/XAT/XATDamageThresholdReachedSystem.cs
@@ -22,7 +22,9 @@ public sealed class XATDamageThresholdReachedSystem : BaseXATSystem<XATDamageThr
 
     private void OnDamageChanged(Entity<XenoArtifactComponent> artifact, Entity<XATDamageThresholdReachedComponent, XenoArtifactNodeComponent> node, ref DamageChangedEvent args)
     {
-        if (!args.DamageIncreased || args.DamageDelta == null || args.Origin == artifact.Owner)
+        //Frontier: allow artifact to self-damage for the purpose of activation of Heat, Cold, physical and radiation damages
+        if (!args.DamageIncreased || args.DamageDelta == null)
+        //Frontier End
             return;
 
         var damageTriggerComponent = node.Comp1;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Allow Artifact damage trigger system to accept self-damage for the purpose of activating nodes using physical, rads, heat and cold damage thresholds

Definitions:
Ambient radiation: the type of radiation accrued by existing inside of a radiation field (Geiger counter noises) as opposed to direct radiation which is accrued by being affected by a direct effect (reagent, uranium bullets, uranium spear) which deal radiation typed damages

## Why / Balance
The cause of this change is to allow artifacts to trigger their radiation nodes from ambient radiation fields.
Prior to this change, an artifact would collect radiation damage by being inside of an ambient radiation area (broken RTG, other radioactive artifacts, etc), but would not trigger its radiation-triggered nodes.

The side effect of this change is that an artifact may now cause one of its effects to activate a node on itself.
If an artifact has the "radiation trigger" currently non-triggered, and complete a separate node causing it to become radioactive, it now may self-trigger. Same as heat, cold and physical, should an artifact both generate such damage and possess a trigger that observe it.

From a balance point of view, this change introduce more possibilities for artifact activations:
- Artifacts may activate other artifacts rads triggers if they a rads effect
- Rads triggered artifacts can be triggered by environmental rads (broken generator, broken RTG, other artifacts, rad barrel, etc)
- **An artifact can potentially self-fulfill trigger conditions** in the rare case where it has both a damage trigger and a damage output of the same type.
-- this should be rare
-- this is mitigated by Frontier only allowing each node to activate once
-- this is mitigated by most nodes requiring multiple triggers, past the initial single trigger nodes

## Technical details
The full reason why ambient rads did not trigger artifacts prior to this change:
Ambient rads are dealt through the following workflow:
- the RadiationSystem.GridCast (Content.Server\Radiation\Systems\RadiationSystem.GridCast.cs) find sources and destination for ambient rads and fire OnIrradiatedEvent with the total combine rads from all sources on each given destination
- upon receiving the OnIrradiatedEvent, the destination DamageableSystem (or other listener like rads collectors) will act on the affected rads. For DamageableSystem, since the system is not aware of each individual causes of radiation, it adds rads damages to its owner and fire a DamageChangedEvent, with the owner as both the target of and the cause of the damage.
- The XATDamageThresholdReachedSystem (Content.Shared\Xenoarchaeology\Artifact\XAT\XATDamageThresholdReachedSystem.cs) subscribes to the DamageChangedEvent. The first check on its onDamageChanged listener checks if the source and the target of the damage are the same. My assumption is this is meant to prevent an artifact from self-activating nodes by dealing physical, rads, heat or cold to itself.

## How to test
Make a broken RTG
Make a bunch of artifacts
Some of them will have a rad trigger, wait a few seconds
Artifacts activate

## Media
<img width="796" height="820" alt="image" src="https://github.com/user-attachments/assets/59d1b96d-83d4-4894-a812-e268cc073a51" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [ ] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None expected

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Artifacts triggers from damages (rads, physical, heat, cold) can activate on self-dealt damage. Can also be activated by environmental radiation (from itself, other artifacts, radioactive objects)

