### PR TITLE
HorizontalExpand Inertial Dampener Buttons

### DIFF
--- a/Content.Client/Shuttles/UI/NavScreen.xaml
+++ b/Content.Client/Shuttles/UI/NavScreen.xaml
@@ -60,20 +60,23 @@
                        VerticalExpand="True"
                        HorizontalAlignment="Center"/>
             </controls1:StripeBack>
+            <!-- Frontier: formatting adjustments / hide player shuttles -->
             <controls:Button Name="IFFToggle"
                     Text="{controls:Loc 'shuttle-console-iff-toggle'}"
                     TextAlign="Center"
+                    Margin="0 0 0 1"
                     ToggleMode="True"/>
-            <!-- Frontier: hide player shuttles -->
             <controls:Button Name="IFFShuttleToggle"
                      Text="{controls:Loc 'shuttle-console-iffshuttles-toggle'}"
                      TextAlign="Center"
+                     Margin="0 0 0 1"
                      ToggleMode="True"/>
-            <!-- End Frontier: hide player shuttles -->
             <controls:Button Name="DockToggle"
                     Text="{controls:Loc 'shuttle-console-dock-toggle'}"
                     TextAlign="Center"
+                    Margin="0 0 0 1"
                     ToggleMode="True"/>
+            <!-- End Frontier: formatting adjustments / hide player shuttles -->
             <!-- Frontier - Inertia dampener controls-->
             <controls:BoxContainer Name="DampenerModeButtons"
                           Orientation="Horizontal"
@@ -85,21 +88,21 @@
                                  Text="{controls:Loc 'shuttle-console-inertia-dampener-off'}"
                                  TextAlign="Center"
                                  ToggleMode="True"
-                                 MinWidth="85"
+                                 HorizontalExpand="True"
                                  StyleClasses="OpenRight"
                                  Margin="0"/>
                 <controls:Button Name="DampenerOn"
                                  Text="{controls:Loc 'shuttle-console-inertia-dampener-dampen'}"
                                  TextAlign="Center"
                                  ToggleMode="True"
-                                 MinWidth="85"
+                                 HorizontalExpand="True"
                                  StyleClasses="OpenBoth"
                                  Margin="0"/>
                 <controls:Button Name="AnchorOn"
                                  Text="{controls:Loc 'shuttle-console-inertia-dampener-anchor'}"
                                  TextAlign="Center"
                                  ToggleMode="True"
-                                 MinWidth="85"
+                                 HorizontalExpand="True"
                                  StyleClasses="OpenLeft"
                                  Margin="0"/>
             </controls:BoxContainer>
@@ -163,7 +166,7 @@
                                      Text="{controls:Loc 'shuttle-console-service-flag-Services-label'}"
                                      TextAlign="Center"
                                      ToggleMode="True"
-                                     MinWidth="30"
+                                     HorizontalExpand="True"
                                      ToolTip="{controls:Loc 'shuttle-console-service-flag-Services-description'}"
                                      StyleClasses="OpenRight"
                                      Margin="0"/>
@@ -171,7 +174,7 @@
                                      Text="{controls:Loc 'shuttle-console-service-flag-Trade-label'}"
                                      TextAlign="Center"
                                      ToggleMode="True"
-                                     MinWidth="30"
+                                     HorizontalExpand="True"
                                      ToolTip="{controls:Loc 'shuttle-console-service-flag-Trade-description'}"
                                      StyleClasses="OpenBoth"
                                      Margin="0"/>
@@ -179,7 +182,7 @@
                                      Text="{controls:Loc 'shuttle-console-service-flag-Social-label'}"
                                      TextAlign="Center"
                                      ToggleMode="True"
-                                     MinWidth="30"
+                                     HorizontalExpand="True"
                                      ToolTip="{controls:Loc 'shuttle-console-service-flag-Social-description'}"
                                      StyleClasses="OpenLeft"
                                      Margin="0"/>


### PR DESCRIPTION
## About the PR
Fixes #4645, they'll expand within the BoxContainer horizontally laying the buttons out

Also does the same for the Services / Shopping / Social buttons

## Why / Balance
Looks cleaner

## Technical details
`HorizontalExpand` used instead of `MinWidth` on the Button controls, as they're placed within a horizontal-orientated BoxContainer

## How to test
Open shuttle control UI

## Media
<img width="274" height="580" alt="Content Client_3PrBjls4yH" src="https://github.com/user-attachments/assets/3f850b34-87c8-4f5d-8dc5-aa83af77e3f7" />

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes
N/A

**Changelog**
N/A, minor cosmetic tweak
