### PR TITLE
Add current ship callsign highlight to chat

### DIFF
--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
@@ -15,12 +15,14 @@ using Content.Client.Stylesheets;
 using Content.Client.UserInterface.Screens;
 using Content.Client.UserInterface.Systems.Chat.Widgets;
 using Content.Client.UserInterface.Systems.Gameplay;
+using Content.Shared._NF.Shipyard.Components;
 using Content.Shared.Administration;
 using Content.Shared.CCVar;
 using Content.Shared.Chat;
 using Content.Shared.Damage.ForceSay;
 using Content.Shared.Decals;
 using Content.Shared.Input;
+using Content.Client.Inventory;
 using Content.Shared.Radio;
 using Content.Shared.Roles.RoleCodeword;
 using Robust.Client.GameObjects;
@@ -58,6 +60,7 @@ public sealed partial class ChatUIController : UIController
     [Dependency] private readonly IStateManager _state = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly IReplayRecordingManager _replayRecording = default!;
+    [UISystemDependency] private readonly ClientInventorySystem _inventory = default!;
 
     [UISystemDependency] private readonly ExamineSystem? _examine = default;
     [UISystemDependency] private readonly GhostSystem? _ghost = default;
@@ -841,6 +844,21 @@ public sealed partial class ChatUIController : UIController
             msg.WrappedMessage = SharedChatSystem.InjectTagAroundString(msg, highlight, "color", _highlightsColor);
         }
 
+        //Color ship ID
+        if (_player.LocalEntity != null && TryGetIdCard(_player.LocalEntity.Value, out var idCard) && _ent.TryGetComponent<ShuttleDeedComponent>(idCard, out var shipDeed))
+        {
+            if (shipDeed.ShuttleName != null)
+                msg.WrappedMessage = SharedChatSystem.InjectTagAroundString(msg, shipDeed.ShuttleName, "color", _highlightsColor);
+
+            if (shipDeed.ShuttleNameSuffix != null)
+            {
+                var suffix = shipDeed.ShuttleNameSuffix;
+                var number = suffix.Split("-")[1];
+                msg.WrappedMessage = SharedChatSystem.InjectTagAroundString(msg, suffix, "color", _highlightsColor);
+                msg.WrappedMessage = SharedChatSystem.InjectTagAroundString(msg, number, "color", _highlightsColor);
+            }
+        }
+
         // Color any codewords for minds that have roles that use them
         if (_player.LocalUser != null && _mindSystem != null && _roleCodewordSystem != null)
         {
@@ -956,6 +974,28 @@ public sealed partial class ChatUIController : UIController
     {
         var colorIdx = Math.Abs(name.GetHashCode() % _chatNameColors.Length);
         return _chatNameColors[colorIdx];
+    }
+
+    private bool TryGetIdCard(EntityUid ent, out EntityUid? idCard)
+    {
+        if (_inventory != null && _inventory.TryGetSlotEntity(ent, "id", out var pdaSlotItem))
+        {
+            if (_ent.HasComponent<Shared.Access.Components.IdCardComponent>(pdaSlotItem))
+            {
+                idCard = pdaSlotItem;
+                return true;
+            }
+
+            if (_ent.TryGetComponent<Shared.PDA.PdaComponent>(pdaSlotItem, out var pda)
+                && pda.ContainedId.HasValue)
+            {
+                idCard = pda.ContainedId.Value;
+                return true;
+            }
+        }
+
+        idCard = null;
+        return false;
     }
 
     private readonly record struct SpeechBubbleData(ChatMessage Message, SpeechBubble.SpeechType Type);

--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
@@ -844,7 +844,7 @@ public sealed partial class ChatUIController : UIController
             msg.WrappedMessage = SharedChatSystem.InjectTagAroundString(msg, highlight, "color", _highlightsColor);
         }
 
-        //Color ship ID
+        // Frontier: Color current ship callsign
         if (_player.LocalEntity != null && TryGetIdCard(_player.LocalEntity.Value, out var idCard) && _ent.TryGetComponent<ShuttleDeedComponent>(idCard, out var shipDeed))
         {
             if (shipDeed.ShuttleName != null)
@@ -858,6 +858,7 @@ public sealed partial class ChatUIController : UIController
                 msg.WrappedMessage = SharedChatSystem.InjectTagAroundString(msg, number, "color", _highlightsColor);
             }
         }
+        // End Frontier
 
         // Color any codewords for minds that have roles that use them
         if (_player.LocalUser != null && _mindSystem != null && _roleCodewordSystem != null)
@@ -976,6 +977,7 @@ public sealed partial class ChatUIController : UIController
         return _chatNameColors[colorIdx];
     }
 
+    // Frontier: Color current ship callsign
     private bool TryGetIdCard(EntityUid ent, out EntityUid? idCard)
     {
         if (_inventory != null && _inventory.TryGetSlotEntity(ent, "id", out var pdaSlotItem))
@@ -997,6 +999,7 @@ public sealed partial class ChatUIController : UIController
         idCard = null;
         return false;
     }
+    // End Frontier
 
     private readonly record struct SpeechBubbleData(ChatMessage Message, SpeechBubble.SpeechType Type);
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

The PR adds chat highlight for your current ShuttleName and ShuttleNamePrefix, based ShuttleDeed on your currently equipped ID.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

It was an idea [discussed on Discord](https://discord.com/channels/1123826877245694004/1537938552099176558). I've had several cases where I missed someone wanting to interact with me, because they only mentioned my ship name prefix, since that is the readily available information on a mass scanner. A highlight would help with making sure you do not miss any message addressed to you.

It can be also useful for Traffic Control or people doing medical dispatches, and in general being able to notice that someone is trying to talk to you is a plus.

I also wanted something easy to finally get into the codebase.

## Technical details
<!-- Summary of code changes for easier review. -->

The code is based on the approach used by antag role highlights, implementation of which [can be seen here](https://github.com/space-wizards/space-station-14/pull/30092/files).

I have borrowed the code from CryoSleepSystem for getting the player's current ID (which required adding ClientInventorySystem to the ChatUIController) and then looked up the ShipDeedComponent that it can have. The data on the ShipDeed are then used to highlight keywords when any message is received.

We're highlighting ship name (i.e Searchlight), ship suffix (XX-123) and the suffix number (123).

This is my first time working with the SS14 codebase, so it's possible that something is terribly wrong or there is a better way how to do it. I have no idea how performance heavy the per-message lookup of Inventory is, but this approach was chosen so we do not have to do a lot of handling for various ways how can a ship name change - to be able to cache the name, we would have to listen to renames, selling, ID switches and the like. Simply polling it was way easier, but if it's unacceptable from performance standpoint I can look into other options, I mainly wanted to get something out to get started with the SS14 codebase and start with contributing.

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->

* Start the server and connect
* Go buy a ship and note it's name and suffix/callsign (XX-123)
* Type either the name, the suffix, the three numbers, or both into chat and see that it's highlighted.
* Drop your PDA or ID and send the message again, it should not be highlighted.
* Sell the ship and buy a new one, it should start highlighting the new keyword.
* Rename the ship, it should highlight the new keyword.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<img width="1547" height="561" alt="image" src="https://github.com/user-attachments/assets/49f76f2b-1f57-48d1-b5ee-bf42b538cd89" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Ship name and suffix is now highlighted in chat, based on the ship owned by your currently slotted ID.
-->
