### PR TITLE
Ports Tritium as radcollector fuel from Harmony by @Svetoslav228

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/collector.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/collector.yml
@@ -2,7 +2,10 @@
   id: RadiationCollector
   name: radiation collector
   suffix: Empty tank
-  description: A machine that collects radiation and turns it into power. Requires plasma gas to function.
+# Harmony change start - Changed description
+# description: A machine that collects radiation and turns it into power. Requires plasma gas to function.
+  description: A machine that collects radiation and turns it into power. Requires plasma or tritium gas to function.
+# Harmony change end
   placement:
     mode: SnapgridCenter
   components:
@@ -61,7 +64,12 @@
     radiationReactiveGases:
       - reactantPrototype: Plasma
         powerGenerationEfficiency: 1
-        reactantBreakdownRate: 0.0001
+#harmony change start
+        reactantBreakdownRate: 0.00012
+      - reactantPrototype: Tritium
+        powerGenerationEfficiency: 1.5
+        reactantBreakdownRate: 0.00006 
+#harmony change end
   - type: RadiationReceiver
   - type: PowerSupplier
   - type: Anchorable


### PR DESCRIPTION
## About the PR
Adds tritium as a more efficient radcollector fuel that depletes slower. Makes plasma deplete slightly faster. [Original PR](https://github.com/ss14-harmony/ss14-harmony/pull/1112)

## Why / Balance
Halves* the depletion rate if you're using tritium. (More like 60%, compared to the original, but nerfs plasma ever so slightly) Having a reason to collect and use tritium in a radcollector is a good gameplay change for edison when they're already planning to use a burnchamber for the TEG, and is a reasonably challenging feat, additionally makes the singulo a more convenient form of generation. Incentivizes plant managers who otherwise wouldn't use the TEG to dip their feet into atmos.

## Technical details
Just yml.

## How to test
Put tritium in rad collector.


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ X ] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X ] I have added media to this PR or it does not require an ingame showcase.
- [ X ] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None

**Changelog**
:cl: Svetoslav228
- add: Tritium is now valid radcollector fuel, it's more efficient and depletes slower than plasma.
- tweak: Plasma depletes ever so slightly faster as radcollector fuel.