### PR TITLE
Biomass Reclaimer Mob Drop Duplication Fix

### DIFF
--- a/Content.Server/Medical/BiomassReclaimer/BiomassReclaimerSystem.cs
+++ b/Content.Server/Medical/BiomassReclaimer/BiomassReclaimerSystem.cs
@@ -239,7 +239,12 @@ namespace Content.Server.Medical.BiomassReclaimer
             }
             if (TryComp<ButcherableComponent>(toProcess, out var butcherableComponent))
             {
-                component.SpawnedEntities = butcherableComponent.SpawnedEntities;
+                // Frontier start - Prevent reclaimable mobs from spewing out special drops e.g. trophies
+                if (butcherableComponent.BiomassReclaimerOverride != null)
+                    component.SpawnedEntities = butcherableComponent.BiomassReclaimerOverride;
+                else
+                    component.SpawnedEntities = butcherableComponent.SpawnedEntities;
+                // Frontier end
             }
 
             var expectedYield = physics.FixturesMass * component.YieldPerUnitMass;

--- a/Content.Server/Medical/BiomassReclaimer/BiomassReclaimerSystem.cs
+++ b/Content.Server/Medical/BiomassReclaimer/BiomassReclaimerSystem.cs
@@ -239,12 +239,8 @@ namespace Content.Server.Medical.BiomassReclaimer
             }
             if (TryComp<ButcherableComponent>(toProcess, out var butcherableComponent))
             {
-                // Frontier start - Prevent reclaimable mobs from spewing out special drops e.g. trophies
-                if (butcherableComponent.BiomassReclaimerOverride != null)
-                    component.SpawnedEntities = butcherableComponent.BiomassReclaimerOverride;
-                else
-                    component.SpawnedEntities = butcherableComponent.SpawnedEntities;
-                // Frontier end
+                // Frontier - Prevent reclaimable mobs from spewing out special drops e.g. trophies
+                component.SpawnedEntities = butcherableComponent.BiomassReclaimerOverride ?? butcherableComponent.SpawnedEntities;
             }
 
             var expectedYield = physics.FixturesMass * component.YieldPerUnitMass;

--- a/Content.Shared/Nutrition/Components/ButcherableComponent.cs
+++ b/Content.Shared/Nutrition/Components/ButcherableComponent.cs
@@ -31,6 +31,15 @@ public sealed partial class ButcherableComponent : Component
     /// </summary>
     [DataField("butcheringType"), AutoNetworkedField]
     public ButcheringType Type = ButcheringType.Knife;
+
+    // Frontier start
+    /// <summary>
+    /// When not null, this entity will be produced as the additional meat flung out of a biomass reclaimer while active
+    /// in place of the entity's butchering loot.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public List<EntitySpawnEntry>? BiomassReclaimerOverride;
+    // Frontier end
 }
 
 public enum ButcheringType : byte

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_aberrant_flesh.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_aberrant_flesh.yml
@@ -41,6 +41,9 @@
   - type: Butcherable
     spawned:
     - id: SpawnDungeonLootNpcAberrantFlesh
+    biomassReclaimerOverride:
+    - id: FoodMeat
+      amount: 1
 
 # region melee
 - type: entity
@@ -371,6 +374,10 @@
   - type: Butcherable
     spawned:
     - id: SpawnDungeonLootNpcAberrantFlesh
+    biomassReclaimerOverride:
+    - id: FoodMeat
+      amount: 1
+
   # Ghost role stuff
   - type: GhostRole
     allowMovement: true

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_argocyte.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_argocyte.yml
@@ -72,6 +72,9 @@
     spawned:
     - id: SpawnDungeonLootNpcArgocyteSmall
       amount: 1
+    biomassReclaimerOverride:
+    - id: FoodMeatXeno
+      amount: 1
 
 # Stalkers morphotype
 # region slurva
@@ -119,6 +122,9 @@
     spawned:
     - id: SpawnDungeonLootNpcArgocyteSmall
       amount: 1
