### PR TITLE
Longer Cassette tapes

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Objects/Devices/tape_recorder.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Devices/tape_recorder.yml
@@ -14,6 +14,7 @@
   - type: Item
     size: Small
   - type: TapeRecorder
+    rewindSpeed: 5 # Frontier add rewindSpeed
   - type: ActiveListener
     range: 4
   - type: UseDelay
@@ -76,7 +77,7 @@
   parent: BaseItem
   id: CassetteTape
   name: cassette tape
-  description: A magnetic tape that can hold up to two minutes of content on either side.
+  description: A magnetic tape that can hold up to ten minutes of content on either side. # Frontier two<ten
   components:
   - type: Sprite
     sprite: _DV/Objects/Devices/cassette_tapes.rsi
@@ -90,7 +91,7 @@
     size: Tiny
   - type: Damageable
   - type: TapeCassette
-    maxCapacity: 180
+    maxCapacity: 600 # Frontier 180<600
     repairWhitelist:
       tags:
       - Screwdriver


### PR DESCRIPTION
## About the PR
Bumped the length a single cassette tape can record to 10 minutes (was 3). Also increased the rewind speed of the recorder from 3 to 5 which means a 10 minute cassette tape will take 2 minutes to rewind (without this bump it would be over 3 minutes). Originally a 3 minute tape took 1 minute to rewind.

## Why / Balance
Things move kind a slow on Frontier. A person who RPs a reporter lamented about how short the tapes last. Especially as they use them for interviews which typically last much longer than 3 minutes. Honestly 10 minutes might not be enough but we can always come back and bump the number if we want.

In a future where we can heal bullet wounds with chemicals and bluespace teleport things around is a 10 minute cassette tape that much of a stretch?

## Technical details
Straightforward YML changes to the cassette tape and recorder.

## How to test
* Spawn a tape recorder, preferably filled with a cassette tape
* inspect the cassette tape and notice the description says it lasts 10 minutes
* record on the tape, say silly things, give yourself rads and spawn a medibot that won't shut up. Spawn anything that can 'talk' figurines, and vending machines
* After 10 minutes the recorder stops
* Print the transcript, scroll to bottom notice the time stamp ends right around the 10 minute mark.

Not sure where to put this, but my main concern with upping the length is the potential lag from the amount of data that could theoretically be put on a 10 minute cassette tape. It records every speech that could be heard including vending machines and probably even other recorders playing back. I spammed some long text for 10 minutes with vending machines around me. Didn't notice any lag. The only lag was when I looked at the transcript (not when printing, but looking). I doubt the paper UI was designed to handle the quantity of text I threw at it, but it was also an extreme case. I was surprised the network monitor never went much above 128kbps. I'm not sure how the engine serializes additions to a list, I would presume it sends the entire list every time, but probably breaks those messages up to keep under a network threshold.

## Media
<img width="2092" height="852" alt="Screenshot 2026-07-13 151307" src="https://github.com/user-attachments/assets/c9968e19-6db5-44fb-99b4-44ad0db8b26a" />
<img width="2053" height="902" alt="image" src="https://github.com/user-attachments/assets/edb894b0-d7bf-4f32-9ae9-ed422456095c" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Pi_Masta
- tweak: Advances have now led to cassette tapes that record for an entire 10 minutes! (was 3)
- tweak: Tape recorders have had their rewind speed slightly increased to account for the larger tapes

