### PR TITLE
Add notifications for incoming mail

### DIFF
--- a/Content.Client/_DV/CartridgeLoader/Cartridges/MailMetricUi.cs
+++ b/Content.Client/_DV/CartridgeLoader/Cartridges/MailMetricUi.cs
@@ -1,15 +1,14 @@
 using Robust.Client.UserInterface;
 using Content.Client.UserInterface.Fragments;
-using Content.Shared.CartridgeLoader;
+using Content.Shared.CartridgeLoader; // Frontier
 using Content.Shared.CartridgeLoader.Cartridges;
-using Robust.Shared.Serialization;
 
 namespace Content.Client._DV.CartridgeLoader.Cartridges;
 
 public sealed partial class MailMetricUi : UIFragment
 {
     private MailMetricUiFragment? _fragment;
-    private BoundUserInterface _userInterface;
+    private BoundUserInterface _userInterface; // Frontier: Required to send messages to the server
 
     public override Control GetUIFragmentRoot()
     {
@@ -19,8 +18,8 @@ public sealed partial class MailMetricUi : UIFragment
     public override void Setup(BoundUserInterface userInterface, EntityUid? fragmentOwner)
     {
         _fragment = new MailMetricUiFragment();
-        _userInterface = userInterface;
-        _fragment.OnToggleNotificationButtonPressed += OnNotificationToggled;
+        _userInterface = userInterface; // Frontier: Save the UI so we can send messages to the server
+        _fragment.OnToggleNotificationButtonPressed += OnNotificationToggled; // Frontier: Detect when the notification button is pressed
 
     }
 
@@ -32,6 +31,8 @@ public sealed partial class MailMetricUi : UIFragment
         }
     }
 
+    // Frontier: Add a method to toggle the visual notification button.
+    // Keep in mind that this is solely a visual toggle, as the data for this program is only stored server side
     public void OnNotificationToggled()
     {
         if (_fragment == null)
@@ -41,5 +42,5 @@ public sealed partial class MailMetricUi : UIFragment
         var message = new MailMetricsNotificationToggleMessage(newStatus);
         _userInterface.SendMessage(new CartridgeUiMessage(message));
     }
+    //End Frontier
 }
-

--- a/Content.Client/_DV/CartridgeLoader/Cartridges/MailMetricUi.cs
+++ b/Content.Client/_DV/CartridgeLoader/Cartridges/MailMetricUi.cs
@@ -1,12 +1,15 @@
 using Robust.Client.UserInterface;
 using Content.Client.UserInterface.Fragments;
+using Content.Shared.CartridgeLoader;
 using Content.Shared.CartridgeLoader.Cartridges;
+using Robust.Shared.Serialization;
 
 namespace Content.Client._DV.CartridgeLoader.Cartridges;
 
 public sealed partial class MailMetricUi : UIFragment
 {
     private MailMetricUiFragment? _fragment;
+    private BoundUserInterface _userInterface;
 
     public override Control GetUIFragmentRoot()
     {
@@ -16,6 +19,9 @@ public sealed partial class MailMetricUi : UIFragment
     public override void Setup(BoundUserInterface userInterface, EntityUid? fragmentOwner)
     {
         _fragment = new MailMetricUiFragment();
+        _userInterface = userInterface;
+        _fragment.OnToggleNotificationButtonPressed += OnNotificationToggled;
+
     }
 
     public override void UpdateState(BoundUserInterfaceState state)
@@ -25,4 +31,15 @@ public sealed partial class MailMetricUi : UIFragment
             _fragment?.UpdateState(cast);
         }
     }
+
+    public void OnNotificationToggled()
+    {
+        if (_fragment == null)
+            return;
+        var newStatus = !_fragment.MailNotificationEnabledButtonStatus;
+        _fragment.SetNotificationButtonVisual(newStatus);
+        var message = new MailMetricsNotificationToggleMessage(newStatus);
+        _userInterface.SendMessage(new CartridgeUiMessage(message));
+    }
 }
+

--- a/Content.Client/_DV/CartridgeLoader/Cartridges/MailMetricUiFragment.xaml
+++ b/Content.Client/_DV/CartridgeLoader/Cartridges/MailMetricUiFragment.xaml
@@ -180,6 +180,7 @@
             Align="Center"
             StyleClasses="LabelBig" />
     </BoxContainer>
