### PR TITLE
Consistent Lights For EVA Suits

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/base_clothinghead.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/base_clothinghead.yml
@@ -214,8 +214,8 @@
   - type: ItemTogglePointLight
   - type: PointLight
     enabled: false
-    radius: 3
-    energy: 2
+    radius: 4.5 # Frontier: 3 < 4.5
+    energy: 4 # Frontier: 2 < 4
     mask: /Textures/Effects/LightMasks/cone.png
     autoRot: true
     netsync: false

--- a/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -4,8 +4,8 @@
 #This is so people don't need to wear both regular, on-station helmets and hardsuits to get full protection.
 #Generally, unless you're adding something like caustic damage, you should probably avoid messing with armor here outside of the above scenario.
 
-# region CREW HARDSUITS
-# region Atmospherics Hardsuit
+#CREW HARDSUITS
+#Atmospherics Hardsuit
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitAtmos
@@ -65,7 +65,7 @@
     - CorgiWearable
     - WhitelistChameleon
 
-# region Engineering Hardsuit
+#Engineering Hardsuit
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitEngineering
@@ -120,7 +120,7 @@
     - CorgiWearable
     - WhitelistChameleon
 
-# region Spationaut Hardsuit
+#Spationaut Hardsuit
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitSpatio
@@ -174,7 +174,7 @@
     - CorgiWearable
     - WhitelistChameleon
 
-# region Salvage Hardsuit
+#Salvage Hardsuit
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitSalvage
@@ -196,7 +196,7 @@
     - CorgiWearable
     - WhitelistChameleon
 
-# region Goliath Hardsuit
+#Goliath Hardsuit
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitGoliath
@@ -250,7 +250,7 @@
     - CorgiWearable
     - WhitelistChameleon
 
-# region Maxim Hardsuit
+#Maxim Hardsuit
 - type: entity
   parent: ClothingHeadHardsuitBase
   id: ClothingHeadHelmetHardsuitMaxim
@@ -273,7 +273,7 @@
         Piercing: 0.9
         Heat: 0.9
 
-# region Security Hardsuit
+#Security Hardsuit
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitSecurity
@@ -301,7 +301,7 @@
     - CorgiWearable
     - WhitelistChameleon
 
-# region Brigmedic Hardsuit
+#Brigmedic Hardsuit
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitBrigmedic
@@ -327,7 +327,7 @@
     highPressureMultiplier: 0.6
     lowPressureMultiplier: 1000
 
-# region Warden's Hardsuit
+#Warden's Hardsuit
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitWarden
@@ -351,7 +351,7 @@
         Piercing: 0.9
         Heat: 0.9
 
-# region Captain's Hardsuit
+#Captain's Hardsuit
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitCap
@@ -370,7 +370,7 @@
     - CorgiWearable
     - WhitelistChameleon
 
-# region Chief Engineer's Hardsuit
+#Chief Engineer's Hardsuit
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitEngineeringWhite
@@ -423,8 +423,10 @@
         shader: unshaded
   - type: PointLight
     color: "#daffad"
+    # Frontier
     radius: 6
     energy: 4
+    # End Frontier
   - type: PressureProtection
     highPressureMultiplier: 0.08
     lowPressureMultiplier: 1000
@@ -436,7 +438,7 @@
     - WhitelistChameleon
   - type: CatWearable # Frontier
 
-# region Chief Medical Officer's Hardsuit
+#Chief Medical Officer's Hardsuit
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitMedical
@@ -449,8 +451,10 @@
     sprite: Clothing/Head/Hardsuits/medical.rsi
   - type: PointLight
     color: "#adf1ff"
+    # Frontier
     radius: 6
     energy: 4
+    # End Frontier
   - type: PressureProtection
     highPressureMultiplier: 0.6
     lowPressureMultiplier: 1000
@@ -459,7 +463,7 @@
     - CorgiWearable
     - WhitelistChameleon
 
-# region Research Director's Hardsuit
+#Research Director's Hardsuit
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitRd
@@ -472,8 +476,10 @@
     sprite: Clothing/Head/Hardsuits/rd.rsi
   - type: PointLight
     color: "#d6adff"
+    # Frontier
     radius: 6
     energy: 4
+    # End Frontier
   - type: PressureProtection
     highPressureMultiplier: 0.60
     lowPressureMultiplier: 1000
@@ -482,7 +488,7 @@
     - CorgiWearable
     - WhitelistChameleon
 
-# region Head of Security's hardsuit
+#Head of Security's hardsuit
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitSecurityRed
@@ -495,8 +501,10 @@
     sprite: Clothing/Head/Hardsuits/security-red.rsi
   - type: PointLight
     color: "#ffeead"
+    # Frontier
     radius: 6
     energy: 4
+    # End Frontier
   - type: PressureProtection
     highPressureMultiplier: 0.45
     lowPressureMultiplier: 1000
@@ -508,7 +516,7 @@
         Piercing: 0.9
         Heat: 0.9
 
-# region Luxury Mining Hardsuit
+#Luxury Mining Hardsuit
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitLuxury #DO NOT MAP - https://github.com/space-wizards/space-station-14/pull/19738#issuecomment-1703486738
@@ -527,8 +535,8 @@
     radius: 7
     energy: 3
 
-# region ANTAG HARDSUITS
-# region Blood-red Hardsuit
+#ANTAG HARDSUITS
+#Blood-red Hardsuit
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitSyndie
@@ -541,8 +549,10 @@
     sprite: Clothing/Head/Hardsuits/syndicate.rsi
   - type: PointLight
     color: green
+    # Frontier
     radius: 5
     energy: 8
+    # End Frontier
   - type: PressureProtection
     highPressureMultiplier: 0.08
     lowPressureMultiplier: 1000
@@ -558,7 +568,7 @@
     - CorgiWearable
     - WhitelistChameleon
 
-# region Blood-red Medic Hardsuit
+#Blood-red Medic Hardsuit
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitSyndieMedic
@@ -571,8 +581,10 @@
     sprite: Clothing/Head/Hardsuits/syndiemedic.rsi
   - type: PointLight
     color: green
+    # Frontier
     radius: 5
     energy: 8
+    # End Frontier
   - type: PressureProtection
     highPressureMultiplier: 0.08
     lowPressureMultiplier: 1000
@@ -584,7 +596,7 @@
         Piercing: 0.9
         Heat: 0.9
 
-# region Syndicate Elite Hardsuit
+#Syndicate Elite Hardsuit
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitSyndieElite
@@ -597,8 +609,10 @@
     sprite: Clothing/Head/Hardsuits/syndieelite.rsi
   - type: PointLight
     color: red
