### PR TITLE
Micro-QoL: Skip appraisal of bluespace event grids when unnecessary

### DIFF
--- a/Content.Server/_NF/StationEvents/Events/BluespaceErrorRule.cs
+++ b/Content.Server/_NF/StationEvents/Events/BluespaceErrorRule.cs
@@ -285,7 +285,11 @@ public sealed class BluespaceErrorRule : StationEventSystem<BluespaceErrorRuleCo
                     _transform.DetachEntity(mob.Entity.Owner, mob.Entity.Comp);
                 }
 
-                var gridValue = _pricing.AppraiseGrid(gridUid, null);
+                // Skip appraisal if there's no reward account. Appraisal eats up too much
+                // frame time for very large grids (e.g. vgroids).
+                var gridValue = component.RewardAccounts.Count > 0
+                    ? _pricing.AppraiseGrid(gridUid, null)
+                    : 0;
 
                 // Deletion has to happen before grid traversal re-parents players.
                 Del(gridUid);


### PR DESCRIPTION
## About the PR
When a `BlueSpaceErrorRule` ends, skip appraisal of the grid if there's no reward account.

## Why / Balance
Appraisal involves traversing basically every single entity on the grid. For large bluespace grids, such as vgroids, this is tens of thousands of entities that all need to be appraised. This involves raising an event, figuring out material composition and contained solutions, calculating stack size, and of course recursing into containers. Grid appraisal contributes a decent bit to the stutter you feel when vgroids despawn. And worst of all, when there's no reward account (as is the normal case; only a few bluespace events give rewards) the result of all this hard work is thrown away.

## Technical details
The tiniest little C# change.

## How to test
0. Before you get started, you may wish to modify the duration of bluespace events. Set the `duration` and `maxDuration` of the various events to something low, like 60 seconds. Too low and they won't have time to spawn in, too high and you'll be waiting for no reason.
1. Spawn a bluespace dungeon event, e.g. `addgamerule BluespaceDungeonBasalt`. Wait for it to go away. Nothing should be different; it just pops out of existence as normal. There will still be a little lag spike from deleting tens of thousands of entities.
2. Spawn a bluespace event that gives a reward, e.g. `addgamerule BluespaceVaultError`. Check station accounts before and after the event to make sure they are given money for the vault.

## Media
N/A

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes
Nope.

**Changelog**
N/A, just a tiny internal change.