### PR TITLE
tweak the variation value of sound_mecha_hydraulic

### DIFF
--- a/Content.Server/Mech/Equipment/Components/MechGrabberComponent.cs
+++ b/Content.Server/Mech/Equipment/Components/MechGrabberComponent.cs
@@ -46,7 +46,7 @@ public sealed partial class MechGrabberComponent : Component
     public SoundSpecifier GrabSound = new SoundPathSpecifier("/Audio/Mecha/sound_mecha_hydraulic.ogg")
     // Frontier: Add sound variation
     {  
-        Params = AudioParams.Default.WithVariation(0.125f)  
+        Params = AudioParams.Default.WithVariation(0.0375f)  
     };
     // End Frontier
 

--- a/Content.Server/_NF/Mech/Equipment/Components/MechForkComponent.cs
+++ b/Content.Server/_NF/Mech/Equipment/Components/MechForkComponent.cs
@@ -47,7 +47,7 @@ public sealed partial class MechForkComponent : Component
     public SoundSpecifier GrabSound = new SoundPathSpecifier("/Audio/Mecha/sound_mecha_hydraulic.ogg")
     // Frontier: Add sound variation
     {  
-        Params = AudioParams.Default.WithVariation(0.125f)  
+        Params = AudioParams.Default.WithVariation(0.0375f)
     };
     // End Frontier
 


### PR DESCRIPTION
## About the PR
This is a small tweak for https://github.com/new-frontiers-14/frontier-station-14/pull/4521  
Just changes the value from 0.125 to 0.0375  

## Why / Balance
Just to make the variance a bit more subtle, as the old value had the tendency to make the sound either too high or too low-pitched.

## Technical details
exact same code as https://github.com/new-frontiers-14/frontier-station-14/pull/4521 
just 0.125 is changed to 0.0375

## How to test
Use EMU hauler in-game and hear pitch shifting on the GrabSounds.

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes
None noticed while testing.

**Changelog**
:cl:
- tweak: Edited the change to the EMU Hauler sound variance to be more subtle.