### PR TITLE
Quickfix: Hide NC Crescent map from spawn menu

### DIFF
--- a/Resources/Prototypes/_NF/Guidebook/shuttle_maps.yml
+++ b/Resources/Prototypes/_NF/Guidebook/shuttle_maps.yml
@@ -300,6 +300,7 @@
   id: ShuttleMapCrescent
   name: "NC Crescent"
   description: "Detailed map of a Crescent shuttle."
+  categories: [ HideSpawnMenu ]
   components:
   - type: Sprite
     sprite: _NF/Guidebook/shuttle_maps/128x96.rsi


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Hides NC Crescent map from spawn menu

## Why / Balance
Uniformity

## Technical details
adds a category [ HideSpawnMenu] to .yml

## How to test
Boot up sandbox
Search for crescent
No result

## Media
Too lazy

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A
