### PR TITLE
Better VIM Instructions

### DIFF
--- a/Resources/Locale/en-US/_NF/mech/mech.ftl
+++ b/Resources/Locale/en-US/_NF/mech/mech.ftl
@@ -1,0 +1,1 @@
+nf-vim-construction-guide-string = Attach two borg legs and an EVA suit to the harness to continue.

--- a/Resources/Prototypes/Recipes/Construction/Graphs/mechs/vim_construction.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/mechs/vim_construction.yml
@@ -7,7 +7,7 @@
     - to: vim
       steps:
       - assemblyId: Vim
-        guideString: mech-construction-guide-string
+        guideString: nf-vim-construction-guide-string # Frontier
 
       - tag: VoiceTrigger
         name: construction-graph-tag-voice-trigger

--- a/Resources/ServerInfo/Guidebook/Science/Robotics.xml
+++ b/Resources/ServerInfo/Guidebook/Science/Robotics.xml
@@ -52,7 +52,7 @@
   To start making a mech, print their harness in the fabricator and insert the limbs, you can [color=#a4885c]examine[/color] it to see how to proceed with construction once all limbs are in place.
   - Every mech requires some combination of wires, tool usage, and their own unique circuit boards to construct after the chassis has been assembled. Most mechs have two or more unique circuit boards. For example, the [color=#a4885c]Ripley[/color] mech requires a [color=#a4885c]ripley controls module[/color] board and a [color=#a4885c]ripley peripherals module[/color] board.
   - Mechs require large amounts of material to create - be sure to ask your fellow scientists and cargo personnel for any materials you're missing!
-  - The Vim exosuit requires a pair of borg legs and an EVA helmet, regular or syndicate, then a voice trigger and a power cell.
+  - The Vim exosuit requires a pair of borg legs and an EVA suit, regular or syndicate, then a voice trigger and a power cell.
 
   ## Equipment
     A mech is nothing more than an expensive hunk of metal without their exclusive tools. Equipment can be created at the fabricator, the same as any other part.


### PR DESCRIPTION
## About the PR
Adjusts the verbiage around making the VIM mech to be clearer.

## Why / Balance
A frequent source of confusion is the process to make a VIM for critter friends. With the change to using EVA suits instead of helmets, the instructions in the guidebook are outright incorrect and the tooltip on inspection is not informative.

## Technical details
Adds mechs.ftl under _NF for a new VIM construction instruction, changes one word of robotics.xml to represent the actual process to make a VIM.

## How to test
1. Get the tech for the VIM harness and voice trigger.
2. Print a VIM harness and inspect it, see the new instruction.
3. Check the guidebook under Jobs>Science>Robotics and see that it now correctly says to use an EVA suit for the VIM.

## Media
<img width="883" height="92" alt="image" src="https://github.com/user-attachments/assets/d4cbbfb0-0418-4d0b-804a-977680e9daba" />
<img width="562" height="354" alt="image" src="https://github.com/user-attachments/assets/c7c57e34-b27c-4dc1-9f0b-b028ed84cbe4" />


## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes
One line changed on the VIM could cause merge conflicts later for the VIM, changes to Robotics.xml. 

**Changelog**
:cl:
- fix: Fixed instructions for the VIM harness to better guide players on building it.
