### PR TITLE
Configurable Shuttle Suffixes

### DIFF
--- a/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.Consoles.cs
+++ b/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.Consoles.cs
@@ -42,6 +42,7 @@ using Content.Server.StationEvents.Components;
 using Content.Shared.Forensics.Components;
 using Robust.Server.Player;
 using Robust.Shared.Timing;
+using Content.Server._NF.Shuttles.Systems;
 
 namespace Content.Server._NF.Shipyard.Systems;
 
@@ -65,7 +66,7 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
     [Dependency] private readonly MindSystem _mind = default!;
     [Dependency] private readonly ShuttleRecordsSystem _shuttleRecordsSystem = default!;
     [Dependency] private readonly IEntityManager _entityManager = default!;
-
+    [Dependency] private readonly ShuttleSuffixSystem _shuttleSuffix = default!;
     private static readonly Regex DeedRegex = new(@"\s*\([^()]*\)");
 
     public void InitializeConsole()
@@ -122,7 +123,7 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
             return;
         }
 
-        var name = vessel.Name;
+
         if (vessel.Price <= 0)
             return;
 
@@ -186,6 +187,25 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
             PlayDenySound(player, shipyardConsoleUid, component);
             return;
         }
+
+
+        var name = vessel.IFFName ?? vessel.ID;
+        var suffix = _shuttleSuffix.GenerateSuffix(vessel, vessel.Designator);
+        var deedID = EnsureComp<ShuttleDeedComponent>(targetId);
+
+        var shuttleOwner = Name(player).Trim();
+        AssignShuttleDeedProperties((targetId, deedID), shuttleUid, name, suffix, shuttleOwner, voucherUsed);
+
+        var deedShuttle = EnsureComp<ShuttleDeedComponent>(shuttleUid);
+        AssignShuttleDeedProperties((shuttleUid, deedShuttle), shuttleUid, name, suffix, shuttleOwner, voucherUsed);
+
+        string fullName = GetFullName(deedShuttle);
+
+        if (!voucherUsed && component.NewJobTitle != null && !HasComp<PreventShipyardTitleOverwriteComponent>(args.Actor))
+        {
+            _idSystem.TryChangeJobTitle(targetId, Loc.GetString(component.NewJobTitle), idCard, player);
+        }
+
         EntityUid? shuttleStation = null;
         // setting up any stations if we have a matching game map prototype to allow late joins directly onto the vessel
         if (_prototypeManager.TryIndex<GameMapPrototype>(vessel.ID, out var stationProto))
@@ -194,8 +214,8 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
             {
                 shuttleUid
             };
-            shuttleStation = _station.InitializeNewStation(stationProto.Stations[vessel.ID], gridUids);
-            name = Name(shuttleStation.Value);
+
+            shuttleStation = _station.InitializeNewStation(stationProto.Stations[vessel.ID], gridUids, fullName);
 
             var vesselInfo = EnsureComp<ExtraShuttleInformationComponent>(shuttleStation.Value);
             vesselInfo.Vessel = vessel.ID;
@@ -208,18 +228,7 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
             _accessSystem.TrySetTags(targetId, newAccess, newCap);
         }
 
-        var deedID = EnsureComp<ShuttleDeedComponent>(targetId);
 
-        var shuttleOwner = Name(player).Trim();
-        AssignShuttleDeedProperties((targetId, deedID), shuttleUid, name, shuttleOwner, voucherUsed);
-
-        var deedShuttle = EnsureComp<ShuttleDeedComponent>(shuttleUid);
-        AssignShuttleDeedProperties((shuttleUid, deedShuttle), shuttleUid, name, shuttleOwner, voucherUsed);
-
-        if (!voucherUsed && component.NewJobTitle != null && !HasComp<PreventShipyardTitleOverwriteComponent>(args.Actor))
-        {
-            _idSystem.TryChangeJobTitle(targetId, Loc.GetString(component.NewJobTitle), idCard, player);
-        }
 
         // The following block of code is entirely to do with trying to sanely handle moving records from station to station.
         // it is ass.
