### PR TITLE
allow fat as frying oil, allow fat in service selective dropper

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Entities/Structures/Machines/deep_fryer.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Structures/Machines/deep_fryer.yml
@@ -111,6 +111,7 @@
       - Cornoil
       - OilGhee
       - OilOlive
+      - Fat #Frontier
     #unsafeOilVolumeEffects: #Can't pass UninitializedSaveTest. Modifies itself on spawn. Very weird.
     #- !type:AreaReactionEffect
     #  duration: 10

--- a/Resources/Prototypes/Reagents/biological.yml
+++ b/Resources/Prototypes/Reagents/biological.yml
@@ -190,7 +190,7 @@
 - type: reagent
   id: Fat
   name: reagent-name-fat
-  group: Biological
+  group: Foods #Frontier: can pick up Fat with service selective dropper
   desc: reagent-desc-fat
   flavor: terrible
   color: "#d8d8b0"


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fat can now be used as frying oil
Fat can now be picked up by the service selective dropper

## Why / Balance
Grinding meat generates fat
Fat is only useful for gravy, which requires equal amount animal proteins, or reconstituting meat from carbon, which is also not a common use case.
For any other use of animal proteins, Fat is a waste product, which is annoying to deal with due to not being interactable by the service selective dropper

Balance: makes fat useful as deep fryer oil, giving it another secondary use other than gravy

## Technical details
Added Fat to the whitelist of frying reagents
modified Fat reagent group from biological to Foods, which allows pickup by the service selective dropper

## How to test
Obtain a beaker of fat
Use a selective dropper to pick up fat
Use the fat on a fryer to fill it and cook delicious lard fries

## Media
No media provided

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [ ] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
None identified

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Fat can now be used as deep-frying oil
- tweak: Fat can now be picked up by the service selective dropper