+    <!-- Start frontier: Mail notification button-->
     <PanelContainer HorizontalExpand="True" MinHeight="32">
         <BoxContainer Orientation="Horizontal"
                       Margin="8,8,8,8"
@@ -192,5 +193,6 @@
                 Margin="0,0,5,0"/>
         </BoxContainer>
     </PanelContainer>
+    <!-- End Frontier-->
 
 </cartridges:MailMetricUiFragment>

--- a/Content.Client/_DV/CartridgeLoader/Cartridges/MailMetricUiFragment.xaml
+++ b/Content.Client/_DV/CartridgeLoader/Cartridges/MailMetricUiFragment.xaml
@@ -180,4 +180,17 @@
             Align="Center"
             StyleClasses="LabelBig" />
     </BoxContainer>
+    <PanelContainer HorizontalExpand="True" MinHeight="32">
+        <BoxContainer Orientation="Horizontal"
+                      Margin="8,8,8,8"
+                      HorizontalExpand="True">
+            <Button
+                Name="NotificationSwitch"
+                ToolTip="{Loc news-reader-ui-mute-tooltip}"
+                Text="{Loc news-read-ui-notification-on}"
+                MinWidth="20"
+                Margin="0,0,5,0"/>
+        </BoxContainer>
+    </PanelContainer>
+
 </cartridges:MailMetricUiFragment>

