### PR TITLE
Shuttle (Proposed Tweak): NSF Hypnos

### DIFF
--- a/Resources/Maps/_NF/Shuttles/Nfsd/hypnos.yml
+++ b/Resources/Maps/_NF/Shuttles/Nfsd/hypnos.yml
@@ -2419,6 +2419,8 @@ entities:
     - type: Transform
       pos: 6.5,-0.5
       parent: 1
+    - type: FuelGenerator
+      targetPower: 45000
 - proto: PosterContrabandHackingGuide
   entities:
   - uid: 474


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

> The Hypnos struggles to bring itself back from a powered down state due to the power draw on the EMP charging. The generator can be changed to 45kw to combat this 
- @inaraincoat 

Proposed change by InaRaincoat to up default power generation from default SUPERPACMAN to 45kW.
I am acting as the implementer of the proposed change.

Changes only default Target Power, and nothing else.

## Why / Balance
Quoted in About section.

## Technical details
adds a fuel generator component to the generator.

## How to test
Spawn a Hypnos, it SHOULD start with the generator set to 45kW.

## Media
MEDIA NOT INCLUDED

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**