### PR TITLE
Prevent loadout wristsets from being marked as contraband

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Clothing/Ears/wrist_radio.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Ears/wrist_radio.yml
@@ -14,6 +14,7 @@
     containers:
       key_slots:
       - EncryptionKeyCommon
+
 - type: entity
   abstract: true
   parent: [NFBaseClothingWristset, BaseClearContraband] #Need BaseClearContraband to not show contraband on security and brigmedic wristsets

--- a/Resources/Prototypes/_NF/Entities/Clothing/Ears/wrist_radio.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Ears/wrist_radio.yml
@@ -17,7 +17,7 @@
 
 - type: entity
   abstract: true
-  parent: [NFBaseClothingWristset, BaseClearContraband] #Need BaseClearContraband to not show contraband on security and brigmedic wristsets
+  parent: [NFBaseClothingWristset, BaseClearContraband] #Need BaseClearContraband to not show contraband on security and brigmedic/first responder wristsets
   id: NFBaseClothingWristsetCommon
   description: An updated, modular intercom worn on the wrist. It accepts encryption keys.
 
@@ -645,7 +645,7 @@
 - type: entity
   parent: [NFBaseClothingWristsetCommon, ClothingHeadsetBrigmedic]
   id: NFClothingWristsetBrigmedicCommon
-  name: brigmedic wristset
+  name: first responder wristset # Named different in game to avoid confusion with an actual brigmedic's wristset
   components:
   - type: Sprite
     layers:

--- a/Resources/Prototypes/_NF/Entities/Clothing/Ears/wrist_radio.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Ears/wrist_radio.yml
@@ -14,6 +14,11 @@
     containers:
       key_slots:
       - EncryptionKeyCommon
+- type: entity
+  abstract: true
+  parent: [NFBaseClothingWristset, BaseClearContraband] #Need BaseClearContraband to not show contraband on security and brigmedic wristsets
+  id: NFBaseClothingWristsetCommon
+  description: An updated, modular intercom worn on the wrist. It accepts encryption keys.
 
 # region frontier command
 - type: entity
@@ -262,7 +267,7 @@
 
 # region contractor
 - type: entity
-  parent: [NFBaseClothingWristset, ClothingHeadsetGrey]
+  parent: [NFBaseClothingWristsetCommon, ClothingHeadsetGrey]
   id: NFClothingWristsetContractorCommon
   name: contractor wristset
   components:
@@ -284,7 +289,7 @@
         shader: unshaded
 
 - type: entity
-  parent: [NFBaseClothingWristset, ClothingHeadsetGrey]
+  parent: [NFBaseClothingWristsetCommon, ClothingHeadsetGrey]
   id: NFClothingWristsetContractorCommonAlt
   name: contractor wristset
   components:
@@ -309,7 +314,7 @@
 
 # region pilot
 - type: entity
-  parent: [NFBaseClothingWristset, ClothingHeadsetGrey]
+  parent: [NFBaseClothingWristsetCommon, ClothingHeadsetGrey]
   id: NFClothingWristsetPilotCommon
   name: pilot wristset
   components:
@@ -332,7 +337,7 @@
 
 # region mercenary
 - type: entity
-  parent: [NFBaseClothingWristset, ClothingHeadsetGrey]
+  parent: [NFBaseClothingWristsetCommon, ClothingHeadsetGrey]
   id: NFClothingWristsetMercenaryCommon
   name: mercenary wristset
   components:
@@ -354,7 +359,7 @@
         shader: unshaded
 
 - type: entity
-  parent: [NFBaseClothingWristset, ClothingHeadsetGrey]
+  parent: [NFBaseClothingWristsetCommon, ClothingHeadsetGrey]
   id: NFClothingWristsetPrivateSecCommon
   name: private security wristset
   components:
@@ -379,7 +384,7 @@
 
 # region captain
 - type: entity
-  parent: [NFBaseClothingWristset, ClothingHeadsetGrey]
+  parent: [NFBaseClothingWristsetCommon, ClothingHeadsetGrey]
   id: NFClothingWristsetCaptainCommon
   name: captain wristset
   components:
@@ -404,7 +409,7 @@
 
 # region supply
 - type: entity
-  parent: [NFBaseClothingWristset, ClothingHeadsetCargo]
+  parent: [NFBaseClothingWristsetCommon, ClothingHeadsetCargo]
   id: NFClothingWristsetCargoCommon
   name: cargo wristset
   components:
@@ -426,7 +431,7 @@
         shader: unshaded
 
 - type: entity
-  parent: [NFBaseClothingWristset, ClothingHeadsetMining]
+  parent: [NFBaseClothingWristsetCommon, ClothingHeadsetMining]
   id: NFClothingWristsetMiningCommon
   name: mining wristset
   components:
@@ -451,7 +456,7 @@
 
 # region engineering
 - type: entity
-  parent: [NFBaseClothingWristset, ClothingHeadsetEngineering]
+  parent: [NFBaseClothingWristsetCommon, ClothingHeadsetEngineering]
   id: NFClothingWristsetEngineeringCommon
   name: engineering wristset
   components:
@@ -484,7 +489,7 @@
       - EncryptionKeyEngineering
 
 - type: entity
-  parent: [NFBaseClothingWristset, ClothingHeadsetEngineering]
+  parent: [NFBaseClothingWristsetCommon, ClothingHeadsetEngineering]
   id: NFClothingWristsetAtmosphericsCommon
   name: atmospherics wristset
   components:
@@ -520,7 +525,7 @@
 
 # region medical
 - type: entity
