### PR TITLE
Fix blueprint lithograph selection bug

### DIFF
--- a/Content.Client/_NF/Lathe/BlueprintLatheClientStateComponent.cs
+++ b/Content.Client/_NF/Lathe/BlueprintLatheClientStateComponent.cs
@@ -16,6 +16,13 @@ public sealed partial class BlueprintLatheClientStateComponent : Component
     public ProtoId<BlueprintPrototype>? CurrentBlueprintType;
 
     /// <summary>
+    /// The default selected blueprint type. Can't be assigned to <c>CurrentBlueprintType</c>
+    /// for dumb internal implementation reasons.
+    /// </summary>
+    [DataField]
+    public ProtoId<BlueprintPrototype> DefaultBlueprintType = "NFAllResearchable";
+
+    /// <summary>
     /// The last set of selected recipes.
     /// </summary>
     [DataField]

--- a/Content.Client/_NF/Lathe/UI/BlueprintLatheNFMenu.xaml.cs
+++ b/Content.Client/_NF/Lathe/UI/BlueprintLatheNFMenu.xaml.cs
@@ -101,18 +101,24 @@ public sealed partial class BlueprintLatheNFMenu : DefaultWindow
             return;
 
         // Coerce a null blueprint type into a valid one if possible.
-        int[]? recipeBitset = null;
-        if (clientLathe.CurrentBlueprintType == null
-            || !RecipesByBlueprintType.TryGetValue(clientLathe.CurrentBlueprintType.Value, out recipeBitset))
+        if (clientLathe.CurrentBlueprintType == null)
         {
-            clientLathe.CurrentBlueprintType = RecipesByBlueprintType.Keys.FirstOrNull();
+            clientLathe.CurrentBlueprintType = clientLathe.DefaultBlueprintType;
+        }
+
+        int[]? recipeBitset = null;
+        if (!RecipesByBlueprintType.TryGetValue(clientLathe.CurrentBlueprintType.Value, out recipeBitset))
+        {
             clientLathe.CurrentRecipes = null;
+            return;
+        }
+        else if (clientLathe.CurrentRecipes == null)
+        {
+            clientLathe.CurrentRecipes = new int[recipeBitset.Length];
         }
 
         // Check that we can still get a set of recipes from what we have.
-        if (clientLathe.CurrentBlueprintType == null
-            || !RecipesByBlueprintType.TryGetValue(clientLathe.CurrentBlueprintType.Value, out recipeBitset)
-            || !_lathe.PrintableRecipesByType.TryGetValue(clientLathe.CurrentBlueprintType.Value, out var recipeList))
+        if (!_lathe.PrintableRecipesByType.TryGetValue(clientLathe.CurrentBlueprintType.Value, out var recipeList))
         {
             return;
         }
@@ -258,7 +264,7 @@ public sealed partial class BlueprintLatheNFMenu : DefaultWindow
 
         // Default to whatever the first item is.  No blueprint type is not a valid selection.
         if (!selectedIndex)
-            BlueprintTypeOption.SelectId(0);
+            BlueprintTypeOption.TrySelect(0);
     }
 
     /// <summary>


### PR DESCRIPTION
## About the PR
You know that bug we keep having to explain to people how to work around, where the blueprint lithograph just refuses to let you select any blueprints until you pick another category and go back to 'All Available'? This PR fixes that bug.

## Why / Balance
Annoying bug. Shouldn't be fixed, not worked around!

## Technical details
The root of the problem was essentially that `BlueprintLatheClientStateComponent.CurrentRecipes` didn't get initialised on initial selection. We can't initialise it until the server sends us a state, so it has to start out null. The code did not initialise to anything when the initial server state was received, only when you changed the category; hence, it stayed null even with a category apparently selected.

In addition to initialising it properly, I've also added a `DefaultBlueprintType` to be used as the fallback when there is no selection. This *guarantees* that 'All Available' is selected initially, instead of whichever category happens to be first in the list.

This change has *not* been ported to the normal lathe system, because it doesn't have categories like the blueprint lithograph does.

## How to test
1. Unlock some stuff on an R&D computer.
2. Plonk down a fresh blueprint lithograph.
3. Print away without even changing the category.
4. Change the category anyway, as a treat.
5. Print some more stuff.
6. Sell blueprints to Steve Salvager and Mike Mercenary.
7. Profit?

## Media
https://github.com/user-attachments/assets/9d564dc4-c63d-448e-a595-bbbfe23b7136

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes

**Changelog**
:cl:
- fix: Fixed that annoying bug where blueprint lithographs would refuse to print until you selected a different category. They now work reliably.