### PR TITLE
Ports ExpireIDCard radio alerts from Harmony by @BlueMoon059

### DIFF
--- a/Content.Server/Access/Systems/IdCardSystem.cs
+++ b/Content.Server/Access/Systems/IdCardSystem.cs
@@ -11,6 +11,7 @@ using Content.Shared.Popups;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Content.Server.Kitchen.EntitySystems;
+using Content.Server.Radio.EntitySystems; //Harmony Change - For Radio Expire ID Message
 
 namespace Content.Server.Access.Systems;
 
@@ -22,6 +23,7 @@ public sealed class IdCardSystem : SharedIdCardSystem
     [Dependency] private readonly IAdminLogManager _adminLogger = default!;
     [Dependency] private readonly ChatSystem _chat = default!;
     [Dependency] private readonly MicrowaveSystem _microwave = default!;
+    [Dependency] private readonly RadioSystem _radio = default!; //Harmony Change - For Radio Expire ID Message
 
     public override void Initialize()
     {
@@ -119,5 +121,12 @@ public sealed class IdCardSystem : SharedIdCardSystem
                 ChatTransmitRange.Normal,
                 true);
         }
+        // Harmony Change Start - ID card radio system
+        if (ent.Comp.ExpireMessageRadio != null)
+        {
+            var message = Loc.GetString(ent.Comp.ExpireMessageRadio, ("name", ent.Owner));
+            _radio.SendRadioMessage(ent.Owner, message, ent.Comp.RadioChannel, ent.Owner);
+        }
+        // Harmony change end
     }
 }

--- a/Content.Shared/Access/Components/ExpireIdCardComponent.cs
+++ b/Content.Shared/Access/Components/ExpireIdCardComponent.cs
@@ -2,6 +2,7 @@ using Content.Shared.Access.Systems;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+using Content.Shared.Radio; // Harmony Change - For Radio Message
 
 namespace Content.Shared.Access.Components;
 
@@ -41,4 +42,27 @@ public sealed partial class ExpireIdCardComponent : Component
     /// </summary>
     [DataField]
     public LocId? ExpireMessage;
+
+    // Harmony Change Start - Radio Channel for Temp IDs
+
+    /// <summary>
+    /// Line spoken by the card on a radio channel when it expires
+    /// </summary>
+    [DataField]
+    public LocId? ExpireMessageRadio;
+
+    /// <summary>
+    /// What radio channel do we broadcast our expire message on?
+    /// </summary>
+    [DataField]
+    public ProtoId<RadioChannelPrototype> RadioChannel = "Security";
+
+    /// <summary>
+    /// Decides if we want to call a radio or not, off by default.
+    /// We'd rather not want any potential expansions to this system to automatically ping Security, after all
+    /// </summary>
+    [DataField]
+    public bool AlertRadio;
+
+    // Harmony Change End
 }

--- a/Content.Shared/Access/Components/ExpireIdCardComponent.cs
+++ b/Content.Shared/Access/Components/ExpireIdCardComponent.cs
@@ -55,7 +55,7 @@ public sealed partial class ExpireIdCardComponent : Component
     /// What radio channel do we broadcast our expire message on?
     /// </summary>
     [DataField]
-    public ProtoId<RadioChannelPrototype> RadioChannel = "Nfsd"; // Frontier
+    public ProtoId<RadioChannelPrototype> RadioChannel; // Frontier - define in the yml instead of defaulting.
 
     /// <summary>
     /// Decides if we want to call a radio or not, off by default.

--- a/Content.Shared/Access/Components/ExpireIdCardComponent.cs
+++ b/Content.Shared/Access/Components/ExpireIdCardComponent.cs
@@ -55,7 +55,7 @@ public sealed partial class ExpireIdCardComponent : Component
     /// What radio channel do we broadcast our expire message on?
     /// </summary>
     [DataField]
-    public ProtoId<RadioChannelPrototype> RadioChannel = "Security";
+    public ProtoId<RadioChannelPrototype> RadioChannel = "Nfsd"; // Frontier
 
     /// <summary>
     /// Decides if we want to call a radio or not, off by default.

--- a/Resources/Locale/en-US/_Harmony/access/components/genpop.ftl
+++ b/Resources/Locale/en-US/_Harmony/access/components/genpop.ftl
@@ -1,0 +1,1 @@
+genpop-prisoner-id-expire-radio = {$name} has expired, as the prisoner's sentence is complete.

--- a/Resources/Locale/en-US/_Harmony/access/components/genpop.ftl
+++ b/Resources/Locale/en-US/_Harmony/access/components/genpop.ftl
@@ -1,1 +1,1 @@
-genpop-prisoner-id-expire-radio = {$name} has expired, as the prisoner's sentence is complete.
+genpop-prisoner-id-expire-radio = {$name} has expired. The prisoner's sentence has been served.'

--- a/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
@@ -763,9 +763,7 @@
     #Harmony Change Start - Adds Radio Alert Systems
     alertRadio: true
     expireMessageRadio: genpop-prisoner-id-expire-radio
-  - type: ActiveRadio
-    channels:
-    - Security
+    radioChannel: Nfsd # Frontier
     #Harmony Change End
   - type: Speech
     speechVerb: Robotic

--- a/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
@@ -760,6 +760,13 @@
     expireMessage: genpop-prisoner-id-expire
     expiredAccess:
     - GenpopLeave
+    #Harmony Change Start - Adds Radio Alert Systems
+    alertRadio: true
+    expireMessageRadio: genpop-prisoner-id-expire-radio
+  - type: ActiveRadio
+    channels:
+    - Security
+    #Harmony Change End
   - type: Speech
     speechVerb: Robotic
   - type: Tag


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Extends ExpireIDCard component with automated radio messages that send when the expiration triggers. [Original PR](https://github.com/ss14-harmony/ss14-harmony/pull/1020) Opens up capabilities to define custom expirable messages on the ExpireIDCard component. Currently this is only relevant for prisoner IDs, but the system is extensible to the point where we could in the future add this to temporary ID cards, for example if an SR hires someone as a janitor for 2-3 hours with an expiration to revert the card into contractor and alert current command staff on shift. The messages are suppressable, but by default they try to send messages, if any are available.

## Why / Balance
We may not have as much prisoner throughput in the frontier as stations do, but it's nice QoL to not have to manually keep track of the prisoner sentences and when they get served. It's not rare to have to deploy after processing someone and most NFSD ships come with criminal records, so being able to change status from detained to released when the alert pops is handy. 

## Technical details
Mostly C#, some YML, one ftl.

## How to test
Create prisoner ID from locker. Listen on NFSD comms. End sentence early.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ X ] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X ] I have added media to this PR or it does not require an ingame showcase.
- [ X ] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None

**Changelog**
:cl: BlueMoon059
- add: Added automated messages for genpop ID expiration to NFSD comms.
