### PR TITLE
Fix assertion when spawning with multi-handed items in loadout

### DIFF
--- a/Content.Shared/Item/MultiHandedItemSystem.cs
+++ b/Content.Shared/Item/MultiHandedItemSystem.cs
@@ -24,6 +24,16 @@ public sealed class MultiHandedItemSystem : EntitySystem
 
     private void OnEquipped(Entity<MultiHandedItemComponent> ent, ref GotEquippedHandEvent args)
     {
+        // Frontier
+        if (_timing.ApplyingState)
+        {
+            // If we're currently applying server-side state, we'll get the virtual item anyway and don't need to
+            // create it client-side; this avoids a debug assertion when a client joins in exactly the same tick a
+            // multi-handed item is picked up
+            return;
+        }
+        // End Frontier
+
         for (var i = 0; i < ent.Comp.HandsNeeded - 1; i++)
         {
             _virtualItem.TrySpawnVirtualItemInHand(ent.Owner, args.User);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
There's an assertion that fails when you spawn in with a multi-handed, in-hand item in your loadout. It no longer fails because we don't do the thing that fails anymore.

## Why / Balance
Crashes the client in debug mode. Crashes are a sub-optimal user experience.

## Technical details
When a user spawns in with a two-handed item in their in-hand loadout, applying the game tick data received from the server initializes the new two-handed entity and inserts it into the user's hand. This makes MultiHandedItemSystem create a `VirtualItem` to block the other hand of the user. Unfortunately, the tick also contains a `VirtualItem` from the server, which ApplyGameState then attempts to insert into the same hand that already contains the client's `VirtualItem`; this fails an assertion because an item slot cannot contain two items at the same time.

(nb: I believe this can also happen if a user joins in the exact same tick as someone else picks up a two-handed item, but actually reproducing that is Not Fun™; it's most likely never come up before because outside of a Debug configuration, you never even notice this and joining under these exact circumstances is unlikely enough as to never have come up before in the first place, let alone with a user playing a debug build.)

We now just don't create the `VirtualItem` while we're applying the server's game state; it will have created the item server-side anyway, so we'll get that without having to create it on the client and then replacing it with the server's.

## How to test
With your client in a Debug configuration, add a two-handed item to the in-hand loadout group; for example by cherry-picking #4609. Go to the lobby and add the item to your current loadout; make sure you don't have any other in-hand items. Join the round. Marvel at the sight of your client not crashing.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
💣🚫

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
no

**Changelog**
even less user-facing than my last PR