+    biomassReclaimerOverride:
+    - id: FoodMeatXeno
+      amount: 1
 
 # region skitter
 - type: entity
@@ -165,6 +171,9 @@
     spawned:
     - id: SpawnDungeonLootNpcArgocyteSmall
       amount: 1
+    biomassReclaimerOverride:
+    - id: FoodMeatXeno
+      amount: 1
 
 # region swiper
 - type: entity
@@ -199,6 +208,9 @@
   - type: Butcherable
     spawned:
     - id: SpawnDungeonLootNpcArgocyteSwiper
+      amount: 1
+    biomassReclaimerOverride:
+    - id: FoodMeatXeno
       amount: 1
 
 # region glider
@@ -235,6 +247,9 @@
     spawned:
     - id: SpawnDungeonLootNpcArgocyteGlider
       amount: 1
+    biomassReclaimerOverride:
+    - id: FoodMeatXeno
+      amount: 1
 
 # region crawler
 - type: entity
@@ -269,6 +284,9 @@
   - type: Butcherable
     spawned:
     - id: SpawnDungeonLootNpcArgocyteCrawler
+      amount: 1
+    biomassReclaimerOverride:
+    - id: FoodMeatXeno
       amount: 1
 
 # region founder
@@ -305,6 +323,9 @@
   - type: Butcherable
     spawned:
     - id: SpawnDungeonLootNpcArgocyteFounder
+      amount: 1
+    biomassReclaimerOverride:
+    - id: FoodMeatXeno
       amount: 1
 
 # Guardian morphotype
@@ -353,6 +374,9 @@
     spawned:
     - id: SpawnDungeonLootNpcArgocyteSmall
       amount: 1
+    biomassReclaimerOverride:
+    - id: FoodMeatXeno
+      amount: 1
 
 # region molder
 - type: entity
@@ -388,6 +412,9 @@
     spawned:
     - id: SpawnDungeonLootNpcArgocyteMolder
       amount: 1
+    biomassReclaimerOverride:
+    - id: FoodMeatXeno
+      amount: 1
 
 # region pouncer
 - type: entity
@@ -421,6 +448,9 @@
   - type: Butcherable
     spawned:
     - id: SpawnDungeonLootNpcArgocytePouncer
+      amount: 1
+    biomassReclaimerOverride:
+    - id: FoodMeatXeno
       amount: 1
 
 # region harvester
@@ -457,6 +487,9 @@
     spawned:
     - id: SpawnDungeonLootNpcArgocyteHarvester
       amount: 1
+    biomassReclaimerOverride:
+    - id: FoodMeatXeno
+      amount: 1
 
 # region enforcer
 - type: entity
@@ -491,6 +524,9 @@
   - type: Butcherable
     spawned:
     - id: SpawnDungeonLootNpcArgocyteEnforcer
+      amount: 1
+    biomassReclaimerOverride:
+    - id: FoodMeatXeno
       amount: 1
 
 # region leviathing (boss)
@@ -549,6 +585,10 @@
     spawned:
     - id: SpawnDungeonLootNpcArgocyteLeviathing
       amount: 1
+    biomassReclaimerOverride:
+    - id: FoodMeatXeno
+      amount: 1
+
   # Ghost role stuff
   - type: GhostRole
     allowMovement: true
@@ -590,6 +630,9 @@
   - type: Butcherable
     spawned:
     - id: SpawnDungeonLootNpcArgocyteSmall
+      amount: 1
+    biomassReclaimerOverride:
+    - id: FoodMeatXeno
       amount: 1
   - type: NPCImprintingOnSpawnBehaviour
     whitelist:

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_carp.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_carp.yml
@@ -9,6 +9,9 @@
     spawned:
     - id: SpawnDungeonLootNpcCarps
       amount: 1
