### PR TITLE
fix pilots of pet mechs can use their mech's equipment

### DIFF
--- a/Content.Server/Mech/Systems/MechSystem.cs
+++ b/Content.Server/Mech/Systems/MechSystem.cs
@@ -342,7 +342,7 @@ public sealed partial class MechSystem : SharedMechSystem
     private void ReceiveEquipmentUiMesssages<T>(EntityUid uid, MechComponent component, T args) where T : MechEquipmentUiMessage
     {
         // Frontier: snails and other simple mobs shouldn't manipulate mech equipment
-        if (!_actionBlocker.CanComplexInteract(args.Actor))
+        if (!_actionBlocker.CanComplexInteract(args.Actor) && !component.PilotSlot.Contains(args.Actor)) //mobs piloting a mech such as HAMTR or VIM should be able to manipulate the equipment if they are piloting it
             return;
         // End Frontier
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Allowing Pets/Simple Mobs piloting a mech to be able to use it's equipment. Namely to drop crates they have picked up. This was inadvertently caused by #4130 which prevented simple mobs from being able to interact with a mech's control panel. Unfortunately this prevented it both while outside and inside the mech.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Mech pilot access is already restricted by a whitelist. If they are moving the mech around and have arms attached they should be able to fully use them. See #4554 

## Technical details
Adds an additional condition allowing the mech pilot to use the equipment, even if they are incapable of complex interaction

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
Spawn hamlet or a hamster
Spawn a HAMTR or VIM with a battery
Spawn a small hydraulic clamp or two
Spawn or find some crates to pick up
Put the clamp(s) on the mech
Control the hamster 
enter the mech
switch to a clamp and pickup a crate
view status of mech and click on crate to drop it, see that the crate is dropped.
Exit mech
Right click on the mech (any mech for that matter) and see that you still cannot access the control panel from outside (which is what #4130 was aiming to fix)

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="556" height="491" alt="image" src="https://github.com/user-attachments/assets/6f3f07bd-cc87-4839-b22d-d8bb8b2c2b0f" />
Image showing that Hamlet still cannot access the control panel from the outside

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Hamsters, mice and other non-humanoid mobs have ended their strike and can now drop crates while piloting a mech such as the VIM or HAMTR

