### PR TITLE
Remove anchorable flag from signs

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/base_structuresigns.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/base_structuresigns.yml
@@ -22,3 +22,7 @@
     price: 20
   - type: Transform
     anchored: false
+  # Frontier: suppress "<sign> is unanchored from the floor!" text on examine
+  - type: Anchorable
+    flags: None
+  # End Frontier


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
A cherry-pick from upstream (#4398) unanchored all signs, but left them anchorable. This makes little sense, since you can't really move them, so unless you wanted to stack all direction signs in a tile on top of each other in the center of the tile there's no point anchoring them.

We'll make them unanchorable, because examining an anchorable unanchored entity shows a warning that is mostly pointless for signs ("It is _unanchored_ from the floor."). This has no further effect since signs are not affected by physics and therefore do not care whether they're anchored or not.

## Why / Balance
Looking at the bus schedule, or any other sign, shouldn't claim it's unanchored, lest vandals try to steal it.

## Technical details


## How to test
Examine bus schedule. It doesn't say that it's unanchored. Look at bridge signpost. Check dock sign. None of them claim to be unanchored.

## Media
Old and busted:
<img width="560" height="199" alt="grafik" src="https://github.com/user-attachments/assets/e1028805-4dcb-44b6-9647-d31c78cf80df" />

New and improved:
<img width="562" height="167" alt="grafik" src="https://github.com/user-attachments/assets/56bb00b9-1773-4b55-8eab-72bcebecf158" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
no

**Changelog**
Purely cosmetic, no impact on players
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
