### PR TITLE
Grounding Rod Price Fix

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_engines.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_engines.yml
@@ -122,6 +122,6 @@
     sprite: Structures/Power/Generation/Tesla/coil.rsi
     state: grounding_rod
   product: CrateEngineeringTeslaGroundingRod
-  cost: 1000 # Frontier - set to 1000, original price 400
+  cost: 4250 # Frontier - set to 4250, original price 400
   category: cargoproduct-category-name-engineering
   group: market

--- a/Resources/Prototypes/Catalog/Fills/Crates/engines.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/engines.yml
@@ -172,3 +172,6 @@
   - type: StorageFill
     contents:
       - id: TeslaGroundingRodFlatpack
+      - id: TeslaGroundingRodFlatpack
+      - id: TeslaGroundingRodFlatpack
+      - id: TeslaGroundingRodFlatpack

--- a/Resources/Prototypes/Catalog/Fills/Crates/engines.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/engines.yml
@@ -172,6 +172,6 @@
   - type: StorageFill
     contents:
       - id: TeslaGroundingRodFlatpack
-      - id: TeslaGroundingRodFlatpack
-      - id: TeslaGroundingRodFlatpack
-      - id: TeslaGroundingRodFlatpack
+      - id: TeslaGroundingRodFlatpack # Frontier
+      - id: TeslaGroundingRodFlatpack # Frontier
+      - id: TeslaGroundingRodFlatpack # Frontier

--- a/Resources/Prototypes/Entities/Objects/Devices/flatpack.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/flatpack.yml
@@ -180,7 +180,7 @@
     layers:
     - state: grounding-rod
   - type: StaticPrice
-    price: 40
+    price: 40 # Frontier
   - type: GuideHelp
     guides:
     - TeslaEngine

--- a/Resources/Prototypes/Entities/Objects/Devices/flatpack.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/flatpack.yml
@@ -179,6 +179,8 @@
   - type: Sprite
     layers:
     - state: grounding-rod
+  - type: StaticPrice
+    price: 40
   - type: GuideHelp
     guides:
     - TeslaEngine


### PR DESCRIPTION
## About the PR
Changed the cost of a grounding rod flatpack from a flatpack vend to 1000 spesos.
Changed the cargo box to have four grounding rod flatpacks, and to cost 4250 spesos.

## Why / Balance
It makes zero sense that a flatpack from the vend costs 6000+ spesos, when a box containing a flatpack costs 1000 spesos. Furthermore, it makes zero sense to have to buy four crates of one flatpack, when there is enough room in a crate for all four. For zesty spice, the crate from the cargo bay has a 250 speso upcharge, for convenience or something.

## Technical details
Added a price to the grounding rod flatpack entry.
Changed the amount of flatpacks in a crate to four.
Changed the price of the grounding rod crate to 4250.

## How to test

1. Go to a flatpack vend
2. Observe your vastly cheaper single grounding rod flatpack
3. Purchase
4. Go to a cargo sale console
5. Observe your more expensive grounding rod crate
6. Purchase
7. Open the crate, notice the four grounding rods!

## Media
<img width="390" height="338" alt="image" src="https://github.com/user-attachments/assets/7f0c912c-18f5-4c0d-83cb-16d96f61bc64" />
<img width="599" height="166" alt="image" src="https://github.com/user-attachments/assets/ae1fc433-254f-4d78-bab5-33cceb24658f" />
<img width="362" height="138" alt="image" src="https://github.com/user-attachments/assets/b94c9648-e273-47a1-b0bb-5f619388b9d4" />


## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes
Should be no breaking changes!

**Changelog**
:cl:
- tweak: Changed the grounding rod crates to have four instead of one
- tweak: Changed the grounding rod flatpacks and crates to have consistent pricing
