### PR TITLE
Material silos/lathes no longer void materials when destroyed

### DIFF
--- a/Content.Server/Materials/MaterialStorageSystem.cs
+++ b/Content.Server/Materials/MaterialStorageSystem.cs
@@ -13,8 +13,8 @@ using Robust.Shared.Audio.Systems;
 using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
 using Content.Server.Storage.Components; // Frontier
-using Content.Shared.Cargo;
-using Content.Shared.Destructible; // Frontier
+using Content.Shared.Cargo; // Frontier
+using Content.Shared.Destructible; //Frontier
 
 namespace Content.Server.Materials;
 
@@ -35,11 +35,12 @@ public sealed class MaterialStorageSystem : SharedMaterialStorageSystem
         base.Initialize();
         SubscribeLocalEvent<MaterialStorageComponent, MachineDeconstructedEvent>(OnDeconstructed);
         SubscribeLocalEvent<MaterialStorageComponent, PriceCalculationEvent>(OnPriceCalculation); // Frontier
-        SubscribeLocalEvent<MaterialStorageComponent, DestructionEventArgs>(OnDestroyed);
+        SubscribeLocalEvent<MaterialStorageComponent, DestructionEventArgs>(OnDestroyed); // Frontier
 
         SubscribeAllEvent<EjectMaterialMessage>(OnEjectMessage);
     }
 
+    //Start Frontier: Ensure silos drop their mats when destroyed
     private void OnDestroyed(EntityUid uid, MaterialStorageComponent component, DestructionEventArgs eventArgs)
     {
         if (!component.DropOnDeconstruct)
@@ -58,6 +59,7 @@ public sealed class MaterialStorageSystem : SharedMaterialStorageSystem
         }
 
     }
+    //End Frontier
 
     private void OnDeconstructed(EntityUid uid, MaterialStorageComponent component, MachineDeconstructedEvent args)
     {

--- a/Content.Server/Materials/MaterialStorageSystem.cs
+++ b/Content.Server/Materials/MaterialStorageSystem.cs
@@ -13,7 +13,8 @@ using Robust.Shared.Audio.Systems;
 using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
 using Content.Server.Storage.Components; // Frontier
-using Content.Shared.Cargo; // Frontier
+using Content.Shared.Cargo;
+using Content.Shared.Destructible; // Frontier
 
 namespace Content.Server.Materials;
 
@@ -34,8 +35,28 @@ public sealed class MaterialStorageSystem : SharedMaterialStorageSystem
         base.Initialize();
         SubscribeLocalEvent<MaterialStorageComponent, MachineDeconstructedEvent>(OnDeconstructed);
         SubscribeLocalEvent<MaterialStorageComponent, PriceCalculationEvent>(OnPriceCalculation); // Frontier
+        SubscribeLocalEvent<MaterialStorageComponent, DestructionEventArgs>(OnDestroyed);
 
         SubscribeAllEvent<EjectMaterialMessage>(OnEjectMessage);
+    }
+
+    private void OnDestroyed(EntityUid uid, MaterialStorageComponent component, DestructionEventArgs eventArgs)
+    {
+        if (!component.DropOnDeconstruct)
+            return;
+
+        if (TryComp<MaterialStorageMagnetPickupComponent>(uid, out var magnet))
+        {
+            //If we don't do this, then the silo will instantly suck up all the materials before being promptly deleted
+            //Guess how we found that out :)
+            magnet.MagnetEnabled = false;
+        }
+
+        foreach (var (material, amount) in component.Storage)
+        {
+            SpawnMultipleFromMaterial(amount, material, Transform(uid).Coordinates);
+        }
+
     }
 
     private void OnDeconstructed(EntityUid uid, MaterialStorageComponent component, MachineDeconstructedEvent args)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Material silos/lathes will now drop all stored materials when they are destroyed, as well as if they are deconstructed with tools.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It feels like a bug, and losing hours of effort just because of a stray lighting bolt/explosive/cannonball just feels bad.`

## Technical details
<!-- Summary of code changes for easier review. -->
Server side `MaterialStorageSystem` now listens for `DestructionEventArgs` event, and upon receiving it, will dump materials identically to if it was deconstructed. It also disables the magnet before dumping, because if you don't, all the mats are instantly sucked back into the silo, just before the silo is deleted, alongside all contained mats. 

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
Spawn into dev env
Acquire throngler
Bash the material silo near spawn until it breaks
You should see a pile of materials appear on top of the destroyed machine

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Material silos will now drop their contents when they are destroyed. 