### PR TITLE
Make Brigmedic Roundstart

### DIFF
--- a/Resources/Prototypes/_NF/PointsOfInterest/nfsd.yml
+++ b/Resources/Prototypes/_NF/PointsOfInterest/nfsd.yml
@@ -44,7 +44,7 @@
             Sheriff: [ 1, 1 ]
             Bailiff: [ 1, 1 ]
             SeniorOfficer: [ 1, 1 ]
-            Brigmedic: [ 0, 0 ]
+            Brigmedic: [ 1, 1 ]
             NFDetective: [ 1, 1 ]
             Deputy: [ 3, 3 ]
             Cadet: [ 0, 0 ]


### PR DESCRIPTION
## About the PR
Brigmedic is now a roundstart option without the presence of a sheriff.

## Why / Balance
I was told that brigmedics not being roundstart is an artifact of before when NFSDO did not have a chemlab, and a brigmedic's presence would be invalidated unless a sheriff took out an Empress. If this is truly the case, then with the new NFSDO having a chemlab, this reasoning is now invalid.

Additionally, brigmedics are the BEST way to encourage positive roleplay and interactions between NFSD and contractors. Brigmedics don't take up the normal medical response from pre-existing responders, but are there for support, and in a med-responder-less sector, they can be the difference between someone rotting and being revived. Oftentimes, in low pop hours, or even just a time with no responders, the NFSD will pick up the slack anyway. I have personally witnessed many solo deputies, sergeants, and bailiffs pick up med response when no one is doing it in-sector. This change ensures that without sheriff intervention, a brigmedic is an option.

And finally, we currently allow sheriffs to spawn in, open the brigmedic (and previously detective) slots, then cryoswap out into them, if they so wished. At this point, we should bypass the somewhat sketchy self-serving cryoswap and make the role roundstart.

## Technical details
Changed two zeroes to two ones.

## How to test
Start in release mode, notice how brigmedic is open.
Alternatively,
/golobby
/setgamepreset NFAdventure
Again, notice how brigmedic is open.

Now go save some lives.

## Media
<img width="409" height="281" alt="image" src="https://github.com/user-attachments/assets/32a15809-690c-4e96-9d03-eb2a9b78924b" />


## Requirements
- [X ] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes
Nope, none, nada, zero.

**Changelog**

:cl:
- tweak: Brigmedic is now a round start role, go save some lives!