--- a/Content.Client/_DV/CartridgeLoader/Cartridges/MailMetricUiFragment.xaml.cs
+++ b/Content.Client/_DV/CartridgeLoader/Cartridges/MailMetricUiFragment.xaml.cs
@@ -10,10 +10,14 @@ public sealed partial class MailMetricUiFragment : BoxContainer
 {
 
     private OpenedMailPercentGrade? _successGrade;
+    public Action? OnToggleNotificationButtonPressed;
+    //This is the visual state of the button. Since the UI data is only saved server side, the client is just saying what it remembers.
+    public bool MailNotificationEnabledButtonStatus { get; private set; } = true; // Frontier: Mail notifications
 
     public MailMetricUiFragment()
     {
         RobustXamlLoader.Load(this);
+        NotificationSwitch.OnPressed += _ => OnToggleNotificationButtonPressed?.Invoke(); // Frontier: Mail notification button
 
         // This my way of adding multiple classes to a XAML control.
         // Haha Batman I'm going to blow up Gotham City
@@ -32,6 +36,7 @@ public sealed partial class MailMetricUiFragment : BoxContainer
     {
         UpdateTextLabels(state);
         UpdateSuccessGrade(state);
+        SetNotificationButtonVisual(state.NotificationsEnabled); // Frontier: Display notification status
     }
 
     public void UpdateTextLabels(MailMetricUiState state)
@@ -73,6 +78,16 @@ public sealed partial class MailMetricUiFragment : BoxContainer
 
         SuccessRatePercent.StyleClasses.Add(GetClassForGrade(_successGrade));
     }
+
+    // Frontier: Update the notification switch text
+    public void SetNotificationButtonVisual(bool notificationsEnabled)
+    {
+        //I'm just stealing the icon from the news system, yoink!
+        var locKey = notificationsEnabled ? "news-read-ui-notification-on" : "news-read-ui-notification-off";
+        NotificationSwitch.Text = Loc.GetString(locKey);
+        MailNotificationEnabledButtonStatus = notificationsEnabled;
+    }
+    // End Frontier
 
     private static OpenedMailPercentGrade GetSuccessRateGrade(double successRate)
     {

--- a/Content.Client/_DV/CartridgeLoader/Cartridges/MailMetricUiFragment.xaml.cs
+++ b/Content.Client/_DV/CartridgeLoader/Cartridges/MailMetricUiFragment.xaml.cs
@@ -10,7 +10,7 @@ public sealed partial class MailMetricUiFragment : BoxContainer
 {
 
     private OpenedMailPercentGrade? _successGrade;
-    public Action? OnToggleNotificationButtonPressed;
+    public Action? OnToggleNotificationButtonPressed; // Frontier: Mail notification
     //This is the visual state of the button. Since the UI data is only saved server side, the client is just saying what it remembers.
     public bool MailNotificationEnabledButtonStatus { get; private set; } = true; // Frontier: Mail notifications
 

--- a/Content.Server/_DV/CartridgeLoader/Cartridges/MailMetricsCartridgeComponent.cs
+++ b/Content.Server/_DV/CartridgeLoader/Cartridges/MailMetricsCartridgeComponent.cs
@@ -1,7 +1,8 @@
 namespace Content.Server._DV.CartridgeLoader.Cartridges;
 
-// Frontier: removed the EntityUid of the station from the component 
+// Frontier: removed the EntityUid of the station from the component
 [RegisterComponent, Access(typeof(MailMetricsCartridgeSystem))]
 public sealed partial class MailMetricsCartridgeComponent : Component
 {
+    public bool NotificationsEnabled = true; // Frontier: Allow toggling notifications
 }

--- a/Content.Server/_DV/CartridgeLoader/Cartridges/MailMetricsCartridgeSystem.cs
+++ b/Content.Server/_DV/CartridgeLoader/Cartridges/MailMetricsCartridgeSystem.cs
@@ -27,13 +27,14 @@ public sealed class MailMetricsCartridgeSystem : EntitySystem
     {
         UpdateUI(args.Loader, ent.Comp); // Frontier: remove station as first arg
     }
-
+    // Frontier: Add an event listener for when the client wants to update its notification state
     private void OnNotificationsUpdated(Entity<MailMetricsCartridgeComponent> program, ref CartridgeMessageEvent eventArgs )
     {
         if (eventArgs is MailMetricsNotificationToggleMessage toggleMessage)
             program.Comp.NotificationsEnabled = toggleMessage.NotificationsEnabled;
 
     }
+    // End Frontier
 
     private void OnLogisticsStatsUpdated(LogisticStatsUpdatedEvent args)
     {
@@ -52,10 +53,11 @@ public sealed class MailMetricsCartridgeSystem : EntitySystem
         {
             if (cartridge.LoaderUid is not { } loader)
                 continue;
-            UpdateUI(loader, comp);
+            UpdateUI(loader, comp); // Frontier
         }
     }
 
+    // Frontier: Add parameter cartComp to allow us to get and send notification status
     private void UpdateUI(EntityUid loader, MailMetricsCartridgeComponent cartComp)
     {
         //if (_station.GetOwningStation(loader) is { } station) // Frontier
@@ -68,7 +70,7 @@ public sealed class MailMetricsCartridgeSystem : EntitySystem
         var unopenedMailCount = GetUnopenedMailCount(); // Frontier: no station arg
 
         // Send logistic stats to cartridge client
-        var state = new MailMetricUiState(logiStats.Metrics, unopenedMailCount, cartComp.NotificationsEnabled);
+        var state = new MailMetricUiState(logiStats.Metrics, unopenedMailCount, cartComp.NotificationsEnabled); // Frontier: Add cartComp.NotificationsEnabled
         _cartridgeLoader.UpdateCartridgeUiState(loader, state);
     }
 

--- a/Content.Server/_DV/CartridgeLoader/Cartridges/MailMetricsCartridgeSystem.cs
+++ b/Content.Server/_DV/CartridgeLoader/Cartridges/MailMetricsCartridgeSystem.cs
@@ -20,11 +20,20 @@ public sealed class MailMetricsCartridgeSystem : EntitySystem
         SubscribeLocalEvent<MailMetricsCartridgeComponent, CartridgeUiReadyEvent>(OnUiReady);
         SubscribeLocalEvent<LogisticStatsUpdatedEvent>(OnLogisticsStatsUpdated);
         SubscribeLocalEvent<MailComponent, MapInitEvent>(OnMapInit);
+        SubscribeLocalEvent<MailMetricsCartridgeComponent, CartridgeMessageEvent>(OnNotificationsUpdated);
     }
 
     private void OnUiReady(Entity<MailMetricsCartridgeComponent> ent, ref CartridgeUiReadyEvent args)
     {
-        UpdateUI(args.Loader); // Frontier: remove station as first arg
+        UpdateUI(args.Loader, ent.Comp); // Frontier: remove station as first arg
+    }
+
+    private void OnNotificationsUpdated(Entity<MailMetricsCartridgeComponent> program, ref CartridgeMessageEvent eventArgs )
+    {
+        if (eventArgs is MailMetricsNotificationToggleMessage toggleMessage)
+            program.Comp.NotificationsEnabled = toggleMessage.NotificationsEnabled;
+        Console.Out.WriteLine("Notification Toggle Recieved, new satus is now " + program.Comp.NotificationsEnabled);
+
     }
 
     private void OnLogisticsStatsUpdated(LogisticStatsUpdatedEvent args)
@@ -44,11 +53,11 @@ public sealed class MailMetricsCartridgeSystem : EntitySystem
         {
             if (cartridge.LoaderUid is not { } loader)
                 continue;
-            UpdateUI(loader);
+            UpdateUI(loader, comp);
         }
     }
 
-    private void UpdateUI(EntityUid loader)
+    private void UpdateUI(EntityUid loader, MailMetricsCartridgeComponent cartComp)
     {
         //if (_station.GetOwningStation(loader) is { } station) // Frontier
         //    ent.Comp.Station = station; // Frontier
@@ -60,7 +69,7 @@ public sealed class MailMetricsCartridgeSystem : EntitySystem
         var unopenedMailCount = GetUnopenedMailCount(); // Frontier: no station arg
 
         // Send logistic stats to cartridge client
-        var state = new MailMetricUiState(logiStats.Metrics, unopenedMailCount);
+        var state = new MailMetricUiState(logiStats.Metrics, unopenedMailCount, cartComp.NotificationsEnabled);
         _cartridgeLoader.UpdateCartridgeUiState(loader, state);
     }
 

--- a/Content.Server/_DV/CartridgeLoader/Cartridges/MailMetricsCartridgeSystem.cs
+++ b/Content.Server/_DV/CartridgeLoader/Cartridges/MailMetricsCartridgeSystem.cs
@@ -32,7 +32,6 @@ public sealed class MailMetricsCartridgeSystem : EntitySystem
     {
         if (eventArgs is MailMetricsNotificationToggleMessage toggleMessage)
             program.Comp.NotificationsEnabled = toggleMessage.NotificationsEnabled;
-        Console.Out.WriteLine("Notification Toggle Recieved, new satus is now " + program.Comp.NotificationsEnabled);
 
     }
 

--- a/Content.Server/_DV/Mail/EntitySystems/MailSystem.cs
+++ b/Content.Server/_DV/Mail/EntitySystems/MailSystem.cs
@@ -803,7 +803,7 @@ namespace Content.Server._DV.Mail.EntitySystems
                 if (validTeleporters[i].HadMail)
                     _audioSystem.PlayPvs(validTeleporters[i].Entity.Comp.TeleportSound, validTeleporters[i].Entity);
             }
