### PR TITLE
Health analyzer in loadout uses powered version

### DIFF
--- a/Resources/Prototypes/_NF/Loadouts/Jobs/Contractor/hands_items.yml
+++ b/Resources/Prototypes/_NF/Loadouts/Jobs/Contractor/hands_items.yml
@@ -152,13 +152,13 @@
     - NetworkConfigurator
 
 - type: loadout
-  id: ContractorHandheldHealthAnalyzerUnpowered
+  id: ContractorHandheldHealthAnalyzer
   effects:
   - !type:GroupLoadoutEffect
     proto: ContractorT1
   price: 350
   inhand:
-    - HandheldHealthAnalyzerUnpowered
+    - HandheldHealthAnalyzer
 
 - type: loadout
   id: ContractorAnomalyScanner

--- a/Resources/Prototypes/_NF/Loadouts/contractor_loadout_groups.yml
+++ b/Resources/Prototypes/_NF/Loadouts/contractor_loadout_groups.yml
@@ -883,7 +883,7 @@
   - ContractorHandheldGPSBasic
   - ContractorRadioHandheld
   - ContractorNetworkConfigurator
-  - ContractorHandheldHealthAnalyzerUnpowered
+  - ContractorHandheldHealthAnalyzer
   - ContractorAnomalyScanner
   - ContractorBucket
   - ContractorGeigerCounter


### PR DESCRIPTION
## About the PR
The in-hand loadout health analyzer tool is now a powered one with a small battery cell.

## Why / Balance
Consistency since all other health analyzers require power

## Technical details
Changed loadout to use `HandheldHealthAnalyzer` from `HandheldHealthAnalyzerUnpowered`. Similarly the name of the load out I removed the 'Unpowered' suffix. See issue #4686 

## How to test
Startup, customize loadout, go to in-hand items choose health analyzer.
Spawn in
Scan yourself see that it works
Examine the analyzer and see that it is using battery

## Media
<img width="639" height="358" alt="image" src="https://github.com/user-attachments/assets/9037ee1c-a57b-4921-b644-96f554cf5c41" />

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
The loadout for the health analyzer has had its name changed, which means anyone that used it will no longer spawn with one unless they go back and select it again. I think this is fine as it keeps the loadout name consistent, I doubt many people even use that analyzer other than maybe for making a medibot, and since we are changing it I think it's better to call attention to the change rather than let them spawn in with a worse scanner for the same cost.

**Changelog**
:cl:
- tweak: Fixed the loadout health analyzer to use the correct prototype.
