### PR TITLE
Fixes Missing Command Key for NFSD

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Clothing/Ears/wrist_radio.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Ears/wrist_radio.yml
@@ -168,6 +168,19 @@
   suffix: Common
 
 - type: entity
+  parent: [NFClothingWristsetNfsdBrown, ClothingHeadsetAltNfsdBrown]
+  id: NFClothingWristsetNfsdBrownCommand
+  name: NFSD wristset
+  suffix: Command
+  components:
+  - type: ContainerFill
+    containers:
+      key_slots:
+      - EncryptionKeyCommon
+      - EncryptionKeyNfsd
+      - EncryptionKeyCommand
+
+- type: entity
   parent: NFClothingWristsetNfsdBrown
   id: NFClothingWristsetNfsdGreen
   components:
@@ -195,6 +208,19 @@
   suffix: Common
 
 - type: entity
+  parent: [NFClothingWristsetNfsdGreen, ClothingHeadsetAltNfsdBrown]
+  id: NFClothingWristsetNfsdGreenCommand
+  name: NFSD wristset
+  suffix: Command
+  components:
+  - type: ContainerFill
+    containers:
+      key_slots:
+      - EncryptionKeyCommon
+      - EncryptionKeyNfsd
+      - EncryptionKeyCommand
+
+- type: entity
   parent: NFClothingWristsetNfsdBrown
   id: NFClothingWristsetNfsdCream
   components:
@@ -220,6 +246,19 @@
   id: NFClothingWristsetNfsdCreamCommon
   name: NFSD wristset
   suffix: Common
+
+- type: entity
+  parent: [NFClothingWristsetNfsdCream, ClothingHeadsetAltNfsdBrown]
+  id: NFClothingWristsetNfsdCreamCommand
+  name: NFSD wristset
+  suffix: Command
+  components:
+  - type: ContainerFill
+    containers:
+      key_slots:
+      - EncryptionKeyCommon
+      - EncryptionKeyNfsd
+      - EncryptionKeyCommand
 
 # region contractor
 - type: entity

--- a/Resources/Prototypes/_NF/Loadouts/Jobs/Nfsd/ears.yml
+++ b/Resources/Prototypes/_NF/Loadouts/Jobs/Nfsd/ears.yml
@@ -53,3 +53,21 @@
   equipment:
     ears: NFClothingWristsetNfsdCream
   groupBy: "EarWristset"
+
+- type: loadout
+  id: NfsdNFClothingWristsetNfsdBrownCommand
+  equipment:
+    ears: NFClothingWristsetNfsdBrownCommand
+  groupBy: "EarWristset"
+
+- type: loadout
+  id: NfsdNFClothingWristsetNfsdGreenCommand
+  equipment:
+    ears: NFClothingWristsetNfsdGreenCommand
+  groupBy: "EarWristset"
+
+- type: loadout
+  id: NfsdNFClothingWristsetNfsdCreamCommand
+  equipment:
+    ears: NFClothingWristsetNfsdCreamCommand
+  groupBy: "EarWristset"

--- a/Resources/Prototypes/_NF/Loadouts/nfsd_loadout_groups.yml
+++ b/Resources/Prototypes/_NF/Loadouts/nfsd_loadout_groups.yml
@@ -164,9 +164,9 @@
   - NfsdClothingHeadsetAltNfsdBrown
   - NfsdClothingHeadsetAltNfsdCreamandBrown
   - NfsdClothingHeadsetAltNfsdGreen
-  - NfsdNFClothingWristsetNfsdBrown
-  - NfsdNFClothingWristsetNfsdCream
-  - NfsdNFClothingWristsetNfsdGreen
+  - NfsdNFClothingWristsetNfsdBrownCommand
+  - NfsdNFClothingWristsetNfsdCreamCommand
+  - NfsdNFClothingWristsetNfsdGreenCommand
   fallbacks:
   - NfsdClothingHeadsetAltNfsdBrown
 
@@ -178,9 +178,9 @@
   - NfsdClothingHeadsetAltNfsdBrown
   - NfsdClothingHeadsetAltNfsdCreamandBrown
   - NfsdClothingHeadsetAltNfsdGreen
-  - NfsdNFClothingWristsetNfsdBrown
-  - NfsdNFClothingWristsetNfsdCream
-  - NfsdNFClothingWristsetNfsdGreen
+  - NfsdNFClothingWristsetNfsdBrownCommand
+  - NfsdNFClothingWristsetNfsdCreamCommand
+  - NfsdNFClothingWristsetNfsdGreenCommand
   fallbacks:
   - NfsdClothingHeadsetAltNfsdCreamandBrown
 
@@ -192,8 +192,8 @@
   - NfsdClothingHeadsetAltNfsdBrown
   - NfsdClothingHeadsetAltNfsdCreamandBrown
   - NfsdClothingHeadsetAltNfsdGreen
-  - NfsdNFClothingWristsetNfsdBrown
-  - NfsdNFClothingWristsetNfsdCream
-  - NfsdNFClothingWristsetNfsdGreen
+  - NfsdNFClothingWristsetNfsdBrownCommand
+  - NfsdNFClothingWristsetNfsdCreamCommand
+  - NfsdNFClothingWristsetNfsdGreenCommand
   fallbacks:
   - NfsdClothingHeadsetAltNfsdGreen


### PR DESCRIPTION
## About the PR
Corrects missing command key on NFSD wristsets for sergeant and bailiff

## Why / Balance
As set up in #4450, the NFSD received their wristsets in similar colours to their headsets, however there was no similar differentiation to the standard headsets vs over-ear headsets, over-ear headsets providing the command comms key for sergeant and bailiff. 

## Technical details
Created Command variants of the NFSD wristsets, visually identical but include command key. Replaced the existing wristsets for sergeant and bailiff with these new command variants.

## How to test
1. Spawn in each of the NFSD Wristset (command) variants and see that they now have the command key in addition to common and NFSD.
2. Restart round and go lobby, check loadouts for sergeant and bailiff, switch to wristset.
3. Start round and enter as sergeant and bailiff, check that your wristset has the correct keys.

## Media
<img width="858" height="584" alt="image" src="https://github.com/user-attachments/assets/6085bb5d-1451-4f8b-82be-0e21c06b58dc" />

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes
This shouldn't break anything already in place, in testing each wristset works fine. 

**Changelog**

:cl:
- fix: Fixed NFSD Bailiff and Sergeant wristsets not having the command key