-            NotifyMailCarriers(deliveryCount);
+            NotifyMailCarriers(deliveryCount); // Frontier; Mail carrier notifications
         }
         // End Frontier: sector-wide mail
 
@@ -856,7 +856,6 @@ namespace Content.Server._DV.Mail.EntitySystems
         }
 
         //Frontier: Send a PDA notification to all active mail carriers when new mail is teleported in.
-        //TODO: Maybe add a way to toggle this notification in mailmetrics?
         /// <summary>
         /// Notifies all in sector mail carriers that mail has arrived
         /// </summary>
@@ -875,6 +874,7 @@ namespace Content.Server._DV.Mail.EntitySystems
                 }
             }
         }
+        // End Frontier
     }
 
     public struct MailRecipient(

--- a/Content.Server/_DV/Mail/EntitySystems/MailSystem.cs
+++ b/Content.Server/_DV/Mail/EntitySystems/MailSystem.cs
@@ -867,9 +867,12 @@ namespace Content.Server._DV.Mail.EntitySystems
             {
                 if (!_cartLoader.TryGetProgram<MailMetricsCartridgeComponent>(pdaUid, out var programUid, out var programComp))
                     continue;
-                _cartLoader.SendNotification(pdaUid,
-                    Loc.GetString("mail-notification-header"),
-                    Loc.GetString("mail-notification-body", ("quantity", packageCount)));
+                if (programComp.NotificationsEnabled)
+                {
+                    _cartLoader.SendNotification(pdaUid,
+                        Loc.GetString("mail-notification-header"),
+                        Loc.GetString("mail-notification-body", ("quantity", packageCount)));
+                }
             }
         }
     }