+    biomassReclaimerOverride:
+    - id: FoodMeatFish
+      amount: 1
 
 #region Carps
 - type: entity

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_dinosaurs.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_dinosaurs.yml
@@ -114,6 +114,9 @@
     spawned:
     - id: SpawnDungeonLootNpcDinosaurCompy
       amount: 1
+    biomassReclaimerOverride:
+    - id: FoodMeat
+      amount: 1
 
 # region dilophosaurus
 - type: entity
@@ -150,6 +153,9 @@
   - type: Butcherable
     spawned:
     - id: SpawnDungeonLootNpcDinosaurDilo
+      amount: 1
+    biomassReclaimerOverride:
+    - id: FoodMeat
       amount: 1
 
 # region velociraptor
@@ -195,6 +201,9 @@
     spawned:
     - id: SpawnDungeonLootNpcDinosaurRaptor
       amount: 1
+    biomassReclaimerOverride:
+    - id: FoodMeat
+      amount: 1
 
 # region parasaurolophus
 - type: entity
@@ -238,6 +247,9 @@
   - type: Butcherable
     spawned:
     - id: SpawnDungeonLootNpcDinosaurPara
+      amount: 1
+    biomassReclaimerOverride:
+    - id: FoodMeat
       amount: 1
 
 # region kentrosaurus
@@ -283,6 +295,9 @@
     spawned:
     - id: SpawnDungeonLootNpcDinosaurKentro
       amount: 1
+    biomassReclaimerOverride:
+    - id: FoodMeat
+      amount: 1
 
 # region triceratops
 - type: entity
@@ -326,6 +341,9 @@
   - type: Butcherable
     spawned:
     - id: SpawnDungeonLootNpcDinosaurTrike
+      amount: 1
+    biomassReclaimerOverride:
+    - id: FoodMeat
       amount: 1
 
 # region ankylosaurus
@@ -371,6 +389,9 @@
     spawned:
     - id: SpawnDungeonLootNpcDinosaurAnki
       amount: 1
+    biomassReclaimerOverride:
+    - id: FoodMeat
+      amount: 1
 
 # region spinosaurus
 - type: entity
@@ -414,6 +435,9 @@
   - type: Butcherable
     spawned:
     - id: SpawnDungeonLootNpcDinosaurSpino
+      amount: 1
+    biomassReclaimerOverride:
+    - id: FoodMeat
       amount: 1
 
 # region stegosaurus
@@ -460,6 +484,9 @@
     spawned:
     - id: SpawnDungeonLootNpcDinosaurStego
       amount: 1
+    biomassReclaimerOverride:
+    - id: FoodMeat
+      amount: 1
 
 #region tyrannosaurus (boss)
 - type: entity
@@ -505,6 +532,10 @@
     spawned:
     - id: SpawnDungeonLootNpcDinosaurTrex
       amount: 1
+    biomassReclaimerOverride:
+    - id: FoodMeat
+      amount: 1
+
   # Ghost role stuff
   - type: GhostRole
     allowMovement: true

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_xeno.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_xeno.yml
@@ -9,6 +9,9 @@
     spawned:
     - id: SpawnDungeonLootNpcXenoBurrower
       amount: 1
+    biomassReclaimerOverride:
+    - id: FoodMeatXeno
+      amount: 1
 
 - type: entity
   parent: [MobStaminaFodder, MobMovementSpeedModifierMelee, NFMobSimpleHostileBase, MobXenoPraetorian]
@@ -20,6 +23,9 @@
     butcheringType: Knife
     spawned:
     - id: SpawnDungeonLootNpcXenoPraetorian
+      amount: 1
+    biomassReclaimerOverride:
+    - id: FoodMeatXeno
       amount: 1
 
 - type: entity
@@ -33,6 +39,9 @@
     spawned:
     - id: SpawnDungeonLootNpcXenoDrone
       amount: 1
+    biomassReclaimerOverride:
+    - id: FoodMeatXeno
+      amount: 1
 
 - type: entity
   parent: [MobHostileBossBase, NFMobSimpleHostileBase, MobXenoQueen]
