### PR TITLE
Give xenoborg modules their weapons back

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -1653,8 +1653,8 @@
     - state: icon-xenoborg-laser
   - type: ItemBorgModule
     moduleId: XenoborgLaser # Frontier
-    hands: [] # Frontier: empty set
-    # - item: XenoborgLaserGun # Frontier
+    hands: # Frontier
+    - item: NFXenoborgLaserGun # Frontier XenoborgLaserGun<NFXenoborgLaserGun
   - type: BorgModuleIcon
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: xenoborg-laser-module }
 
@@ -1670,8 +1670,8 @@
     - state: icon-xenoborg-laser2
   - type: ItemBorgModule
     moduleId: XenoborgLaserHeavy # Frontier
-    hands: [] # Frontier
-    # - item: XenoborgHeavyLaserGun # Frontier
+    hands: # Frontier
+    - item: NFXenoborgHeavyLaserGun # Frontier XenoborgHeavyLaserGun<NFXenoborgHeavyLaserGun
   - type: BorgModuleIcon
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: xenoborg-laser2-module }
 

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -1653,7 +1653,7 @@
     - state: icon-xenoborg-laser
   - type: ItemBorgModule
     moduleId: XenoborgLaser # Frontier
-    hands: # Frontier
+    hands:
     - item: NFXenoborgLaserGun # Frontier XenoborgLaserGun<NFXenoborgLaserGun
   - type: BorgModuleIcon
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: xenoborg-laser-module }
@@ -1670,7 +1670,7 @@
     - state: icon-xenoborg-laser2
   - type: ItemBorgModule
     moduleId: XenoborgLaserHeavy # Frontier
-    hands: # Frontier
+    hands:
     - item: NFXenoborgHeavyLaserGun # Frontier XenoborgHeavyLaserGun<NFXenoborgHeavyLaserGun
   - type: BorgModuleIcon
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: xenoborg-laser2-module }

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Battery/upstream_redefinitions.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Battery/upstream_redefinitions.yml
@@ -6,3 +6,12 @@
   - type: HitscanBatteryAmmoProvider
     proto: NFRedMediumLaser
 
+- type: entity
+  name: xenoborg laser gun
+  parent: XenoborgLaserGun
+  id: NFXenoborgLaserGun
+
+- type: entity
+  name: xenoborg heavy laser gun
+  parent: XenoborgHeavyLaserGun
+  id: NFXenoborgHeavyLaserGun


### PR DESCRIPTION
## About the PR
NyuVT reported that the Heavy Xenoborg does not have guns on their weapon modules. This fixes that.

## Why / Balance
Admeme. Currently these are only spawnable by an admin. If they don't want them to have weapons, take the module away.

## Technical details
Created 'NF' variants of the existing Xenoborg lasers (which change nothing other than what was already tweaked). Updated the modules to use the NF variant of the lasers.

## How to test
Spawn a heavy Xenoborg
Take control
Switch to weapon module
Pew! Pew!

Optionally install the xenoborg heavy laser weapon module and check it out.

## Media
<img width="306" height="451" alt="image" src="https://github.com/user-attachments/assets/932a3183-c517-48ba-800c-a935c68096f1" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Pi_Masta
- fix: Xenoborg weapon modules now function. Don't worry it's only for self defense.