### PR TITLE
Fix VIRTUAL ITEM YOU SHOULD NOT SEE THIS popup

### DIFF
--- a/Content.Shared/Inventory/VirtualItem/SharedVirtualItemSystem.cs
+++ b/Content.Shared/Inventory/VirtualItem/SharedVirtualItemSystem.cs
@@ -129,7 +129,13 @@ public abstract class SharedVirtualItemSystem : EntitySystem
                     continue;
 
                 if (!TerminatingOrDeleted(held))
+                { //Frontier Begin - Fix showing Virtual Item when wielding
+                    if (TryComp<VirtualItemComponent>(held, out var otherVirt))
+                    {
+                        held = otherVirt.BlockingEntity;
+                    } //Frontier End
                     _popup.PopupClient(Loc.GetString("virtual-item-dropped-other", ("dropped", held)), user, user);
+                } // Frontier
 
                 empty = hand;
                 break;


### PR DESCRIPTION
## About the PR
Prevent the Virtual Item from showing up in a popup message

## Why / Balance
Virtual Item name should never be seen. It even says so.

## Technical details
When trying to spawn a virtual item, it displays a popup if it drop any other items in hand. This now check that if what you dropped was a virtual item, it gets the entity the virtual item was representing.

## How to test
Grab any 2 handed weapon
Start pulling anything which will block a hand
Wield the weapon
Notice no message about 'VIRTUAL ITEM YOU SHOULD NOT SEE THIS'

## Media
https://github.com/user-attachments/assets/30c55554-feae-48b1-afe0-ad38bf461e70

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Wielding a weapon while dragging or driving a vehicle should no longer show a message that you should not see
