### PR TITLE
Butcher Time Reduction

### DIFF
--- a/Content.Shared/Kitchen/Components/KitchenSpikeComponent.cs
+++ b/Content.Shared/Kitchen/Components/KitchenSpikeComponent.cs
@@ -120,7 +120,7 @@ public sealed partial class KitchenSpikeComponent : Component
     /// This is summed up with a <see cref="ButcherableComponent"/>'s butcher delay in butcher DoAfter.
     /// </remarks>
     [DataField, AutoNetworkedField]
-    public TimeSpan ButcherDelayAlive = TimeSpan.FromSeconds(8);
+    public TimeSpan ButcherDelayAlive = TimeSpan.FromSeconds(4); // Frontier: 8<4
 
     /// <summary>
     /// Value by which the butchering delay will be multiplied if the victim is dead.

--- a/Content.Shared/Nutrition/Components/ButcherableComponent.cs
+++ b/Content.Shared/Nutrition/Components/ButcherableComponent.cs
@@ -24,7 +24,7 @@ public sealed partial class ButcherableComponent : Component
     /// Time required to butcher that entity.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public float ButcherDelay = 8.0f;
+    public float ButcherDelay = 4.0f; // Frontier: 8.0<4.0
 
     /// <summary>
     /// Tool type used to butcher that entity.


### PR DESCRIPTION
## About the PR
Halves the amount of time it takes to butcher something on a meat spike.

## Why / Balance
Upstream increased the amount of time it takes to butcher something to make it more difficult to round remove players, but this presents a sizeable inconvenience to service players on the Frontier who frequently have to butcher animals en masse. This brings the numbers more in-line with what we had prior to the last upstream merge. 

## Technical details
Halved the ButcherDelay in ButcherableComponent.cs and the ButcherDelayAlive TimeSpan in KitchenSpikeComponent.cs

## How to test
1. Throngle a monkey
2. Throw it on a meat spike and butcher it
3. It's faster now

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes
Given the change only affects the time to butcher, this should not affect anything in a breaking sort of way.

**Changelog**
:cl:
- tweak: Halved the time it takes to butcher things on a meat spike.
