### PR TITLE
Add two-way ATMs to mapchecker blacklist for ships

### DIFF
--- a/.github/mapchecker/config.py
+++ b/.github/mapchecker/config.py
@@ -66,5 +66,8 @@ CONDITIONALLY_ILLEGAL_MATCHES = {
         "PlastititaniumWindowDiagonalIndestructible",
         "ClosetMaintenanceFilledRandom",
         "ClosetWallMaintenanceFilledRandom",
+        # Ships should not have anything but withdraw-only ATMs
+        "ComputerBankATM",
+        "ComputerWallmountBankATM",
     ]
 }


### PR DESCRIPTION
## About the PR
Adds regular ATMs to the mapchecker blacklist for everything but POIs.

## Why / Balance
No ships are allowed to have ATMs where one can deposit money. They should all be withdraw-only, all the time, always. Since we can easily detect this with the mapchecker script, let's do so.

## Technical details
Tiny Python change. :)

## How to test
1. Run mapchecker.

## Media
N/A

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes
No.

**Changelog**
N/A, internal change