### PR TITLE
Removed marking poster rolls as contraband

### DIFF
--- a/Content.Shared/_NF/Preferences/Loadouts/Effects/RoleBlacklistLoadoutEffect.cs
+++ b/Content.Shared/_NF/Preferences/Loadouts/Effects/RoleBlacklistLoadoutEffect.cs
@@ -12,10 +12,12 @@ public sealed partial class RoleBlacklistLoadoutEffect : LoadoutEffect
 {
     [DataField(required: true)]
     public List<ProtoId<RoleLoadoutPrototype>> Blacklist = default!;
+    [DataField]
+    public bool Inverted = false; //If inverted it's a whitelist
 
     public override bool Validate(HumanoidCharacterProfile profile, RoleLoadout loadout, ICommonSession? session, IDependencyCollection collection, [NotNullWhen(false)] out FormattedMessage? reason)
     {
-        if (Blacklist.Contains(loadout.Role))
+        if (Blacklist.Contains(loadout.Role) != Inverted)
         {
             reason = new FormattedMessage();
             reason.TryAddMarkup(Loc.GetString("role-blacklist-loadout-invalid"), out var _);

--- a/Resources/Prototypes/_NF/Entities/Objects/Decoration/art.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Decoration/art.yml
@@ -52,7 +52,7 @@
   abstract: true
   parent: [NFBasePoster]
   id: NFPosterRolledContraband
-  description: "A rolled up \"contraband\" poster."
+  description: A rolled up contraband poster.
   suffix: rolled
   components:
   - type: Sprite

--- a/Resources/Prototypes/_NF/Entities/Objects/Decoration/art.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Decoration/art.yml
@@ -50,9 +50,9 @@
 
 - type: entity
   abstract: true
-  parent: [BaseC3ContrabandUnredeemable, NFBasePoster]
+  parent: [NFBasePoster]
   id: NFPosterRolledContraband
-  description: A rolled up contraband poster.
+  description: "A rolled up \"contraband\" poster."
   suffix: rolled
   components:
   - type: Sprite

--- a/Resources/Prototypes/_NF/Loadouts/Jobs/Contractor/backpack_items.yml
+++ b/Resources/Prototypes/_NF/Loadouts/Jobs/Contractor/backpack_items.yml
@@ -639,6 +639,9 @@
 - type: loadout
   id: ContractorNFPosterContraband
   price: 7500
+  hideEffects:
+    - !type:GroupLoadoutEffect
+      proto: NFNotFrontierOrNFSDStaff
   storage:
     back:
     - NFPosterContraband

--- a/Resources/Prototypes/_NF/Loadouts/loadout_effects.yml
+++ b/Resources/Prototypes/_NF/Loadouts/loadout_effects.yml
@@ -83,3 +83,17 @@
   - !type:SpeciesLoadoutEffect
     species:
     - Goblin
+
+- type: loadoutEffectGroup
+  id: NFNotFrontierOrNFSDStaff
+  effects:
+  - !type:RoleBlacklistLoadoutEffect
+    inverted: true #This is actually a white list of roles allowed (way smaller list than if we made it a blacklist)
+    blacklist:
+    - JobContractor
+    - JobPilot
+    - JobMercenary
+    - JobNFPirate
+    - JobNFPirateFirstMate
+    - JobNFPirateCaptain
+    - JobPrisoner


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Removed marking contraband posters as contraband. To resolve #4664 Also removed them as loadout options for Frontier and NFSD staff.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The actual unrolled posters are not marked as such, the majority of the posters it could spawn are commonly on ships and stations

## Technical details
<!-- Summary of code changes for easier review. -->
* Removed `BaseC3ContrabandUnredeemable` parent from the contraband poster roll. 
* Modified `RoleBlacklistLoadoutEffect` to have an inverted flag making it a whitelist (figured we don't really want whitelist class that is the same as the other but logic inverted). 
* Used an inverted Role Blacklist to only allow Contractor, Pilot, Mercenary and Pirate roles for a loadout effect
* Added loadout effect to the contraband poster loadout

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
Notice that only Contractors, Pilots, Mercenaries and Pirate roles can have the contraband poster.
Spawn in with a "contraband" poster in your loadout. Examine poster, notice it is not contraband.

## Media
<img width="421" height="211" alt="image" src="https://github.com/user-attachments/assets/07abd405-a3b7-48cf-a98a-92da3bbc5c40" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Pi_Masta
- fix: Contraband posters, are posters OF contraband and are not contraband in and of themselves
- remove: Frontier and NFSD staff can no longer start with a contraband poster.