@@ -44,6 +53,9 @@
     butcheringType: Knife
     spawned:
     - id: SpawnDungeonLootNpcXenoQueen
+      amount: 1
+    biomassReclaimerOverride:
+    - id: FoodMeatXeno
       amount: 1
   - type: ReplacementAccent
     accent: xeno
@@ -72,6 +84,9 @@
     spawned:
     - id: SpawnDungeonLootNpcXenoRavager
       amount: 1
+    biomassReclaimerOverride:
+    - id: FoodMeatXeno
+      amount: 1
 
 - type: entity
   parent: [MobStaminaSpecial, MobMovementSpeedModifierSpecial, NFMobSimpleHostileBase, MobXenoRunner]
@@ -83,6 +98,9 @@
     butcheringType: Knife
     spawned:
     - id: SpawnDungeonLootNpcXenoRavager
+      amount: 1
+    biomassReclaimerOverride:
+    - id: FoodMeatXeno
       amount: 1
 
 - type: entity
@@ -96,6 +114,9 @@
     spawned:
     - id: SpawnDungeonLootNpcXenoRavager
       amount: 1
+    biomassReclaimerOverride:
+    - id: FoodMeatXeno
+      amount: 1
 
 - type: entity
   parent: [MobStaminaFodder, MobMovementSpeedModifierRanged, NFMobSimpleHostileBase, MobXenoSpitter]
@@ -107,6 +128,9 @@
     butcheringType: Knife
     spawned:
     - id: SpawnDungeonLootNpcXenoSpitter
+      amount: 1
+    biomassReclaimerOverride:
+    - id: FoodMeatXeno
       amount: 1
 
 - type: entity

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_zombies.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_zombies.yml
@@ -70,6 +70,9 @@
     spawned:
     - id: NFSpawnZombieLoot
       amount: 1
+    biomassReclaimerOverride:
+    - id: FoodMeatRotten
+      amount: 1
   - type: Bloodstream
     bloodReagent: ZombieBlood
     bloodMaxVolume: 250
@@ -476,6 +479,9 @@
   - type: Butcherable
     spawned:
     - id: NFSpawnZombieLoot
+      amount: 1
+    biomassReclaimerOverride:
+    - id: FoodMeatRotten
       amount: 1
     - id: ClothingShoesClownModKetchup
       amount: 1


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Fixes an oversight where the biomass reclaimer would drop items from mob loot tables while grinding them down, including head trophies and other high value sellables. In the case of high density mobs like xeno queens, this could lead to them dropping their head many, many times.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
If I were to put you in a meat grinder, and the only thing that came out was your head. And your head. And your head. And your head. The economy would probably be dead. (This is unintentional and makes biomassing a single mob give upwards of 100k in loot)

## Technical details
<!-- Summary of code changes for easier review. -->
Biomass reclaimer usually pulls from the butchered loot table of mobs and randomly chucks out those items as a little extra flair while grinding them. This should just be meat. In our case, the butcher loot table drops multiple high value items. On top of this, the processing time is based on the density of the mob, which causes super heavy mobs like xeno queens to process for a long time and thus spew a lot of loot.
Adds a new nullable field to butcherable component, BiomassReclaimerOverride, which takes an entity spawner list.
Adds a check in the biomass reclaimer system to use the entity spawner list from the override field instead of the normal butchering loot field if it is present.
Adds an override to mobs which a) can be biomassed and b) have a unique drop table on butchering. This override is usually 1 corresponding meat item (meat, xeno meat or rotten meat).

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
Spawn some xeno queens and some biomassers. Kill them and shove them in. Wait until you see some meat fly out.
Either use the vvwrite command to set BiomassReclaimerOverride in an xeno queen's butcherable component to null, or edit the NF xeno queen prototype and remove the BiomassReclaimerOverride field. Blend a queen and watch it go back to spawning multiple heads.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [ ] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
