### PR TITLE
Ports optical thermal gas temperature sensing

### DIFF
--- a/Content.Client/Atmos/Overlays/GasTileDangerousTemperatureOverlay.cs
+++ b/Content.Client/Atmos/Overlays/GasTileDangerousTemperatureOverlay.cs
@@ -1,0 +1,253 @@
+using Content.Client.Atmos.EntitySystems;
+using Content.Shared.Atmos;
+using Content.Shared.Atmos.Components;
+using Content.Shared.Atmos.EntitySystems;
+using Robust.Client.Graphics;
+using Robust.Shared.Enums;
+using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
+using System.Numerics;
+
+namespace Content.Client.Atmos.Overlays;
+
+/// <summary>
+/// Renders a thermal heatmap overlay for gas tiles, used for equipment like thermal glasses.
+/// /// </summary>
+public sealed class GasTileDangerousTemperatureOverlay : Overlay
+{
+    public override bool RequestScreenTexture { get; set; } = false;
+
+    [Dependency] private readonly IEntityManager _entManager = default!;
+    [Dependency] private readonly IMapManager _mapManager = default!;
+    [Dependency] private readonly IClyde _clyde = default!;
+
+    private GasTileOverlaySystem? _gasTileOverlay;
+    private readonly SharedTransformSystem _xformSys;
+    private EntityQuery<GasTileOverlayComponent> _overlayQuery;
+
+    private IRenderTexture? _temperatureTarget;
+
+    // Cache used to transform ThermalByte into Color for overlay
+    private readonly Color[] _colorCache = new Color[256];
+
+    public override OverlaySpace Space => OverlaySpace.WorldSpaceBelowFOV;
+
+    public GasTileDangerousTemperatureOverlay()
+    {
+        IoCManager.InjectDependencies(this);
+        _xformSys = _entManager.System<SharedTransformSystem>();
+
+        _overlayQuery = _entManager.GetEntityQuery<GasTileOverlayComponent>();
+
+        for (byte i = 0; i <= ThermalByte.TempResolution; i++)
+        {
+            _colorCache[i] = PreCalculateColor(i);
+        }
+
+        _colorCache[ThermalByte.StateVacuum] = Color.Teal;
+        _colorCache[ThermalByte.StateVacuum].A = 0.6f;
+        _colorCache[ThermalByte.AtmosImpossible] = Color.Transparent;
+
+#if DEBUG // This shouldn't happend so tell me if you see this LimeGreen on the screen
+        _colorCache[ThermalByte.ReservedFuture0] = Color.LimeGreen;
+        _colorCache[ThermalByte.ReservedFuture1] = Color.LimeGreen;
+        _colorCache[ThermalByte.ReservedFuture2] = Color.LimeGreen;
+#else
+        _colorCache[ThermalByte.ReservedFuture0] = Color.Transparent;
+        _colorCache[ThermalByte.ReservedFuture1] = Color.Transparent;
+        _colorCache[ThermalByte.ReservedFuture2] = Color.Transparent;
+#endif
+    }
+
+
+    /// <summary>
+    /// Used for Calculating onscreen color from ThermalByte core value
+    /// /// </summary>
+    private static Color PreCalculateColor(byte byteTemp)
+    {
+        // Color Thresholds in Kelvin
+        // -150 C
+        const float deepFreezeK = 123.15f;
+        // -50 C
+        const float freezeStartK = 223.15f;
+        // 0 C
+        const float waterFreezeK = 273.15f;
+        // 50 C
+        const float heatStartK = 323.15f;
+        // 100 C
+        const float waterBoilK = 373.15f;
+        // 300 C
+        const float superHeatK = 573.15f;
+
+        var tempK = byteTemp * ThermalByte.TempDegreeResolution;
+
+        // Neutral Zone Check (0C to 50C)
+        // If between 273.15K and 323.15K, it's transparent.
+        if (tempK >= waterFreezeK && tempK < heatStartK)
+        {
+            return Color.Transparent;
+        }
+
+        Color resultingColor;
+
+        switch (tempK)
+        {
+            case < deepFreezeK:
+                resultingColor = Color.FromHex("#330066");
+                resultingColor.A = 0.7f;
+                break;
+            case < freezeStartK:
+                // Interpolate Deep Purple -> Blue
+                // Range: 123.15 to 223.15 (Span: 100)
+                resultingColor = Color.InterpolateBetween(
+                    Color.FromHex("#330066"),
+                    Color.Blue,
+                    (tempK - deepFreezeK) * 0.01f);
+                resultingColor.A = 0.6f;
+                break;
+            case < waterFreezeK:
+                // Interpolate Blue -> Transparent
+                // Range: 223.15 to 273.15 (Span: 50)
+
+                resultingColor = Color.InterpolateBetween(
+                    new Color(Color.Blue.R, Color.Blue.G, Color.Blue.B, 0.6f),
+                    new Color(Color.Blue.R, Color.Blue.G, Color.Blue.B, 0.2f),
+                    (tempK - freezeStartK) * 0.02f);
+                break;
+            case < waterBoilK:
+                // Interpolate Transparent -> Yellow
+                // Range: 323.15 to 373.15 (Span: 50)
+
+                resultingColor = Color.InterpolateBetween(
+                    new Color(Color.Yellow.R, Color.Yellow.G, Color.Yellow.B, 0.2f),
+                    new Color(Color.Yellow.R, Color.Yellow.G, Color.Yellow.B, 0.6f),
+                    (tempK - heatStartK) * 0.02f);
+                break;
+            case < superHeatK:
+                // Interpolate Yellow -> Red
+                // Range: 373.15 to 573.15 (Span: 200)
+                resultingColor = Color.InterpolateBetween(
+                    Color.Yellow,
+                    Color.Red,
+                    (tempK - waterBoilK) * 0.005f);
+                resultingColor.A = 0.6f;
+                break;
+            default:
+                resultingColor = Color.DarkRed;
+                resultingColor.A = 0.7f;
+                break;
+        }
+
+        return resultingColor;
+    }
+
+    protected override bool BeforeDraw(in OverlayDrawArgs args)
+    {
+        if (args.MapId == MapId.Nullspace)
+            return false;
+
+        _gasTileOverlay ??= _entManager.System<GasTileOverlaySystem>();
+        if (_gasTileOverlay == null)
+            return false;
+
+        var target = args.Viewport.RenderTarget;
+
+        if (_temperatureTarget?.Texture.Size != target.Size)
+        {
+            _temperatureTarget?.Dispose();
+            _temperatureTarget = _clyde.CreateRenderTarget(
+                target.Size,
+                new RenderTargetFormatParameters(RenderTargetColorFormat.Rgba8Srgb),
+                name: nameof(GasTileDangerousTemperatureOverlay));
+        }
+
+        var drawHandle = args.WorldHandle;
+        var worldBounds = args.WorldBounds;
+        var worldAABB = args.WorldAABB;
+        var mapId = args.MapId;
+        var worldToViewportLocal = args.Viewport.GetWorldToLocalMatrix();
+
+        var anyGasDrawn = false;
+        List<Entity<MapGridComponent>> grids = new();
+
+        drawHandle.RenderInRenderTarget(_temperatureTarget,
+            () =>
+            {
+                grids.Clear();
+                _mapManager.FindGridsIntersecting(mapId, worldAABB, ref grids);
+
+                foreach (var grid in grids)
+                {
+                    if (!_overlayQuery.TryGetComponent(grid.Owner, out var comp))
+                        continue;
+
+                    var gridTileSizeVec = grid.Comp.TileSizeVector;
+                    var gridTileCenterVec = grid.Comp.TileSizeHalfVector;
+                    var gridEntToWorld = _xformSys.GetWorldMatrix(grid.Owner);
+                    var gridEntToViewportLocal = gridEntToWorld * worldToViewportLocal;
+
+                    drawHandle.SetTransform(gridEntToViewportLocal);
+
+                    var worldToGridLocal = _xformSys.GetInvWorldMatrix(grid.Owner);
+                    var floatBounds = worldToGridLocal.TransformBox(worldBounds).Enlarged(grid.Comp.TileSize);
+
+                    var localBounds = new Box2i(
+                        (int)MathF.Floor(floatBounds.Left),
+                        (int)MathF.Floor(floatBounds.Bottom),
+                        (int)MathF.Ceiling(floatBounds.Right),
+                        (int)MathF.Ceiling(floatBounds.Top));
+
+                    foreach (var chunk in comp.Chunks.Values)
+                    {
+                        var enumerator = new GasChunkEnumerator(chunk);
+                        while (enumerator.MoveNext(out var tileGas))
+                        {
+                            var tilePosition = chunk.Origin + (enumerator.X, enumerator.Y);
+                            if (!localBounds.Contains(tilePosition))
+                                continue;
+
+                            var gasColor = _colorCache[tileGas.ByteGasTemperature.Value];
+
+                            if (gasColor.A <= 0f)
+                                continue;
+
+                            anyGasDrawn = true;
+
+                            drawHandle.DrawRect(
+                                Box2.CenteredAround(tilePosition + gridTileCenterVec, gridTileSizeVec),
+                                gasColor
+                            );
+                        }
+                    }
+                }
+            },
+            new Color(0, 0, 0, 0));
+
+        drawHandle.SetTransform(Matrix3x2.Identity);
+
+        if (!anyGasDrawn)
+        {
+            _temperatureTarget?.Dispose();
+            _temperatureTarget = null;
+            return false;
+        }
+
+        return true;
+    }
+
+    protected override void Draw(in OverlayDrawArgs args)
+    {
+        if (_temperatureTarget is null)
+            return;
+
+        args.WorldHandle.DrawTextureRect(_temperatureTarget.Texture, args.WorldBounds);
+        args.WorldHandle.SetTransform(Matrix3x2.Identity);
+    }
+
+    protected override void DisposeBehavior()
+    {
+        _temperatureTarget?.Dispose();
+        _temperatureTarget = null;
+        base.DisposeBehavior();
+    }
+}

