### PR TITLE
Shuttle (Hotfix): Balena withdraw-only ATMs

### DIFF
--- a/Resources/Maps/_NF/Shuttles/balena.yml
+++ b/Resources/Maps/_NF/Shuttles/balena.yml
@@ -2758,7 +2758,7 @@ entities:
     - type: Transform
       pos: 0.5,5.5
       parent: 1
-- proto: ComputerWallmountBankATM
+- proto: ComputerWallmountWithdrawBankATM
   entities:
   - uid: 325
     components:


### PR DESCRIPTION
## About the PR
Changes the Balena's ATMs to be withdraw-only.

## Why / Balance
Fully capable ATMs are not permitted on ships. Oopsies.

## Technical details
Hand-edited YAML

## How to test
1. Buy Balena
2. Find ATMs
3. Make sure they're withdraw-only

## Media
N/A

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes

**Changelog**
:cl:
- fix: The Balena now has withdraw-only ATMs.