+    # Frontier
     radius: 5
     energy: 8
+    # End Frontier
   - type: PressureProtection
     highPressureMultiplier: 0.08
     lowPressureMultiplier: 1000
@@ -619,7 +633,7 @@
     - CorgiWearable
     - WhitelistChameleon
 
-# region Syndicate Commander Hardsuit
+#Syndicate Commander Hardsuit
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitSyndieCommander
@@ -632,8 +646,10 @@
     sprite: Clothing/Head/Hardsuits/syndiecommander.rsi
   - type: PointLight
     color: green
+    # Frontier
     radius: 5
     energy: 8
+    # End Frontier
   - type: PressureProtection
     highPressureMultiplier: 0.08
     lowPressureMultiplier: 1000
@@ -649,7 +665,7 @@
     - CorgiWearable
     - WhitelistChameleon
 
-# region Cybersun Juggernaut Hardsuit
+#Cybersun Juggernaut Hardsuit
 - type: entity
   parent: ClothingHeadHardsuitBase
   id: ClothingHeadHelmetHardsuitCybersun
@@ -675,7 +691,7 @@
     - CorgiWearable
     - WhitelistChameleon
 
-# region Wizard Hardsuit
+#Wizard Hardsuit
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitWizard
@@ -688,8 +704,10 @@
     sprite: Clothing/Head/Hardsuits/wizard.rsi
   - type: PointLight
     color: "#ffadfb"
+    # Frontier
     radius: 5
     energy: 4
+    # End Frontier
   - type: PressureProtection
     highPressureMultiplier: 0.27
     lowPressureMultiplier: 1000
@@ -705,7 +723,7 @@
     - CorgiWearable
     - WhitelistChameleon
 
-# region Organic Space Suit
+#Organic Space Suit
 - type: entity
   parent: ClothingHeadHardsuitBase
   id: ClothingHeadHelmetHardsuitLing
@@ -720,7 +738,7 @@
     highPressureMultiplier: 0.225
     lowPressureMultiplier: 1000
 
-# region Pirate EVA Suit (Deep Space EVA Suit)
+#Pirate EVA Suit (Deep Space EVA Suit)
 - type: entity
   parent: ClothingHeadHardsuitBase
   id: ClothingHeadHelmetHardsuitPirateEVA
@@ -736,7 +754,7 @@
     highPressureMultiplier: 0.3
     lowPressureMultiplier: 1000
 
-# region Pirate Captain Hardsuit
+#Pirate Captain Hardsuit
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitPirateCap
@@ -781,8 +799,8 @@
         Piercing: 0.9
         Heat: 0.9
 
-# region CENTCOMM / ERT HARDSUITS
-# region ERT Leader Hardsuit
+#CENTCOMM / ERT HARDSUITS
+#ERT Leader Hardsuit
 - type: entity
   parent: [ BaseCentcommContraband, ClothingHeadHelmetHardsuitSyndieCommander ]
   id: ClothingHeadHelmetHardsuitERTLeader
@@ -794,8 +812,10 @@
   - type: Clothing
     sprite: Clothing/Head/Hardsuits/ERThelmets/ertleader.rsi
   - type: PointLight
+  # Frontier
     radius: 5
     energy: 4
+    # End Frontier
     color: "#addbff"
   - type: Armor
     modifiers:
@@ -805,7 +825,7 @@
         Piercing: 0.9
         Heat: 0.9
 
-# region ERT Chaplain Hardsuit
+#ERT Chaplain Hardsuit
 - type: entity
   parent: [ BaseCentcommContraband, ClothingHeadHelmetHardsuitSyndie ]
   id: ClothingHeadHelmetHardsuitERTChaplain
@@ -818,10 +838,12 @@
     sprite: Clothing/Head/Hardsuits/ERThelmets/ertchaplain.rsi
   - type: PointLight
     color: "#ffffff"
+    # Frontier
     radius: 5
     energy: 4
+    # End Frontier
 
-# region ERT Engineer Hardsuit
+#ERT Engineer Hardsuit
 - type: entity
   parent: [ BaseCentcommContraband, ClothingHeadHelmetHardsuitSyndie ]
   id: ClothingHeadHelmetHardsuitERTEngineer
@@ -834,8 +856,10 @@
     sprite: Clothing/Head/Hardsuits/ERThelmets/ertengineer.rsi
   - type: PointLight
     color: "#f4ffad"
+    # Frontier
     radius: 5
     energy: 4
+    # End Frontier
   - type: FireProtection
     reduction: 0.2
   - type: Armor
@@ -846,7 +870,7 @@
         Piercing: 0.9
         Heat: 0.9
 
-# region ERT Medical Hardsuit
+#ERT Medical Hardsuit
 - type: entity
   parent: [ BaseCentcommContraband, ClothingHeadHelmetHardsuitSyndieElite ]
   id: ClothingHeadHelmetHardsuitERTMedical
@@ -859,10 +883,12 @@
     sprite: Clothing/Head/Hardsuits/ERThelmets/ertmedical.rsi
   - type: PointLight
     color: "#adffec"
+    # Frontier
     radius: 5
     energy: 4
+    # End Frontier
 
-# region ERT Security Hardsuit
+#ERT Security Hardsuit
 - type: entity
   parent: [ BaseCentcommContraband, ClothingHeadHelmetHardsuitSyndie ]
   id: ClothingHeadHelmetHardsuitERTSecurity
@@ -875,8 +901,10 @@
     sprite: Clothing/Head/Hardsuits/ERThelmets/ertsecurity.rsi
   - type: PointLight
     color: "#ffadc6"
+    # Frontier
     radius: 5
     energy: 4
+    # End Frontier
   - type: Armor
     modifiers:
       coefficients:
@@ -885,7 +913,7 @@
         Piercing: 0.9
         Heat: 0.9
 
-# region ERT Janitor Hardsuit
+#ERT Janitor Hardsuit
 - type: entity
   parent: [ BaseCentcommContraband, ClothingHeadHelmetHardsuitSyndie ]
   id: ClothingHeadHelmetHardsuitERTJanitor
@@ -898,10 +926,12 @@
     sprite: Clothing/Head/Hardsuits/ERThelmets/ertjanitor.rsi
   - type: PointLight
     color: "#cbadff"
+    # Frontier
     radius: 5
     energy: 4
+    # End Frontier
 