--- a/Content.Client/Overlays/ThermalSightOverlaySystem.cs
+++ b/Content.Client/Overlays/ThermalSightOverlaySystem.cs
@@ -1,0 +1,34 @@
+using Content.Client.Atmos.Overlays;
+using Content.Shared.Inventory.Events;
+using Content.Shared.Overlays;
+using Robust.Client.Graphics;
+
+namespace Content.Client.Overlays;
+
+public sealed partial class ThermalSightOverlaySystem : EquipmentHudSystem<ThermalSightComponent>
+{
+    [Dependency] private readonly IOverlayManager _overlayMan = default!;
+
+    private GasTileDangerousTemperatureOverlay _temperatureOverlay = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        _temperatureOverlay = new();
+    }
+
+    protected override void UpdateInternal(RefreshEquipmentHudEvent<ThermalSightComponent> component)
+    {
+        base.UpdateInternal(component);
+
+        _overlayMan.AddOverlay(_temperatureOverlay);
+    }
+
+    protected override void DeactivateInternal()
+    {
+        base.DeactivateInternal();
+
+        _overlayMan.RemoveOverlay(_temperatureOverlay);
+    }
+}

--- a/Content.IntegrationTests/Tests/Atmos/SharedGasTileOverlaySystemTest.cs
+++ b/Content.IntegrationTests/Tests/Atmos/SharedGasTileOverlaySystemTest.cs
@@ -1,0 +1,103 @@
+using Content.Server.Atmos.EntitySystems;
+using Content.Shared.Atmos;
+using Content.Shared.Atmos.Components;
+using Content.Shared.Atmos.EntitySystems;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Maths;
+using Robust.Shared.Utility;
+using System.Linq;
+using System.Numerics;
+
+namespace Content.IntegrationTests.Tests.Atmos;
+
+/// <summary>
+/// GasTileOverlay is being tested here
+/// </summary>
+public sealed class GasTileOverlayTemperatureNetworkingTest : AtmosTest
+{
+    protected override ResPath? TestMapPath => new("Maps/Test/Atmospherics/DeltaPressure/deltapressuretest.yml");
+
+    [Test]
+    public async Task TestGasOverlayDataSync()
+    {
+        var sMapSys = Server.System<SharedMapSystem>();
+
+        var gridComp = ProcessEnt.Comp3;
+        var gridNetEnt = Server.EntMan.GetNetEntity(ProcessEnt);
+
+        var gridCoords = new EntityCoordinates(ProcessEnt, Vector2.Zero);
+        var tileIndices = sMapSys.TileIndicesFor(ProcessEnt, gridComp, gridCoords);
+        var mixture = SAtmos.GetTileMixture(ProcessEnt, null, tileIndices, true);
+
+        // Get data for client side.
+        var cGridEnt = CEntMan.GetEntity(gridNetEnt);
+        Assert.That(CEntMan.TryGetComponent<GasTileOverlayComponent>(cGridEnt, out var cOverlay),
+            "Client grid is missing GasTileOverlayComponent");
+
+        // Check if the server actually sent the gas chunks
+        Assert.That(cOverlay, Is.Not.Null, "Gas overlay is null on the client.");
+        Assert.That(cOverlay.Chunks, Is.Not.Empty, "Gas overlay chunks are empty on the client.");
+
+        //Start real tests
+        await InjectHotPlasma(ProcessEnt, tileIndices, mixture, 400f);
+
+        await CheckForInjectedGas(cOverlay, tileIndices, 400f);
+
+        await InjectHotPlasma(ProcessEnt, tileIndices, mixture, 800f + ThermalByte.TempDegreeResolution - 1); // Rounding test
+
+        await CheckForInjectedGas(cOverlay, tileIndices, 800f);
+
+        await InjectHotPlasma(ProcessEnt, tileIndices, mixture, ThermalByte.TempMaximum + 200f); // This one hits max temperature
+
+        await CheckForInjectedGas(cOverlay, tileIndices, ThermalByte.TempMaximum);
+
+        await InjectHotPlasma(ProcessEnt, tileIndices, mixture, ThermalByte.TempMinimum);
+        await InjectHotPlasma(ProcessEnt, tileIndices, mixture, ThermalByte.TempMinimum + (ThermalByte.TempDegreeResolution * 2) - 1); // Test the networking optimisation, this should not be networked yet
+
+        await CheckForInjectedGas(cOverlay, tileIndices, ThermalByte.TempMinimum);
+
+        await InjectHotPlasma(ProcessEnt, tileIndices, mixture, ThermalByte.TempMinimum + (ThermalByte.TempDegreeResolution * 2)); // This should
+
+        await CheckForInjectedGas(cOverlay, tileIndices, ThermalByte.TempMinimum + (ThermalByte.TempDegreeResolution * 2));
+    }
+
+    private async Task CheckForInjectedGas(GasTileOverlayComponent overlay, Vector2i indices, float expectedTemp)
+    {
+        await Client.WaitPost(() =>
+        {
+            var chunkIndices = SharedGasTileOverlaySystem.GetGasChunkIndices(indices);
+
+            Assert.That(overlay.Chunks.TryGetValue(chunkIndices, out var chunk), "Chunk not found");
+            Assert.That(chunk, Is.Not.Null, "Chunk not found");
+
+            // Calculate the exact index in the TileData array
+            var localX = MathHelper.Mod(indices.X, SharedGasTileOverlaySystem.ChunkSize);
+            var localY = MathHelper.Mod(indices.Y, SharedGasTileOverlaySystem.ChunkSize);
+            int tileIndex = localX + localY * SharedGasTileOverlaySystem.ChunkSize;
+
+            var tile = chunk.TileData[tileIndex];
+            tile.ByteGasTemperature.TryGetTemperature(out var actualTemp);
+
+            Assert.That(actualTemp, Is.EqualTo(expectedTemp).Within(0.01f), $"Tile at {indices} had wrong temperature!");
+        });
+    }
+
+    private async Task InjectHotPlasma(EntityUid gridEnt, Vector2i tileIndices, GasMixture mixture, float temperature)
+    {
+        //Server makes atmos
+        await Server.WaitPost(() =>
+        {
+            if (mixture != null)
+            {
+                mixture.Clear();
+                mixture.AdjustMoles(Gas.Plasma, 100f); // Inject hot plasma
+                mixture.Temperature = temperature;
+                SAtmos.InvalidateVisuals(gridEnt, tileIndices);
+            }
+        });
+
+        await RunTicks(60);
+        await Task.WhenAll(Client.WaitIdleAsync(), Server.WaitIdleAsync());
+    }
+}

