### PR TITLE
Allow wheelchair users to crawl

### DIFF
--- a/Content.Shared/Stunnable/SharedStunSystem.Knockdown.cs
+++ b/Content.Shared/Stunnable/SharedStunSystem.Knockdown.cs
@@ -13,6 +13,7 @@ using Content.Shared.Movement.Systems;
 using Content.Shared.Popups;
 using Content.Shared.Rejuvenate;
 using Content.Shared.Standing;
+using Content.Shared.Traits.Assorted;
 using Robust.Shared.Audio;
 using Robust.Shared.Configuration;
 using Robust.Shared.Input.Binding;
@@ -244,11 +245,17 @@ public abstract partial class SharedStunSystem
         if (!Resolve(entity, ref entity.Comp1, false) || !_cfgManager.GetCVar(CCVars.MovementCrawling))
             return;
 
+        if (TryComp<BuckleComponent>(entity.Owner, out var buckle) && buckle.Buckled) // Frontier: wheelchair users can crawl
+            return; // Frontier: wheelchair users can crawl
+
         if (!Resolve(entity, ref entity.Comp2, false))
         {
             TryKnockdown(entity.Owner, entity.Comp1.DefaultKnockedDuration, true, false, false);
             return;
         }
+
+        if (HasComp<LegsParalyzedComponent>(entity)) // Frontier: wheelchair users can crawl
+            return; // Frontier: wheelchair users can crawl
 
         var stand = !entity.Comp2.DoAfterId.HasValue;
         SetAutoStand((entity, entity.Comp2), stand);

--- a/Content.Shared/Traits/Assorted/LegsParalyzedSystem.cs
+++ b/Content.Shared/Traits/Assorted/LegsParalyzedSystem.cs
@@ -46,7 +46,7 @@ public sealed class LegsParalyzedSystem : EntitySystem
 
     private void OnUnbuckled(EntityUid uid, LegsParalyzedComponent component, ref UnbuckledEvent args)
     {
-        _standingSystem.Down(uid, true, false, true); // Frontier: wheelchair users can crawl
+        _stunSystem.TryKnockdown(uid, null, false, false, false, true); // Frontier: wheelchair users can crawl
     }
 
     // Start Frontier: wheelchair users can crawl

--- a/Content.Shared/Traits/Assorted/LegsParalyzedSystem.cs
+++ b/Content.Shared/Traits/Assorted/LegsParalyzedSystem.cs
@@ -4,7 +4,7 @@ using Content.Shared.Movement.Events;
 using Content.Shared.Movement.Systems;
 using Content.Shared.Standing;
 using Content.Shared.Throwing;
-using Content.Shared.Movement.Components;
+using Content.Shared.Movement.Components; // Frontier
 using Content.Shared.Stunnable; // Frontier: wheelchair users can crawl
 
 namespace Content.Shared.Traits.Assorted;

--- a/Content.Shared/Traits/Assorted/LegsParalyzedSystem.cs
+++ b/Content.Shared/Traits/Assorted/LegsParalyzedSystem.cs
@@ -46,8 +46,8 @@ public sealed class LegsParalyzedSystem : EntitySystem
 
     private void OnUnbuckled(EntityUid uid, LegsParalyzedComponent component, ref UnbuckledEvent args)
     {
-        _standingSystem.Down(uid, true, false, false); // Frontier: wheelchair users can crawl
-        _stunSystem.TryCrawling(uid); // Frontier: wheelchair users can crawl
+        _standingSystem.Down(uid, true, false, true); // Frontier: wheelchair users can crawl
+        _stunSystem.TryCrawling(uid, null, false, false, false, true); // Frontier: wheelchair users can crawl
     }
 
     // Start Frontier: wheelchair users can crawl

--- a/Content.Shared/Traits/Assorted/LegsParalyzedSystem.cs
+++ b/Content.Shared/Traits/Assorted/LegsParalyzedSystem.cs
@@ -4,7 +4,8 @@ using Content.Shared.Movement.Events;
 using Content.Shared.Movement.Systems;
 using Content.Shared.Standing;
 using Content.Shared.Throwing;
-using Content.Shared.Movement.Components; // Frontier
+using Content.Shared.Movement.Components;
+using Content.Shared.Stunnable; // Frontier: wheelchair users can crawl
 
 namespace Content.Shared.Traits.Assorted;
 
@@ -13,6 +14,7 @@ public sealed class LegsParalyzedSystem : EntitySystem
     [Dependency] private readonly MovementSpeedModifierSystem _movementSpeedModifierSystem = default!;
     [Dependency] private readonly StandingStateSystem _standingSystem = default!;
     [Dependency] private readonly SharedBodySystem _bodySystem = default!;
