### PR TITLE
Make detective roundstart

### DIFF
--- a/Resources/Prototypes/_NF/PointsOfInterest/nfsd.yml
+++ b/Resources/Prototypes/_NF/PointsOfInterest/nfsd.yml
@@ -45,7 +45,7 @@
             Bailiff: [ 1, 1 ]
             SeniorOfficer: [ 1, 1 ]
             Brigmedic: [ 0, 0 ]
-            NFDetective: [ 0, 0 ]
+            NFDetective: [ 1, 1 ]
             Deputy: [ 3, 3 ]
             Cadet: [ 0, 0 ]
             # Others:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Allow one detective to spawn roundstart, without a sheriff.

## Why / Balance
Reduction of command reliance; we already give NFSD a forensics module on the outpost, if we trust deputies to not invalidate the smuggling gameplay loop a detective should be fine too. 

## Technical details
Barely even yml.

## How to test
Start in release mode, observe detective spawn being available, maybe even join in as one. Alternatively golobby -> setgamepreset NFAdventure -> spawn in -> check NFSDO station records -> observe detective having a slot open

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ X ] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X ] I have added media to this PR or it does not require an ingame showcase.
- [ X ] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None.

**Changelog**
:cl:
- tweak: One detective may now join at roundstart without sheriff involvement. Dark corners to brood in not included.
