### PR TITLE
Fix psychologist bed construction graph

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Furniture/beds.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/beds.yml
@@ -141,7 +141,7 @@
   - type: Construction
     graph: bedNF
     node: mattress
-  # Frontier: break into cloth, not steel.
+  # End Frontier
   - type: Destructible
     thresholds:
     - trigger:
@@ -208,6 +208,11 @@
     damage:
       types:
         Cold: -0.5
+  # Frontier: deconstruct into appropriate materials.
+  - type: Construction
+    graph: bedNF
+    node: PsychBed
+  # End Frontier
   - type: Destructible
     thresholds:
     - trigger: # Excess damage, don't spawn entities


### PR DESCRIPTION
## About the PR
Set the construction graph for the psychologist bed to `bedNF`.

## Why / Balance
Deconstructs into the wrong materials, because it inherits `bed`. Oops.

Continuation of #2000 :)

## Technical details
YAML, my beloved.

## How to test
1. Construct a psychologist bed.
2. Deconstruct a psychologist bed. Get the same materials back.
3. Spawn a fresh psychologist bed, then deconstruct it. Get the same materials as before.

## Media
N/A

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes

**Changelog**
:cl:
- fix: The psychologist bed now deconstructs into the same materials it was made of.