-# region CBURN Hardsuit
+#CBURN Hardsuit
 - type: entity
   parent: [ BaseCentcommContraband, ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetCBURN
@@ -930,8 +960,10 @@
         shader: unshaded
   - type: PointLight
     color: orange
+    # Frontier
     radius: 5
     energy: 4
+    # End Frontier
   - type: PressureProtection
     highPressureMultiplier: 0.08
     lowPressureMultiplier: 1000
@@ -948,7 +980,7 @@
   - type: ZombificationResistance
     zombificationResistanceCoefficient: 0.75
 
-# region Deathsquad Hardsuit
+#Deathsquad Hardsuit
 - type: entity
   parent: [ BaseCentcommContraband, ClothingHeadHardsuitBase ]
   id: ClothingHeadHelmetHardsuitDeathsquad
@@ -975,8 +1007,8 @@
         Radiation: 0.80
         Caustic: 0.95
 
-# region MISC. HARDSUITS
-# region Clown Hardsuit
+#MISC. HARDSUITS
+#Clown Hardsuit
 - type: entity
   parent: ClothingHeadHelmetHardsuitSecurity
   id: ClothingHeadHelmetHardsuitClown
@@ -991,7 +1023,7 @@
     equipSound: /Audio/Mecha/mechmove03.ogg
     unequipSound: /Audio/Effects/Emotes/parp1.ogg
 
-# region Mime Hardsuit
+#Mime Hardsuit
 - type: entity
   parent: ClothingHeadHelmetHardsuitSecurity
   id: ClothingHeadHelmetHardsuitMime
@@ -1004,7 +1036,7 @@
   - type: Clothing
     sprite: Clothing/Head/Hardsuits/mime.rsi
 
-# region Santas Hardsuit
+#Santas Hardsuit
 - type: entity
   parent: ClothingHeadHardsuitBase
   id: ClothingHeadHelmetHardsuitSanta

--- a/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -572,7 +572,7 @@
   - type: PointLight
     color: green
     radius: 5
-    energy: 4
+    energy: 8
   - type: PressureProtection
     highPressureMultiplier: 0.08
     lowPressureMultiplier: 1000
@@ -598,7 +598,7 @@
   - type: PointLight
     color: red
     radius: 5
-    energy: 4
+    energy: 8
   - type: PressureProtection
     highPressureMultiplier: 0.08
     lowPressureMultiplier: 1000
@@ -633,7 +633,7 @@
   - type: PointLight
     color: green
     radius: 5
-    energy: 4
+    energy: 8
   - type: PressureProtection
     highPressureMultiplier: 0.08
     lowPressureMultiplier: 1000

--- a/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -534,7 +534,7 @@
   - type: PointLight
     color: green
     # Frontier
-    energy: 8 # the green light is too dim on lower values
+    energy: 12 # the green light is too dim on lower values
     # End Frontier
   - type: PressureProtection
     highPressureMultiplier: 0.08
@@ -565,7 +565,7 @@
   - type: PointLight
     color: green
     # Frontier
-    energy: 8 # the green light is too dim on lower values
+    energy: 12 # the green light is too dim on lower values
     # End Frontier
   - type: PressureProtection
     highPressureMultiplier: 0.08
@@ -592,7 +592,7 @@
   - type: PointLight
     color: red
     # Frontier
-    energy: 8 # the green light is too dim on lower values
+    energy: 8 # the red light is too dim on lower values
     # End Frontier
   - type: PressureProtection
     highPressureMultiplier: 0.08
@@ -628,7 +628,7 @@
   - type: PointLight
     color: green
     # Frontier
-    energy: 8 # the green light is too dim on lower values
+    energy: 12 # the green light is too dim on lower values
     # End Frontier
   - type: PressureProtection
     highPressureMultiplier: 0.08

--- a/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -534,7 +534,7 @@
   - type: PointLight
     color: green
     # Frontier
-    energy: 8
+    energy: 8 # the green light is too dim on lower values
     # End Frontier
   - type: PressureProtection
     highPressureMultiplier: 0.08
@@ -565,7 +565,7 @@
   - type: PointLight
     color: green
     # Frontier
-    energy: 8
+    energy: 8 # the green light is too dim on lower values
     # End Frontier
   - type: PressureProtection
     highPressureMultiplier: 0.08
@@ -592,7 +592,7 @@
   - type: PointLight
     color: red
     # Frontier
-    energy: 8
+    energy: 8 # the green light is too dim on lower values
     # End Frontier
   - type: PressureProtection
     highPressureMultiplier: 0.08
@@ -628,7 +628,7 @@
   - type: PointLight
     color: green
     # Frontier
-    energy: 8
+    energy: 8 # the green light is too dim on lower values
     # End Frontier
   - type: PressureProtection
     highPressureMultiplier: 0.08

--- a/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -4,8 +4,8 @@
 #This is so people don't need to wear both regular, on-station helmets and hardsuits to get full protection.
 #Generally, unless you're adding something like caustic damage, you should probably avoid messing with armor here outside of the above scenario.
 
-#CREW HARDSUITS
-#Atmospherics Hardsuit
+# region CREW HARDSUITS
+# region Atmospherics Hardsuit
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitAtmos
@@ -65,7 +65,7 @@
     - CorgiWearable
     - WhitelistChameleon
 
-#Engineering Hardsuit
+# region Engineering Hardsuit
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitEngineering
@@ -120,7 +120,7 @@
     - CorgiWearable
     - WhitelistChameleon
 
-#Spationaut Hardsuit
+# region Spationaut Hardsuit
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitSpatio
@@ -174,7 +174,7 @@
     - CorgiWearable
     - WhitelistChameleon
 
-#Salvage Hardsuit
+# region Salvage Hardsuit
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitSalvage
@@ -196,7 +196,7 @@
     - CorgiWearable
     - WhitelistChameleon
 
-#Goliath Hardsuit
+# region Goliath Hardsuit
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitGoliath
@@ -250,7 +250,7 @@
     - CorgiWearable
     - WhitelistChameleon
 
-#Maxim Hardsuit
+# region Maxim Hardsuit
 - type: entity
   parent: ClothingHeadHardsuitBase
   id: ClothingHeadHelmetHardsuitMaxim
@@ -273,7 +273,7 @@
         Piercing: 0.9
         Heat: 0.9
 
-#Security Hardsuit
+# region Security Hardsuit
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitSecurity
@@ -301,7 +301,7 @@
     - CorgiWearable
     - WhitelistChameleon
 
-#Brigmedic Hardsuit
+# region Brigmedic Hardsuit
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitBrigmedic
@@ -327,7 +327,7 @@
     highPressureMultiplier: 0.6
     lowPressureMultiplier: 1000
 
-#Warden's Hardsuit
+# region Warden's Hardsuit
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitWarden
@@ -351,7 +351,7 @@
         Piercing: 0.9
         Heat: 0.9
 
-#Captain's Hardsuit
+# region Captain's Hardsuit
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitCap
@@ -370,7 +370,7 @@
     - CorgiWearable
     - WhitelistChameleon
 
-#Chief Engineer's Hardsuit
+# region Chief Engineer's Hardsuit
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitEngineeringWhite
@@ -423,6 +423,8 @@
         shader: unshaded
   - type: PointLight
     color: "#daffad"
+    radius: 6
+    energy: 4
   - type: PressureProtection
     highPressureMultiplier: 0.08
     lowPressureMultiplier: 1000
@@ -434,7 +436,7 @@
     - WhitelistChameleon
   - type: CatWearable # Frontier
 
-#Chief Medical Officer's Hardsuit
+# region Chief Medical Officer's Hardsuit
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitMedical
@@ -447,6 +449,8 @@
     sprite: Clothing/Head/Hardsuits/medical.rsi
   - type: PointLight
     color: "#adf1ff"
+    radius: 6
+    energy: 4
   - type: PressureProtection
     highPressureMultiplier: 0.6
     lowPressureMultiplier: 1000
@@ -455,7 +459,7 @@
     - CorgiWearable
     - WhitelistChameleon
 
-#Research Director's Hardsuit
+# region Research Director's Hardsuit
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitRd
@@ -468,6 +472,8 @@
     sprite: Clothing/Head/Hardsuits/rd.rsi
   - type: PointLight
     color: "#d6adff"
+    radius: 6
+    energy: 4
   - type: PressureProtection
     highPressureMultiplier: 0.60
     lowPressureMultiplier: 1000
@@ -476,7 +482,7 @@
     - CorgiWearable
     - WhitelistChameleon
 
-#Head of Security's hardsuit
+# region Head of Security's hardsuit
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitSecurityRed
@@ -489,6 +495,8 @@
     sprite: Clothing/Head/Hardsuits/security-red.rsi
   - type: PointLight
     color: "#ffeead"
+    radius: 6
+    energy: 4
   - type: PressureProtection
     highPressureMultiplier: 0.45
     lowPressureMultiplier: 1000
@@ -500,7 +508,7 @@
         Piercing: 0.9
         Heat: 0.9
 
-#Luxury Mining Hardsuit
+# region Luxury Mining Hardsuit
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitLuxury #DO NOT MAP - https://github.com/space-wizards/space-station-14/pull/19738#issuecomment-1703486738
@@ -519,8 +527,8 @@
     radius: 7
     energy: 3
 
-#ANTAG HARDSUITS
-#Blood-red Hardsuit
+# region ANTAG HARDSUITS
+# region Blood-red Hardsuit
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitSyndie
@@ -533,6 +541,8 @@
     sprite: Clothing/Head/Hardsuits/syndicate.rsi
   - type: PointLight
     color: green
+    radius: 5
+    energy: 8
   - type: PressureProtection
     highPressureMultiplier: 0.08
     lowPressureMultiplier: 1000
@@ -548,7 +558,7 @@
     - CorgiWearable
     - WhitelistChameleon
 
-#Blood-red Medic Hardsuit
+# region Blood-red Medic Hardsuit
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitSyndieMedic
@@ -561,6 +571,8 @@
     sprite: Clothing/Head/Hardsuits/syndiemedic.rsi
   - type: PointLight
     color: green
+    radius: 5
+    energy: 4
   - type: PressureProtection
     highPressureMultiplier: 0.08
     lowPressureMultiplier: 1000
@@ -572,7 +584,7 @@
         Piercing: 0.9
         Heat: 0.9
 
-#Syndicate Elite Hardsuit
+# region Syndicate Elite Hardsuit
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitSyndieElite
@@ -585,6 +597,8 @@
     sprite: Clothing/Head/Hardsuits/syndieelite.rsi
   - type: PointLight
     color: red
+    radius: 5
+    energy: 4
   - type: PressureProtection
     highPressureMultiplier: 0.08
     lowPressureMultiplier: 1000
@@ -605,7 +619,7 @@
     - CorgiWearable
     - WhitelistChameleon
 
-#Syndicate Commander Hardsuit
+# region Syndicate Commander Hardsuit
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitSyndieCommander
@@ -618,6 +632,8 @@
     sprite: Clothing/Head/Hardsuits/syndiecommander.rsi
   - type: PointLight
     color: green
+    radius: 5
+    energy: 4
   - type: PressureProtection
     highPressureMultiplier: 0.08
     lowPressureMultiplier: 1000
@@ -633,7 +649,7 @@
     - CorgiWearable
     - WhitelistChameleon
 
-#Cybersun Juggernaut Hardsuit
+# region Cybersun Juggernaut Hardsuit
 - type: entity
   parent: ClothingHeadHardsuitBase
   id: ClothingHeadHelmetHardsuitCybersun
@@ -659,7 +675,7 @@
     - CorgiWearable
     - WhitelistChameleon
 
-#Wizard Hardsuit
+# region Wizard Hardsuit
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitWizard
@@ -672,6 +688,8 @@
     sprite: Clothing/Head/Hardsuits/wizard.rsi
   - type: PointLight
     color: "#ffadfb"
+    radius: 5
+    energy: 4
   - type: PressureProtection
     highPressureMultiplier: 0.27
     lowPressureMultiplier: 1000
@@ -687,7 +705,7 @@
     - CorgiWearable
     - WhitelistChameleon
 
-#Organic Space Suit
+# region Organic Space Suit
 - type: entity
   parent: ClothingHeadHardsuitBase
   id: ClothingHeadHelmetHardsuitLing
@@ -702,7 +720,7 @@
     highPressureMultiplier: 0.225
     lowPressureMultiplier: 1000
 
-#Pirate EVA Suit (Deep Space EVA Suit)
+# region Pirate EVA Suit (Deep Space EVA Suit)
 - type: entity
   parent: ClothingHeadHardsuitBase
   id: ClothingHeadHelmetHardsuitPirateEVA
@@ -718,7 +736,7 @@
     highPressureMultiplier: 0.3
     lowPressureMultiplier: 1000
 
-#Pirate Captain Hardsuit
+# region Pirate Captain Hardsuit
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitPirateCap
@@ -763,8 +781,8 @@
         Piercing: 0.9
         Heat: 0.9
 
-#CENTCOMM / ERT HARDSUITS
-#ERT Leader Hardsuit
+# region CENTCOMM / ERT HARDSUITS
+# region ERT Leader Hardsuit
 - type: entity
   parent: [ BaseCentcommContraband, ClothingHeadHelmetHardsuitSyndieCommander ]
   id: ClothingHeadHelmetHardsuitERTLeader
@@ -776,6 +794,8 @@
   - type: Clothing
     sprite: Clothing/Head/Hardsuits/ERThelmets/ertleader.rsi
   - type: PointLight
+    radius: 5
+    energy: 4
     color: "#addbff"
   - type: Armor
     modifiers:
@@ -785,7 +805,7 @@
         Piercing: 0.9
         Heat: 0.9
 
-#ERT Chaplain Hardsuit
+# region ERT Chaplain Hardsuit
 - type: entity
   parent: [ BaseCentcommContraband, ClothingHeadHelmetHardsuitSyndie ]
   id: ClothingHeadHelmetHardsuitERTChaplain
@@ -798,8 +818,10 @@
     sprite: Clothing/Head/Hardsuits/ERThelmets/ertchaplain.rsi
   - type: PointLight
     color: "#ffffff"
+    radius: 5
+    energy: 4
 
-#ERT Engineer Hardsuit
+# region ERT Engineer Hardsuit
 - type: entity
   parent: [ BaseCentcommContraband, ClothingHeadHelmetHardsuitSyndie ]
   id: ClothingHeadHelmetHardsuitERTEngineer
@@ -812,6 +834,8 @@
     sprite: Clothing/Head/Hardsuits/ERThelmets/ertengineer.rsi
   - type: PointLight
     color: "#f4ffad"
+    radius: 5
+    energy: 4
   - type: FireProtection
     reduction: 0.2
   - type: Armor
@@ -822,7 +846,7 @@
         Piercing: 0.9
         Heat: 0.9
 
-#ERT Medical Hardsuit
+# region ERT Medical Hardsuit
 - type: entity
   parent: [ BaseCentcommContraband, ClothingHeadHelmetHardsuitSyndieElite ]
   id: ClothingHeadHelmetHardsuitERTMedical
@@ -835,8 +859,10 @@
     sprite: Clothing/Head/Hardsuits/ERThelmets/ertmedical.rsi
   - type: PointLight
     color: "#adffec"
+    radius: 5
+    energy: 4
 
-#ERT Security Hardsuit
+# region ERT Security Hardsuit
 - type: entity
   parent: [ BaseCentcommContraband, ClothingHeadHelmetHardsuitSyndie ]
   id: ClothingHeadHelmetHardsuitERTSecurity
@@ -849,6 +875,8 @@
     sprite: Clothing/Head/Hardsuits/ERThelmets/ertsecurity.rsi
   - type: PointLight
     color: "#ffadc6"
+    radius: 5
+    energy: 4
   - type: Armor
     modifiers:
       coefficients:
@@ -857,7 +885,7 @@
         Piercing: 0.9
         Heat: 0.9
 
-#ERT Janitor Hardsuit
+# region ERT Janitor Hardsuit
 - type: entity
   parent: [ BaseCentcommContraband, ClothingHeadHelmetHardsuitSyndie ]
   id: ClothingHeadHelmetHardsuitERTJanitor
@@ -870,8 +898,10 @@
     sprite: Clothing/Head/Hardsuits/ERThelmets/ertjanitor.rsi
   - type: PointLight
     color: "#cbadff"
+    radius: 5
+    energy: 4
 
-#CBURN Hardsuit
+# region CBURN Hardsuit
 - type: entity
   parent: [ BaseCentcommContraband, ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetCBURN
@@ -900,6 +930,8 @@
         shader: unshaded
   - type: PointLight
     color: orange
+    radius: 5
+    energy: 4
   - type: PressureProtection
     highPressureMultiplier: 0.08
     lowPressureMultiplier: 1000
@@ -916,7 +948,7 @@
   - type: ZombificationResistance
     zombificationResistanceCoefficient: 0.75
 
-#Deathsquad Hardsuit
+# region Deathsquad Hardsuit
 - type: entity
   parent: [ BaseCentcommContraband, ClothingHeadHardsuitBase ]
   id: ClothingHeadHelmetHardsuitDeathsquad
@@ -943,8 +975,8 @@
         Radiation: 0.80
         Caustic: 0.95
 
-#MISC. HARDSUITS
-#Clown Hardsuit
+# region MISC. HARDSUITS
+# region Clown Hardsuit
 - type: entity
   parent: ClothingHeadHelmetHardsuitSecurity
   id: ClothingHeadHelmetHardsuitClown
@@ -959,7 +991,7 @@
     equipSound: /Audio/Mecha/mechmove03.ogg
     unequipSound: /Audio/Effects/Emotes/parp1.ogg
 
-#Mime Hardsuit
+# region Mime Hardsuit
 - type: entity
   parent: ClothingHeadHelmetHardsuitSecurity
   id: ClothingHeadHelmetHardsuitMime
@@ -972,7 +1004,7 @@
   - type: Clothing
     sprite: Clothing/Head/Hardsuits/mime.rsi
 
-#Santas Hardsuit
+# region Santas Hardsuit
 - type: entity
   parent: ClothingHeadHardsuitBase
   id: ClothingHeadHelmetHardsuitSanta

--- a/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -541,9 +541,7 @@
     sprite: Clothing/Head/Hardsuits/syndicate.rsi
   - type: PointLight
     color: green
-    # Frontier
-    energy: 12 # the green light is too dim on lower values
-    # End Frontier
+    energy: 12 # Frontier: the green light is too dim on lower values
   - type: PressureProtection
     highPressureMultiplier: 0.08
     lowPressureMultiplier: 1000
@@ -572,9 +570,7 @@
     sprite: Clothing/Head/Hardsuits/syndiemedic.rsi
   - type: PointLight
     color: green
-    # Frontier
-    energy: 12 # the green light is too dim on lower values
-    # End Frontier
+    energy: 12 # Frontier: the green light is too dim on lower values
   - type: PressureProtection
     highPressureMultiplier: 0.08
     lowPressureMultiplier: 1000
@@ -599,9 +595,7 @@
     sprite: Clothing/Head/Hardsuits/syndieelite.rsi
   - type: PointLight
     color: red
-    # Frontier
-    energy: 8 # the red light is too dim on lower values
-    # End Frontier
+    energy: 8 # Frontier: the red light is too dim on lower values
   - type: PressureProtection
     highPressureMultiplier: 0.08
     lowPressureMultiplier: 1000
@@ -635,9 +629,7 @@
     sprite: Clothing/Head/Hardsuits/syndiecommander.rsi
   - type: PointLight
     color: green
-    # Frontier
-    energy: 12 # the green light is too dim on lower values
-    # End Frontier
+    energy: 12 # Frontier: the green light is too dim on lower values
   - type: PressureProtection
     highPressureMultiplier: 0.08
     lowPressureMultiplier: 1000
@@ -770,8 +762,10 @@
   - type: ItemTogglePointLight
   - type: PointLight
     color: "#f3ea9c"
+  # Frontier
   #  radius: 7
   #  energy: 3
+  # End Frontier
   - type: PressureProtection
     highPressureMultiplier: 0.3
     lowPressureMultiplier: 1000
@@ -1006,5 +1000,7 @@
     sprite: Clothing/Head/Hardsuits/santahelm.rsi
   - type: PointLight
     color: "#f4ffad"
+  # Frontier
   #  radius: 5
   #  energy: 2
+  # End Frontier

--- a/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -164,8 +164,6 @@
       - state: equipped-head-dog
       - state: equipped-head-unshaded-dog
         shader: unshaded
-  - type: PointLight
-    radius: 6
   - type: PressureProtection
     highPressureMultiplier: 0.72
     lowPressureMultiplier: 1000
@@ -188,9 +186,6 @@
   - type: PressureProtection
     highPressureMultiplier: 0.525
     lowPressureMultiplier: 1000
-  - type: PointLight
-    radius: 7
-    energy: 3
   - type: Tag
     tags:
     - CorgiWearable
@@ -240,8 +235,6 @@
       - state: equipped-head-dog
       - state: equipped-head-unshaded-dog
         shader: unshaded
-  - type: PointLight
-    radius: 6
   - type: PressureProtection
     highPressureMultiplier: 0.72
     lowPressureMultiplier: 1000
@@ -423,10 +416,6 @@
         shader: unshaded
   - type: PointLight
     color: "#daffad"
-    # Frontier
-    radius: 6
-    energy: 4
-    # End Frontier
   - type: PressureProtection
     highPressureMultiplier: 0.08
     lowPressureMultiplier: 1000
@@ -451,10 +440,6 @@
     sprite: Clothing/Head/Hardsuits/medical.rsi
   - type: PointLight
     color: "#adf1ff"
-    # Frontier
-    radius: 6
-    energy: 4
-    # End Frontier
   - type: PressureProtection
     highPressureMultiplier: 0.6
     lowPressureMultiplier: 1000
@@ -476,10 +461,6 @@
     sprite: Clothing/Head/Hardsuits/rd.rsi
   - type: PointLight
     color: "#d6adff"
-    # Frontier
-    radius: 6
-    energy: 4
-    # End Frontier
   - type: PressureProtection
     highPressureMultiplier: 0.60
     lowPressureMultiplier: 1000
@@ -501,10 +482,6 @@
     sprite: Clothing/Head/Hardsuits/security-red.rsi
   - type: PointLight
     color: "#ffeead"
-    # Frontier
-    radius: 6
-    energy: 4
-    # End Frontier
   - type: PressureProtection
     highPressureMultiplier: 0.45
     lowPressureMultiplier: 1000
@@ -531,9 +508,6 @@
   - type: PressureProtection
     highPressureMultiplier: 0.525
     lowPressureMultiplier: 1000
-  - type: PointLight
-    radius: 7
-    energy: 3
 
 #ANTAG HARDSUITS
 #Blood-red Hardsuit
@@ -550,7 +524,6 @@
   - type: PointLight
     color: green
     # Frontier
-    radius: 5
     energy: 8
     # End Frontier
   - type: PressureProtection
@@ -582,7 +555,6 @@
   - type: PointLight
     color: green
     # Frontier
-    radius: 5
     energy: 8
     # End Frontier
   - type: PressureProtection
@@ -610,7 +582,6 @@
   - type: PointLight
     color: red
     # Frontier
-    radius: 5
     energy: 8
     # End Frontier
   - type: PressureProtection
@@ -647,7 +618,6 @@
   - type: PointLight
     color: green
     # Frontier
-    radius: 5
     energy: 8
     # End Frontier
   - type: PressureProtection
@@ -704,10 +674,6 @@
     sprite: Clothing/Head/Hardsuits/wizard.rsi
   - type: PointLight
     color: "#ffadfb"
-    # Frontier
-    radius: 5
-    energy: 4
-    # End Frontier
   - type: PressureProtection
     highPressureMultiplier: 0.27
     lowPressureMultiplier: 1000
@@ -784,10 +750,8 @@
       - state: equipped-HELMET-unshaded-vox
         shader: unshaded
   - type: ItemTogglePointLight
-  - type: PointLight # Color matches visor colors, radius/energy same as mining hardsuit for the big captain.
+  - type: PointLight
     color: "#f3ea9c"
-    radius: 7
-    energy: 3
   - type: PressureProtection
     highPressureMultiplier: 0.3
     lowPressureMultiplier: 1000
@@ -812,10 +776,6 @@
   - type: Clothing
     sprite: Clothing/Head/Hardsuits/ERThelmets/ertleader.rsi
   - type: PointLight
-  # Frontier
-    radius: 5
-    energy: 4
-    # End Frontier
     color: "#addbff"
   - type: Armor
     modifiers:
@@ -838,10 +798,6 @@
     sprite: Clothing/Head/Hardsuits/ERThelmets/ertchaplain.rsi
   - type: PointLight
     color: "#ffffff"
-    # Frontier
-    radius: 5
-    energy: 4
-    # End Frontier
 
 #ERT Engineer Hardsuit
 - type: entity
@@ -856,10 +812,6 @@
     sprite: Clothing/Head/Hardsuits/ERThelmets/ertengineer.rsi
   - type: PointLight
     color: "#f4ffad"
-    # Frontier
-    radius: 5
-    energy: 4
-    # End Frontier
   - type: FireProtection
     reduction: 0.2
   - type: Armor
@@ -883,10 +835,6 @@
     sprite: Clothing/Head/Hardsuits/ERThelmets/ertmedical.rsi
   - type: PointLight
     color: "#adffec"
-    # Frontier
-    radius: 5
-    energy: 4
-    # End Frontier
 
 #ERT Security Hardsuit
 - type: entity
@@ -901,10 +849,6 @@
     sprite: Clothing/Head/Hardsuits/ERThelmets/ertsecurity.rsi
   - type: PointLight
     color: "#ffadc6"
-    # Frontier
-    radius: 5
-    energy: 4
-    # End Frontier
   - type: Armor
     modifiers:
       coefficients:
@@ -926,10 +870,6 @@
     sprite: Clothing/Head/Hardsuits/ERThelmets/ertjanitor.rsi
   - type: PointLight
     color: "#cbadff"
-    # Frontier
-    radius: 5
-    energy: 4
-    # End Frontier
 
 #CBURN Hardsuit
 - type: entity
@@ -960,10 +900,6 @@
         shader: unshaded
   - type: PointLight
     color: orange
-    # Frontier
-    radius: 5
-    energy: 4
-    # End Frontier
   - type: PressureProtection
     highPressureMultiplier: 0.08
     lowPressureMultiplier: 1000
@@ -1050,5 +986,3 @@
     sprite: Clothing/Head/Hardsuits/santahelm.rsi
   - type: PointLight
     color: "#f4ffad"
-    radius: 5
-    energy: 2

--- a/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -164,8 +164,10 @@
       - state: equipped-head-dog
       - state: equipped-head-unshaded-dog
         shader: unshaded
+  # Frontier
   #- type: PointLight
   #  radius: 6
+  # End Frontier
   - type: PressureProtection
     highPressureMultiplier: 0.72
     lowPressureMultiplier: 1000
@@ -188,9 +190,11 @@
   - type: PressureProtection
     highPressureMultiplier: 0.525
     lowPressureMultiplier: 1000
+  # Frontier
   #- type: PointLight
   #  radius: 7
   #  energy: 3
+  # End Frontier
   - type: Tag
     tags:
     - CorgiWearable
@@ -240,8 +244,10 @@
       - state: equipped-head-dog
       - state: equipped-head-unshaded-dog
         shader: unshaded
+  # Frontier
   #- type: PointLight
   #  radius: 6
+  # End Frontier
   - type: PressureProtection
     highPressureMultiplier: 0.72
     lowPressureMultiplier: 1000
@@ -515,9 +521,11 @@
   - type: PressureProtection
     highPressureMultiplier: 0.525
     lowPressureMultiplier: 1000
+  # Frontier
   #- type: PointLight
   #  radius: 7
   #  energy: 3
+  # End Frontier
 
 #ANTAG HARDSUITS
 #Blood-red Hardsuit

--- a/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -164,6 +164,8 @@
       - state: equipped-head-dog
       - state: equipped-head-unshaded-dog
         shader: unshaded
+  #- type: PointLight
+  #  radius: 6
   - type: PressureProtection
     highPressureMultiplier: 0.72
     lowPressureMultiplier: 1000
@@ -186,6 +188,9 @@
   - type: PressureProtection
     highPressureMultiplier: 0.525
     lowPressureMultiplier: 1000
+  #- type: PointLight
+  #  radius: 7
+  #  energy: 3
   - type: Tag
     tags:
     - CorgiWearable
@@ -235,6 +240,8 @@
       - state: equipped-head-dog
       - state: equipped-head-unshaded-dog
         shader: unshaded
+  #- type: PointLight
+  #  radius: 6
   - type: PressureProtection
     highPressureMultiplier: 0.72
     lowPressureMultiplier: 1000
@@ -508,6 +515,9 @@
   - type: PressureProtection
     highPressureMultiplier: 0.525
     lowPressureMultiplier: 1000
+  #- type: PointLight
+  #  radius: 7
+  #  energy: 3
 
 #ANTAG HARDSUITS
 #Blood-red Hardsuit
@@ -752,6 +762,8 @@
   - type: ItemTogglePointLight
   - type: PointLight
     color: "#f3ea9c"
+  #  radius: 7
+  #  energy: 3
   - type: PressureProtection
     highPressureMultiplier: 0.3
     lowPressureMultiplier: 1000
@@ -986,3 +998,5 @@
     sprite: Clothing/Head/Hardsuits/santahelm.rsi
   - type: PointLight
     color: "#f4ffad"
+  #  radius: 5
+  #  energy: 2

--- a/Resources/Prototypes/_NF/Entities/Clothing/Head/base_clothinghead.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Head/base_clothinghead.yml
@@ -4,8 +4,8 @@
   id: NFClothingHeadHardsuitWithLightBase
   components:
   - type: PointLight
-    radius: 4
-    energy: 3
+    radius: 4.5
+    energy: 4
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/_NF/Entities/Clothing/Head/base_clothinghead.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Head/base_clothinghead.yml
@@ -2,6 +2,10 @@
   abstract: true
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: NFClothingHeadHardsuitWithLightBase
+  components:
+  - type: PointLight
+    radius: 4
+    energy: 3
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/_NF/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -362,7 +362,7 @@
     sprite: _NF/Clothing/Head/Hardsuits/hostile_environment.rsi
   - type: PointLight
     enabled: true
-    radius: 3.5
+    radius: 6
     energy: 5
     color: "#ffeead"
     soft: true
@@ -401,6 +401,8 @@
     color: "#A60000"
     soft: true
     castShadows: false
+    radius: 6
+    energy: 5
   - type: Armor
     modifiers:
       coefficients:

--- a/Resources/Prototypes/_NF/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -89,9 +89,6 @@
     sprite: _NF/Clothing/Head/Hardsuits/maxim_prototype.rsi
   - type: Clothing
     sprite: _NF/Clothing/Head/Hardsuits/maxim_prototype.rsi
-  - type: PointLight # Luxury Hardsuit Light
-    radius: 7
-    energy: 3
 
 #Security patrol suit
 - type: entity
@@ -249,10 +246,6 @@
         Blunt: 0.9
         Slash: 0.9
         Piercing: 0.8
-  - type: PointLight
-    radius: 7
-    energy: 2
-    #color: "#d6adff"
 
 #Tactical hardsuit Helmet
 - type: entity
@@ -362,8 +355,6 @@
     sprite: _NF/Clothing/Head/Hardsuits/hostile_environment.rsi
   - type: PointLight
     enabled: true
-    radius: 6
-    energy: 5
     color: "#ffeead"
     soft: true
     castShadows: false
@@ -401,8 +392,6 @@
     color: "#A60000"
     soft: true
     castShadows: false
-    radius: 6
-    energy: 5
   - type: Armor
     modifiers:
       coefficients:

--- a/Resources/Prototypes/_NF/Entities/Clothing/Head/softsuits-helmets.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Head/softsuits-helmets.yml
@@ -179,9 +179,6 @@
         color: "#f2b833"
       - state: equipped-head-visor
         color: "#fbe6b8"
-  - type: PointLight
-    radius: 5
-    energy: 2
   - type: CatWearable # Frontier
 
 - type: entity
@@ -209,9 +206,6 @@
         color: "#704900"
       - state: equipped-head-visor
         color: "#adcfd5"
-  - type: PointLight
-    radius: 5
-    energy: 2
   - type: CatWearable # Frontier
 
 - type: entity
@@ -243,9 +237,6 @@
         color: "#ffce5b"
       - state: equipped-head-visor
         color: "#2572bf"
-  - type: PointLight
-    radius: 5
-    energy: 2
   - type: CatWearable # Frontier
 
 #region engineering
@@ -284,8 +275,6 @@
   - type: ItemTogglePointLight
   - type: PointLight
     enabled: false
-    radius: 2
-    energy: 2
     color: "#ff7f00"
     mask: /Textures/Effects/LightMasks/double_cone.png
   - type: RotatingLight
@@ -374,8 +363,6 @@
         color: "#ad2aea"
       - state: equipped-head-visor
         color: "#adcfd5"
-  - type: PointLight
-    radius: 6
   - type: CatWearable # Frontier
 
 #region medical
@@ -443,8 +430,6 @@
   - type: ItemTogglePointLight
   - type: PointLight
     enabled: false
-    radius: 2
-    energy: 2
     color: blue
     mask: /Textures/Effects/LightMasks/double_cone.png
   - type: RotatingLight
@@ -851,8 +836,6 @@
   - type: ItemTogglePointLight
   - type: PointLight
     enabled: false
-    radius: 2
-    energy: 2
     color: red
     mask: /Textures/Effects/LightMasks/double_cone.png
   - type: RotatingLight
@@ -895,8 +878,6 @@
   - type: ItemTogglePointLight
   - type: PointLight
     enabled: false
-    radius: 2
-    energy: 2
     mask: /Textures/_NF/Effects/LightMasks/skullmask.png
   - type: RotatingLight
     speed: 360
@@ -1005,8 +986,6 @@
   - type: ItemTogglePointLight
   - type: PointLight
     color: "#adf1ff"
-    radius: 5
-    energy: 2
   - type: HideLayerClothing
     slots:
     - Hair

--- a/Resources/Prototypes/_NF/Entities/Clothing/Head/softsuits-helmets.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Head/softsuits-helmets.yml
@@ -275,6 +275,8 @@
   - type: ItemTogglePointLight
   - type: PointLight
     enabled: false
+    radius: 2 # These are rotating blinker lights meant as alarm lights/sirens rather than actual lighting
+    energy: 2
     color: "#ff7f00"
     mask: /Textures/Effects/LightMasks/double_cone.png
   - type: RotatingLight
@@ -430,6 +432,8 @@
   - type: ItemTogglePointLight
   - type: PointLight
     enabled: false
+    radius: 2 # These are rotating blinker lights meant as alarm lights/sirens rather than actual lighting
+    energy: 2
     color: blue
     mask: /Textures/Effects/LightMasks/double_cone.png
   - type: RotatingLight
@@ -836,6 +840,8 @@
   - type: ItemTogglePointLight
   - type: PointLight
     enabled: false
+    radius: 2 # These are rotating blinker lights meant as alarm lights/sirens rather than actual lighting
+    energy: 2
     color: red
     mask: /Textures/Effects/LightMasks/double_cone.png
   - type: RotatingLight
@@ -878,6 +884,8 @@
   - type: ItemTogglePointLight
   - type: PointLight
     enabled: false
+    radius: 2 # These are rotating blinker lights meant as alarm lights/sirens rather than actual lighting
+    energy: 2
     mask: /Textures/_NF/Effects/LightMasks/skullmask.png
   - type: RotatingLight
     speed: 360

--- a/Resources/Prototypes/_NF/Entities/Clothing/Head/softsuits-helmets.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Head/softsuits-helmets.yml
@@ -59,8 +59,8 @@
   - type: PointLight
     #color: "#adffe6"
     enabled: false
-    radius: 3
-    energy: 2
+    radius: 5
+    energy: 1
     mask: /Textures/Effects/LightMasks/cone.png
     autoRot: true
     netsync: false

--- a/Resources/Prototypes/_NF/Entities/Clothing/Head/softsuits-helmets.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Head/softsuits-helmets.yml
@@ -59,7 +59,7 @@
   - type: PointLight
     #color: "#adffe6"
     enabled: false
-    radius: 5
+    radius: 6
     energy: 1
     mask: /Textures/Effects/LightMasks/cone.png
     autoRot: true

--- a/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/softsuits_departmental.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/softsuits_departmental.yml
@@ -74,8 +74,8 @@
   - type: PointLight
     #color: "#adffe6"
     enabled: false
-    radius: 3
-    energy: 2
+    radius: 5
+    energy: 1
     mask: /Textures/Effects/LightMasks/cone.png
     autoRot: true
     netsync: false

--- a/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/softsuits_departmental.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/softsuits_departmental.yml
@@ -74,7 +74,7 @@
   - type: PointLight
     #color: "#adffe6"
     enabled: false
-    radius: 5
+    radius: 6
     energy: 1
     mask: /Textures/Effects/LightMasks/cone.png
     autoRot: true


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Consistent Lights For EVA Suits

modifies the base prototype that has lights for both Soft EVA Suits and Hardsuits.

the soft ones have around a flashlight's range and less intensity, while hardsuits have lower light level with higher intensity
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
have you wanted to use a REALLY cool looking eva suit (Like Private Security or any other) but found the light level to be abismal? do you hate the lights that barely extend farther than your FUCKING PDA??? worry no longer!
## Technical details
<!-- Summary of code changes for easier review. -->
added a radius and energy parameter into: 
NFClothingHeadHardsuitWithLightBase
ClothingHeadEVAHelmetWithLightBase
NFDepartmentalEVASuitShoulderLight
## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
spawn in the Soft suits by typing:
clothingouterEVAsuit
then spawn them in one by one and test.

then get to the hardsuits by typing:
clothingouterhardsuit
then spawn them in one by one and test.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Soft Suit Light Level Compared to flashlight
<img width="654" height="356" alt="image" src="https://github.com/user-attachments/assets/4972877b-b57f-488b-b714-d20470dbbcc3" />

HardSuit light level Compared to Flashlight 
<img width="663" height="333" alt="image" src="https://github.com/user-attachments/assets/1f357473-b48b-41e5-8da9-b27fb72867bd" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:


- tweak: Standardised light levels between the Softsuits. they've all been increased to be around a flashlight's level
- tweak: Standardised light levels between the Hardsuits. to be marginally smaller than a flashlight