+    [Dependency] private readonly SharedStunSystem _stunSystem = default!; // Frontier: wheelchair users can crawl
 
     public override void Initialize()
     {
@@ -21,13 +23,14 @@ public sealed class LegsParalyzedSystem : EntitySystem
         SubscribeLocalEvent<LegsParalyzedComponent, BuckledEvent>(OnBuckled);
         SubscribeLocalEvent<LegsParalyzedComponent, UnbuckledEvent>(OnUnbuckled);
         SubscribeLocalEvent<LegsParalyzedComponent, ThrowPushbackAttemptEvent>(OnThrowPushbackAttempt);
-        SubscribeLocalEvent<LegsParalyzedComponent, UpdateCanMoveEvent>(OnUpdateCanMoveEvent);
+        //SubscribeLocalEvent<LegsParalyzedComponent, UpdateCanMoveEvent>(OnUpdateCanMoveEvent); // Frontier: wheelchair users can crawl
+        SubscribeLocalEvent<LegsParalyzedComponent, StandAttemptEvent>(OnStandAttemptEvent); // Frontier: wheelchair users can crawl
     }
 
     private void OnStartup(EntityUid uid, LegsParalyzedComponent component, ComponentStartup args)
     {
         // TODO: In future probably must be surgery related wound
-        _movementSpeedModifierSystem.ChangeBaseSpeed(uid, 0, 0, 20);
+        _movementSpeedModifierSystem.ChangeBaseSpeed(uid, 1.5f, 2.5f, MovementSpeedModifierComponent.DefaultAcceleration); // Frontier: wheelchair users can crawl
     }
 
     private void OnShutdown(EntityUid uid, LegsParalyzedComponent component, ComponentShutdown args)
@@ -43,19 +46,29 @@ public sealed class LegsParalyzedSystem : EntitySystem
 
     private void OnUnbuckled(EntityUid uid, LegsParalyzedComponent component, ref UnbuckledEvent args)
     {
-        _standingSystem.Down(uid);
+        _standingSystem.Down(uid, true, false, false); // Frontier: wheelchair users can crawl
+        _stunSystem.TryCrawling(uid); // Frontier: wheelchair users can crawl
     }
 
-    private void OnUpdateCanMoveEvent(EntityUid uid, LegsParalyzedComponent component, UpdateCanMoveEvent args)
-    {
-        if (HasComp<RelayInputMoverComponent>(uid)) // Frontier: allow relaying input with paralyzed legs
-            return; // Frontier: allow relaying input with paralyzed legs
-
-        args.Cancel();
-    }
+    // Start Frontier: wheelchair users can crawl
+    // private void OnUpdateCanMoveEvent(EntityUid uid, LegsParalyzedComponent component, UpdateCanMoveEvent args)
+    // {
+    //     if (HasComp<RelayInputMoverComponent>(uid)) // Frontier: allow relaying input with paralyzed legs
+    //         return; // Frontier: allow relaying input with paralyzed legs
+    //
+    //     args.Cancel();
+    // }
+    // End Frontier: wheelchair users can crawl
 
     private void OnThrowPushbackAttempt(EntityUid uid, LegsParalyzedComponent component, ThrowPushbackAttemptEvent args)
     {
         args.Cancel();
     }
+
+    // Frontier: wheelchair users can crawl
+    private void OnStandAttemptEvent(EntityUid uid, LegsParalyzedComponent component, StandAttemptEvent args)
+    {
+        args.Cancel();
+    }
+    // End Frontier: wheelchair users can crawl
 }

--- a/Content.Shared/Traits/Assorted/LegsParalyzedSystem.cs
+++ b/Content.Shared/Traits/Assorted/LegsParalyzedSystem.cs
@@ -1,6 +1,5 @@
 ﻿using Content.Shared.Body.Systems;
 using Content.Shared.Buckle.Components;
-using Content.Shared.Movement.Events;
 using Content.Shared.Movement.Systems;
 using Content.Shared.Standing;
 using Content.Shared.Throwing;
@@ -24,7 +23,9 @@ public sealed class LegsParalyzedSystem : EntitySystem
         SubscribeLocalEvent<LegsParalyzedComponent, UnbuckledEvent>(OnUnbuckled);
         SubscribeLocalEvent<LegsParalyzedComponent, ThrowPushbackAttemptEvent>(OnThrowPushbackAttempt);
         //SubscribeLocalEvent<LegsParalyzedComponent, UpdateCanMoveEvent>(OnUpdateCanMoveEvent); // Frontier: wheelchair users can crawl