@@ -275,9 +284,9 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
             sellValue = CalculateShipResaleValue((shipyardConsoleUid, component), sellValue);
         }
 
-        SendPurchaseMessage(shipyardConsoleUid, player, name, component.ShipyardChannel, secret: false);
+        SendPurchaseMessage(shipyardConsoleUid, player, fullName, component.ShipyardChannel, secret: false);
         if (component.SecretShipyardChannel is { } secretChannel)
-            SendPurchaseMessage(shipyardConsoleUid, player, name, secretChannel, secret: true);
+            SendPurchaseMessage(shipyardConsoleUid, player, fullName, secretChannel, secret: true);
 
         PlayConfirmSound(player, shipyardConsoleUid, component);
         if (voucherUsed)
@@ -302,18 +311,7 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
             );
         }
 
-        RefreshState(shipyardConsoleUid, bank.Balance, true, name, sellValue, targetId, (ShipyardConsoleUiKey)args.UiKey, voucherUsed);
-    }
-
-    private void TryParseShuttleName(ShuttleDeedComponent deed, string name)
-    {
-        // The logic behind this is: if a name part fits the requirements, it is the required part. Otherwise it's the name.
-        // This may cause problems but ONLY when renaming a ship. It will still display properly regardless of this.
-        var nameParts = name.Split(' ');
-
-        var hasSuffix = nameParts.Length > 1 && nameParts.Last().Length < ShuttleDeedComponent.MaxSuffixLength && nameParts.Last().Contains('-');
-        deed.ShuttleNameSuffix = hasSuffix ? nameParts.Last() : null;
-        deed.ShuttleName = String.Join(" ", nameParts.SkipLast(hasSuffix ? 1 : 0));
+        RefreshState(shipyardConsoleUid, bank.Balance, true, fullName, sellValue, targetId, (ShipyardConsoleUiKey)args.UiKey, voucherUsed);
     }
 
     public void OnSellMessage(EntityUid uid, ShipyardConsoleComponent component, ShipyardConsoleSellMessage args)
@@ -784,10 +782,11 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
     }
 
     #region Deed Assignment
-    void AssignShuttleDeedProperties(Entity<ShuttleDeedComponent> deed, EntityUid? shuttleUid, string? shuttleName, string? shuttleOwner, bool purchasedWithVoucher)
+    void AssignShuttleDeedProperties(Entity<ShuttleDeedComponent> deed, EntityUid? shuttleUid, string? shuttleName, string? shuttleSuffix, string? shuttleOwner, bool purchasedWithVoucher)
     {
         deed.Comp.ShuttleUid = shuttleUid;
-        TryParseShuttleName(deed.Comp, shuttleName!);
+        deed.Comp.ShuttleName = shuttleName;
+        deed.Comp.ShuttleNameSuffix = shuttleSuffix;
         deed.Comp.ShuttleOwner = shuttleOwner;
         deed.Comp.PurchasedWithVoucher = purchasedWithVoucher;
         Dirty(deed);
@@ -809,7 +808,7 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
         _idSystem.TryChangeFullName(uid, output); // Update the card with owner name
 
         var deedID = EnsureComp<ShuttleDeedComponent>(uid);
-        AssignShuttleDeedProperties((uid, deedID), shuttleDeed.ShuttleUid, shuttleDeed.ShuttleName, shuttleDeed.ShuttleOwner, shuttleDeed.PurchasedWithVoucher);
+        AssignShuttleDeedProperties((uid, deedID), shuttleDeed.ShuttleUid, shuttleDeed.ShuttleName, shuttleDeed.ShuttleNameSuffix, shuttleDeed.ShuttleOwner, shuttleDeed.PurchasedWithVoucher);
     }
     #endregion
 

