### PR TITLE
Metal Foam grenades to Mall

### DIFF
--- a/Resources/Prototypes/_NF/Catalog/Cargo/cargo_materials.yml
+++ b/Resources/Prototypes/_NF/Catalog/Cargo/cargo_materials.yml
@@ -81,3 +81,13 @@
   cost: 2500
   category: cargoproduct-category-name-atmospherics
   group: market
+
+- type: cargoProduct
+  id: CrateEngineeringFoamGrenade
+  icon:
+    sprite: Structures/Storage/Crates/engicrate_secure.rsi
+    state: icon
+  product: CrateEngineeringFoamGrenade
+  cost: 5000
+  category: cargoproduct-category-name-atmospherics
+  group: market


### PR DESCRIPTION


## About the PR
Added sealing/metal foam grenades to trademall. 
## Why / Balance
while uncommon, ship spacing does happen, and while holofans exist, it's a science unlock and engiship thing. Especially if we end up getting spacewhales, I feel like there should be a way to patch a leak quickly.
## Technical details
Added metal foam crate to the cargo listing under atmospherics


## How to test
go to the mall
buy the crate
open the crate and retreive your purchase

## Media

<img width="1919" height="1075" alt="image" src="https://github.com/user-attachments/assets/a40407ab-0aac-4d06-9a30-d0253e23f00f" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes
I didn't see any?
**Changelog**

:cl:
- add: Added metal foam crates to the mall's cargo listings.