### PR TITLE
Adds a nullcheck on a racecondition that updates admin status.

### DIFF
--- a/Content.Server/Administration/Managers/AdminManager.cs
+++ b/Content.Server/Administration/Managers/AdminManager.cs
@@ -389,8 +389,13 @@ namespace Content.Server.Administration.Managers
             };
 
             _admins.Add(session, reg);
+            var contentdata = session.ContentData();
+            if (contentdata == null)
+            {
+                return;
+            }
 
-            if (session.ContentData()!.Stealthed)
+            if (contentdata.Stealthed)
                 reg.Data.Stealth = true;
 
             if (reg.Data.Active)

--- a/Content.Server/Administration/Managers/AdminManager.cs
+++ b/Content.Server/Administration/Managers/AdminManager.cs
@@ -389,13 +389,14 @@ namespace Content.Server.Administration.Managers
             };
 
             _admins.Add(session, reg);
+            // Frontier begin
             var contentdata = session.ContentData();
             if (contentdata == null)
             {
                 return;
             }
-
-            if (contentdata.Stealthed)
+            // Frontier end
+            if (contentdata.Stealthed) // Frontier session.ContentData()!<contentdata
                 reg.Data.Stealth = true;
 
             if (reg.Data.Active)


### PR DESCRIPTION
## About the PR
Performs a nullcheck on admin status update. This is unlikely to affect anything outside of localhost development. Guards against trying to access a field on null value resulting in a fatal error. Would probably be cleaner to retry with a short timeout and max tries, but this is good enough.

## Why / Balance
I'd rather not have my admin status set than have the server crash with a fatal error if the race condition resolves in an unfavorable sequence, which is about 30% of the time at least for my devenv. I'm tired of patching it for every branch I make and it might help other people when they set up their devenv and get confused by this error.

## Technical details
Just a guard statement with a null value check.

## How to test
Keep starting up the server and logging in. Observe how you don't get the error as shown below.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="1373" height="266" alt="image" src="https://github.com/user-attachments/assets/b54027dc-f61b-47b0-bd21-8ec91fe2175f" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ X ] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X ] I have added media to this PR or it does not require an ingame showcase.
- [ X ] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None