### PR TITLE
Add Laser Repeater to Loot Pools

### DIFF
--- a/Resources/Prototypes/_NF/Catalog/Fills/Items/weapon_cases_expedition.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/Items/weapon_cases_expedition.yml
@@ -430,6 +430,17 @@
 
 - type: entity
   parent: [WeaponCaseLong, RareWeaponCase]
+  id: WeaponCaseLongLaserRepeaterExpedition
+  suffix: Dungeon, Laser Repeater
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: StorageFill
+    contents:
+    - id: NFWeaponEnergyRifleAssaultLaserRepeater
+      amount: 1
+
+- type: entity
+  parent: [WeaponCaseLong, RareWeaponCase]
   id: WeaponCaseLongLaserCarbineExpedition
   suffix: Dungeon, Laser Carbine
   categories: [ HideSpawnMenu ]

--- a/Resources/Prototypes/_NF/Catalog/Fills/NPCsLoot/npc_loot_mercenaries.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/NPCsLoot/npc_loot_mercenaries.yml
@@ -66,9 +66,11 @@
     table: !type:GroupSelector
       children:
       - id: WeaponCaseShortLaserGunExpedition
-        weight: 0.75
+        weight: 0.70
       - id: WeaponCaseShortSvalinnExpedition
-        weight: 0.23
+        weight: 0.20
+      - id: WeaponCaseLongLaserRepeaterExpedition
+        weight: 0.08
       - id: WeaponCaseLongLaserCarbineExpedition
         weight: 0.01
       - id: WeaponCaseShortAdvancedLaserExpedition

--- a/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/Items/weapon_tables.yml
+++ b/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/Items/weapon_tables.yml
@@ -218,6 +218,7 @@
       - id: WeaponCaseLongSVSExpedition
       - id: WeaponCaseLongKammererExpedition
       - id: WeaponCaseShortLaserGunExpedition
+      - id: WeaponCaseLongLaserRepeaterExpedition
     - !type:NestedSelector
       weight: 0.05
       tableId: TableDungeonLootWeaponsRangedTier3

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/expedition_guns.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/expedition_guns.yml
@@ -256,6 +256,13 @@
   categories: [ HideSpawnMenu ]
   id: NFWeaponRifleAssaultGestioExpedition
 
+- type: entity
+  parent:
+  - BaseExpeditionWeaponTier2
+  - NFWeaponEnergyRifleAssaultLaserRepeater
+  categories: [ HideSpawnMenu ]
+  id: NFWeaponEnergyRifleAssaultLaserRepeaterExpedition
+
 ## Rifles
 - type: entity
   parent:


### PR DESCRIPTION
## About the PR
Add the Laser Repeater to gun loot pools, created long weapon case fill for it.

## Why / Balance
Adding them for consistency, as the Laser Repeater is the most recently added rifle and it was not added to the loot pools on introduction.

## Technical details
Created NFWeaponEnergyRifleAssaultLaserRepeaterExpedition and WeaponCaseLongLaserRepeaterExpedition, added the case to the weapon table and to mercenary loot table. 

## How to test
1. Spawn a basalt VGRoid
2. Search for weapon cases until you find a laser repeater
3. Kill mercenaries for their loot bundles
4. Open the bundles until you get a weapon case with a laser repeater

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

**Changelog**
:cl:
- add: Added the laser repeater to weapon and mercenary loot pools
