### PR TITLE
Fix red altar construction path

### DIFF
--- a/Resources/Prototypes/_NF/Recipes/Construction/Graphs/furniture/altars.yml
+++ b/Resources/Prototypes/_NF/Recipes/Construction/Graphs/furniture/altars.yml
@@ -62,7 +62,7 @@
       conditions:
       - !type:EntityAnchored {}
       steps:
-      - component: FireExtinguisher
+      - tag: FireExtinguisher
         name: construction-graph-component-fire-extinguisher
         store: altar_component
         icon:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Red altar wants FireExtinguisherComponent on it's step; there is no FireExtinguisherComponent marker or otherwise. There is a FireExtinguisher tag, so we use the tag, even though they're evil cause it already exists.

## Why / Balance
Bugs should be fixed.

## Technical details
Barely even yml

## How to test
Try constructing the red altar. Should accept pocket, regular and bluespace versions. Not scrap.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ X ] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X ] I have added media to this PR or it does not require an ingame showcase.
- [ X ] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None