### PR TITLE
Dirty EmitterComponent when changing BoltType by signal

### DIFF
--- a/Content.Server/Singularity/EntitySystems/EmitterSystem.cs
+++ b/Content.Server/Singularity/EntitySystems/EmitterSystem.cs
@@ -299,6 +299,7 @@ namespace Content.Server.Singularity.EntitySystems
             else if (component.SetTypePorts.TryGetValue(args.Port, out var boltType))
             {
                 component.BoltType = boltType;
+                Dirty(uid, component); // Frontier: dirty the component to send the new bolt type
             }
         }
     }


### PR DESCRIPTION
## About the PR
Title!

## Why / Balance
Informs clients that the bolt type has changed. Otherwise clients end up out of sync, which is especially bad when the bolt type changes without you knowing, for example if a tech anomaly interferes with the APE. Oopsies.

Upstream has the same bug, might PR this fix there too.

## Technical details
One (1) entire line of C#.

## How to test
1. Spawn yourself an A.P.E.
2. Link some signal source, perhaps a signaller, to one of its ports for setting the particle type.
3. Make sure the A.P.E. is set to a different type.
4. Trigger the signal.
5. Watch the particle type change in the UI. No desync. Happy days.

## Media
Do I reeeally have to get a recording for such a tiny fix?

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes

**Changelog**
:cl:
- fix: A.P.E. particle type is correctly replicated to clients when changed by signal.