### PR TITLE
Spawned structures now properly give back machine parts on deconstruct

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Power/substation.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/substation.yml
@@ -251,12 +251,12 @@
   - type: ContainerFill
     containers:
       board: [ WallmountSubstationElectronics ]
-      manipulator: [ MicroManipulatorStockPart ]
+      machine_parts: [ CapacitorStockPart ] # Frontier: MicroManipulatorStockPart<CapacitorStockPart
       powercell: [ PowerCellSmall ]
   - type: ContainerContainer
     containers:
       board: !type:Container
-      manipulator: !type:Container
+      machine_parts: !type:Container # Frontier: manipulator<machine_parts
       powercell: !type:Container
 
       # Construction Frame

--- a/Resources/Prototypes/Entities/Structures/gates.yml
+++ b/Resources/Prototypes/Entities/Structures/gates.yml
@@ -291,3 +291,13 @@
     - Output
   - type: Construction
     node: memory_cell
+  # Frontier begin
+  - type: ContainerFill
+    containers:
+      machine_parts:
+      - MicroManipulatorStockPart
+      - MicroManipulatorStockPart
+  - type: ContainerContainer
+    containers:
+      machine_parts: !type:Container
+ # Frontier end


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
When adding support for machine parts in construction graphs, i didn't update the prototypes of wallmounted substations and memory cells entities.

That resulted in :
- spawned (or present at roundstart) wallsubstations giving back a manipulator instead of a capacitor (sorry for Bigsy that ended marooned because of that)
- spawned (or roundstart) memory cells not giving back any machine part despite requiring two manipulator for construction.


## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

If a machine part is needed for construction, people expect to get it back on deconstruction.

## Technical details
<!-- Summary of code changes for easier review. -->
Yaml containers light changes.

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
Spawn a memory cell or wallmount substation, deconstruct and verify that machine parts are given back.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
None

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: non constructed (station/ships initial) wallmount substations now properly give back a capacitor on deconstruct
- fix: non constructed memory cells now gives back manipulators on deconstruct

