### PR TITLE
Remove GITHUB_TOKEN from changelog validation env

### DIFF
--- a/.github/workflows/nf-validate-changelog.yml
+++ b/.github/workflows/nf-validate-changelog.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     types: [opened, edited, reopened, synchronize]
 
-env:
-  GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
-
 jobs:
   validate-changelog:
     name: Changelog validator


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Removes `GITHUB_TOKEN` from the env passed to the changelog validator.

## Why / Balance
A maliciously crafted `validate_changelog.js` from just about anyone could steal the token. Upon reviewing the script, I realised the token was completely unnecessary, so I simply removed it.

## Technical details
Tiny YAML change. :)

## How to test
I don't really know how to test this properly. Make sure the changelog validator still works? But it runs only on GitHub, so...

## Media
N/A

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes
None.

**Changelog**
no