### PR TITLE
Disabled the more destructive admin smites & adjusted verb icons

### DIFF
--- a/Content.Server/Administration/Systems/AdminVerbSystem.Smites.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.Smites.cs
@@ -124,32 +124,33 @@ public sealed partial class AdminVerbSystem
         };
         args.Verbs.Add(explode);
 
-        var chessName = Loc.GetString("admin-smite-chess-dimension-name").ToLowerInvariant();
-        Verb chess = new()
-        {
-            Text = chessName,
-            Category = VerbCategory.Smite,
-            Icon = new SpriteSpecifier.Rsi(new ("/Textures/Objects/Fun/Tabletop/chessboard.rsi"), "chessboard"),
-            Act = () =>
-            {
-                _sharedGodmodeSystem.EnableGodmode(args.Target); // So they don't suffocate.
-                EnsureComp<TabletopDraggableComponent>(args.Target);
-                RemComp<PhysicsComponent>(args.Target); // So they can be dragged around.
-                var xform = Transform(args.Target);
-                _popupSystem.PopupEntity(Loc.GetString("admin-smite-chess-self"), args.Target,
-                    args.Target, PopupType.LargeCaution);
-                _popupSystem.PopupCoordinates(
-                    Loc.GetString("admin-smite-chess-others", ("name", args.Target)), xform.Coordinates,
-                    Filter.PvsExcept(args.Target), true, PopupType.MediumCaution);
-                var board = Spawn("ChessBoard", xform.Coordinates);
-                var session = _tabletopSystem.EnsureSession(Comp<TabletopGameComponent>(board));
-                _transformSystem.SetMapCoordinates(args.Target, session.Position);
-                _transformSystem.SetWorldRotationNoLerp((args.Target, xform), Angle.Zero);
-            },
-            Impact = LogImpact.Extreme,
-            Message = string.Join(": ", chessName, Loc.GetString("admin-smite-chess-dimension-description"))
-        };
-        args.Verbs.Add(chess);
+        // Frontier: disabled some more destructive smites
+        // var chessName = Loc.GetString("admin-smite-chess-dimension-name").ToLowerInvariant();
+        // Verb chess = new()
+        // {
+        //     Text = chessName,
+        //     Category = VerbCategory.Smite,
+        //     Icon = new SpriteSpecifier.Rsi(new ("/Textures/Objects/Fun/Tabletop/chessboard.rsi"), "chessboard"),
+        //     Act = () =>
+        //     {
+        //         _sharedGodmodeSystem.EnableGodmode(args.Target); // So they don't suffocate.
+        //         EnsureComp<TabletopDraggableComponent>(args.Target);
+        //         RemComp<PhysicsComponent>(args.Target); // So they can be dragged around.
+        //         var xform = Transform(args.Target);
+        //         _popupSystem.PopupEntity(Loc.GetString("admin-smite-chess-self"), args.Target,
+        //             args.Target, PopupType.LargeCaution);
+        //         _popupSystem.PopupCoordinates(
+        //             Loc.GetString("admin-smite-chess-others", ("name", args.Target)), xform.Coordinates,
+        //             Filter.PvsExcept(args.Target), true, PopupType.MediumCaution);
+        //         var board = Spawn("ChessBoard", xform.Coordinates);
+        //         var session = _tabletopSystem.EnsureSession(Comp<TabletopGameComponent>(board));
+        //         _transformSystem.SetMapCoordinates(args.Target, session.Position);
+        //         _transformSystem.SetWorldRotationNoLerp((args.Target, xform), Angle.Zero);
+        //     },
+        //     Impact = LogImpact.Extreme,
+        //     Message = string.Join(": ", chessName, Loc.GetString("admin-smite-chess-dimension-description"))
+        // };
+        // args.Verbs.Add(chess);
 
         if (TryComp<FlammableComponent>(args.Target, out var flammable))
         {
@@ -218,20 +219,25 @@ public sealed partial class AdminVerbSystem
                 Act = () =>
                 {
                     int damageToDeal;
-                    if (!_mobThresholdSystem.TryGetThresholdForState(args.Target, MobState.Critical, out var criticalThreshold)) {
-                        // We can't crit them so try killing them.
-                        if (!_mobThresholdSystem.TryGetThresholdForState(args.Target, MobState.Dead,
-                                out var deadThreshold))
-                            return;// whelp.
-                        damageToDeal = deadThreshold.Value.Int() - (int) damageable.TotalDamage;
-                    }
-                    else
-                    {
-                        damageToDeal = criticalThreshold.Value.Int() - (int) damageable.TotalDamage;
-                    }
 
-                    if (damageToDeal <= 0)
-                        damageToDeal = 100; // murder time.
+                    // Frontier: make electrocute do fixed 50 damage
+                    // if (!_mobThresholdSystem.TryGetThresholdForState(args.Target, MobState.Critical, out var criticalThreshold)) {
+                    //     // We can't crit them so try killing them.
+                    //     if (!_mobThresholdSystem.TryGetThresholdForState(args.Target, MobState.Dead,
+                    //             out var deadThreshold))
+                    //         return;// whelp.
+                    //     damageToDeal = deadThreshold.Value.Int() - (int) damageable.TotalDamage;
+                    // }
+                    // else
+                    // {
+                    //     damageToDeal = criticalThreshold.Value.Int() - (int) damageable.TotalDamage;
+                    // }
+
+                    // if (damageToDeal <= 0)
+                    //     damageToDeal = 100; // murder time.
+
+                    damageToDeal = 50;
+                    // End Frontier: make electrocute do fixed 50 damage
 
                     if (_inventorySystem.TryGetSlots(args.Target, out var slotDefinitions))
                     {
@@ -610,20 +616,21 @@ public sealed partial class AdminVerbSystem
             */
         }
 
-        var angerPointingArrowsName = Loc.GetString("admin-smite-anger-pointing-arrows-name").ToLowerInvariant();
-        Verb angerPointingArrows = new()
-        {
-            Text = angerPointingArrowsName,
-            Category = VerbCategory.Smite,
-            Icon = new SpriteSpecifier.Rsi(new ("/Textures/Interface/Misc/pointing.rsi"), "pointing"),
-            Act = () =>
-            {
-                EnsureComp<PointingArrowAngeringComponent>(args.Target);
-            },
-            Impact = LogImpact.Extreme,
-            Message = string.Join(": ", angerPointingArrowsName, Loc.GetString("admin-smite-anger-pointing-arrows-description"))
-        };
-        args.Verbs.Add(angerPointingArrows);
+        // Frontier: disabled some more destructive smites
+        // var angerPointingArrowsName = Loc.GetString("admin-smite-anger-pointing-arrows-name").ToLowerInvariant();
+        // Verb angerPointingArrows = new()
+        // {
+        //     Text = angerPointingArrowsName,
+        //     Category = VerbCategory.Smite,
+        //     Icon = new SpriteSpecifier.Rsi(new ("/Textures/Interface/Misc/pointing.rsi"), "pointing"),
+        //     Act = () =>
+        //     {
+        //         EnsureComp<PointingArrowAngeringComponent>(args.Target);
+        //     },
+        //     Impact = LogImpact.Extreme,
+        //     Message = string.Join(": ", angerPointingArrowsName, Loc.GetString("admin-smite-anger-pointing-arrows-description"))
+        // };
+        // args.Verbs.Add(angerPointingArrows);
 
         var dustName = Loc.GetString("admin-smite-dust-name").ToLowerInvariant();
         Verb dust = new()
@@ -831,24 +838,25 @@ public sealed partial class AdminVerbSystem
         };
         args.Verbs.Add(disarmProne);
 
-        var superSpeedName = Loc.GetString("admin-smite-super-speed-name").ToLowerInvariant();
-        Verb superSpeed = new()
-        {
-            Text = superSpeedName,
-            Category = VerbCategory.Smite,
-            Icon = new SpriteSpecifier.Texture(new ("/Textures/Interface/AdminActions/super_speed.png")),
-            Act = () =>
-            {
-                var movementSpeed = EnsureComp<MovementSpeedModifierComponent>(args.Target);
-                _movementSpeedModifierSystem?.ChangeBaseSpeed(args.Target, 400, 8000, 40, movementSpeed);
+        // Frontier: disabled some more destructive smites
+        // var superSpeedName = Loc.GetString("admin-smite-super-speed-name").ToLowerInvariant();
+        // Verb superSpeed = new()
+        // {
+        //     Text = superSpeedName,
+        //     Category = VerbCategory.Smite,
+        //     Icon = new SpriteSpecifier.Texture(new ("/Textures/Interface/AdminActions/super_speed.png")),
+        //     Act = () =>
+        //     {
+        //         var movementSpeed = EnsureComp<MovementSpeedModifierComponent>(args.Target);
+        //         _movementSpeedModifierSystem?.ChangeBaseSpeed(args.Target, 400, 8000, 40, movementSpeed);
 
-                _popupSystem.PopupEntity(Loc.GetString("admin-smite-super-speed-prompt"), args.Target,
-                    args.Target, PopupType.LargeCaution);
-            },
-            Impact = LogImpact.Extreme,
-            Message = string.Join(": ", superSpeedName, Loc.GetString("admin-smite-super-speed-description"))
-        };
-        args.Verbs.Add(superSpeed);
+        //         _popupSystem.PopupEntity(Loc.GetString("admin-smite-super-speed-prompt"), args.Target,
+        //             args.Target, PopupType.LargeCaution);
+        //     },
+        //     Impact = LogImpact.Extreme,
+        //     Message = string.Join(": ", superSpeedName, Loc.GetString("admin-smite-super-speed-description"))
+        // };
+        // args.Verbs.Add(superSpeed);
 
         //Bonk
         var superBonkLiteName = Loc.GetString("admin-smite-super-bonk-lite-name").ToLowerInvariant();
@@ -866,20 +874,22 @@ public sealed partial class AdminVerbSystem
         };
         args.Verbs.Add(superBonkLite);
 
