### PR TITLE
Fix supercompacted rock prototypes

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/Salvage/minerals.yml
+++ b/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/Salvage/minerals.yml
@@ -657,13 +657,13 @@
   id: NFSandMineralHardRich
   table: !type:GroupSelector
     children:
-    - id: NFWallBasaltCobblebrick
+    - id: NFWallSandstone
       weight: 0.3
-    - id: NFWallBasaltCobblebrickArtifactFragment
+    - id: NFWallSandstoneArtifactFragment
       weight: 0.3
-    - id: NFWallBasaltCobblebrickBluespace
+    - id: NFWallSandstoneBluespace
       weight: 0.1
-    - id: NFWallBasaltCobblebrickDiamond
+    - id: NFWallSandstoneDiamond
       weight: 0.3
 
 - type: entity
@@ -795,13 +795,13 @@
   id: NFChromiteMineralHardRich
   table: !type:GroupSelector
     children:
-    - id: NFWallBasaltCobblebrick
+    - id: NFWallChromiteCobblebrick
       weight: 0.3
-    - id: NFWallBasaltCobblebrickArtifactFragment
+    - id: NFWallChromiteCobblebrickArtifactFragment
       weight: 0.25
-    - id: NFWallBasaltCobblebrickBluespace
+    - id: NFWallChromiteCobblebrickBluespace
       weight: 0.25
-    - id: NFWallBasaltCobblebrickDiamond
+    - id: NFWallChromiteCobblebrickDiamond
       weight: 0.2
 
 - type: entity


### PR DESCRIPTION
## About the PR
Change two of the rich supercompacted rock prototypes to match their biome.

## Why / Balance
Basalt on my chromite or sandstone asteroids?! How very dare you!

## Technical details
YAML.

## How to test
Fly around a whole bunch and look at an enormous number of chromite and sandstone asteroids. Chromite is the purple one. I don't really know how else to test this.

## Media
As reported yesterday, here's the bug this PR fixes:

<img width="694" height="360" alt="image" src="https://github.com/user-attachments/assets/e9f11ca6-def4-4068-a3a4-4bf34496299e" />

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes

**Changelog**
N/A, just a tiny bug fix