### PR TITLE
Grammar and Spelling Wizardry

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Objects/Specific/Wizard/magical_items.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Specific/Wizard/magical_items.yml
@@ -148,7 +148,7 @@
   id: GasTankWizardBottomless
   parent: [ GasTankRoundBase, BaseC3WizardContraband ]
   name: bottomless gas tank
-  description: An unusual looking gas tank that can hold more volume that it's size would suggest. Lovingly crafted for commercial use by the "Bottomless" brand.
+  description: An unusual looking gas tank that can hold more volume than its size would suggest. Lovingly crafted for commercial use by the "Bottomless" brand.
   components:
   - type: Sprite
     sprite: _NF/Objects/Tanks/wizard.rsi

--- a/Resources/Prototypes/_NF/Entities/Structures/Specific/wizards.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Specific/wizards.yml
@@ -100,7 +100,7 @@
   parent: [ BaseMachine, BaseC3WizardContraband ]
   id: SingingRock
   name: singing rock
-  description: A rock with charming, melodic voice.
+  description: A rock with a charming, melodic voice.
   components:
   - type: StationAiWhitelist
   - type: Sprite
@@ -165,7 +165,7 @@
   id: WizardGasCanisterBottomlessOxygen
   name: bottomless canister
   suffix: Filled, Oxygen
-  description: A canister that can hold more gas that it's size would suggest. Lovingly crafted for commercial use by the "Bottomless" brand.
+  description: A canister that can hold more gas than its size would suggest. Lovingly crafted for commercial use by the "Bottomless" brand.
   components:
     - type: Sprite
       sprite: _NF/Structures/Specific/Wizard/canister.rsi
@@ -195,7 +195,7 @@
   id: WizardGasCanisterBottomlessNitrogen
   name: bottomless canister
   suffix: Filled, Nitrogen
-  description: A canister that can hold more gas that it's size would suggest. Lovingly crafted for commercial use by the "Bottomless" brand.
+  description: A canister that can hold more gas than its size would suggest. Lovingly crafted for commercial use by the "Bottomless" brand.
   components:
     - type: Sprite
       sprite: _NF/Structures/Specific/Wizard/canister.rsi


### PR DESCRIPTION
## About the PR
Corrects the descriptions on the bottomless tank and canisters from the wizard loot, small correction to the singing rock description

## Why / Balance
Grammar error reported, following up on the report.

## Technical details
Minor yml changes

## How to test
Spawn in SingingRock, WizardGasCanisterBottomlessOxygen, WizardGasCanisterBottomlessNitrogen and GasTankWizardBottomless and examine for the descriptions

## Media
N/A

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

**Changelog**
Minor corrections