-        var superBonkName = Loc.GetString("admin-smite-super-bonk-name").ToLowerInvariant();
-        Verb superBonk = new()
-        {
-            Text = superBonkName,
-            Category = VerbCategory.Smite,
-            Icon = new SpriteSpecifier.Rsi(new("Structures/Furniture/Tables/generic.rsi"), "full"),
-            Act = () =>
-            {
-                _superBonkSystem.StartSuperBonk(args.Target);
-            },
-            Impact = LogImpact.Extreme,
-            Message = string.Join(": ", superBonkName, Loc.GetString("admin-smite-super-bonk-description"))
-        };
-        args.Verbs.Add(superBonk);
+        // Frontier: disabled some more destructive smites
+        // var superBonkName = Loc.GetString("admin-smite-super-bonk-name").ToLowerInvariant();
+        // Verb superBonk = new()
+        // {
+        //     Text = superBonkName,
+        //     Category = VerbCategory.Smite,
+        //     Icon = new SpriteSpecifier.Rsi(new("Structures/Furniture/Tables/generic.rsi"), "full"),
+        //     Act = () =>
+        //     {
+        //         _superBonkSystem.StartSuperBonk(args.Target);
+        //     },
+        //     Impact = LogImpact.Extreme,
+        //     Message = string.Join(": ", superBonkName, Loc.GetString("admin-smite-super-bonk-description"))
+        // };
+        // args.Verbs.Add(superBonk);
+
 
         var superslipName = Loc.GetString("admin-smite-super-slip-name").ToLowerInvariant();
         Verb superslip = new()