-        SubscribeLocalEvent<LegsParalyzedComponent, StandAttemptEvent>(OnStandAttemptEvent); // Frontier: wheelchair users can crawl
+        SubscribeLocalEvent<LegsParalyzedComponent, StandUpAttemptEvent>(OnStandUpAttemptEvent, before: [typeof(SharedStunSystem)]); // Frontier: wheelchair users can crawl
+        SubscribeLocalEvent<LegsParalyzedComponent, StandAttemptEvent>(OnStandAttemptEvent, before: [typeof(SharedStunSystem)]); // Frontier: wheelchair users can crawl
+        SubscribeLocalEvent<LegsParalyzedComponent, KnockedDownAlertEvent>(OnKnockedDownAlertEvent, before: [typeof(SharedStunSystem)]); // Frontier: wheelchair users can crawl
     }
 
     private void OnStartup(EntityUid uid, LegsParalyzedComponent component, ComponentStartup args)
@@ -42,11 +43,13 @@ public sealed class LegsParalyzedSystem : EntitySystem
     private void OnBuckled(EntityUid uid, LegsParalyzedComponent component, ref BuckledEvent args)
     {
         _standingSystem.Stand(uid);
+        _stunSystem.SetAutoStand(uid, true); // Frontier: wheelchair users can crawl
     }
 
     private void OnUnbuckled(EntityUid uid, LegsParalyzedComponent component, ref UnbuckledEvent args)
     {
-        _stunSystem.TryKnockdown(uid, null, false, false, false, true); // Frontier: wheelchair users can crawl
+        _standingSystem.Down(uid, true, false, true); // Frontier: wheelchair users can crawl
+        _stunSystem.TryCrawling(uid, null, false, false, false, true); // Frontier: wheelchair users can crawl
     }
 
     // Start Frontier: wheelchair users can crawl
@@ -57,17 +60,29 @@ public sealed class LegsParalyzedSystem : EntitySystem
     //
     //     args.Cancel();
     // }
+
+    private void OnStandUpAttemptEvent(EntityUid uid, LegsParalyzedComponent component, StandUpAttemptEvent args)
+    {
+        if (args.Cancelled)
+            return;
+
+        args.Cancelled = true;
+        args.Autostand = false;
+    }
+
+    private void OnStandAttemptEvent(EntityUid uid, LegsParalyzedComponent component, StandAttemptEvent args)
+    {
+        args.Cancel();
+    }
+
+    private void OnKnockedDownAlertEvent(EntityUid uid, LegsParalyzedComponent component, KnockedDownAlertEvent args)
+    {
+        args.Handled = true;
+    }
     // End Frontier: wheelchair users can crawl
 
     private void OnThrowPushbackAttempt(EntityUid uid, LegsParalyzedComponent component, ThrowPushbackAttemptEvent args)
     {
         args.Cancel();
     }
-
-    // Frontier: wheelchair users can crawl
-    private void OnStandAttemptEvent(EntityUid uid, LegsParalyzedComponent component, StandAttemptEvent args)
-    {
-        args.Cancel();
-    }
-    // End Frontier: wheelchair users can crawl
 }

--- a/Content.Shared/Traits/Assorted/LegsParalyzedSystem.cs
+++ b/Content.Shared/Traits/Assorted/LegsParalyzedSystem.cs
@@ -44,7 +44,7 @@ public sealed class LegsParalyzedSystem : EntitySystem
     private void OnBuckled(EntityUid uid, LegsParalyzedComponent component, ref BuckledEvent args)
     {
         _standingSystem.Stand(uid);
-        _stunSystem.SetAutoStand(uid, true); // Frontier: wheelchair users can crawl
+        RemComp<KnockedDownComponent>(uid); // Frontier: wheelchair users can crawl
     }
 
     private void OnUnbuckled(EntityUid uid, LegsParalyzedComponent component, ref UnbuckledEvent args)

--- a/Content.Shared/Traits/Assorted/LegsParalyzedSystem.cs
+++ b/Content.Shared/Traits/Assorted/LegsParalyzedSystem.cs
@@ -1,5 +1,6 @@
 ﻿using Content.Shared.Body.Systems;
 using Content.Shared.Buckle.Components;
+//using Content.Shared.Movement.Events; // Frontier: wheelchair users can crawl
 using Content.Shared.Movement.Systems;
 using Content.Shared.Standing;
 using Content.Shared.Throwing;

--- a/Content.Shared/Traits/Assorted/LegsParalyzedSystem.cs
+++ b/Content.Shared/Traits/Assorted/LegsParalyzedSystem.cs
@@ -47,7 +47,6 @@ public sealed class LegsParalyzedSystem : EntitySystem
     private void OnUnbuckled(EntityUid uid, LegsParalyzedComponent component, ref UnbuckledEvent args)
     {
         _standingSystem.Down(uid, true, false, true); // Frontier: wheelchair users can crawl
-        _stunSystem.TryCrawling(uid, null, false, false, false, true); // Frontier: wheelchair users can crawl
     }
 
     // Start Frontier: wheelchair users can crawl