-  parent: [NFBaseClothingWristset, ClothingHeadsetMedical]
+  parent: [NFBaseClothingWristsetCommon, ClothingHeadsetMedical]
   id: NFClothingWristsetMedicalCommon
   name: medical wristset
   components:
@@ -543,7 +548,7 @@
 
 # region science
 - type: entity
-  parent: [NFBaseClothingWristset, ClothingHeadsetScience]
+  parent: [NFBaseClothingWristsetCommon, ClothingHeadsetScience]
   id: NFClothingWristsetScienceCommon
   name: science wristset
   components:
@@ -566,7 +571,7 @@
         shader: unshaded
 
 - type: entity
-  parent: [NFBaseClothingWristset, ClothingHeadsetMedicalScience]
+  parent: [NFBaseClothingWristsetCommon, ClothingHeadsetMedicalScience]
   id: NFClothingWristsetMedicalScienceCommon
   name: medical science wristset
   components:
@@ -590,7 +595,7 @@
         shader: unshaded
 
 - type: entity
-  parent: [NFBaseClothingWristset, ClothingHeadsetRobotics]
+  parent: [NFBaseClothingWristsetCommon, ClothingHeadsetRobotics]
   id: NFClothingWristsetRoboticsCommon
   name: robotics wristset
   components:
@@ -615,7 +620,7 @@
 
 # region security
 - type: entity
-  parent: [NFBaseClothingWristset, ClothingHeadsetSecurity]
+  parent: [NFBaseClothingWristsetCommon, ClothingHeadsetSecurity]
   id: NFClothingWristsetSecurityCommon
   name: security wristset
   components:
@@ -637,7 +642,7 @@
         shader: unshaded
 
 - type: entity
-  parent: [NFBaseClothingWristset, ClothingHeadsetBrigmedic]
+  parent: [NFBaseClothingWristsetCommon, ClothingHeadsetBrigmedic]
   id: NFClothingWristsetBrigmedicCommon
   name: brigmedic wristset
   components:
@@ -662,7 +667,7 @@
 
 # region service
 - type: entity
-  parent: [NFBaseClothingWristset, ClothingHeadsetService]
+  parent: [NFBaseClothingWristsetCommon, ClothingHeadsetService]
   id: NFClothingWristsetServiceCommon
   name: service wristset
   components:
@@ -684,7 +689,7 @@
         shader: unshaded
 
 - type: entity
-  parent: [NFBaseClothingWristset, ClothingHeadsetService]
+  parent: [NFBaseClothingWristsetCommon, ClothingHeadsetService]
   id: NFClothingWristsetServiceJanitorCommon
   name: janitor wristset
   components:
@@ -708,7 +713,7 @@
         shader: unshaded
 
 - type: entity
-  parent: [NFBaseClothingWristset, ClothingHeadsetService]
+  parent: [NFBaseClothingWristsetCommon, ClothingHeadsetService]
   id: NFClothingWristsetServiceClownCommon
   name: clown wristset
   components:
@@ -734,7 +739,7 @@
         shader: unshaded
 
 - type: entity
-  parent: [NFBaseClothingWristset, ClothingHeadsetService]
+  parent: [NFBaseClothingWristsetCommon, ClothingHeadsetService]
   id: NFClothingWristsetServiceMimeCommon
   name: mime wristset
   components:
@@ -759,7 +764,7 @@
 
 # region punk
 - type: entity
-  parent: [NFBaseClothingWristset, ClothingHeadsetService]
+  parent: [NFBaseClothingWristsetCommon, ClothingHeadsetService]
   id: NFClothingWristsetPunkCommon
   name: punk wristset
   components:


### PR DESCRIPTION
## About the PR
Created a new `NFBaseClothingWristsetCommon` entity that has the clear values on a Contraband component (inherits from `BaseClearContraband`). Then set all wristsets with only common encryption keys to use that as a base instead of the original `NFBaseClothingWristset`.

In a nutshell, prevents mercs who choose the brigmedic or security wristsets from showing up as contraband.

Also per request renamed the 'brigmedic' wristset to 'first responder' wristset.

## Why / Balance
Mercs could choose 2 wristsets that were flagged as contraband in their loadouts. The C2 Contra flag needed to be removed or the wristsets. See #4665 
## Technical details
Covered in the About section primarily. Is strange how it was done for the normal headsets by adding a Contraband Component with a 'clearValues' flag set to true which I presume hides the contraband indicator. This is apparently inherited by all the others, and if they do have a contraband component, like the security and brigmedic headsets do, that flag is not cleared.

I did this the same way as PR #2934 fixed it for the headsets. Primarily because I wasn't sure if there was some reason for this specific approach. I might make a later refactoring PR that removes the contraband parent from the brigmedic and security headset in the base files and add it to an appropriate 'NFSD' parent type which has the encryption keys

## How to test
Startup, change loadout as merc to have security or first responder wristset. Save changes
Spawn in, notice your wristset isn't contraband. You would never wear contraband as a mercenary.

## Media
<img width="399" height="246" alt="image" src="https://github.com/user-attachments/assets/85ba5fc4-d1fb-4794-a9ee-5d54b2a7bb26" />
<img width="411" height="229" alt="image" src="https://github.com/user-attachments/assets/e1a153ae-0310-44be-a6e5-f04b7b3ab1f6" />

Security headset I spawned in via console, thus why it doesn't have the traffic key.


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:
- fix: Mercenaries spawning with Brigmedic (now First Responder) or Security wristsets will no longer be flagged as contraband

