### PR TITLE
Ticks no longer go under doors

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_space.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_space.yml
@@ -66,3 +66,14 @@
     thresholds:
       0: Alive
       12: Dead
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeCircle
+          radius: 0.20
+        density: 20
+        mask:
+        - MobMask
+        layer:
+        - SmallMobLayer


### PR DESCRIPTION


## About the PR
Space ticks no longer go under doors
## Why / Balance
Complaints from players getting ambushed by ticks going under their doors and doing a large amount of damage before they could react.

## Technical details
Changed the mask of NFMobTick from Small to regular MobMask
## How to test
Spawn a space tick, notice they take a moment to pry a door instead of ignoring the door entirely.

## Media
<img width="483" height="176" alt="image" src="https://github.com/user-attachments/assets/6017d356-e121-4a68-9cc8-7004b92ff000" />


## Requirements

- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes
Nothing I noticed during testing.
**Changelog**
:cl:
- tweak: Space Ticks no longer are able to go under doors.

