### PR TITLE
Make vehicles upgradable (and refactor part exchanger system, oops)

### DIFF
--- a/Content.Client/_NF/Vehicle/EntitySystems/VehicleSystem.cs
+++ b/Content.Client/_NF/Vehicle/EntitySystems/VehicleSystem.cs
@@ -4,7 +4,7 @@ using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
 using Robust.Shared.Graphics.RSI;
 
-namespace Content.Client._NF.Vehicles;
+namespace Content.Client._NF.Vehicle.EntitySystems;
 
 // Rewritten from Goobstation's VehicleSystem.
 public sealed class VehicleSystem : SharedVehicleSystem

--- a/Content.Client/_NF/Vehicle/EntitySystems/VehicleUpgradeSystem.cs
+++ b/Content.Client/_NF/Vehicle/EntitySystems/VehicleUpgradeSystem.cs
@@ -1,0 +1,6 @@
+using Content.Shared._NF.Vehicle.EntitySystems;
+
+namespace Content.Client._NF.Vehicle.EntitySystems;
+
+public sealed class VehicleUpgradeSystem : SharedVehicleUpgradeSystem
+{ }

--- a/Content.Server/Construction/Components/MachineFrameComponent.cs
+++ b/Content.Server/Construction/Components/MachineFrameComponent.cs
@@ -4,7 +4,6 @@ using Content.Shared.Stacks;
 using Content.Shared.Tag;
 using Robust.Shared.Containers;
 using Robust.Shared.Prototypes;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Dictionary; // Frontier: upgradeable machine parts
 
 namespace Content.Server.Construction.Components
 {

--- a/Content.Server/_NF/Construction/Components/PartExchangerSystem.cs
+++ b/Content.Server/_NF/Construction/Components/PartExchangerSystem.cs
@@ -17,6 +17,9 @@ using Robust.Shared.Collections;
 using Robust.Shared.Prototypes;
 using Content.Shared.Stacks;
 using Content.Shared.Construction.Prototypes;
+using Content.Shared.Verbs;
+using Content.Shared._NF.Vehicle.Components;
+using Content.Server._NF.Vehicle.EntitySystems;
 
 namespace Content.Server._NF.Construction;
 
@@ -29,297 +32,33 @@ public sealed class PartExchangerSystem : EntitySystem
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly StorageSystem _storage = default!;
     [Dependency] private readonly StackSystem _stack = default!;
+    [Dependency] private readonly VehicleUpgradeSystem _upgradableVehicle = default!;
+
+    private const string UpgradeIconPath = "/Textures/Interface/VerbIcons/pickup.svg.192dpi.png";
 
     /// <inheritdoc/>
     public override void Initialize()
     {
         SubscribeLocalEvent<PartExchangerComponent, AfterInteractEvent>(OnAfterInteract);
         SubscribeLocalEvent<PartExchangerComponent, ExchangerDoAfterEvent>(OnDoAfter);
+
+        SubscribeLocalEvent<VehicleUpgradeComponent, GetVerbsEvent<InteractionVerb>>(OnGetVehicleInteractionVerbs);
     }
 
     private struct UpgradePartState
     {
         public MachinePartComponent Part;
         public StackComponent? Stack;
-        public bool InContainer;
+        public bool InExchanger;
     }
 
-    private void OnDoAfter(EntityUid uid, PartExchangerComponent component, DoAfterEvent args)
+    private struct UpgradeStepCallbacks
     {
-        if (args.Cancelled)
-        {
-            component.AudioStream = _audio.Stop(component.AudioStream);
-            return;
-        }
-
-        if (args.Handled || args.Args.Target == null)
-            return;
-
-        if (!TryComp<StorageComponent>(uid, out var storage) || storage.Container == null)
-            return;
-
-        var partsByType = new Dictionary<ProtoId<MachinePartPrototype>, List<(EntityUid, UpgradePartState)>>();
-
-        // Insert the contained parts into a dictionary for indexing.
-        // Note: these parts remain in the starting container.
-        foreach (var item in storage.Container.ContainedEntities)
-        {
-            if (_construction.GetMachinePartState(item, out var partState))
-            {
-                UpgradePartState upgrade;
-                upgrade.Part = partState.Part;
-                upgrade.Stack = partState.Stack;
-                upgrade.InContainer = true;
-
-                var partType = upgrade.Part.PartType;
-                if (!partsByType.ContainsKey(partType))
-                    partsByType[partType] = new List<(EntityUid, UpgradePartState)>();
-                partsByType[partType].Add((item, upgrade));
-            }
-        }
-
-        // Exchange machine parts with the machine or frame.
-        if (TryComp<MachineComponent>(args.Args.Target.Value, out var machine))
-            TryExchangeMachineParts(machine, args.Args.Target.Value, uid, partsByType, component.PreferHigherRating);
-        else if (TryComp<MachineFrameComponent>(args.Args.Target.Value, out var machineFrame))
-            TryConstructMachineParts(machineFrame, args.Args.Target.Value, uid, partsByType, component.PreferHigherRating);
-
-        args.Handled = true;
+        public Action<UpgradePartState>? OnPartRemovedFromTarget;
+        public Action<MachinePartState>? OnPartInsertedIntoTarget;
     }
 
-    private void TryExchangeMachineParts(MachineComponent machine, EntityUid uid, EntityUid storageUid, Dictionary<ProtoId<MachinePartPrototype>, List<(EntityUid part, UpgradePartState state)>> partsByType, bool preferHigherRating)
-    {
-        var board = machine.BoardContainer.ContainedEntities.FirstOrNull();
-
-        if (board == null || !TryComp<MachineBoardComponent>(board, out var macBoardComp))
-            return;
-
-        // Add all components in the machine to form a complete set of available components.
-        foreach (var item in new ValueList<EntityUid>(machine.PartContainer.ContainedEntities)) //clone so don't modify during enumeration
-        {
-            if (_construction.GetMachinePartState(item, out var partState))
-            {
-                UpgradePartState upgrade;
-                upgrade.Part = partState.Part;
-                upgrade.Stack = partState.Stack;
-                upgrade.InContainer = false;
-
-                var partType = upgrade.Part.PartType;
-                if (!partsByType.ContainsKey(partType))
-                    partsByType[partType] = new List<(EntityUid, UpgradePartState)>();
-                partsByType[partType].Add((item, upgrade));
-
-                _container.RemoveEntity(uid, item);
-            }
-        }
-
-        // Sort the preferred parts first so they are selected for the machine.
-        foreach (var (partKey, partList) in partsByType)
-        {
-            partList.Sort((x, y) => preferHigherRating
-                ? y.state.Part.Rating.CompareTo(x.state.Part.Rating)
-                : x.state.Part.Rating.CompareTo(y.state.Part.Rating));
-        }
-
-        var updatedParts = new List<(EntityUid id, MachinePartState state, int index)>();
-        foreach (var (type, amount) in macBoardComp.Requirements)
-        {
-            if (partsByType.ContainsKey(type))
-            {
-                var partsNeeded = amount;
-                int index = 0;
-                foreach ((var part, var state) in partsByType[type])
-                {
-                    // No more space for components
-                    if (partsNeeded <= 0)
-                        break;
-
-                    if (state.Stack is not null)
-                    {
-                        var count = state.Stack.Count;
-                        // Entire stack is needed, add it to the things to bring over.
-                        if (count <= partsNeeded)
-                        {
-                            MachinePartState partState;
-                            partState.Part = state.Part;
-                            partState.Stack = state.Stack;
-
-                            updatedParts.Add((part, partState, index));
-                            partsNeeded -= count;
-                        }
-                        else
-                        {
-                            // Partial stack is needed, split off what we need, ensure the new entry is moved.
-                            EntityUid splitStack = _stack.Split(part, partsNeeded, Transform(uid).Coordinates, state.Stack) ?? EntityUid.Invalid;
-
-                            if (splitStack == EntityUid.Invalid)
-                                continue;
-
-                            // Create a new MachinePartState out of our new entity
-                            if (_construction.GetMachinePartState(splitStack, out var splitState))
-                            {
-                                updatedParts.Add((splitStack, splitState, -1)); // Use -1 for index, nothing to remove
-                                partsNeeded = 0;
-                            }
-                        }
-                    }
-                    else
-                    {
-                        // Not a stack, move the single part.
-                        MachinePartState partState;
-                        partState.Part = state.Part;
-                        partState.Stack = state.Stack;
-
-                        updatedParts.Add((part, partState, index));
-                        partsNeeded--;
-                    }
-                    // Adjust the index for parts being removed from the container.
-                    index++;
-                }
-            }
-        }
-
-        // Move selected parts to the machine, removing them from the dictionary of contained parts.
-        // Iterate through list backwards, remove later entries first (maintain validity of earlier indices).
-        for (int i = updatedParts.Count - 1; i >= 0; i--)
-        {
-            var part = updatedParts[i];
-            bool inserted = _container.Insert(part.id, machine.PartContainer);
-            if (part.index >= 0)
-                partsByType[part.state.Part.PartType].RemoveAt(part.index);
-        }
-
-        //Put the unused parts back into the container (if they aren't already there)
-        foreach (var (partType, partSet) in partsByType)
-        {
-            foreach (var partState in partSet)
-            {
-                if (!partState.state.InContainer)
-                    _storage.Insert(storageUid, partState.part, out _, playSound: false);
-            }
-        }
-        _construction.RefreshParts(uid, machine);
-    }
-
-    private void TryConstructMachineParts(MachineFrameComponent machine, EntityUid uid, EntityUid storageEnt, Dictionary<ProtoId<MachinePartPrototype>, List<(EntityUid part, UpgradePartState state)>> partsByType, bool preferHigherRating)
-    {
-        var board = machine.BoardContainer.ContainedEntities.FirstOrNull();
-
-        if (!machine.HasBoard || !TryComp<MachineBoardComponent>(board, out var macBoardComp))
-            return;
-
-        // Add all components in the machine to form a complete set of available components.
-        foreach (var item in new ValueList<EntityUid>(machine.PartContainer.ContainedEntities)) //clone so don't modify during enumeration
-        {
-            if (_construction.GetMachinePartState(item, out var partState))
-            {
-                // Construct our entry
-                UpgradePartState upgrade;
-                upgrade.Part = partState.Part;
-                upgrade.Stack = partState.Stack;
-                upgrade.InContainer = false;
-
-                // Add it to the table
-                var partType = upgrade.Part.PartType;
-                if (!partsByType.ContainsKey(partType))
-                    partsByType[partType] = new List<(EntityUid, UpgradePartState)>();
-                partsByType[partType].Add((item, upgrade));
-
-                // Make sure the construction status is consistent with the removed parts.
-                machine.Progress[partType] -= partState.Quantity();
-                machine.Progress[partType] = int.Max(0, machine.Progress[partType]); // Ensure progress isn't negative.
-
-                _container.RemoveEntity(uid, item);
-            }
-        }
-
-        // Sort the preferred parts first so they are selected for the machine frame.
-        foreach (var partList in partsByType.Values)
-        {
-            partList.Sort((x, y) => preferHigherRating
-                ? y.state.Part.Rating.CompareTo(x.state.Part.Rating)
-                : x.state.Part.Rating.CompareTo(y.state.Part.Rating));
-        }
-
-        var updatedParts = new List<(EntityUid id, MachinePartState state, int index)>();
-        foreach (var (type, amount) in macBoardComp.Requirements)
-        {
-            if (partsByType.ContainsKey(type))
-            {
-                var partsNeeded = amount;
-                var index = 0;
-                foreach ((var part, var state) in partsByType[type])
-                {
-                    // No more space for components
-                    if (partsNeeded <= 0)
-                        break;
-
-                    if (state.Stack is not null)
-                    {
-                        var count = state.Stack.Count;
-                        // Entire stack is needed, add it to the things to bring over.
-                        if (count <= partsNeeded)
-                        {
-                            MachinePartState partState;
-                            partState.Part = state.Part;
-                            partState.Stack = state.Stack;
-
-                            updatedParts.Add((part, partState, index));
-                            partsNeeded -= count;
-                        }
-                        else
-                        {
-                            // Partial stack is needed, split off what we need, ensure the new entry is moved.
-                            EntityUid splitStack = _stack.Split(part, partsNeeded, Transform(uid).Coordinates, state.Stack) ?? EntityUid.Invalid;
-
-                            if (splitStack == EntityUid.Invalid)
-                                continue;
-
-                            // Create a new MachinePartState out of our new entity
-                            if (_construction.GetMachinePartState(splitStack, out var splitState))
-                            {
-                                updatedParts.Add((splitStack, splitState, -1)); // New entity, nothing to remove, set index to -1 to flag this.
-                                partsNeeded = 0;
-                            }
-                        }
-                    }
-                    else
-                    {
-                        // Not a stack, move the single part.
-                        MachinePartState partState;
-                        partState.Part = state.Part;
-                        partState.Stack = state.Stack;
-
-                        updatedParts.Add((part, partState, index));
-                        partsNeeded--;
-                    }
-                    // Adjust the index for parts being removed from the container.
-                    index++;
-                }
-            }
-        }
-
-        // Move selected parts to the machine, removing them from the dictionary of contained parts.
-        // Iterate through list backwards, remove later entries first (maintain validity of earlier indices).
-        for (int i = updatedParts.Count - 1; i >= 0; i--)
-        {
-            var part = updatedParts[i];
-            _container.Insert(part.id, machine.PartContainer, force: true);
-            if (part.index >= 0)
-                partsByType[part.state.Part.PartType].RemoveAt(part.index);
-            machine.Progress[part.state.Part.PartType] += part.state.Quantity();
-        }
-
-        //Put the unused parts back into the container (if they aren't already there)
-        foreach (var (partType, partSet) in partsByType)
-        {
-            foreach (var partState in partSet)
-            {
-                if (!partState.state.InContainer)
-                    _storage.Insert(storageEnt, partState.part, out _, playSound: false);
-            }
-        }
-    }
+    #region Event handlers
 
     private void OnAfterInteract(EntityUid uid, PartExchangerComponent component, AfterInteractEvent args)
     {
@@ -329,26 +68,287 @@ public sealed class PartExchangerSystem : EntitySystem
         if (args.Target == null)
             return;
 
-        if (!HasComp<MachineComponent>(args.Target) && !HasComp<MachineFrameComponent>(args.Target))
-            return;
+        TryStartDoAfter((uid, component), args.Target.Value, args.User);
+    }
 
-        if (TryComp<WiresPanelComponent>(args.Target, out var panel) && !panel.Open)
+    private void OnDoAfter(EntityUid uid, PartExchangerComponent exchanger, DoAfterEvent args)
+    {
+        if (args.Cancelled)
         {
-            _popup.PopupEntity(Loc.GetString("construction-step-condition-wire-panel-open"),
-                args.Target.Value);
+            exchanger.AudioStream = _audio.Stop(exchanger.AudioStream);
             return;
         }
 
-        var audioStream = _audio.PlayPvs(component.ExchangeSound, uid);
+        if (args.Handled || args.Args.Target is not { } target)
+            return;
+
+        if (!TryComp<StorageComponent>(uid, out var storage) || storage.Container == null)
+            return;
+
+        // Exchange machine parts with the target.
+        Entity<PartExchangerComponent, StorageComponent> exchangerEnt = (uid, exchanger, storage);
+        if (TryComp<MachineComponent>(target, out var machine))
+            TryExchangeMachineParts((target, machine), exchangerEnt);
+        else if (TryComp<MachineFrameComponent>(target, out var machineFrame))
+            TryConstructMachineParts((target, machineFrame), exchangerEnt);
+        else if (TryComp<VehicleUpgradeComponent>(target, out var vehicle))
+            TryUpgradeVehicle((target, vehicle), exchangerEnt);
+
+        args.Handled = true;
+    }
+
+    private void OnGetVehicleInteractionVerbs(Entity<VehicleUpgradeComponent> vehicle, ref GetVerbsEvent<InteractionVerb> args)
+    {
+        if (!args.CanAccess || !args.CanInteract)
+            return;
+
+        if (!TryComp<PartExchangerComponent>(args.Using, out var exchanger))
+            return;
+
+        // The user is holding a PartExchanger and is targetting a VehicleUpgrade.
+        var exchangerUid = args.Using.Value;
+        var user = args.User;
+        InteractionVerb verb = new()
+        {
+            Act = () =>
+            {
+                TryStartDoAfter((exchangerUid, exchanger), vehicle, user);
+            },
+            Icon = new SpriteSpecifier.Texture(new(UpgradeIconPath)),
+            Text = exchanger.PreferHigherRating
+                ? Loc.GetString("vehicle-verb-upgrade")
+                : Loc.GetString("vehicle-verb-downgrade")
+        };
+        args.Verbs.Add(verb);
+    }
+
+    #endregion
+
+    #region Upgrading
+
+    private void TryExchangeMachineParts(Entity<MachineComponent> target, Entity<PartExchangerComponent, StorageComponent> exchanger)
+    {
+        // Get the container machine board so we can figure out what parts are needed
+        var board = target.Comp.BoardContainer.ContainedEntities.FirstOrNull();
+        if (board == null || !TryComp<MachineBoardComponent>(board, out var macBoardComp))
+            return;
+
+        PerformUpgrade(target,
+            target.Comp.PartContainer,
+            macBoardComp.Requirements,
+            exchanger,
+            callbacks: default);
+        _construction.RefreshParts(target);
+    }
+
+    private void TryConstructMachineParts(Entity<MachineFrameComponent> target, Entity<PartExchangerComponent, StorageComponent> exchanger)
+    {
+        // Get the container machine board so we can figure out what parts are needed
+        var board = target.Comp.BoardContainer.ContainedEntities.FirstOrNull();
+        if (board == null || !TryComp<MachineBoardComponent>(board, out var macBoardComp))
+            return;
+
+        UpgradeStepCallbacks callbacks;
+        callbacks.OnPartRemovedFromTarget = upgrade =>
+        {
+            // Make sure the construction status is consistent with the removed parts.
+            var partType = upgrade.Part.PartType;
+            var progress = target.Comp.Progress[partType];
+            target.Comp.Progress[partType] = int.Max(0, progress - (upgrade.Stack?.Count ?? 1));
+        };
+        callbacks.OnPartInsertedIntoTarget = part =>
+        {
+            // Same here, make sure construction status is consistent with the inserted parts.
+            target.Comp.Progress[part.Part.PartType] += part.Quantity();
+        };
+        PerformUpgrade(target,
+            target.Comp.PartContainer,
+            macBoardComp.Requirements,
+            exchanger,
+            callbacks);
+    }
+
+    private void TryUpgradeVehicle(Entity<VehicleUpgradeComponent> target, Entity<PartExchangerComponent, StorageComponent> exchanger)
+    {
+        PerformUpgrade(target,
+            target.Comp.PartContainer,
+            target.Comp.Requirements,
+            exchanger,
+            callbacks: default);
+        _upgradableVehicle.UpdateParts(target);
+    }
+
+    private void PerformUpgrade(EntityUid targetUid,
+        Container targetPartContainer,
+        Dictionary<ProtoId<MachinePartPrototype>, int> targetPartRequirements,
+        Entity<PartExchangerComponent, StorageComponent> exchanger,
+        UpgradeStepCallbacks callbacks)
+    {
+        // High-level summary of steps taken in this method:
+        // 1. collect *all* available parts, from the exchanger and the target.
+        // 2. sort parts by rating (either descending or ascending, depending on the exchanger)
+        // 3. pick the best parts that match the target's requirements.
+        // 4. put the remaining parts in the exchanger.
+
+        // Collect all the parts in the exchanger.
+        // Note: these parts remain in the exchanger.
+        var partsByType = new Dictionary<ProtoId<MachinePartPrototype>, List<(EntityUid, UpgradePartState)>>();
+        foreach (var (item, upgrade) in ContainedMachineParts(exchanger.Comp2.Container, inExchanger: true))
+        {
+            partsByType.GetOrNew(upgrade.Part.PartType).Add((item, upgrade));
+        }
+
+        // Add all components in the machine to form a complete set of available components.
+        foreach (var (item, upgrade) in ContainedMachineParts(targetPartContainer, inExchanger: false))
+        {
+            var partType = upgrade.Part.PartType;
+            partsByType.GetOrNew(partType).Add((item, upgrade));
+            callbacks.OnPartRemovedFromTarget?.Invoke(upgrade);
+            _container.RemoveEntity(targetUid, item);
+        }
+
+        // Sort the preferred parts first so they are selected for the machine frame.
+        Comparison<(EntityUid part, UpgradePartState state)> comparison = exchanger.Comp1.PreferHigherRating
+            ? (x, y) => y.state.Part.Rating.CompareTo(x.state.Part.Rating)
+            : (x, y) => x.state.Part.Rating.CompareTo(y.state.Part.Rating);
+        foreach (var partList in partsByType.Values)
+        {
+            partList.Sort(comparison);
+        }
+
+        // Keep track of which parts have been taken.
+        var takenParts = new List<(EntityUid id, MachinePartState state, int index)>();
+        foreach (var (type, amount) in targetPartRequirements)
+        {
+            if (!partsByType.TryGetValue(type, out var partsOfType))
+                // We don't have any parts of this type.
+                continue;
+
+            var partsNeeded = amount;
+            var index = 0;
+            foreach (var (part, state) in partsOfType)
+            {
+                // No more space for components
+                if (partsNeeded <= 0)
+                    break;
+
+                if (state.Stack is not null)
+                {
+                    var count = state.Stack.Count;
+                    // Entire stack is needed, add it to the things to bring over.
+                    if (count <= partsNeeded)
+                    {
+                        MachinePartState partState;
+                        partState.Part = state.Part;
+                        partState.Stack = state.Stack;
+
+                        takenParts.Add((part, partState, index));
+                        partsNeeded -= count;
+                    }
+                    else
+                    {
+                        // Partial stack is needed, split off what we need, ensure the new entry is moved.
+                        var splitStack = _stack.Split(part, partsNeeded, Transform(targetUid).Coordinates, state.Stack) ?? EntityUid.Invalid;
+
+                        if (splitStack == EntityUid.Invalid)
+                            continue;
+
+                        // Create a new MachinePartState out of our new entity
+                        if (_construction.GetMachinePartState(splitStack, out var splitState))
+                        {
+                            // New entity, nothing to remove, set index to -1 to flag this.
+                            takenParts.Add((splitStack, splitState, -1));
+                            partsNeeded = 0;
+                        }
+                    }
+                }
+                else
+                {
+                    // Not a stack, move the single part.
+                    MachinePartState partState;
+                    partState.Part = state.Part;
+                    partState.Stack = state.Stack;
+
+                    takenParts.Add((part, partState, index));
+                    partsNeeded--;
+                }
+                // Adjust the index for parts being removed from the container.
+                index++;
+            }
+        }
+
+        // Move selected parts to the machine, removing them from the dictionary of contained parts.
+        // Iterate through list backwards, remove later entries first (maintain validity of earlier indices).
+        for (int i = takenParts.Count - 1; i >= 0; i--)
+        {
+            var (id, state, index) = takenParts[i];
+            _container.Insert(id, targetPartContainer, force: true);
+            if (index >= 0)
+                partsByType[state.Part.PartType].RemoveAt(index);
+            callbacks.OnPartInsertedIntoTarget?.Invoke(state);
+        }
+
+        // Put the unused parts back into the exchanger (if they aren't already there)
+        foreach (var (partType, partSet) in partsByType)
+        {
+            foreach (var (part, state) in partSet)
+            {
+                if (!state.InExchanger)
+                    _storage.Insert(exchanger, part, out _, playSound: false);
+            }
+        }
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private void TryStartDoAfter(Entity<PartExchangerComponent> exchanger, EntityUid target, EntityUid user)
+    {
+        if (!HasComp<MachineComponent>(target) &&
+            !HasComp<MachineFrameComponent>(target) &&
+            !HasComp<VehicleUpgradeComponent>(target))
+            return;
+
+        if (TryComp<WiresPanelComponent>(target, out var panel) && !panel.Open)
+        {
+            _popup.PopupEntity(Loc.GetString("construction-step-condition-wire-panel-open"), target);
+            return;
+        }
+
+        var audioStream = _audio.PlayPvs(exchanger.Comp.ExchangeSound, exchanger);
         if (audioStream != null)
         {
-            component.AudioStream = audioStream.Value.Entity;
+            exchanger.Comp.AudioStream = audioStream.Value.Entity;
         }
 
-        _doAfter.TryStartDoAfter(new DoAfterArgs(EntityManager, args.User, component.ExchangeDuration, new ExchangerDoAfterEvent(), uid, target: args.Target, used: uid)
+        _doAfter.TryStartDoAfter(new DoAfterArgs(EntityManager, user, exchanger.Comp.ExchangeDuration, new ExchangerDoAfterEvent(), exchanger, target: target, used: exchanger)
         {
             BreakOnDamage = true,
             BreakOnMove = true
         });
     }
+
+    /// <summary>
+    /// Helper method for walking the machine parts in a container.
+    /// </summary>
+    /// <param name="inExchanger">True if the container belongs to the part exchanger; false if it's the target.</param>
+    /// <returns></returns>
+    private IEnumerable<(EntityUid, UpgradePartState)> ContainedMachineParts(Container partContainer, bool inExchanger)
+    {
+        // Make a copy of the list so it's safe to modify
+        foreach (var item in new ValueList<EntityUid>(partContainer.ContainedEntities))
+        {
+            if (_construction.GetMachinePartState(item, out var partState))
+            {
+                UpgradePartState upgrade;
+                upgrade.Part = partState.Part;
+                upgrade.Stack = partState.Stack;
+                upgrade.InExchanger = inExchanger;
+                yield return (item, upgrade);
+            }
+        }
+    }
+
+    #endregion
 }

--- a/Content.Server/_NF/Construction/ConstructionSystem.Machine.Upgrades.cs
+++ b/Content.Server/_NF/Construction/ConstructionSystem.Machine.Upgrades.cs
@@ -3,7 +3,6 @@ using Content.Server.Construction.Components;
 using Content.Shared.Construction.Components;
 using Content.Shared.Construction.Prototypes;
 using Content.Shared.Examine;
-using Content.Shared.Stacks;
 using Content.Shared.Verbs;
 using Robust.Shared.Utility;
 
@@ -107,8 +106,13 @@ public sealed partial class ConstructionSystem
 
     public void RefreshParts(EntityUid uid, MachineComponent component)
     {
-        var parts = GetAllParts(component);
-        EntityManager.EventBus.RaiseLocalEvent(uid, new RefreshPartsEvent
+        RefreshParts((uid, component));
+    }
+
+    public void RefreshParts(Entity<MachineComponent> machine)
+    {
+        var parts = GetAllParts(machine.Comp);
+        EntityManager.EventBus.RaiseLocalEvent(machine, new RefreshPartsEvent
         {
             Parts = parts,
             PartRatings = GetPartsRatings(parts),

--- a/Content.Server/_NF/Vehicle/EntitySystems/VehicleUpgradeSystem.cs
+++ b/Content.Server/_NF/Vehicle/EntitySystems/VehicleUpgradeSystem.cs
@@ -1,0 +1,110 @@
+using Content.Server.Construction;
+using Content.Shared._NF.Vehicle.Components;
+using Content.Shared._NF.Vehicle.EntitySystems;
+using Content.Shared.Construction.Prototypes;
+using Content.Shared.Movement.Systems;
+using Robust.Server.Containers;
+using Robust.Shared.Containers;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._NF.Vehicle.EntitySystems;
+
+public sealed class VehicleUpgradeSystem : SharedVehicleUpgradeSystem
+{
+    [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+    [Dependency] private readonly ContainerSystem _container = default!;
+    [Dependency] private readonly ConstructionSystem _construction = default!;
+    [Dependency] private readonly MovementSpeedModifierSystem _movementSpeedModifier = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<VehicleUpgradeComponent, ComponentStartup>(OnVehicleStartup);
+        SubscribeLocalEvent<VehicleUpgradeComponent, RefreshMovementSpeedModifiersEvent>(OnRefreshMovementSpeedModifiers);
+    }
+
+    private void OnVehicleStartup(Entity<VehicleUpgradeComponent> ent, ref ComponentStartup args)
+    {
+        var partContainer = _container.EnsureContainer<Container>(ent, VehicleUpgradeComponent.PartContainerName);
+        if (partContainer.ContainedEntities.Count > 0)
+            // Already initialized, don't add double the parts.
+            return;
+
+        ent.Comp.PartContainer = partContainer;
+
+        var xform = Transform(ent);
+        foreach (var (part, amount) in ent.Comp.Requirements)
+        {
+            var partProto = _prototypeManager.Index(part);
+            for (var i = 0; i < amount; i++)
+            {
+                var p = EntityManager.SpawnEntity(partProto.StockPartPrototype, xform.Coordinates);
+
+                if (!_container.Insert(p, partContainer))
+                    throw new Exception($"Couldn't insert machine part of type {part} to vehicle with prototype {partProto.StockPartPrototype.ToString() ?? "N/A"}!");
+            }
+        }
+    }
+
+    private void OnRefreshMovementSpeedModifiers(Entity<VehicleUpgradeComponent> ent, ref RefreshMovementSpeedModifiersEvent args)
+    {
+        args.ModifySpeed(ent.Comp.CurrentSpeedModifier);
+    }
+
+    public void UpdateParts(Entity<VehicleUpgradeComponent> ent)
+    {
+        // First, let's find the tier for each relevant machine part type.
+        var ratingByPartType = new Dictionary<ProtoId<MachinePartPrototype>, float>();
+        foreach (var (partType, count) in ent.Comp.Requirements)
+        {
+            var totalRating = 0;
+            foreach (var x in ent.Comp.PartContainer.ContainedEntities)
+            {
+                if (!_construction.GetMachinePartState(x, out var machinePart) ||
+                    machinePart.Part.PartType != partType)
+                    // Weird but okay
+                    continue;
+
+                var stackCount = machinePart.Stack?.Count ?? 1;
+                totalRating += machinePart.Part.Rating * stackCount;
+            }
+
+            var averageRating = (float)totalRating / count;
+            ratingByPartType.Add(partType, averageRating);
+        }
+
+        // Second, calculate the upgrade multiplier per available upgrade.
+        foreach (var (target, upgrade) in ent.Comp.AvailableUpgrades)
+        {
+            var partRating = ratingByPartType.GetValueOrDefault(upgrade.PartType);
+            var multiplier = GetUpgradeMultiplier(partRating, upgrade);
+
+            switch (target)
+            {
+                case UpgradableVehicleProperty.Speed:
+                    ent.Comp.CurrentSpeedModifier = multiplier;
+                    break;
+                default:
+                    throw new Exception($"Upgradable vehicle property not handled: {target}");
+            }
+        }
+
+        // Lastly, housekeeping to update dependent systems.
+        Dirty(ent);
+        _movementSpeedModifier.RefreshMovementSpeedModifiers(ent);
+    }
+
+    private float GetUpgradeMultiplier(float partRating, VehicleUpgrade upgrade)
+    {
+        var tier = (int)partRating;
+        if (tier >= upgrade.UpgradePerTier.Count - 1)
+        {
+            // We've reached max tier for this vehicle, no need to interpolate.
+            return upgrade.UpgradePerTier[^1];
+        }
+        // Note: partRating < tier + 1, hence partRating - tier is in [0, 1).
+        // If partRating is an integer, partRating - tier = 0 and we use the lower tier (fine).
+        return MathHelper.Lerp(upgrade.UpgradePerTier[tier], upgrade.UpgradePerTier[tier + 1], partRating - tier);
+    }
+}

--- a/Content.Shared/_NF/Vehicle/Components/VehicleUpgradeComponent.cs
+++ b/Content.Shared/_NF/Vehicle/Components/VehicleUpgradeComponent.cs
@@ -1,0 +1,62 @@
+using Content.Shared.Construction.Prototypes;
+using Robust.Shared.Containers;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._NF.Vehicle.Components;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class VehicleUpgradeComponent : Component
+{
+    public const string PartContainerName = "machine_parts";
+
+    /// <summary>
+    /// Contains the vehicle's machine parts.
+    /// </summary>
+    [ViewVariables]
+    public Container PartContainer = default!;
+
+    /// <summary>
+    /// Machine parts needed to upgrade this vehicle.
+    /// </summary>
+    [DataField(required: true)]
+    public Dictionary<ProtoId<MachinePartPrototype>, int> Requirements = default!;
+
+    /// <summary>
+    /// Available upgrades for this vehicle.
+    /// Note: Only one machine part per upgradable property. Can't have speed depend on
+    /// both capacitors and manipulators, for example.
+    /// </summary>
+    [DataField(required: true)]
+    public Dictionary<UpgradableVehicleProperty, VehicleUpgrade> AvailableUpgrades = default!;
+
+    /// <summary>
+    /// Current modifier applied to the vehicle's speed.
+    /// </summary>
+    [ViewVariables]
+    [AutoNetworkedField]
+    public float CurrentSpeedModifier = 1.0f;
+}
+
+[DataDefinition]
+public partial struct VehicleUpgrade
+{
+    /// <summary>
+    /// The machine part used for this upgrade.
+    /// </summary>
+    [DataField(required: true)]
+    public ProtoId<MachinePartPrototype> PartType;
+
+    /// <summary>
+    /// The upgrade multiplier per tier. These are factors applied to the base
+    /// value of the target property. This list should normally contain five
+    /// values (none [unused], basic, advanced, super, bluespace).
+    /// </summary>
+    [DataField(required: true)]
+    public List<float> UpgradePerTier;
+}
+
+public enum UpgradableVehicleProperty : byte
+{
+    Speed,
+}

--- a/Content.Shared/_NF/Vehicle/EntitySystems/SharedVehicleUpgradeSystem.cs
+++ b/Content.Shared/_NF/Vehicle/EntitySystems/SharedVehicleUpgradeSystem.cs
@@ -1,0 +1,46 @@
+using Content.Shared._NF.Vehicle.Components;
+using Content.Shared.Examine;
+using Content.Shared.Verbs;
+using Robust.Shared.Utility;
+
+namespace Content.Shared._NF.Vehicle.EntitySystems;
+
+public abstract class SharedVehicleUpgradeSystem : EntitySystem
+{
+    [Dependency] private readonly ExamineSystemShared _examine = default!;
+
+    private const string UpgradeIconPath = "/Textures/Interface/VerbIcons/pickup.svg.192dpi.png";
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<VehicleUpgradeComponent, GetVerbsEvent<ExamineVerb>>(OnVehicleVerbExamine);
+    }
+
+    private void OnVehicleVerbExamine(Entity<VehicleUpgradeComponent> ent, ref GetVerbsEvent<ExamineVerb> args)
+    {
+        if (!args.CanInteract || !args.CanAccess)
+            return;
+
+        var markup = new FormattedMessage();
+        GetSpeedModifierExamine(markup, ent);
+
+        _examine.AddDetailedExamineVerb(args, ent.Comp, markup,
+            Loc.GetString("vehicle-verb-examinable-upgrades-text"),
+            UpgradeIconPath,
+            Loc.GetString("vehicle-verb-examinable-upgrades-message"));
+    }
+
+    private void GetSpeedModifierExamine(FormattedMessage msg, Entity<VehicleUpgradeComponent> ent)
+    {
+        var percent = Math.Round(100 * MathF.Abs(ent.Comp.CurrentSpeedModifier - 1), 2);
+        var locId = ent.Comp.CurrentSpeedModifier switch
+        {
+            < 1 => "vehicle-upgrade-speed-decreased",
+            1 or float.NaN => "vehicle-upgrade-speed-not-upgraded",
+            > 1 => "vehicle-upgrade-speed-increased",
+        };
+        msg.AddMarkupOrThrow(Loc.GetString(locId, ("percent", percent)));
+    }
+}

--- a/Resources/Locale/en-US/vehicle/vehicle.ftl
+++ b/Resources/Locale/en-US/vehicle/vehicle.ftl
@@ -3,3 +3,20 @@ vehicle-use-key = You use {THE($keys)} to start {THE($vehicle)}.
 vehicle-cannot-pull = You need to stop pulling {THE($object)} before you can ride {THE($vehicle)}.
 
 vehicle-slot-component-slot-name-keys = Keys
+
+# Frontier
+vehicle-verb-upgrade = Upgrade
+# Frontier
+vehicle-verb-downgrade = Downgrade
+
+# Frontier
+vehicle-verb-examinable-upgrades-text = Vehicle Upgrades
+# Frontier
+vehicle-verb-examinable-upgrades-message = Examine the vehicle upgrades
+
+# Frontier
+vehicle-upgrade-speed-increased = [color=yellow]Speed[/color] increased by {$percent}%.
+# Frontier
+vehicle-upgrade-speed-decreased = [color=yellow]Speed[/color] reduced by {percent}%.
+# Frontier
+vehicle-upgrade-speed-not-upgraded = [color=yellow]Speed[/color] not upgraded.

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Vehicles/vehicles.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Vehicles/vehicles.yml
@@ -300,3 +300,16 @@
     slots: {} # Frontier: no keys required
   - type: Strap # Frontier
     unbuckleOnInteractHand: False # Frontier
+  # Frontier: upgradable hoverchair
+  - type: ContainerContainer
+    containers:
+      machine_parts: !type:Container
+        ents: [] # initialized on startup
+  - type: VehicleUpgrade
+    requirements:
+      Capacitor: 8
+    availableUpgrades:
+      Speed:
+        partType: Capacitor
+        upgradePerTier: [0.75, 1, 1.25, 1.5, 1.75]
+  # End Frontier

--- a/Resources/Prototypes/_NF/Entities/Objects/Vehicles/vehicles.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Vehicles/vehicles.yml
@@ -268,7 +268,6 @@
   - type: ContainerContainer
     containers:
       machine_parts: !type:Container
-        ents: [] # initialized on startup
   - type: VehicleUpgrade
     requirements:
       Capacitor: 8
@@ -535,6 +534,18 @@
       collection: NFVehicleHorn # resetting from the motorbike
       params:
         variation: 0.125
+  - type: ContainerContainer
+    containers:
+      storagebase: !type:Container
+      machine_parts: !type:Container
+  - type: VehicleUpgrade
+    requirements:
+      Capacitor: 8
+    availableUpgrades:
+      Speed:
+        partType: Capacitor
+        # slightly smaller step from super to BS, still a noticeable speedup
+        upgradePerTier: [0.75, 1, 1.35, 1.70, 2]
 
 - type: entity
   parent: VehicleHoverbikeMailcarrier

--- a/Resources/Prototypes/_NF/Entities/Objects/Vehicles/vehicles.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Vehicles/vehicles.yml
@@ -265,6 +265,18 @@
   - type: PointLight
     radius: 7
     energy: 3
+  - type: ContainerContainer
+    containers:
+      machine_parts: !type:Container
+        ents: [] # initialized on startup
+  - type: VehicleUpgrade
+    requirements:
+      Capacitor: 8
+    availableUpgrades:
+      Speed:
+        partType: Capacitor
+        # slightly smaller step from super to BS, still a noticeable speedup
+        upgradePerTier: [0.75, 1, 1.35, 1.70, 2]
 
 - type: entity
   parent: NFVehicleHoverbike


### PR DESCRIPTION
## About the PR
This PR does two things I probably shouldn't have mixed but couldn't really separate.

Firstly, this PR reworks `PartExchangerSystem` to be less of a horrible copy-pasted mess. Don't get me wrong, it's still a mess, but _less_ so.

Secondly, this PR enables vehicles to be upgraded, by adding a new component and tweaking the way the RPED interacts with it. Only hoverbikes and the hoverchair are made upgradable with this PR, but the new component also makes it trivial to make more vehicles upgradable in the future, and paves the way for allowing other aspects of a vehicle to be upgraded. (E.g. maybe we want ATV lights to be upgraded with capacitors in the future.)

## Why / Balance
I love hoverbikes! They're so much fun, and travelling through space on a hoverbike with no ship to your name is awesome. However, it's painfully slow at times, especially now that the sector is really spread out and big. By upgrading your hoverbike with 8 super capacitors, you can reach speeds of 13.6 m/s – considerably faster than the standard 8, still much slower than a ship. Get lucky enough to find bluespace caps and you can get all the way up to 16 m/s, twice as fast as usual.

RPED is *required* to upgrade hoverbikes. It is not possible to disassemble the bike and tear out the components yourself. You have to right-click and select the 'Upgrade' verb. Left-click and Alt+click both interact with the storage system, oops. (For the YarRPED, the text changes to 'Downgrade'.)

I settled on the values as follows:
- I don't want hoverbikes to become obscenely fast. Not only is it hard to control, it also gives them WAY too much utility in combat situations. I could imagine people using them to clear vgroids very fast, _but_ this is balanced largely by the inability to use a two-handed weapon on a hoverbike, and gathering loot is much harder too.
- Even a maxed-out hoverbike should be slower than a ship. They are much smaller and weaker, of course. And you should always be able to catch up to a hoverbiker with your ship.
- 8 capacitors because it visually has four thrusters, and I figured two capacitors per thruster would make sense. Arbitrary roundish number of capacitors that takes a little bit of effort to find if you don't have science help.

For the hoverchair, I just kinda picked values that seemed to make sense. Even with full bluespace capacitors, it's (slightly) slower than speed boots, but of course does *not* suffer slowdown from your hardsuit and weapon. It's probably fine. This vehicle is basically never actually used.

## Technical details
Re `PartExchangerSystem`: It was extremely confusing how some logic happened in one method, some other logic happened in another method, and nothing was named in a way that aided comprehension. `InContainer`? Which container – the RPED or the machine?! I've tried to rename things in a way that's *hopefully* sensible and straightforward, as well as use `Entity<...>` to pair IDs with components where appropriate. I'm not 100% fond of the callback hooks I needed for machine frames, but it's either that or duplicate an uncomfortable amount of code. I chose callbacks.

The vehicle upgrade stuff should ideally be pretty self-explanatory. As it's *currently* written, `VehicleUpgradeComponent` does not actually depend on `VehicleComponent`; you could slap it on any old entity to allow its speed to be upgraded. But the naming is meant to suggest that it be used for vehicles, and in future we might add more `UpgradableVehicleProperty` members for vehicle-specific things.

I also moved the client-side `VehicleSystem` to `_NF/Vehicle/EntitySystems` for better symmetry with Shared and Server.

## How to test
1. Spawn yourself a hoverbike, any hoverbike.
2. Spawn an RPED, put some fancy capacitors in it.
3. Right-click the hoverbike and pick 'Upgrade'. Wait for the RPED to do its thing.
4. Inspect the hoverbike's speed and note that it's been upgraded and improved and stuff. Now take it for a test drive and enjoy LUDICROUS SPEED!
5. Put some basic capacitors in a YarRPED and note that you can also 'Downgrade' the hoverbike. Amazing! Try to get its speed back to normal.
6. Spawn a hoverchair and repeat the process. Since the hoverchair has no storage, you can also just click on it to upgrade it.
7. Also, try to upgrade some machines with an RPED, to make sure I haven't completely botched that part of the game.
8. And try to finish constructing some machine frames, too. Test with machine frames that have none, some and all of their machine parts.

## Media
https://streamable.com/6w895m

<img width="349" height="157" alt="image" src="https://github.com/user-attachments/assets/7f172079-b6d7-4e32-80b7-74f6f9f1d32d" />
<img width="601" height="150" alt="image" src="https://github.com/user-attachments/assets/58d4fa06-00c4-4b5b-8ac9-5f4cb4acb88b" />
<img width="342" height="129" alt="image" src="https://github.com/user-attachments/assets/12d0b4ce-2a2b-46d8-a693-d88dd2e2d6f5" />
<img width="341" height="146" alt="image" src="https://github.com/user-attachments/assets/f1f06832-d271-421c-a7aa-d074e8a24242" />

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes

**Changelog**
:cl:
- add: Hoverbikes can now have their speed upgraded with an RPED. Put some capacitors in it, right-click and upgrade!
- add: Hoverchairs can now have their speed upgraded with an RPED. Put some capacitors in it, click and upgrade!