--- a/Content.Server/_DV/Mail/EntitySystems/MailSystem.cs
+++ b/Content.Server/_DV/Mail/EntitySystems/MailSystem.cs
@@ -39,15 +39,18 @@ using Robust.Shared.Random;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
+using Content.Server._DV.CartridgeLoader.Cartridges; //Frontier
 using Timer = Robust.Shared.Timing.Timer;
 using Content.Server.Power.EntitySystems; // Frontier
 using Content.Server._NF.Bank; // Frontier
 using Content.Server._NF.Mail.Components; // Frontier
 using Content.Server._NF.SectorServices; // Frontier
+using Content.Server.CartridgeLoader; // Frontier
 using Content.Shared.SSDIndicator; // Frontier
 using Content.Shared.Station.Components; // Frontier
 using Content.Shared._NF.Bank.BUI; // Frontier
 using Content.Shared._NF.Bank.Components; // Frontier
+using Content.Shared.CartridgeLoader; // Frontier
 using Robust.Server.Player; // Frontier
 using Robust.Shared.Enums; // Frontier
 
@@ -78,6 +81,7 @@ namespace Content.Server._DV.Mail.EntitySystems
         [Dependency] private readonly BankSystem _bank = default!; // Frontier
         [Dependency] private readonly PowerReceiverSystem _powerReceiver = default!; // Frontier
         [Dependency] private readonly IPlayerManager _player = default!; // Frontier
+        [Dependency] private readonly CartridgeLoaderSystem _cartLoader = default!; // Frontier
 
         private ISawmill _sawmill = default!;
         private static readonly ProtoId<TagPrototype> MailTag = "Mail"; // Frontier
@@ -799,6 +803,7 @@ namespace Content.Server._DV.Mail.EntitySystems
                 if (validTeleporters[i].HadMail)
                     _audioSystem.PlayPvs(validTeleporters[i].Entity.Comp.TeleportSound, validTeleporters[i].Entity);
             }
+            NotifyMailCarriers(deliveryCount);
         }
         // End Frontier: sector-wide mail
 
@@ -848,6 +853,24 @@ namespace Content.Server._DV.Mail.EntitySystems
             if (TryComp(_sectorService.GetServiceEntity(), out SectorLogisticStatsComponent? logisticStats))
                 action(logisticStats);
             // End Frontier
+        }
+
+        //Frontier: Send a PDA notification to all active mail carriers when new mail is teleported in.
+        //TODO: Maybe add a way to toggle this notification in mailmetrics?
+        /// <summary>
+        /// Notifies all in sector mail carriers that mail has arrived
+        /// </summary>
+        public void NotifyMailCarriers(int packageCount)
+        {
+            var pdaQuery = EntityQueryEnumerator<CartridgeLoaderComponent>();
+            while (pdaQuery.MoveNext(out var pdaUid, out var cartLoaderComp))
+            {
+                if (!_cartLoader.TryGetProgram<MailMetricsCartridgeComponent>(pdaUid, out var programUid, out var programComp))
+                    continue;
+                _cartLoader.SendNotification(pdaUid,
+                    Loc.GetString("mail-notification-header"),
+                    Loc.GetString("mail-notification-body", ("quantity", packageCount)));
+            }
         }
     }
 

--- a/Content.Shared/_DV/CartridgeLoader/Cartridges/MailMetricUiState.cs
+++ b/Content.Shared/_DV/CartridgeLoader/Cartridges/MailMetricUiState.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Preferences;
 using Robust.Shared.Serialization;
 
 namespace Content.Shared.CartridgeLoader.Cartridges;
