### PR TITLE
Use non-throwing ways of reading loadout groups

### DIFF
--- a/Content.Client/Lobby/UI/Loadouts/LoadoutGroupContainer.xaml.cs
+++ b/Content.Client/Lobby/UI/Loadouts/LoadoutGroupContainer.xaml.cs
@@ -302,7 +302,7 @@ public sealed partial class LoadoutGroupContainer : BoxContainer
     /// <returns>A fully initialized LoadoutContainer for UI display.</returns>
     private LoadoutContainer CreateLoadoutUI(LoadoutPrototype proto, HumanoidCharacterProfile profile, RoleLoadout loadout, ICommonSession session, IDependencyCollection collection, LoadoutSystem loadoutSystem)
     {
-        var selected = loadout.SelectedLoadouts[_groupProto.ID];
+        var selected = loadout.SelectedLoadouts.GetValueOrDefault(_groupProto.ID, new()); // Frontier: indexer<GetValueOrDefault
 
         var pressed = selected.Any(e => e.Prototype == proto.ID);
 

--- a/Content.Shared/Preferences/Loadouts/RoleLoadout.cs
+++ b/Content.Shared/Preferences/Loadouts/RoleLoadout.cs
@@ -397,7 +397,7 @@ public sealed partial class RoleLoadout : IEquatable<RoleLoadout>
     /// </summary>
     public bool AddLoadout(ProtoId<LoadoutGroupPrototype> selectedGroup, ProtoId<LoadoutPrototype> selectedLoadout, IPrototypeManager protoManager)
     {
-        var groupLoadouts = SelectedLoadouts[selectedGroup];
+        var groupLoadouts = SelectedLoadouts.GetOrNew(selectedGroup); // Frontier: indexer<GetOrNew
 
         // Need to unselect existing ones if we're at or above limit
         var limit = Math.Max(0, groupLoadouts.Count + 1 - protoManager.Index(selectedGroup).MaxLimit);
@@ -438,7 +438,7 @@ public sealed partial class RoleLoadout : IEquatable<RoleLoadout>
     {
         // Although this may bring us below minimum we'll let EnsureValid handle it.
 
-        var groupLoadouts = SelectedLoadouts[selectedGroup];
+        var groupLoadouts = SelectedLoadouts.GetOrNew(selectedGroup); // Frontier: indexer<GetOrNew
 
         for (var i = 0; i < groupLoadouts.Count; i++)
         {


### PR DESCRIPTION
## About the PR
Wherever the game reads from `RoleLoadout.SelectedLoadouts`, use non-throwing methods, either `GetOrNew()` (which mutates the dictionary) or `GetValueOrDefault()` (which does not).

## Why / Balance
When we add loadout groups, every existing character loadout lacks the new group. If you've customised your loadout for any role at all, there's a high chance the loadout window will throw an exception as it tries to read from a dictionary key that doesn't exist in the database. Rather than do expensive-ish prototype lookups when constructing loadout data, I opted for a lenient read: if it exists, use it; otherwise, default it.

## Technical details
Literally just C# this time. Probably don't need to write more than the above.

## How to test
I genuinely don't know how to test this properly, as the loadout window very annoyingly seems *not* to want to crash in development.

## Media
N/A

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes
Nope.

**Changelog**
Small fix, doesn't seem super worth highlighting.