--- a/Content.Shared/Atmos/EntitySystems/SharedGasTileOverlaySystem.cs
+++ b/Content.Shared/Atmos/EntitySystems/SharedGasTileOverlaySystem.cs
@@ -1,113 +1,257 @@
 using Content.Shared.Atmos.Components;
-using Content.Shared.Atmos.Prototypes;
+using Robust.Shared.Configuration;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
 
-namespace Content.Shared.Atmos.EntitySystems
-{
-    public abstract class SharedGasTileOverlaySystem : EntitySystem
-    {
-        public const byte ChunkSize = 8;
-        protected float AccumulatedFrameTime;
-        protected bool PvsEnabled;
+namespace Content.Shared.Atmos.EntitySystems;
 
-        [Dependency] protected readonly IPrototypeManager ProtoMan = default!;
+public abstract class SharedGasTileOverlaySystem : EntitySystem
+{
+    public const byte ChunkSize = 8;
+    protected float AccumulatedFrameTime;
+    protected bool PvsEnabled;
+
+    [Dependency] protected readonly IPrototypeManager ProtoMan = default!;
+    [Dependency] protected readonly IConfigurationManager ConfMan = default!;
+    [Dependency] private readonly SharedAtmosphereSystem _atmosphere = default!;
+
+    /// <summary>
+    ///     array of the ids of all visible gases.
+    /// </summary>
+    public int[] VisibleGasId = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<GasTileOverlayComponent, ComponentGetState>(OnGetState);
+
+        List<int> visibleGases = new();
+
+        for (var i = 0; i < Atmospherics.TotalNumberOfGases; i++)
+        {
+            var gasPrototype = ProtoMan.Index<GasPrototype>(i.ToString());
+            if (!string.IsNullOrEmpty(gasPrototype.GasOverlayTexture) ||
+                (!string.IsNullOrEmpty(gasPrototype.GasOverlaySprite) && !string.IsNullOrEmpty(gasPrototype.GasOverlayState)))
+                visibleGases.Add(i);
+        }
+        VisibleGasId = visibleGases.ToArray();
+    }
+
+    private void OnGetState(EntityUid uid, GasTileOverlayComponent component, ref ComponentGetState args)
+    {
+        if (PvsEnabled && !args.ReplayState)
+            return;
+
+        // Should this be a full component state or a delta-state?
+        if (args.FromTick <= component.CreationTick || args.FromTick <= component.ForceTick)
+        {
+            args.State = new GasTileOverlayState(component.Chunks);
+            return;
+        }
+
+        var data = new Dictionary<Vector2i, GasOverlayChunk>();
+        foreach (var (index, chunk) in component.Chunks)
+        {
+            if (chunk.LastUpdate >= args.FromTick)
+                data[index] = chunk;
+        }
+
+        args.State = new GasTileOverlayDeltaState(data, new(component.Chunks.Keys));
+    }
+
+    public static Vector2i GetGasChunkIndices(Vector2i indices)
+    {
+        return new Vector2i((int)MathF.Floor((float)indices.X / ChunkSize), (int)MathF.Floor((float)indices.Y / ChunkSize));
+    }
+
+    [Serializable, NetSerializable]
+    public readonly struct GasOverlayData : IEquatable<GasOverlayData>
+    {
+        [ViewVariables] public readonly byte FireState;
+        [ViewVariables] public readonly byte[] Opacity;
+        // TODO change fire color based on ByteTemp
 
         /// <summary>
-        ///     array of the ids of all visible gases.
+        /// Network-synced air temperature, compressed to a single byte per tile for bandwidth optimization.
+        /// Note: Values are approximate and may deviate even ~10°C from the precise server side only temperature.
         /// </summary>
-        public int[] VisibleGasId = default!;
+        [ViewVariables]
+        public readonly ThermalByte ByteGasTemperature;
 
-        public override void Initialize()
+
+        public GasOverlayData(byte fireState, byte[] opacity, ThermalByte byteTemp)
         {
-            base.Initialize();
-            SubscribeLocalEvent<GasTileOverlayComponent, ComponentGetState>(OnGetState);
-
-            List<int> visibleGases = new();
-
-            for (var i = 0; i < Atmospherics.TotalNumberOfGases; i++)
-            {
-                var gasPrototype = ProtoMan.Index<GasPrototype>(i.ToString());
-                if (!string.IsNullOrEmpty(gasPrototype.GasOverlayTexture) || !string.IsNullOrEmpty(gasPrototype.GasOverlaySprite) && !string.IsNullOrEmpty(gasPrototype.GasOverlayState))
-                    visibleGases.Add(i);
-            }
-
-            VisibleGasId = visibleGases.ToArray();
+            FireState = fireState;
+            Opacity = opacity;
+            ByteGasTemperature = byteTemp;
         }
 
-        private void OnGetState(EntityUid uid, GasTileOverlayComponent component, ref ComponentGetState args)
+        public bool Equals(GasOverlayData other)
         {
-            if (PvsEnabled && !args.ReplayState)
-                return;
+            if (FireState != other.FireState)
+                return false;
 
-            // Should this be a full component state or a delta-state?
-            if (args.FromTick <= component.CreationTick || args.FromTick <= component.ForceTick)
+            if (Opacity?.Length != other.Opacity?.Length)
+                return false;
+
+            if (Opacity != null && other.Opacity != null)
             {
-                args.State = new GasTileOverlayState(component.Chunks);
-                return;
-            }
-
-            var data = new Dictionary<Vector2i, GasOverlayChunk>();
-            foreach (var (index, chunk) in component.Chunks)
-            {
-                if (chunk.LastUpdate >= args.FromTick)
-                    data[index] = chunk;
-            }
-
-            args.State = new GasTileOverlayDeltaState(data, new(component.Chunks.Keys));
-        }
-
-        public static Vector2i GetGasChunkIndices(Vector2i indices)
-        {
-            return new((int) MathF.Floor((float) indices.X / ChunkSize), (int) MathF.Floor((float) indices.Y / ChunkSize));
-        }
-
-        [Serializable, NetSerializable]
-        public readonly struct GasOverlayData : IEquatable<GasOverlayData>
-        {
-            [ViewVariables]
-            public readonly byte FireState;
-
-            [ViewVariables]
-            public readonly byte[] Opacity;
-
-            // TODO change fire color based on temps
-            // But also: dont dirty on a 0.01 kelvin change in temperatures.
-            // Either have a temp tolerance, or map temperature -> byte levels
-
-            public GasOverlayData(byte fireState, byte[] opacity)
-            {
-                FireState = fireState;
-                Opacity = opacity;
-            }
-
-            public bool Equals(GasOverlayData other)
-            {
-                if (FireState != other.FireState)
-                    return false;
-
-                if (Opacity?.Length != other.Opacity?.Length)
-                    return false;
-
-                if (Opacity != null && other.Opacity != null)
+                for (var i = 0; i < Opacity.Length; i++)
                 {
-                    for (var i = 0; i < Opacity.Length; i++)
-                    {
-                        if (Opacity[i] != other.Opacity[i])
-                            return false;
-                    }
+                    if (Opacity[i] != other.Opacity[i])
+                        return false;
                 }
-
-                return true;
             }
-        }
 
-        [Serializable, NetSerializable]
-        public sealed class GasOverlayUpdateEvent : EntityEventArgs
-        {
-            public Dictionary<NetEntity, List<GasOverlayChunk>> UpdatedChunks = new();
-            public Dictionary<NetEntity, HashSet<Vector2i>> RemovedChunks = new();
+            if (ByteGasTemperature != other.ByteGasTemperature)
+                return false;
+
+            return true;
         }
+    }
+
+    [Serializable, NetSerializable]
+    public sealed class GasOverlayUpdateEvent : EntityEventArgs
+    {
+        public Dictionary<NetEntity, List<GasOverlayChunk>> UpdatedChunks = new();
+        public Dictionary<NetEntity, HashSet<Vector2i>> RemovedChunks = new();
+    }
+}
+
+/// <summary>
+///     Struct for networking gas temperatures to all clients using a single struct(byte) per tile.
+/// </summary>
+/// <remarks>
+///     <para>
+///         This struct compresses the gas temperature into a 1-byte value (0-255).
+///         It clamps the temperature to a maximum of 1000K and divides it by 4, creating a range of 0-250.
+///         This provides a resolution of 4 degrees Kelvin.
+///     </para>
+///     <para>
+///         The remaining bytes are used as special flags:
+///         <list type="bullet">
+///             <item><description><b>255</b>: Represents a Wall (block cannot hold atmosphere).</description></item>
+///             <item><description><b>254</b>: Represents a Vacuum.</description></item>
+///             <item><description><b>251-253</b>: Reserved for future use.</description></item>
+///         </list>
+///     </para>
+///     <para>
+///         <b>Dirtying Logic:</b> The value is only dirtied and networked if the difference between the
+///         networked byte and the real atmosphere byte is greater than 1. This prevents network spam
+///         from minor temperature fluctuations (e.g., heating from 1K to 8K will not trigger an update,
+///         but hitting 9K moves the byte index enough to sync).
+///     </para>
+///     <para>
+///         Currently, the conversion is linear. Future improvements might involve a quadratic scale
+///         or pre-defined resolution points to offer higher precision at room temperatures
+///         and lower precision at extreme temperatures (1000K).
+///     </para>
+/// </remarks>
+[Serializable, NetSerializable]
+public struct ThermalByte : IEquatable<ThermalByte>
+{
+    public const float TempMinimum = 0f;
+    public const float TempMaximum = 1000f;
+    public const int TempResolution = 250;
+
+    public const byte ReservedFuture0 = 251;
+    public const byte ReservedFuture1 = 252;
+    public const byte ReservedFuture2 = 253;
+    public const byte StateVacuum = 254;
+    public const byte AtmosImpossible = 255;
+
+    public const float TempDegreeResolution = (TempMaximum - TempMinimum) / TempResolution;
+    public const float TempToByteFactor = TempResolution / (TempMaximum - TempMinimum);
+
+    private byte _coreValue;
+
+    public ThermalByte(float temperatureKelvin)
+    {
+        SetTemperature(temperatureKelvin);
+    }
+
+    public ThermalByte()
+    {
+        _coreValue = AtmosImpossible;
+    }
+
+    /// <summary>
+    /// Set temperature of air in this in Kelvin.
+    /// </summary>
+    public void SetTemperature(float temperatureKelvin)
+    {
+        var clampedTemp = Math.Clamp(temperatureKelvin, TempMinimum, TempMaximum);
+        _coreValue = (byte)((clampedTemp - TempMinimum) * TempResolution / (TempMaximum - TempMinimum));
+    }
+
+    public void SetAtmosIsImpossible()
+    {
+        _coreValue = AtmosImpossible;
+    }
+
+    public void SetVacuum()
+    {
+        _coreValue = StateVacuum;
+    }
+
+    public bool IsAtmosImpossible => _coreValue == AtmosImpossible; // Cold space, solid walls
+    public bool IsVacuum => _coreValue == StateVacuum;
+    public byte Value => _coreValue;
+
+    /// <summary>
+    /// Attempts to get the air temperature in Kelvin.
+    /// </summary>
+    /// <param name="temperature">The temperature in Kelvin, if the tile has a valid temperature.</param>
+    /// <param name="onVacuumReturnTcmb">
+    /// If true and the tile is a vacuum, <paramref name="temperature"/> will be set to <see cref="Atmospherics.TCMB"/>
+    /// and the method will return <see langword="true"/>.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> if the tile contains a valid temperature (including vacuum if <paramref name="onVacuumReturnTcmb"/> is set);
+    /// otherwise <see langword="false"/> (e.g., walls).
+    /// </returns>
+    public readonly bool TryGetTemperature(out float temperature, bool onVacuumReturnTcmb = true)
+    {
+        switch (_coreValue)
+        {
+            case AtmosImpossible:
+                temperature = 0f;
+                return false;
+            case StateVacuum when onVacuumReturnTcmb:
+                temperature = Atmospherics.TCMB;
+                return true;
+            case StateVacuum:
+                temperature = 0f;
+                return false;
+            default:
+                temperature = (_coreValue * TempDegreeResolution) + TempMinimum;
+                return true;
+        }
+    }
+
+    public bool Equals(ThermalByte other)
+    {
+        return _coreValue == other._coreValue;
+    }
+
+    public static bool operator ==(ThermalByte left, ThermalByte right)
+    {
+        return left.Equals(right);
+    }
+
+    public static bool operator !=(ThermalByte left, ThermalByte right)
+    {
+        return !left.Equals(right);
+    }
+
+    public override bool Equals(object? obj)
+    {
+        return obj is ThermalByte other && Equals(other);
+    }
+
+    public override int GetHashCode()
+    {
+        return _coreValue.GetHashCode();
     }
 }

--- a/Content.Shared/CCVar/CCVars.Net.cs
+++ b/Content.Shared/CCVar/CCVars.Net.cs
@@ -1,4 +1,4 @@
-﻿using Robust.Shared.Configuration;
+using Robust.Shared.Configuration;
 
 namespace Content.Shared.CCVar;
 

--- a/Content.Shared/Inventory/InventorySystem.Relay.cs
+++ b/Content.Shared/Inventory/InventorySystem.Relay.cs
@@ -95,6 +95,7 @@ public partial class InventorySystem
         SubscribeLocalEvent<InventoryComponent, RefreshEquipmentHudEvent<ShowCriminalRecordIconsComponent>>(RefRelayInventoryEvent);
         SubscribeLocalEvent<InventoryComponent, RefreshEquipmentHudEvent<BlackAndWhiteOverlayComponent>>(RefRelayInventoryEvent);
         SubscribeLocalEvent<InventoryComponent, RefreshEquipmentHudEvent<NoirOverlayComponent>>(RefRelayInventoryEvent);
+        SubscribeLocalEvent<InventoryComponent, RefreshEquipmentHudEvent<ThermalSightComponent>>(RefRelayInventoryEvent);
 
         SubscribeLocalEvent<InventoryComponent, GetVerbsEvent<EquipmentVerb>>(OnGetEquipmentVerbs);
         SubscribeLocalEvent<InventoryComponent, GetVerbsEvent<InnateVerb>>(OnGetInnateVerbs);

--- a/Content.Shared/Overlays/ThermalSightComponent.cs
+++ b/Content.Shared/Overlays/ThermalSightComponent.cs
@@ -1,0 +1,10 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Overlays;
+
+/// <summary>
+/// Makes the entity see air temperature.
+/// When added to a clothing item it will also grant the wearer the same overlay.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class ThermalSightComponent : Component;

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/engivend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/engivend.yml
@@ -6,6 +6,7 @@
     MaintenanceJack: 10 # Frontier
     Multitool: 10 # Frontier: 4<10
     ClothingEyesGlassesMeson: 10
+    ClothingEyesGlassesThermal: 10 # Frontier 4<10
     ClothingHeadHatWelding: 6
 #    HolofanProjector: 10    # Frontier
     BoxInflatable: 2

--- a/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
@@ -251,6 +251,7 @@
   - type: GroupExamine
   - type: IdentityBlocker
     coverage: EYES
+  - type: ThermalSight
 
 - type: entity
   parent: ClothingEyesBase

--- a/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/engivend.yml
+++ b/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/engivend.yml
@@ -6,6 +6,7 @@
     MaintenanceJack: 4294967295 # Infinite
     Multitool: 4294967295 # Infinite
     ClothingEyesGlassesMeson: 4294967295 # Infinite
+    ClothingEyesGlassesThermal: 4294967295 # Infinite
     ClothingHeadHatWelding: 4294967295 # Infinite
 #    HolofanProjector: 10
     NFInflatableWallStack: 4294967295 # Infinite


### PR DESCRIPTION

## About the PR
Ports https://github.com/space-wizards/space-station-14/pull/42613 from Upstream
## Why / Balance
Seems like a neat feature.

## Technical details
New component and the systems to support it

## How to test
Buy a pair of Optic Thermals, put them on, notice the neat color shading for gas temperature

## Media
(TODO)
## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes
not building due to an unrecognized term "ThermalScanner"
"The type or namespace name 'GasPrototype' could not be found"
**Changelog**

:cl:
- add: Ports optical thermal scanners now show gas temperature from upstream