### PR TITLE
Fix intercom and signal timer construction

### DIFF
--- a/Content.Client/Construction/ConstructionSystem.cs
+++ b/Content.Client/Construction/ConstructionSystem.cs
@@ -294,7 +294,6 @@ namespace Content.Client.Construction
             _ghosts.Add(comp.GhostId, ghost.Value);
 
             var sprite = Comp<SpriteComponent>(ghost.Value);
-            _sprite.SetColor((ghost.Value, sprite), new Color(48, 255, 48, 128));
 
             if (targetProto.TryGetComponent(out IconComponent? icon, EntityManager.ComponentFactory))
             {
@@ -309,30 +308,19 @@ namespace Content.Client.Construction
                 var targetSprite = EnsureComp<SpriteComponent>(dummy);
                 EntityManager.System<AppearanceSystem>().OnChangeData(dummy, targetSprite);
 
-                var ghostSpriteIdx = 0; // Frontier: Fix intercom construction
-                for (var i = 0; i < targetSprite.AllLayers.Count(); i++)
+                _sprite.CopySprite((dummy, targetSprite), (ghost.Value, sprite));
+
+                for (var i = 0; i < sprite.AllLayers.Count(); i++)
                 {
-                    if (!targetSprite[i].Visible || !targetSprite[i].RsiState.IsValid)
-                        continue;
-
-                    var rsi = targetSprite[i].Rsi ?? targetSprite.BaseRSI;
-                    if (rsi is null || !rsi.TryGetState(targetSprite[i].RsiState, out var state) ||
-                        state.StateId.Name is null)
-                        continue;
-
-                    // Frontier Begin - Fix Intercom construction... i<ghostSpriteIdx
-                    _sprite.AddBlankLayer((ghost.Value, sprite), ghostSpriteIdx);
-                    _sprite.LayerSetSprite((ghost.Value, sprite), ghostSpriteIdx, new SpriteSpecifier.Rsi(rsi.Path, state.StateId.Name));
-                    sprite.LayerSetShader(ghostSpriteIdx, "unshaded");
-                    _sprite.LayerSetVisible((ghost.Value, sprite), ghostSpriteIdx, true);
-                    ghostSpriteIdx++;
-                    // Frontier End
+                    sprite.LayerSetShader(i, "unshaded");
                 }
 
                 Del(dummy);
             }
             else
                 return false;
+
+            _sprite.SetColor((ghost.Value, sprite), new Color(48, 255, 48, 128));
 
             if (prototype.CanBuildInImpassable)
                 EnsureComp<WallMountComponent>(ghost.Value).Arc = new(Math.Tau);

--- a/Content.Client/Construction/ConstructionSystem.cs
+++ b/Content.Client/Construction/ConstructionSystem.cs
@@ -309,6 +309,7 @@ namespace Content.Client.Construction
                 var targetSprite = EnsureComp<SpriteComponent>(dummy);
                 EntityManager.System<AppearanceSystem>().OnChangeData(dummy, targetSprite);
 
+                var ghostSpriteIdx = 0; // Frontier: Fix intercom construction
                 for (var i = 0; i < targetSprite.AllLayers.Count(); i++)
                 {
                     if (!targetSprite[i].Visible || !targetSprite[i].RsiState.IsValid)
@@ -319,10 +320,13 @@ namespace Content.Client.Construction
                         state.StateId.Name is null)
                         continue;
 
-                    _sprite.AddBlankLayer((ghost.Value, sprite), i);
-                    _sprite.LayerSetSprite((ghost.Value, sprite), i, new SpriteSpecifier.Rsi(rsi.Path, state.StateId.Name));
-                    sprite.LayerSetShader(i, "unshaded");
-                    _sprite.LayerSetVisible((ghost.Value, sprite), i, true);
+                    // Frontier Begin - Fix Intercom construction... i<ghostSpriteIdx
+                    _sprite.AddBlankLayer((ghost.Value, sprite), ghostSpriteIdx);
+                    _sprite.LayerSetSprite((ghost.Value, sprite), ghostSpriteIdx, new SpriteSpecifier.Rsi(rsi.Path, state.StateId.Name));
+                    sprite.LayerSetShader(ghostSpriteIdx, "unshaded");
+                    _sprite.LayerSetVisible((ghost.Value, sprite), ghostSpriteIdx, true);
+                    ghostSpriteIdx++;
+                    // Frontier End
                 }
 
                 Del(dummy);

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/intercom.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/intercom.yml
@@ -115,6 +115,7 @@
           False: { visible: false }
 
 - type: entity
+  parent: BaseWallmountMetallic # Frontier: add parent: BaseWallmountMetallic
   id: IntercomAssembly
   name: intercom assembly
   description: An intercom. It doesn't seem very helpful right now.

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/timer.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/timer.yml
@@ -103,6 +103,7 @@
 # Construction Frame
 
 - type: entity
+  parent: BaseWallmountMetallic # Frontier: add parent: BaseWallmountMetallic
   id: TimerFrame
   name: timer frame
   description: A construction frame for a timer.


### PR DESCRIPTION
## About the PR
The intercom and signal timer assemblies did not have a parent set and thus were not interactable or highlightable. You could get around this limitation by right clicking the wall and left clicking the assembly.

Also the ConstructionSystem on the client would throw an index out of bounds exception when placing the intercom ghost, so I fixed that too.

## Why / Balance
Client shouldn't throw an exception when placing a construction ghost. Also consistency for crafting and shouldn't need workarounds to make things.

## Technical details
It seems the sprite system is in the middle of a rewrite. The method to set a sprite layer as unshaded requires knowing the layer index which is not accessible outside of the engine. The construction system loops through the target entity sprite layers counting up, but skips layers with invalid states and other conditions. This however keeps that counter incrementing. The engine code for `AddBlankLayer` only checks if the index you pass is equal to the total number of current layers. This works in majority of cases apparently, but intercom apparently had some valid layers that skipped a few indices resulting in the engine throwing an out of bounds exception.

I fixed that by having a separate integer count up the layers we add to the ghost that doesn't get incremented if we skip over an invalid layer.

Finally the reason the intercom and signal timer assemblies couldn't be clicked on is because they had no parent and defined no clickable or interactable components. I tried to check for other cases of this, closest I could find was some construction frames having no parent but also defined the clickable and interactable components. Ideally they would use some parent base but I figured I was already in the weeds enough with the ConstructionSystem change.


## How to test
Spawn in
Use the crafting menu to place an intercom ghost
Rejoice an exception wasn't thrown
Craft the intercom with steel, wires, etc.
Notice you can interact with the assembly.
Repeat for signal timer.

## Media
If you want pictures let me know

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: B-Krill Pi_Masta
- fix: Ported fix from WizDen preventing a crash when placing an intercom construction ghost (and potentially others)
- fix: Made Intercom and Signal Timer assemblies interactable bringing them in line with other mid construction machines