--- a/Content.Server/_NF/Shuttles/Systems/ShuttleSuffixSystem.cs
+++ b/Content.Server/_NF/Shuttles/Systems/ShuttleSuffixSystem.cs
@@ -1,0 +1,112 @@
+using System.Linq;
+using System.Text;
+using Content.Shared._NF.Shipyard.Components;
+using Content.Shared._NF.Shipyard.Prototypes;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
+using Robust.Shared.Utility;
+
+namespace Content.Server._NF.Shuttles.Systems;
+
+public sealed partial class ShuttleSuffixSystem : EntitySystem
+{
+    private string[] DefaultSuffixCodes => ["LV", "NX", "EV", "QT", "PR"];
+
+    [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+
+    private const int OffsetA = 'A';
+    private const int NumLetters = 26;
+
+    public string GenerateSuffix(ProtoId<VesselPrototype> vesselId, SuffixGeneratorInputEntry? vesselDesignator = null)
+    {
+        if (!_prototypeManager.TryIndex(vesselId, out var vessel) || vessel.SuffixGenerator is null)
+        {
+            return DefaultSuffixGeneration();
+        }
+
+        if (!_prototypeManager.TryIndex(vessel.SuffixGenerator, out var suffixGen))
+        {
+            //Log a warning perhaps?
+            return DefaultSuffixGeneration();
+        }
+
+        var designators = new List<SuffixGeneratorInputEntry>() { vesselDesignator ?? suffixGen.DefaultDesignator };
+
+        designators.AddRange(suffixGen.Designators);
+        return string.Format(suffixGen.Format, designators.Select(GenerateInput).ToArray());
+
+    }
+
+    //Mimics the NanotrasenNameGenerator suffix, which is what all shuttles used previously
+    private string DefaultSuffixGeneration()
+    {
+        return $"{_random.Pick(DefaultSuffixCodes)}-{_random.Next(0, 1000):D3}";
+    }
+
+    private string GenerateInput(SuffixGeneratorInputEntry entry)
+    {
+        return entry.Type switch
+        {
+            SuffixGeneratorInputType.Alpha => GenerateAlpha(entry),
+            SuffixGeneratorInputType.AlphaNumeric => GenerateAlphaNumeric(entry),
+            SuffixGeneratorInputType.Numeric => GenerateNumeric(entry),
+            SuffixGeneratorInputType.List => GenerateList(entry),
+            _ => ""
+        };
+    }
+
+    private string GenerateAlpha(SuffixGeneratorInputEntry entry)
+    {
+        var min = Math.Clamp(entry.Min ?? 1, 1, ShuttleDeedComponent.MaxSuffixLength);
+        var max = Math.Clamp(entry.Max ?? 1, min, ShuttleDeedComponent.MaxSuffixLength);
+        var count = _random.Next(min, max + 1); //max is exclusive
+        var buffer = new byte[count];
+        _random.NextBytes(buffer);
+
+        return new string(buffer.Select(b => (char)(b % NumLetters + OffsetA)).ToArray());
+    }
+
+    private string GenerateAlphaNumeric(SuffixGeneratorInputEntry entry)
+    {
+        var min = Math.Clamp(entry.Min ?? 1, 1, ShuttleDeedComponent.MaxSuffixLength);
+        var max = Math.Clamp(entry.Max ?? 1, min, ShuttleDeedComponent.MaxSuffixLength);
+        var count = _random.Next(min, max + 1); //max is exclusive
+        var builder = new StringBuilder();
+        for (var i = 0; i < count; i++)
+        {
+            var value = _random.Next(NumLetters + 10); //There are 10 digits, should I really make a constant?
+            if (value < NumLetters)
+            {
+                builder.Append((char)(value + OffsetA));
+            }
+            else
+            {
+                builder.Append(value - NumLetters);
+            }
+        }
+        return builder.ToString();
+    }
+
+    private string GenerateNumeric(SuffixGeneratorInputEntry entry)
+    {
+        var min = Math.Max(entry.Min ?? 0, 0);
+        var max = Math.Max(entry.Max ?? 9, min);
+        var value = _random.Next(min, max + 1);
+        var format = entry.Format ?? "{0}";
+        return string.Format(format, value);
+    }
+
+    private string GenerateList(SuffixGeneratorInputEntry entry)
+    {
+        //If they forgot to fill out the items array just give an empty result
+        if (entry.Items is null || entry.Items.Length == 0)
+        {
+            return "";
+        }
+
+        return _random.Pick(entry.Items);
+
+    }
+
+}

--- a/Content.Shared/_NF/Shipyard/Prototypes/SuffixGeneratorPrototype.cs
+++ b/Content.Shared/_NF/Shipyard/Prototypes/SuffixGeneratorPrototype.cs
@@ -1,0 +1,72 @@
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._NF.Shipyard.Prototypes;
+
+[Prototype]
+public sealed class SuffixGeneratorPrototype : IPrototype
+{
+    [IdDataField]
+    public string ID { get; } = default!;
+
+    /// <summary>
+    /// Format string to combine all inputs into final suffix
+    /// </summary>
+    [DataField(required: true)]
+    public string Format = default!;
+
+    /// <summary>
+    /// If a ship does not specify a designator, use this to generate one.
+    /// If the suffix generator doesn't specify, fallback to the Nanotrasen name generator ones
+    /// </summary>
+    [DataField]
+    public SuffixGeneratorInputEntry DefaultDesignator = new()
+    {
+        Type = SuffixGeneratorInputType.List,
+        Items = ["LV", "NX", "EV", "QT", "PR"] // The OG Suffix Prefixes
+    };
+
+    /// <summary>
+    /// Different 'parts' of the suffix, each specifing how they generate
+    /// </summary>
+    [DataField(required: true)]
+    public List<SuffixGeneratorInputEntry> Designators = [];
+
+}
+
+[DataDefinition]
+public readonly partial record struct SuffixGeneratorInputEntry()
+{
+    /// <summary>
+    /// Generator type, determines which function is called to make up part of the string
+    /// </summary>
+    [DataField(required: true)]
+    public SuffixGeneratorInputType Type { get; init; } = default!;
+    /// <summary>
+    /// Used by all but List type, specifies the minimum characters the input produces, or for numeric the minimum value
+    /// </summary>
+    [DataField]
+    public int? Min { get; init; } = default;
+    /// <summary>
+    /// Used by all but List type, specifies the maximum characters the input produces, or for numeric the maximum value
+    /// </summary>
+    [DataField]
+    public int? Max { get; init; } = default;
+    /// <summary>
+    /// Only used by the numeric type, defaults to just normal decimal representation but any .NET number format specifier can be used
+    /// </summary>
+    [DataField]
+    public string? Format { get; init; } = default;
+    /// <summary>
+    /// Only used by the List type, a random entry from the list of strings will be chosen
+    /// </summary>
+    [DataField]
+    public string[]? Items { get; init; } = default;
+}
+
+public enum SuffixGeneratorInputType : byte
+{
+    Alpha,
+    AlphaNumeric,
+    Numeric,
+    List
+}

--- a/Content.Shared/_NF/Shipyard/Prototypes/VesselPrototype.cs
+++ b/Content.Shared/_NF/Shipyard/Prototypes/VesselPrototype.cs
@@ -24,6 +24,11 @@ public sealed class VesselPrototype : IPrototype, IInheritingPrototype
     [DataField] public string Name = string.Empty;
 
     /// <summary>
+    ///     Name of shuttle when purchased to use on entity and deed, if null will use the ID
+    /// </summary>
+    [DataField] public string? IFFName = default;
+
+    /// <summary>
     ///     Short description of the vessel.
     /// </summary>
     [DataField] public string Description = string.Empty;
@@ -83,6 +88,11 @@ public sealed class VesselPrototype : IPrototype, IInheritingPrototype
     [DataField]
     public ProtoId<GuideEntryPrototype>? GuidebookPage = default!;
 
+    [DataField]
+    public ProtoId<SuffixGeneratorPrototype>? SuffixGenerator = default!; //TODO: Make ShuttleSuffixGeneratorProtypes
+
+    [DataField]
+    public SuffixGeneratorInputEntry? Designator = default!;
     /// <summary>
     ///     The price markup of the vessel testing
     /// </summary>

--- a/Resources/Prototypes/_NF/Shipyard/SuffixGenerator/lvhi.yml
+++ b/Resources/Prototypes/_NF/Shipyard/SuffixGenerator/lvhi.yml
@@ -1,0 +1,14 @@
+- type: suffixGenerator
+  id: LVHI
+  format: '{1}{0}-{2}'
+  defaultDesignator:
+    type: Alpha # This is {0} unless a ship specifies a designator
+    min: 2 # always 2 letters, max is clamped to min
+  designators:
+  - type: AlphaNumeric # This is {1}
+    min: 1
+    max: 2 # will have 1 or 2 alpha numeric digits
+  - type: Numeric # This is {2}
+    format: '{0:D2}' # This will pad 0s to make it always 2 characters long
+    min: 0
+    max: 100

--- a/Resources/Prototypes/_NF/Shipyard/adder.yml
+++ b/Resources/Prototypes/_NF/Shipyard/adder.yml
@@ -17,6 +17,13 @@
   category: Small
   group: Shipyard
   shuttlePath: /Maps/_NF/Shuttles/adder.yml
+  suffixGenerator: LVHI
+  designator:
+    type: List
+    items:
+    - AD
+    - A1
+    - A7
   guidebookPage: ShipyardAdder
   class:
   - Salvage
@@ -32,11 +39,6 @@
     Adder:
       stationProto: StandardFrontierVessel
       components:
-        - type: StationNameSetup
-          mapNameTemplate: 'Adder {1}'
-          nameGenerator:
-            !type:NanotrasenNameGenerator
-            prefixCreator: '14'
         - type: StationJobs
           availableJobs:
             ContractorInterview: [ 0, 0 ]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Changed how ships are named when purchased from the shuttle console using a new `ShuttleSuffixSystem` . This allows us to define suffix generators based on say manufacturer and apply those to the shipyard vessel metadata files. Each suffix is composed of multiple 'designators' with the first (0) being a little special in that a vessel can provide its own generator for that designator.

For this I modified the LVHI Adder to use a LVHI Suffix Generator, with it's designator being one of AD, A1, or A7. Other ships could be set to use the LVHI generator but will have random letters in place of the designator.
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Why / Balance
More variety of IFF designators, could possibly make it to where folks can recognize the manufacturer or model from the IFF code alone. Also it is currently possible (though improbable) for 2 ships to be given the same name and suffix as nothing checks to make them unique. While this PR doesn't fix that it would make it more improbable once ships are changed to use these generators.
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->
Most of the work is done in `ShipyardSystem::OnPurchaseMessage`, previously it relied that the `GameMapPrototype` had a `ShipNameSetup` component with a specific format that put in a suffix. This suffix is put in by `NanotrasenNameGenerator`. Unfortunately it returns the entire full name (Adder LV-200). We were having to try to parse out the suffix to place on the deed so it persists with renames. This changes it so that the name is generated before the grid is loaded, which allows us to override the name put on it (that override was already in place). This lets us generate the suffix separately from the full name of the ship, eliminating the need for parsing the suffix. 
It should also remove the need for a `StationNameSetup` component on the grid map. It would only be needed if say an admin decided to load in a ship manually, however that has its own problems of not having a deed or ship record, plus they can manually edit the name themselves (which they likely would do)

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
Spawn in, eject your ID and buy and Adder. Notice how it has a funky IFF Suffix like N7AD-04.
Try selling and buying several and see the suffix change (though the part before the - should always be one of A1, A7 or AD).
Try renaming the ship and see that the suffix carries over.
Try buying something other than an Adder and see a suffix like PR-123 or LV-456 or NX-789 etc.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="321" height="175" alt="image" src="https://github.com/user-attachments/assets/87b88f36-c582-4f1d-bc9b-e0ebf464d6db" />
<img width="405" height="198" alt="image" src="https://github.com/user-attachments/assets/30443433-7b41-490a-ac1d-668d91058dd4" />
<img width="466" height="262" alt="image" src="https://github.com/user-attachments/assets/e5ffc719-a285-45b1-8fe4-7edd6ca68320" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
Shouldn't be any. Not modified shuttles will continue to generate the same names as before.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Configurable Suffix names for shuttles
- tweak: The Adder now has a LVHI specific suffix on its shuttles similar to XNA7-13
-->
