### PR TITLE
Make the janicart safe to drink

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Objects/Vehicles/vehicles.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Vehicles/vehicles.yml
@@ -395,6 +395,7 @@
     edible: Drink
     solution: bucket
     utensil: Spoon
+    destroyOnEmpty: false
   - type: ContainerContainer
     containers:
       storagebase: !type:Container


### PR DESCRIPTION
## About the PR
Made it safe to drink the janicart. It no longer disappears when you empty the internal bucket.

## Why / Balance
Mmmm, tasty janicart.

But seriously, I mean, you don't wanna drink up the entire janicart, do you? It's *incredibly* funny, but totally unintended.

I'm still giggling.

## Technical details
A line of YAML. YAMLine.

## How to test
1. Put some liquid in a janicart's internal bucket.
2. Drink the janicart.
3. Still have a janicart. You didn't slurp it up. Congratulations!

## Media
The bug in action:

https://github.com/user-attachments/assets/676264de-d751-491a-b9f6-dad2e279735e

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes

**Changelog**
:cl:
- fix: You can now safely drink from a janicart without slurping up the entire janicart.