### PR TITLE
Predict ReplaceOnTrigger spawning and despawning

### DIFF
--- a/Content.Shared/_NF/Trigger/Systems/TriggerSystem.Frontier.cs
+++ b/Content.Shared/_NF/Trigger/Systems/TriggerSystem.Frontier.cs
@@ -51,13 +51,13 @@ public sealed partial class TriggerSystem
         if (_container.TryGetContainingContainer((ent, xform), out var container))
         {
             _container.Remove(ent.Owner, container, force: true);
-            SpawnInContainerOrDrop(ent.Comp.Proto, container.Owner, container.ID);
+            PredictedSpawnInContainerOrDrop(ent.Comp.Proto, container.Owner, container.ID);
         }
         else
         {
-            Spawn(ent.Comp.Proto, xform.Coordinates);
+            PredictedSpawnAtPosition(ent.Comp.Proto, xform.Coordinates);
         }
-        QueueDel(ent);
+        PredictedQueueDel(ent);
     }
 
     private void OnProjectileHitEvent(EntityUid uid, TriggerOnProjectileHitComponent component, ref ProjectileHitEvent args)


### PR DESCRIPTION
## About the PR
Make `ReplaceOnTrigger` fully predicted. This exclusively affects napkins at the moment.

## Why / Balance
Without prediction, while the deletion seems to work just fine, the spawning goes all kinds of haywire and the client never wires up its locally spawned entity to track the server-spawned entity. Hilarity ensues:
<img width="490" height="331" alt="image" src="https://github.com/user-attachments/assets/a319c94c-817b-4b5f-a207-a4c1dcfd3eda" />

## Technical details
Changed spawning and deletion in the `ReplaceOnTrigger` implementation to be fully predicted. That's it, really.

## How to test
1. Grab a napkin.
2. Use the napkin.
3. Note that you do not have several phantom napkins stuck to your person.

## Media
https://github.com/user-attachments/assets/32908d30-d5f6-4f02-9a8b-9ee6255b01da

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes
No. :)

**Changelog**
:cl:
- fix: Phantom crumpled napkins no longer get stuck to your person.