--- a/Content.Server/Administration/Systems/AdminVerbSystem.Tools.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.Tools.cs
@@ -113,7 +113,7 @@ public sealed partial class AdminVerbSystem
                 Text = "Rejuvenate",
                 Category = VerbCategory.Tricks,
                 // Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/AdminActions/rejuvenate.png")), // Frontier
-                Icon = new SpriteSpecifier.Texture(new ("/Textures/Interface/VerbIcons/rejuvenate.svg.192dpi.png")), // Frontier: consistent verb icons
+                Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/VerbIcons/rejuvenate.svg.192dpi.png")), // Frontier: consistent verb icons
                 Act = () =>
                 {
                     _rejuvenate.PerformRejuvenate(args.Target);

--- a/Content.Server/Administration/Systems/AdminVerbSystem.Tools.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.Tools.cs
@@ -112,7 +112,8 @@ public sealed partial class AdminVerbSystem
             {
                 Text = "Rejuvenate",
                 Category = VerbCategory.Tricks,
-                Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/AdminActions/rejuvenate.png")),
+                // Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/AdminActions/rejuvenate.png")), // Frontier
+                Icon = new SpriteSpecifier.Texture(new ("/Textures/Interface/VerbIcons/rejuvenate.svg.192dpi.png")), // Frontier: consistent verb icons
                 Act = () =>
                 {
                     _rejuvenate.PerformRejuvenate(args.Target);
@@ -130,7 +131,8 @@ public sealed partial class AdminVerbSystem
             {
                 Text = "Make Indestructible",
                 Category = VerbCategory.Tricks,
-                Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/VerbIcons/plus.svg.192dpi.png")),
+                // Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/VerbIcons/plus.svg.192dpi.png")), // Frontier
+                Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/AdminActions/rejuvenate.png")), // Frontier, wand makes more sense for godmode?
                 Act = () =>
                 {
                     _sharedGodmodeSystem.EnableGodmode(args.Target);
@@ -147,7 +149,8 @@ public sealed partial class AdminVerbSystem
             {
                 Text = "Make Vulnerable",
                 Category = VerbCategory.Tricks,
-                Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/VerbIcons/plus.svg.192dpi.png")),
+                // Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/VerbIcons/plus.svg.192dpi.png")), // Frontier
+                Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/AdminActions/rejuvenate.png")), // Frontier, wand makes more sense for godmode?
                 Act = () =>
                 {
                     _sharedGodmodeSystem.DisableGodmode(args.Target);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Disabled:
- Chess Dimension (reportedly could cause server instability)
- Angry Arrows
- Superspeed (run up)
- Super bonk (table slamming a corpse across the entire sector gets old pretty fast)

Adjusted:
- Electrocute now does a fixed 50 shock damage.
- Rejuvenate verb icon adjusted to match the other rejuvenate verb icon (tricks vs debug)
- Make indestructible verb icon switched to the magic wand (which was trick rejuvenate's old icon)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
By admin request.

## Technical details
<!-- Summary of code changes for easier review. -->
It's mostly just commenting out the verbs. All the underlying code is still present and is required for stuff like super bonk lite.

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
- Right click on yourself (as admin) and see that the smites menu is a little smaller.
- Make sure all the smites you expected to be there are there.
- Look at the tricks menu and mouseover the changed icons to check what they are.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="377" height="257" alt="image" src="https://github.com/user-attachments/assets/fdfa5d21-dda3-40d2-bcb0-69bd1a9eef26" />
<img width="343" height="114" alt="image" src="https://github.com/user-attachments/assets/2156421d-5d0f-4106-867c-33dcfa56de05" />



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [ ] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
no cl, not player facing. (although I guess it is admin facing...)