### PR TITLE
Fix inconsistent animal breeding behavior

### DIFF
--- a/Content.Server/Nutrition/EntitySystems/AnimalHusbandrySystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/AnimalHusbandrySystem.cs
@@ -73,6 +73,9 @@ public sealed class AnimalHusbandrySystem : EntitySystem
         var partners = new HashSet<Entity<ReproductivePartnerComponent>>();
         _entityLookup.GetEntitiesInRange(xform.Coordinates, component.BreedRange, partners);
 
+        // Frontier - Exclude any breeding partners that aren't breedable partners anyway
+        partners.RemoveWhere(partner => !_whitelistSystem.IsWhitelistPass(component.PartnerWhitelist, partner) || _mobState.IsIncapacitated(partner));
+
         if (partners.Count >= component.Capacity)
             return false;
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
I fixed an invisible but constant problem with animal husbandry.
While animal husbandry has been around for a long time, it's been acknowledged that something's broken in it.  I figured out what's been broken and fixed it.
Let's discuss how this all works:

For an animal to breed, it must satisfy the following requirements:

- Not gestating
- Not an infant
- Not dead
- Hunger at or above 'okay' satiation
- Thirst at or above 'okay' satiation

If these check out, it rolls a check based on its probability, defined in its ReproductiveComponent.  If it succeeds, it attempts to breed.
It checks in a radius around itself (based on the reproductivecomponent's range, typically 3 tiles) for all entities with the ReproductivePartner component.  If the number of ReproductivePartners exceeds its defined Capacity (6 in most cases here; normally chickens have a capacity of like 12 on other forks), it stops its breeding attempt as this defines its population cap.
However, this **didn't** actually check for _valid reproductive partners_.  So, let's take a small example of what's been happening up to this point.
Say you have two cows and two chickens penned near each other.  You feed the chickens, and eventually they make two more chickens.  Great, they'll eventually be a box of chicken nuggets sold out of your Skipper.
You also feed your cows, but they don't ever make a new cow.  This is because the **chickens count against the cows'  population limit**.  That doesn't make a whole lot of sense.  So, after a while, you notice none of your animals are breeding anymore.  Behind the scenes, this is because both the  cows and chickens have reached their capacity (the 4 chickens are blocked from breeding up to their 6 capacity because they count the two cows as part of their capacity limit; the 2 cows are in the same situation but in reverse).
You suspect maybe you have too many animals.  You kill a couple of chickens, but leave them in the pen for now.  Your chickens and cows _are still not breeding_, because even dead animals count against this capacity check.

This made the breeding system very confusing and appear broken most of the time.  I've gone ahead and fixed this issue.   Now, when a creature is checking for nearby breeding partners, it filters out any creatures that are dead or aren't on its breeding partner whitelist.  So, cows only check cows for their population limit.  Chickens only check chickens.  And the like.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Many ships, like the Ceres, provide enough resources to make pairs of animals.  It's safe to assume there's an expectation for animal husbandry to make more animals.  More pigs become more bacon.  More cows and goats can become more meat (or more milk).  More chickens become more boxes of chicken nuggets.
It's been really annoying having to rely on the biogenerator to make my meat; I'd like to have the  option to have a few pens of livestock on my ship to work with for satisfying meat demands.  Biomassmaxxing will probably still happen as it's an incredibly versatile machine, but now  we have a more realistic option to move our meat production burden to the animal husbandry system.

## Technical details
<!-- Summary of code changes for easier review. -->
In AnimalHusbandrySystem, a simple filter was added when trying to reproduce to filter out any non-relevant or dead creatures as potential breeding partners to avoid running into arbitrary and invisible restrictions. 

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
Make several pens with a pair of different livestock creatures in each.  Feed and water them, and wait a while for them to breed.  Keep them fed as time goes on.  You should eventually reach a healthy number of livestock in these pens (at or around the Capacity set by  the ReproductiveComponent of the creature).

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="1187" height="927" alt="image" src="https://github.com/user-attachments/assets/39500b10-e582-43bf-bf14-82673499173f" />
Image shown is several pens in a rearranged hydroponics room on the Ceres.  Each pen started with two creatures in each, and they were continually supplied with food and drink until they all reached population caps for their own species (there are seven  pigs, this is because two pigs began gestating  near the same time when the population count was 5  in their pen).

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**

:cl: Sparlight
- fix:  Animals no longer arbitrarily stop breeding unexpectedly after a little while.
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