--- a/Content.Shared/Traits/Assorted/LegsParalyzedSystem.cs
+++ b/Content.Shared/Traits/Assorted/LegsParalyzedSystem.cs
@@ -23,10 +23,12 @@ public sealed class LegsParalyzedSystem : EntitySystem
         SubscribeLocalEvent<LegsParalyzedComponent, BuckledEvent>(OnBuckled);
         SubscribeLocalEvent<LegsParalyzedComponent, UnbuckledEvent>(OnUnbuckled);
         SubscribeLocalEvent<LegsParalyzedComponent, ThrowPushbackAttemptEvent>(OnThrowPushbackAttempt);
-        //SubscribeLocalEvent<LegsParalyzedComponent, UpdateCanMoveEvent>(OnUpdateCanMoveEvent); // Frontier: wheelchair users can crawl
-        SubscribeLocalEvent<LegsParalyzedComponent, StandUpAttemptEvent>(OnStandUpAttemptEvent, before: [typeof(SharedStunSystem)]); // Frontier: wheelchair users can crawl
-        SubscribeLocalEvent<LegsParalyzedComponent, StandAttemptEvent>(OnStandAttemptEvent, before: [typeof(SharedStunSystem)]); // Frontier: wheelchair users can crawl
-        SubscribeLocalEvent<LegsParalyzedComponent, KnockedDownAlertEvent>(OnKnockedDownAlertEvent, before: [typeof(SharedStunSystem)]); // Frontier: wheelchair users can crawl
+        // Start Frontier: wheelchair users can crawl
+        //SubscribeLocalEvent<LegsParalyzedComponent, UpdateCanMoveEvent>(OnUpdateCanMoveEvent);
+        SubscribeLocalEvent<LegsParalyzedComponent, StandUpAttemptEvent>(OnStandUpAttemptEvent, before: [typeof(SharedStunSystem)]);
+        SubscribeLocalEvent<LegsParalyzedComponent, StandAttemptEvent>(OnStandAttemptEvent, before: [typeof(SharedStunSystem)]);
+        SubscribeLocalEvent<LegsParalyzedComponent, KnockedDownAlertEvent>(OnKnockedDownAlertEvent, before: [typeof(SharedStunSystem)]);
+        // End Frontier: wheelchair users can crawl
     }
 
     private void OnStartup(EntityUid uid, LegsParalyzedComponent component, ComponentStartup args)
@@ -56,8 +58,8 @@ public sealed class LegsParalyzedSystem : EntitySystem
     // Start Frontier: wheelchair users can crawl
     // private void OnUpdateCanMoveEvent(EntityUid uid, LegsParalyzedComponent component, UpdateCanMoveEvent args)
     // {
-    //     if (HasComp<RelayInputMoverComponent>(uid)) // Frontier: allow relaying input with paralyzed legs
-    //         return; // Frontier: allow relaying input with paralyzed legs
+    //     if (HasComp<RelayInputMoverComponent>(uid))
+    //         return;
     //
     //     args.Cancel();
     // }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
There was something stopping wheelchair users from moving unless in a vehicle. I'm assuming this was before crawling was added and so they could not crawl either. I've made it so that a wheelchair user (has wheelchair-bound trait) can always relay movement, but their base movement speed is lowered. They can't stand up anyway, so it shouldn't matter if they can relay movement (unless I missed something!).

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
A lot of discussion has happened in the [Wheelchair Improvements! ideas thread](https://discord.com/channels/1123826877245694004/1387961514862051459) but [this](https://discord.com/channels/1123826877245694004/1387961514862051459/1512314495899537539) message is when I first mentioned crawling. I feel like it makes logical sense for someone with paralysis affecting their legs to still be able to drag themselves across the ground with their increased upper body strength. After all, they use their arms to move all day. Balance-wise, I tried lowering the base speed of somebody with wheelchair-bound, rather than setting it to 0. This is to reflect that they're not able to crawl around on all fours, so "crawling" will be slower.

## Technical details
<!-- Summary of code changes for easier review. -->
All changes are in the file that the wheelchair-bound trait uses. I think the main thing is commenting out OnUpdateCanMoveEvent so that movement by a wheelchair-bound person can be relayed whenever. I've also changed the base speed that the person gets set to, which was 0 and now is more than 0. Lastly I blocked stand up attempts.

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
Join as a wheelchair-bound character and unbuckle yourself (or 'drop' your wheelchair), you can now crawl. You won't be able to toggle crawling to stand up.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
🆑
- tweak: Wheelchair users can now crawl
