### PR TITLE
Space Adders are no longer able to slip through shutters, airlocks, etc

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_carp.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_carp.yml
@@ -132,7 +132,7 @@
           radius: 0.35
         density: 25
         mask:
-        - SmallMobMask
+        - MobMask
         layer:
         - SmallMobLayer # Allows small snakes to pass under the tables
   - type: Sprite


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Made Space Adders no longer being able to slip through airlocks, shutters and so on.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Space Adders going under airlocks, shutters, etc while Space Ticks can't is a bit misleading for players.
## Technical details
<!-- Summary of code changes for easier review. -->
Space Adder going from `SmallMobMask` to `MobMask` for collisions.
## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
Spawn a Space Adder, try to slip under shutters... no longer !
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
None.
**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Space Adders are no longer able to slip through shutters, airlocks, etc

