### PR TITLE
Drop carried person when they are cryo'd

### DIFF
--- a/Content.Server/_EE/Carrying/CarryingSystem.cs
+++ b/Content.Server/_EE/Carrying/CarryingSystem.cs
@@ -85,7 +85,7 @@ namespace Content.Server.Carrying
         //Frontier Begin - Remove virtual item when cryosleeping held character
         private void OnCarriedCryoEnter(Entity<BeingCarriedComponent> ent, ref CryosleepEnterEvent args)
         {
-            DropCarried(ent.Comp.Carrier, ent);
+            DropCarried(ent.Comp.Carrier, ent, attachToMap: false);
         }
         //Frontier End
 
@@ -330,7 +330,7 @@ namespace Content.Server.Carrying
             return true;
         }
 
-        public void DropCarried(EntityUid carrier, EntityUid carried)
+        public void DropCarried(EntityUid carrier, EntityUid carried, bool attachToMap = true) //Frontier add attachToMap parameter
         {
             RemComp<CarryingComponent>(carrier); // get rid of this first so we don't recursively fire that event
             RemComp<CarryingSlowdownComponent>(carrier);
@@ -338,7 +338,10 @@ namespace Content.Server.Carrying
             RemComp<KnockedDownComponent>(carried);
             _actionBlockerSystem.UpdateCanMove(carried);
             _virtualItemSystem.DeleteInHandsMatching(carrier, carried);
-            _transform.AttachToGridOrMap(carried);
+            if (attachToMap) //Frontier
+            { //Frontier
+                _transform.AttachToGridOrMap(carried);
+            } //Frontier
             _standingState.Stand(carried);
             _movementSpeed.RefreshMovementSpeedModifiers(carrier);
         }
@@ -382,7 +385,7 @@ namespace Content.Server.Carrying
                 // when this happens, it needs to be dropped because it leads to weird behavior
                 if (xform.ParentUid != carrier)
                 {
-                    DropCarried(carrier, carried);
+                    DropCarried(carrier, carried, attachToMap: false);
                     continue;
                 }
 

--- a/Content.Server/_EE/Carrying/CarryingSystem.cs
+++ b/Content.Server/_EE/Carrying/CarryingSystem.cs
@@ -32,7 +32,7 @@ using Content.Shared.Storage;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Physics.Components;
 using Robust.Server.GameObjects;
-using Content.Shared.Hands.EntitySystems;
+using Content.Shared.Hands.EntitySystems; // Frontier
 using Content.Server._NF.CryoSleep; // Frontier
 
 namespace Content.Server.Carrying

--- a/Content.Server/_EE/Carrying/CarryingSystem.cs
+++ b/Content.Server/_EE/Carrying/CarryingSystem.cs
@@ -32,7 +32,8 @@ using Content.Shared.Storage;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Physics.Components;
 using Robust.Server.GameObjects;
-using Content.Shared.Hands.EntitySystems; // Frontier
+using Content.Shared.Hands.EntitySystems;
+using Content.Server._NF.CryoSleep; // Frontier
 
 namespace Content.Server.Carrying
 {
@@ -78,7 +79,15 @@ namespace Content.Server.Carrying
             SubscribeLocalEvent<BeingCarriedComponent, StrappedEvent>(OnBuckleChange);
             SubscribeLocalEvent<BeingCarriedComponent, UnstrappedEvent>(OnBuckleChange);
             SubscribeLocalEvent<CarriableComponent, CarryDoAfterEvent>(OnDoAfter);
+            SubscribeLocalEvent<BeingCarriedComponent, CryosleepEnterEvent>(OnCarriedCryoEnter); //Frontier
         }
+
+        //Frontier Begin - Remove virtual item when cryosleeping held character
+        private void OnCarriedCryoEnter(Entity<BeingCarriedComponent> ent, ref CryosleepEnterEvent args)
+        {
+            DropCarried(ent.Comp.Carrier, ent);
+        }
+        //Frontier End
 
         private void AddCarryVerb(EntityUid uid, CarriableComponent component, GetVerbsEvent<AlternativeVerb> args)
         {

--- a/Content.Server/_EE/Carrying/CarryingSystem.cs
+++ b/Content.Server/_EE/Carrying/CarryingSystem.cs
@@ -338,10 +338,12 @@ namespace Content.Server.Carrying
             RemComp<KnockedDownComponent>(carried);
             _actionBlockerSystem.UpdateCanMove(carried);
             _virtualItemSystem.DeleteInHandsMatching(carrier, carried);
-            if (attachToMap) //Frontier
-            { //Frontier
+            //Begin Frontier: Drop person carried when dragging to cryo
+            if (attachToMap)
+            {
                 _transform.AttachToGridOrMap(carried);
-            } //Frontier
+            }
+            //End Frontier
             _standingState.Stand(carried);
             _movementSpeed.RefreshMovementSpeedModifiers(carrier);
         }


### PR DESCRIPTION
## About the PR
Appears the we use some custom code for the cryopods and doesn't handle if you drag a person you are carrying into the pod. This leaves a virtual item in the users' hands and they are unable to do anything (cause their hands are blocked by the virtual item) until someone else helps them out. See #4392 

## Why / Balance
As the name/description of the virtual item states: YOU SHOULD NOT SEE THIS
This makes that happen under these circumstances.

## Technical details
As best as I can tell there was no easy event in the base code being raised by the `CryoSleepSystem` So I added a listener to the custom `CryoSleepEnterEvent` in whatever fork '_EE' carry system is.

## How to test
Spawn in
Spawn an 'Urist' or other cryo-able mob
Alt click them or otherwise carry them in both hands
Click drag with your mouse the Urist's sprite into a cryopod.
Rejoice you can still use your hands.
## Media

https://github.com/user-attachments/assets/6b3f2125-f523-4f81-9d31-4922f9851ffa



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Pi_Masta
- fix: Cryo sleep chambers no longer break your hands when you drag someone you are carrying to cryo sleep.