@@ -9,13 +10,15 @@ public sealed class MailMetricUiState : BoundUserInterfaceState
     public int UnopenedMailCount { get; }
     public int TotalMail { get; }
     public double SuccessRate { get; }
+    public bool NotificationsEnabled { get; }
 
-    public MailMetricUiState(MailStats metrics, int unopenedMailCount)
+    public MailMetricUiState(MailStats metrics, int unopenedMailCount, bool notificationsEnabled)
     {
         Metrics = metrics;
         UnopenedMailCount = unopenedMailCount;
         TotalMail = metrics.TotalMail(unopenedMailCount);
         SuccessRate = metrics.SuccessRate(unopenedMailCount);
+        NotificationsEnabled = notificationsEnabled;
     }
 }
 
@@ -46,4 +49,10 @@ public partial record struct MailStats
             ? Math.Round((double)OpenedCount / totalMail * 100, 2)
             : 0;
     }
+}
+
+[Serializable] [NetSerializable]
+public sealed class MailMetricsNotificationToggleMessage(bool notificationsEnabled) : CartridgeMessageEvent
+{
+    public readonly bool NotificationsEnabled = notificationsEnabled;
 }

--- a/Content.Shared/_DV/CartridgeLoader/Cartridges/MailMetricUiState.cs
+++ b/Content.Shared/_DV/CartridgeLoader/Cartridges/MailMetricUiState.cs
@@ -10,15 +10,16 @@ public sealed class MailMetricUiState : BoundUserInterfaceState
     public int UnopenedMailCount { get; }
     public int TotalMail { get; }
     public double SuccessRate { get; }
-    public bool NotificationsEnabled { get; }
+    public bool NotificationsEnabled { get; } // Frontier: Mail notification toggle
 
+    // Frontier: Add notifications enabled parameter
     public MailMetricUiState(MailStats metrics, int unopenedMailCount, bool notificationsEnabled)
     {
         Metrics = metrics;
         UnopenedMailCount = unopenedMailCount;
         TotalMail = metrics.TotalMail(unopenedMailCount);
         SuccessRate = metrics.SuccessRate(unopenedMailCount);
-        NotificationsEnabled = notificationsEnabled;
+        NotificationsEnabled = notificationsEnabled; // Frontier
     }
 }
 

--- a/Resources/Locale/en-US/_NF/mail/mail.ftl
+++ b/Resources/Locale/en-US/_NF/mail/mail.ftl
@@ -2,7 +2,11 @@ ent-BaseMailLarge = package
 mail-large-item-name-addressed = package ({$recipient})
 mail-large-desc-far = A large package.
 mail-large-desc-close = A large package addressed to {CAPITALIZE($name)}, {$job}. Last known location: {$station}.
-
+mail-notification-title = Mail Delivery
+mail-notification-body = {$quantity ->
+    [one] 1 package has arrived at the sector's mail teleporters.
+    *[other] {$quantity} packages have arrived at the sector's mail teleporters.
+}
 
 
 command-mailto-no-mailservice = Unable to get mail service.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Mail carriers(technically, anyone with a MailMetrics cartridge installed on their PDA) will now receive notifications whenever teleporters warp a batch of mail in.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I just thought it would be nice for mail carriers to know when mail was warped in, so they could know when they needed to fly back and pick more up. I also added a button to toggle the notification so SRs don't have to get spammed with it, and carriers can turn it off at their preference.

## Technical details
<!-- Summary of code changes for easier review. -->
Changes to the MailMetrics: Added a new field that controls if notifications are on or off, defaulting to on. This is passed to the client whenever the state of the mail stats is updated. The server will also now listen for an event indicating notification preference has been changed, and upon receiving it, toggle the server side variable. The client side UI will also display this value, and send a message whenever its toggled.
Changes to MailSystem: Added a method that pushes a notification to everyone with the MailMetrics installed, and notifications enabled.

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
Spawn in a MailMetrics cartridge and install it
Use the `mailnow` command to spawn in mail, notice you get a notification
Toggle the notifications on and off, using the button in MailMetrics, while using `mailnow` to ensure the toggle works
(Remember to clear the mail teleporter so more mail can spawn!)

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: Mail carriers will now receive a toggleable PDA notification whenever mail enters the sector.